### PR TITLE
fix: strip newlines from version validation script

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,11 +25,11 @@ jobs:
     - name: Validate version consistency
       if: github.ref_type == 'tag'
       run: |
-        # Extract version components from build.gradle.kts
-        MAJOR=$(grep '^val majorVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/')
-        MINOR=$(grep '^val minorVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/')
-        PATCH=$(grep '^val patchVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/')
-        QUALIFIER=$(grep '^val qualifier' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/')
+        # Extract version components from build.gradle.kts (strip newlines with tr)
+        MAJOR=$(grep '^val majorVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | tr -d '\n')
+        MINOR=$(grep '^val minorVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | tr -d '\n')
+        PATCH=$(grep '^val patchVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | tr -d '\n')
+        QUALIFIER=$(grep '^val qualifier' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | tr -d '\n')
 
         # Build gradle version with qualifier if present
         if [ -z "$QUALIFIER" ]; then


### PR DESCRIPTION
Fixes the newline issue in the version validation script that caused version mismatch errors.

## Problem
The previous fix extracted version components correctly, but each component contained trailing newlines from the `sed` output. This caused the concatenated version string to be multi-line:
```
Gradle version: 1
.1
.0
-beta-01
```
Instead of: `Gradle version: 1.1.0-beta-01`

This caused validation to fail even though logically the versions matched.

## Solution
Add `| tr -d '\n'` to each variable extraction to strip newlines:
```bash
MAJOR=$(grep '^val majorVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | tr -d '\n')
```

## Testing
This will allow the `v1.1.0-beta-01` tag to successfully validate and deploy.

Fixes the deployment issue for 1.1.0-beta-01 release.