### PR TITLE
fix: use xargs for version validation whitespace trimming

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,11 +25,11 @@ jobs:
     - name: Validate version consistency
       if: github.ref_type == 'tag'
       run: |
-        # Extract version components from build.gradle.kts (strip newlines with tr)
-        MAJOR=$(grep '^val majorVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | tr -d '\n')
-        MINOR=$(grep '^val minorVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | tr -d '\n')
-        PATCH=$(grep '^val patchVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | tr -d '\n')
-        QUALIFIER=$(grep '^val qualifier' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | tr -d '\n')
+        # Extract version components from build.gradle.kts (trim whitespace with xargs)
+        MAJOR=$(grep '^val majorVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | xargs)
+        MINOR=$(grep '^val minorVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | xargs)
+        PATCH=$(grep '^val patchVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | xargs)
+        QUALIFIER=$(grep '^val qualifier' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | xargs)
 
         # Build gradle version with qualifier if present
         if [ -z "$QUALIFIER" ]; then


### PR DESCRIPTION
Replaces `tr -d '\n'` with `xargs` for more robust whitespace trimming in the version validation script.

## Problem
The previous approach using `tr -d '\n'` still failed on GitHub Actions with the same newline symptoms, despite working locally. This suggests differences in how bash command substitution behaves in GitHub Actions' temporary script execution environment.

## Solution
Use `xargs` which is the recommended approach for trimming whitespace in bash:
```bash
MAJOR=$(grep '^val majorVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | xargs)
```

## Why xargs?
- Automatically trims both leading and trailing whitespace (including `\n` and `\r`)
- Single command, no parameters needed
- Works reliably across Linux and Windows Git Bash
- Commonly used in GitHub Actions workflows (confirmed via research of real-world projects)
- More robust than `tr -d '\n'` for cross-platform compatibility

## Testing
✅ Tested locally and confirmed clean version string extraction
✅ Hex dump shows no hidden characters in extracted values

This is the third iteration attempting to fix the version validation for v1.1.0-beta-01 deployment.