### PR TITLE
fix: update version validation to handle qualifiers in GitHub workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,16 +25,25 @@ jobs:
     - name: Validate version consistency
       if: github.ref_type == 'tag'
       run: |
-        # Extract version from build.gradle.kts
-        GRADLE_VERSION=$(grep -E '^val (majorVersion|minorVersion|patchVersion)' build.gradle.kts | \
-          sed 's/.*= "\(.*\)"/\1/' | paste -sd '.' -)
-        
+        # Extract version components from build.gradle.kts
+        MAJOR=$(grep '^val majorVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/')
+        MINOR=$(grep '^val minorVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/')
+        PATCH=$(grep '^val patchVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/')
+        QUALIFIER=$(grep '^val qualifier' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/')
+
+        # Build gradle version with qualifier if present
+        if [ -z "$QUALIFIER" ]; then
+          GRADLE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+        else
+          GRADLE_VERSION="${MAJOR}.${MINOR}.${PATCH}-${QUALIFIER}"
+        fi
+
         # Extract tag version (remove 'v' prefix)
         TAG_VERSION=${GITHUB_REF_NAME#v}
-        
+
         echo "Gradle version: $GRADLE_VERSION"
         echo "Git tag version: $TAG_VERSION"
-        
+
         if [ "$GRADLE_VERSION" != "$TAG_VERSION" ]; then
           echo "ERROR: Version mismatch! Gradle version ($GRADLE_VERSION) does not match git tag ($TAG_VERSION)"
           exit 1


### PR DESCRIPTION
Fixes the version validation script in the GitHub Actions workflow to properly handle version qualifiers (alpha, beta, rc).

## Problem
The current version validation script failed when trying to tag `v1.1.0-beta-01` because:
- The `paste` command wasn't working correctly on GitHub Actions runners
- The script didn't account for the qualifier field in build.gradle.kts

## Solution
- Extract version components individually (major, minor, patch, qualifier)
- Build version string with qualifier when present
- Properly concatenate version components

## Testing
This fix is required to successfully tag and deploy version 1.1.0-beta-01.

Related to the 1.1.0-beta-01 release preparation.