### PR TITLE
fix: use Gradle task for version validation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,18 +25,8 @@ jobs:
     - name: Validate version consistency
       if: github.ref_type == 'tag'
       run: |
-        # Extract version components from build.gradle.kts (trim whitespace with xargs)
-        MAJOR=$(grep '^val majorVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | xargs)
-        MINOR=$(grep '^val minorVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | xargs)
-        PATCH=$(grep '^val patchVersion' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | xargs)
-        QUALIFIER=$(grep '^val qualifier' build.gradle.kts | sed 's/.*= "\(.*\)"/\1/' | xargs)
-
-        # Build gradle version with qualifier if present
-        if [ -z "$QUALIFIER" ]; then
-          GRADLE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
-        else
-          GRADLE_VERSION="${MAJOR}.${MINOR}.${PATCH}-${QUALIFIER}"
-        fi
+        # Get version from Gradle task (most reliable - single source of truth)
+        GRADLE_VERSION=$(./gradlew -q printTagVersion)
 
         # Extract tag version (remove 'v' prefix)
         TAG_VERSION=${GITHUB_REF_NAME#v}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -145,6 +145,18 @@ tasks.register("printVersion") {
     }
 }
 
+// Print tag version (without build number) for git tag validation
+tasks.register("printTagVersion") {
+    doLast {
+        val tagVersion = if (qualifier.isNotEmpty()) {
+            "$baseVersion-$qualifier"
+        } else {
+            baseVersion
+        }
+        println(tagVersion)
+    }
+}
+
 kotlin {
     jvmToolchain(23)
     sourceSets.main {


### PR DESCRIPTION
Uses Gradle's `printTagVersion` task to get the version directly from build configuration, eliminating all bash string parsing issues.

## Problem
Previous approaches (sed, awk, xargs, tr) all failed on GitHub Actions with the same symptom: version string appearing as multiline output. Research revealed this is caused by carriage returns (`\r`) in the extracted values, which cause `echo` to overwrite the same line, creating the visual appearance of multiline output.

## Root Cause
When bash command substitution extracts values from the gradle file, carriage return characters are preserved, causing:
```
echo "1\r.1\r.0\r-beta-01"
```
To display as:
```
1
.1  
.0
-beta-01
```

## Solution
Instead of parsing the gradle file with bash tools, use Gradle itself to output the version:

1. **Added `printTagVersion` task** to build.gradle.kts that outputs version in tag format (e.g., `1.1.0-beta-01`)
2. **Updated workflow** to call `./gradlew -q printTagVersion` 
3. **Single source of truth** - Gradle calculates the version using its own logic

## Benefits
- ✅ No string parsing issues (carriage returns, newlines, whitespace)
- ✅ Uses Gradle's version calculation logic directly
- ✅ Simpler and more maintainable (3 lines vs 20+)
- ✅ Matches industry best practices for Gradle version validation
- ✅ Tested locally and confirmed working

## Testing
```bash
$ ./gradlew -q printTagVersion
1.1.0-beta-01
```

This is the fourth and final iteration to fix version validation for v1.1.0-beta-01 deployment.