### PR TITLE
fix: add execute permissions to gradlew in workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,6 +25,9 @@ jobs:
     - name: Validate version consistency
       if: github.ref_type == 'tag'
       run: |
+        # Make gradlew executable
+        chmod +x gradlew
+
         # Get version from Gradle task (most reliable - single source of truth)
         GRADLE_VERSION=$(./gradlew -q printTagVersion)
 


### PR DESCRIPTION
Adds `chmod +x gradlew` before running the Gradle task in the version validation step.

## Problem
The workflow failed with:
```
./gradlew: Permission denied
Error: Process completed with exit code 126.
```

## Root Cause
When GitHub Actions checks out the repository, the `gradlew` script doesn't have execute permissions by default on Linux runners.

## Solution
Add `chmod +x gradlew` before invoking the script:
```bash
chmod +x gradlew
GRADLE_VERSION=$(./gradlew -q printTagVersion)
```

## Alternative Considered
Could also use `bash gradlew -q printTagVersion` but `chmod +x` is the standard approach and more explicit.

This is a common issue with Gradle projects on GitHub Actions.