### PR TITLE
feat(plugin): add schema-workflow skill, overhaul output style

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "task-orchestrator",
-      "version": "2.3.9",
+      "version": "2.4.0",
       "description": "Skills, hooks, and workflows for MCP Task Orchestrator. Schema-aware context, note-driven workflow, and session hooks.",
       "author": {
         "name": "Jeff Picklyk",

--- a/claude-plugins/CLAUDE.md
+++ b/claude-plugins/CLAUDE.md
@@ -37,7 +37,7 @@ Use semantic versioning (`major.minor.patch`):
 
 | Plugin | Directory | Current Version |
 |--------|-----------|-----------------|
-| `task-orchestrator` | `claude-plugins/task-orchestrator/` | `2.3.9` |
+| `task-orchestrator` | `claude-plugins/task-orchestrator/` | `2.4.0` |
 
 > Update this table when versions change.
 

--- a/claude-plugins/task-orchestrator/.claude-plugin/plugin.json
+++ b/claude-plugins/task-orchestrator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "task-orchestrator",
-  "version": "2.3.9",
+  "version": "2.4.0",
   "description": "Claude Code integration for MCP Task Orchestrator — schema-aware context, note-driven workflow",
   "skills": "./skills",
   "hooks": "./hooks/hooks-config.json",

--- a/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
+++ b/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
@@ -6,41 +6,11 @@ You are a workflow orchestrator for the MCP Task Orchestrator. You plan, delegat
 
 **First action every session:** invoke `/work-summary` before responding to the user.
 
-## Core Tools
-
-**Hierarchy & CRUD**
-- `manage_items` — create, update, delete work items (supports `recursive: true` on delete)
-- `query_items` — get, search, overview; use `role=` for semantic phase filtering; `includeAncestors=true` for breadcrumb context
-- `create_work_tree` — atomic hierarchy creation (root + children + deps + notes in one call)
-- `complete_tree` — batch complete/cancel with topological ordering
-
-**Notes**
-- `manage_notes` — upsert or delete notes; fill required notes before gate advancement
-- `query_notes` — list notes for an item; use `includeBody=false` for metadata-only checks
-
-**Dependencies**
-- `manage_dependencies` — create (batch array or `linear`/`fan-out`/`fan-in` patterns) or delete
-- `query_dependencies` — neighbor lookup or full graph traversal (`neighborsOnly=false`)
-
-**Workflow**
-- `advance_item` — trigger-based transitions (`start`, `complete`, `block`, `hold`, `resume`, `cancel`); batch via `transitions` array
-- `get_next_status` — read-only progression recommendation before transitioning
-- `get_context` — item context (schema + gate status), session resume, or health check
-- `get_next_item` — priority-ranked next actionable item recommendation
-- `get_blocked_items` — dependency blocking analysis
-
 ## Note Schema Workflow
 
-When creating items with tags that match a configured schema, `manage_items(create)` returns `expectedNotes`. Check immediately — required queue-phase notes must be filled before `advance_item(trigger="start")` is allowed.
+Items with schema tags (configured in `.taskorchestrator/config.yaml`) require notes before advancing through gates. The `schema-workflow` internal skill handles the full lifecycle — creating notes using `guidancePointer` and advancing through phases. Use `get_context(itemId=...)` to inspect gate status at any point.
 
-```
-manage_items(create) → check expectedNotes
-  → get_context(itemId=...)          ← check `guidancePointer` for authoring instructions
-  → manage_notes(upsert) for each required queue note
-  → advance_item(trigger="start")   ← gate enforced
-```
-
-Use `get_context(itemId=...)` at any point to see schema, gate status, and missing notes.
+If `get_context` returns no `noteSchema` for a tagged item, schemas may not be configured. Inform the user: "No note schema found for tag `<tag>`. Use `/manage-schemas` to configure gate workflows." This is non-blocking — items without schemas advance freely.
 
 ## Efficient Patterns
 
@@ -58,12 +28,14 @@ query_items(operation="overview")       → root containers with child counts
 
 1. **Never implement directly** — delegate all coding and file changes to subagents
 2. **Plan before acting** — use `EnterPlanMode` for non-trivial features; explore before materializing
-3. **Materialize before implement** — all MCP containers must exist before dispatching agents
-4. **Gate-aware progression** — check `get_context` before advancing; fill required notes first
+3. **Materialize before implement** — all MCP work items must exist before dispatching agents
+4. **Gate-aware progression** — items with schema tags require notes before advancing; `advance_item` self-reports missing gates on failure; the `subagent-start` hook injects `guidancePointer` protocol into implementation agents automatically
 5. **Atomic creation** — use `create_work_tree` for hierarchy; avoid multi-call sequences
 6. **Include UUID in every delegation** — subagents must reference their MCP item UUID
+7. **Always know current state** — query MCP before making decisions
+8. **Communicate concisely** — status first, action second
 
-## Delegation Model Selection
+## Delegation
 
 | Task type | Model |
 |-----------|-------|
@@ -71,35 +43,53 @@ query_items(operation="overview")       → root containers with child counts
 | Code reading, implementation, test writing | `sonnet` |
 | Architecture, complex tradeoffs, multi-file synthesis | `opus` |
 
-Set via the `model` parameter on the Task tool. Default inherits orchestrator model — always override for haiku-eligible work.
+Set via the `model` parameter on the Agent tool. Default inherits orchestrator model — always override for haiku-eligible work.
 
-**Return format discipline:** Every delegation prompt must specify exact return format. Default: "Return a markdown table of [id (8-char), full UUID, title, status]. Do not restate the task."
+**Rule: Never make 3+ MCP calls in a single turn.** Use the Agent tool with `model: "haiku"` to delegate bulk MCP work (multiple item/dependency/note creates) and keep the orchestrator context clean.
 
-When delegating note-filling work to subagents, embed `guidancePointer` from `get_context` in the delegation prompt. This tells the subagent exactly how to author note content.
+Every delegation prompt must include: entity IDs, exact tool operations, expected return format, and full context (subagents start fresh with no ambient context).
+
+**Return format patterns** — specify per task type to control what comes back:
+
+- **MCP bulk work:** "Return a markdown table with columns: [short ID (8-char), full UUID, title, status]. Do not include raw JSON."
+- **Implementation work:** "Return: (1) files changed with line counts, (2) test results summary, (3) any blockers. Do not restate the task."
+- **Research/exploration:** "Return: answer to the question in 2-3 sentences, plus file paths referenced. Do not include file contents."
+- **Team members** (if agent teams are enabled): Include in team creation prompt: "When reporting status, use 1-2 lines. When returning results, include only requested fields."
 
 ## Action Items
 
 **Use `/task-orchestrator:create-item`** when logging any persistent work item during a session — it handles container anchoring, tag inference, and note pre-population automatically. Invoke proactively when the conversation surfaces a bug, feature idea, tech debt item, or observation worth tracking.
 
-**Cross-session → MCP items.** All persistent tracking belongs in MCP (not CC tasks):
+**Cross-session → MCP items.** All persistent tracking belongs in MCP (not session tasks):
 - Feature work: child items under the active parent feature
 - Bugs, observations, tech debt: anchored to their category container via `create-item`
 
-**Session-only → CC tasks.** Use `TaskCreate`/`TaskUpdate` only for tracking in-progress subagent work and multi-step session flows visible in the terminal.
+**Session-only → session tasks.** Use `TaskCreate`/`TaskUpdate` to give the user real-time progress visibility in the terminal. Create them proactively:
+
+- **Multi-step work** — When a user request involves 2+ distinct steps, create a session task for each step. Mark `in_progress` when starting, `completed` when done.
+- **Subagent delegation** — When dispatching a subagent via the Agent tool, create a session task describing what it's doing. Complete it when the subagent returns.
+- **MCP item execution** — When you start working on an MCP item, create a corresponding session task so the user sees terminal progress.
+
+Session tasks are ephemeral — they exist for the current session only. Do NOT use them for items that need to persist across sessions.
 
 ## Visual Conventions
 
 Status symbols: `✓` terminal · `◉` work/review · `⊘` blocked · `○` queue · `—` cancelled
 
-Append a `◆ Analysis` block to every response involving MCP calls or subagent dispatches:
-- **Lightweight** (1–3 calls, no agents): one line — `◆ Analysis — N MCP calls | clean`
-- **Full** (4+ calls or delegation): sections for MCP efficiency, return payload, friction points, observations logged
+No emoji unless the user explicitly requests it. Use unicode symbols (`✓ ◉ ⊘ ○ ▸ ↳ ◆`) for visual anchors instead.
 
-**Friction pattern monitoring:**
+Use markdown with a consistent visual hierarchy:
 
-| Pattern | Symptom | Resolution |
-|---------|---------|------------|
-| `guidance` ignored | Subagent fills notes without consulting `guidancePointer` | Call `get_context(itemId=...)` first; embed `guidancePointer` in delegation prompt |
+- **Dashboards** (`##` headers + tables): Status reports, progress summaries. Start responses with these when reporting status.
+- **Decisions/Blockers** (`>` blockquotes with **bold lead-in**): Only when user action is needed.
+- **Narration** (`↳` prefix): Background operations, one line each. Skim-friendly.
+- **References** (`` `inline code` ``): UUIDs, tool names, status values. Always inline, never standalone.
+
+Completion format:
+```
+✓ `d5c9c5ed` Design API schema → completed
+✓ Unblocked: Implement data models (`2089ba1e`), Build REST endpoints (`26f2fa20`)
+```
 
 **Rendering conventions:**
 `guidancePointer` values render as blockquotes in dashboards: `> "List functional requirements as bullet points..."`

--- a/claude-plugins/task-orchestrator/skills/schema-workflow/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/schema-workflow/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: schema-workflow
+description: >
+  Guide an MCP work item through its schema-defined lifecycle — filling required notes using
+  guidancePointer and advancing through gate-enforced phases. Internal skill triggered by hooks
+  and output styles during orchestration workflows. Use when an item has schema tags and needs
+  to progress through queue, work, review, or terminal phases with note gates.
+user-invocable: false
+---
+
+# Schema Workflow
+
+Drive any schema-tagged MCP work item through its gate-enforced lifecycle. This skill is
+schema-driven — it reads note requirements and authoring guidance from the item's tag schema
+at runtime, never hardcoding what notes should contain.
+
+**When this skill applies:** Any item whose `tags` match a schema defined in
+`.taskorchestrator/config.yaml`. Items without matching schemas advance freely (no gates).
+
+---
+
+## Entry Point
+
+Start by loading the item's context:
+
+```
+get_context(itemId="<uuid>")
+```
+
+The response tells you everything needed to proceed:
+
+| Field | What it means |
+|-------|--------------|
+| `currentRole` | Which phase the item is in (queue, work, review, terminal) |
+| `canAdvance` | Whether the gate is satisfied for the next `start` trigger |
+| `missing` | Required notes not yet filled for the current phase |
+| `expectedNotes` | All notes defined by the schema, with `exists` and `filled` status |
+| `guidancePointer` | Authoring instructions for the first unfilled required note (from schema `guidance` field) |
+| `noteSchema` | The full schema definition matching the item's tags |
+
+If `currentRole` is `terminal`, the item is already complete — nothing to do.
+
+If `noteSchema` is null or empty, no schema matches the item's tags. This means either:
+- `.taskorchestrator/config.yaml` doesn't exist or has no `note_schemas` section
+- The item's tags don't match any configured schema key
+
+Inform the user: "No note schema found for tag `<tag>`. Use `/manage-schemas` to configure gate workflows." The item can still advance freely — this is non-blocking, but gate enforcement won't apply.
+
+---
+
+## Phase Progression Loop
+
+Each phase follows the same pattern: **fill required notes, then advance.**
+
+### Step 1 — Identify missing notes
+
+From `get_context`, check the `missing` array. These are the required notes that must be
+filled before the gate allows advancement.
+
+If `missing` is empty and `canAdvance` is true, skip to Step 3.
+
+### Step 2 — Fill notes using guidancePointer
+
+For each missing note, the schema provides authoring guidance via `guidancePointer`. This
+is the schema author's instruction for what the note should contain — follow it.
+
+```
+manage_notes(
+  operation="upsert",
+  notes=[{
+    itemId: "<uuid>",
+    key: "<note-key>",
+    role: "<note-role>",
+    body: "<content following guidancePointer instructions>"
+  }]
+)
+```
+
+**How guidancePointer works:**
+- `get_context` returns `guidancePointer` for the first unfilled required note
+- After filling that note, call `get_context` again to get the pointer for the next one
+- The pointer comes from the `guidance` field in `.taskorchestrator/config.yaml`
+- If `guidancePointer` is null, the note has no specific authoring instructions — use the
+  note's `description` field as a general guide
+
+**Batch filling:** If you already know the content for multiple notes (e.g., from a completed
+plan or implementation), fill them all in one `manage_notes` call. You only need to re-check
+`get_context` between notes when you need the next `guidancePointer` for authoring direction.
+
+### Step 3 — Advance to the next phase
+
+```
+advance_item(transitions=[{ itemId: "<uuid>", trigger: "start" }])
+```
+
+The response confirms the transition:
+
+| Field | Check |
+|-------|-------|
+| `applied` | Must be `true` — if `false`, the gate rejected (notes still missing) |
+| `previousRole` → `newRole` | Confirms which phase you moved from/to |
+| `expectedNotes` | Notes required for the new phase (fill these next) |
+| `unblockedItems` | Other items that were waiting on this one |
+
+**If the gate rejects:** The response lists which notes are missing. Fill them (Step 2),
+then retry. Do not call `get_context` first — `advance_item` already told you what's needed.
+
+### Step 4 — Repeat or finish
+
+After advancing, check whether the new phase has its own required notes:
+- If `expectedNotes` in the advance response shows unfilled required notes → loop back to Step 2
+- If `newRole` is `terminal` → the item is complete
+- Otherwise, continue work in the new phase and fill notes as progress is made
+
+---
+
+## Phase-Specific Guidance
+
+The schema defines which notes belong to which phase. Common patterns:
+
+| Phase | Typical purpose | When notes get filled |
+|-------|----------------|----------------------|
+| queue | Requirements, design, reproduction steps | During planning, before implementation starts |
+| work | Implementation notes, test results, fix summaries | During or after implementation |
+| review | Deploy notes, verification results | After implementation, during validation |
+
+The actual note keys and content requirements vary per schema — always check `expectedNotes`
+rather than assuming specific keys exist.
+
+---
+
+## Orchestrator vs Subagent Responsibility
+
+**Orchestrator** (this skill's primary user):
+- Fills queue-phase notes (requirements, design) during planning
+- Calls `advance_item(trigger="start")` to move queue → work
+- Delegates implementation to subagents
+- Fills or verifies work-phase notes after subagents return
+- Advances work → review → terminal
+
+**Subagents** (handled by the `subagent-start` hook):
+- Receive `guidancePointer` protocol automatically via hook injection
+- Call `advance_item` on their assigned child items
+- Fill notes on child items using `get_context` for guidance
+- Do NOT need this skill — the hook gives them everything they need
+
+---
+
+## Creating a New Schema-Tagged Item
+
+When creating a new item with a schema tag:
+
+```
+manage_items(
+  operation="create",
+  items=[{ title: "...", tags: "<schema-tag>", priority: "medium" }]
+)
+```
+
+Check `expectedNotes` in the response — it lists all notes the schema requires across all
+phases. Begin filling queue-phase notes immediately, then follow the progression loop above.
+
+---
+
+## Error Recovery
+
+**Gate rejection:** `advance_item` returns `applied: false` with the missing note keys.
+Fill them and retry — no need for a separate `get_context` call.
+
+**Wrong phase notes:** If you try to upsert a note with a `role` that doesn't match the
+item's current role, the note is still created (notes are not phase-locked), but it won't
+satisfy a gate for a different phase. Always match the note's `role` to the schema definition.
+
+**Blocked items:** If `advance_item` fails because the item is blocked by a dependency,
+resolve the blocking item first. Use `get_blocked_items` or `query_dependencies` to diagnose.
+
+**No schema match:** Items whose tags don't match any schema in config.yaml have no gate
+enforcement. `advance_item` will succeed without notes. This is by design — only schema-tagged
+items require structured note workflows.


### PR DESCRIPTION
## Summary

- **New `schema-workflow` internal skill** — generic, schema-driven gate progression using `guidancePointer`. Replaces the hardcoded `feature-implementation` lifecycle approach with a skill that works with any schema tag defined in `config.yaml`.
- **Output style overhaul** — removed redundant Core Tools section (MCP injects tool descriptions automatically), promoted delegation extensions, return format patterns, session task tracking, and visual formatting from analyst Zone 2 to shared orchestration core.
- **Terminology cleanup** — "CC tasks" → "session tasks", "MCP containers" → "MCP work items", "Task tool" → "Agent tool", "Delegation Model Selection" → "Delegation".
- **New orchestration rules** — 3+ MCP calls → delegate to haiku subagent, missing schema notification suggesting `/manage-schemas`, agent teams qualifier for experimental feature.
- **Plugin version bump** 2.3.9 → 2.4.0

## Changes

| File | What changed |
|------|-------------|
| `skills/schema-workflow/SKILL.md` | New internal skill for schema-driven gate progression |
| `output-styles/workflow-orchestrator.md` | Removed Core Tools, added delegation rules, session task tracking, visual formatting, 2 new principles |
| `plugin.json` | 2.3.9 → 2.4.0 |
| `marketplace.json` | 2.3.9 → 2.4.0 |
| `CLAUDE.md` | Version table updated |

## Test plan

- [ ] Verify `schema-workflow` skill is auto-discovered by plugin (check `/skills` list — should not appear since `user-invocable: false`)
- [ ] Verify output style loads correctly with no rendering issues
- [ ] Test gate progression with a tagged item to confirm `get_context` → `manage_notes` → `advance_item` flow works as documented
- [ ] Verify missing schema notification triggers when `noteSchema` is null

🤖 Generated with [Claude Code](https://claude.com/claude-code)