### PR TITLE
ci: automate releases via tag push, add plugin-only release track

### DIFF
--- a/.claude/skills/prepare-release.md
+++ b/.claude/skills/prepare-release.md
@@ -1,13 +1,14 @@
 ---
-description: Prepare a versioned release from main — reads commits since last tag, infers semver bump, drafts changelog, creates release branch and PR, then provides the trigger command for Docker publish and GitHub release.
+description: Prepare a versioned release from main — reads commits since last tag, detects release type (server, plugin, or both), drafts changelog, creates release branch and PR. After merge, tags the release to automatically trigger the appropriate CI workflow.
 ---
 
 # Prepare Release
 
 Prepares a release from the current state of `main`. Reads commits since the last release tag,
-infers the semver bump, drafts a user-facing changelog, confirms with you, then creates a
-`release/vX.Y.Z` branch, commits the version bump, and opens a PR. After you merge the PR,
-one command triggers the Docker build and GitHub release.
+detects whether this is a server release, plugin-only release, or both, drafts a user-facing
+changelog, confirms with you, then creates a release branch, commits the version bump, and
+opens a PR. After you merge the PR, tags the release — pushing the tag automatically triggers
+the appropriate CI workflow.
 
 **Usage:** `/prepare-release`
 
@@ -17,34 +18,48 @@ Run this from any branch after all feature PRs have been merged to `main`.
 
 ## Step 1 — Ensure Clean Main
 
-Switch to `main` and pull latest:
+Switch to `main`, pull latest, and clean up stale branches:
 
 ```bash
 git checkout main
-git pull origin main
+git pull origin main --tags
+git fetch --prune
 git status
 ```
 
 If `git status` shows uncommitted changes, stop and resolve them before continuing. The
 working tree must be clean.
 
+**Clean up merged branches** — delete local branches whose remote tracking branch is gone
+(meaning the PR was merged and the remote branch deleted):
+```bash
+git branch -vv | grep ': gone]' | awk '{print $1}' | xargs -r git branch -d
+```
+This uses `-d` (safe delete) — only branches fully merged into HEAD are removed.
+Report which branches were cleaned up. If any branches fail to delete (unmerged work),
+list them and ask the user whether to force-delete or keep them.
+
 ---
 
-## Step 2 — Find Last Release Tag
+## Step 2 — Find Last Release Tags
+
+Find the most recent tags for both release tracks:
 
 ```bash
-git describe --tags --abbrev=0
+git tag -l 'v*' --sort=-v:refname | head -1
+git tag -l 'plugin-v*' --sort=-v:refname | head -1
 ```
 
-Note this as `LAST_TAG` (e.g., `v2.0.2`). All commits after this tag are candidates for
-the release.
+Note these as `LAST_SERVER_TAG` and `LAST_PLUGIN_TAG`. The appropriate one will be used
+as the baseline depending on the release type detected in Step 4.
 
-If this command fails (no tags exist yet), use the full history — note the first commit
-hash as the baseline and treat the release as the initial version.
+If neither tag exists, use the full history and treat this as the initial release.
 
 ---
 
 ## Step 3 — Gather Commits Since Last Tag
+
+Use the **more recent** of the two tags as the baseline for the commit log:
 
 ```bash
 git log <LAST_TAG>...HEAD --oneline
@@ -56,71 +71,117 @@ Collect the full output of each. Do not truncate.
 
 ---
 
-## Step 4 — Filter and Synthesize (Critical Reasoning Step)
+## Step 4 — Detect Release Type
+
+Examine the changed files from Step 3 and classify:
+
+| Changed paths | Release type |
+|---------------|-------------|
+| Only `claude-plugins/`, `.claude-plugin/` | **plugin-only** |
+| Only `current/`, `gradle/`, `Dockerfile`, `build.gradle.kts`, `src/` | **server** |
+| Both plugin and server paths | **both** |
+
+Files that are neutral (`.github/`, `README.md`, `CHANGELOG.md`, `version.properties`,
+`.claude/`, `.gitignore`, `docs/`) do not influence the classification — they follow
+whichever type the substantive changes belong to. If only neutral files changed, ask the
+user which release type to use.
+
+Record the release type — it determines which version files to bump, which tag scheme to
+use, and which CI workflow gets triggered.
+
+| Release type | Version files | Tag scheme | CI triggered |
+|-------------|---------------|------------|-------------|
+| **server** | `version.properties` | `vX.Y.Z` | `docker-publish.yml` (Docker + GitHub Release) |
+| **plugin-only** | `plugin.json` + `marketplace.json` | `plugin-vX.Y.Z` | `plugin-release.yml` (GitHub Release only) |
+| **both** | All three files | `vX.Y.Z` | `docker-publish.yml` (Docker + GitHub Release) |
+
+For **both** releases: a single `v*` tag triggers the Docker workflow and GitHub Release.
+The plugin version bump is included in the same commit so the plugin cache updates when
+users re-add the marketplace.
+
+---
+
+## Step 5 — Filter and Synthesize (Critical Reasoning Step)
 
 **This is not a raw dump of commit messages.** Analyze the material and produce a curated,
 user-facing summary.
 
-### 4a. Discard internal-only commits
+### 5a. Discard internal-only commits
 
 Ignore commits that match any of the following:
 
 - Subject starts with: `wip`, `WIP`, `checkpoint`, `fixup!`, `chore: rebase`,
   `Merge branch`, `version bump`, `release:`
 - Commit only touches: `build.gradle.kts`, `gradle/`, `*.properties`, `.gitignore`,
-  `.github/`, `Dockerfile`, `docker-compose.yml`, `scripts/`, `*.md` files with no API impact
+  `.github/`, `Dockerfile`, `docker-compose.yml`, `scripts/`
 - Subject is a bare file list or CI housekeeping note
 
-### 4b. Group meaningful changes by theme
+**Plugin-aware filtering:** Do NOT discard commits that only touch `claude-plugins/` files.
+Plugin skills, hooks, and output styles are user-facing content. Summarize them as features
+or fixes as appropriate.
+
+### 5b. Group meaningful changes by theme
 
 Use only these categories (omit any that have no entries):
 
-- **Breaking Changes** — removed tool, renamed/removed parameter, incompatible schema change
-- **New Features** — new MCP tool, new operation on existing tool, new config option, new query parameter
+- **Breaking Changes** — removed tool, renamed/removed parameter, incompatible schema change,
+  removed/renamed skill
+- **New Features** — new MCP tool, new operation on existing tool, new config option, new
+  query parameter, new skill, new hook, new output style
+- **Improvements** — enhanced skill behavior, better prompts, workflow refinements
 - **Bug Fixes** — incorrect behavior corrected, crash fixed, data integrity issue resolved
 - **Performance** — measurable throughput or latency improvement
 - **Documentation** — user-visible docs (only if substantive)
 
-### 4c. Write 3–8 user-facing bullet points
+### 5c. Write 3-8 user-facing bullet points
 
 Rules for each bullet:
 - Start with a past-tense verb (Added, Fixed, Improved, Removed, Changed)
-- Name the tool or feature affected (e.g., `query_items`, `advance_item`)
+- Name the tool, skill, or feature affected (e.g., `query_items`, `prepare-release`)
 - Describe the **benefit to the user**, not the implementation detail
 - Do not mention internal class names, Kotlin types, or file paths
 - Example: `Added \`includeAncestors\` to \`query_items\` — eliminates parent-walk call chains for breadcrumb context`
+- Example: `Added \`prepare-release\` skill — automates versioned releases with changelog generation`
 
 ---
 
-## Step 5 — Infer Bump Level
+## Step 6 — Infer Bump Level
 
 Examine the synthesized changes and determine the bump level:
 
 | Condition | Bump |
 |-----------|------|
-| Any breaking API change (removed tool, renamed/removed required parameter, incompatible response schema) | **major** |
-| New tool, new capability on existing tool, new config option, new query parameter | **minor** |
-| Bug fix, performance improvement, docs only, internal refactor with no API change | **patch** |
+| Any breaking API change (removed tool, renamed/removed required parameter, incompatible response schema, removed skill) | **major** |
+| New tool, new capability on existing tool, new config option, new query parameter, new skill, new hook | **minor** |
+| Bug fix, performance improvement, docs only, internal refactor with no API change, skill content fixes | **patch** |
 
 If multiple conditions apply, use the highest applicable level.
 
 State the bump level and the one-sentence reason. Example:
-> Bump: **minor** — GitHub wiki CI sync and release automation added (new capability, no breaking change).
+> Bump: **minor** — new skills and workflow hooks added (new capability, no breaking change).
 
-Calculate the proposed new version:
-- **patch**: increment `VERSION_PATCH` by 1, keep others
-- **minor**: increment `VERSION_MINOR` by 1, reset `VERSION_PATCH` to 0, keep `VERSION_MAJOR`
-- **major**: increment `VERSION_MAJOR` by 1, reset `VERSION_MINOR` and `VERSION_PATCH` to 0
+Calculate the proposed new version based on the **release type**:
+
+- **server** or **both**: bump from current `version.properties` values
+- **plugin-only**: bump from current `plugin.json` version
+- **both**: bump `version.properties` AND `plugin.json` independently — they may get
+  different bump levels if the changes warrant it. Present both.
+
+Version arithmetic:
+- **patch**: increment patch by 1, keep others
+- **minor**: increment minor by 1, reset patch to 0, keep major
+- **major**: increment major by 1, reset minor and patch to 0
 
 ---
 
-## Step 6 — Present for Confirmation
+## Step 7 — Present for Confirmation
 
 Output the following block and **stop**. Wait for the user to confirm or request changes.
 
 ```
-## Proposed Release: vX.Y.Z  (CURRENT → NEW)
+## Proposed Release: <TAG>  (CURRENT -> NEW)
 
+**Release type:** <server | plugin-only | both>
 **Bump level:** <major | minor | patch>
 **Reason:** <one sentence>
 
@@ -128,7 +189,7 @@ Output the following block and **stop**. Wait for the user to confirm or request
 
 ## [X.Y.Z] - YYYY-MM-DD
 
-### <Added | Changed | Fixed>
+### <Added | Changed | Fixed | Improved>
 - <bullet 1>
 - <bullet 2>
 ...
@@ -136,36 +197,49 @@ Output the following block and **stop**. Wait for the user to confirm or request
 ---
 ```
 
+For **both** releases, show both version bumps:
+```
+**Server version:** CURRENT -> NEW
+**Plugin version:** CURRENT -> NEW
+```
+
 Use today's date in `YYYY-MM-DD` format. If the user requests changes, revise and
 re-present before continuing.
 
 ---
 
-## Step 7 — Create Release Branch
+## Step 8 — Create Release Branch
 
 After confirmation:
 
 ```bash
-git checkout -b release/vX.Y.Z
+git checkout -b release/<TAG>
 ```
+
+Where `<TAG>` is `vX.Y.Z` for server/both releases, or `plugin-vX.Y.Z` for plugin-only.
 
 ---
 
-## Step 8 — Apply Changes
+## Step 9 — Apply Changes
 
-### 8a. Update `version.properties`
+### 9a. Update version files
 
-Edit `version.properties` in the project root. Set only the lines that need to change.
-Reset lower components on a major or minor bump.
-
-Example for a minor bump from 2.0.2 → 2.1.0:
+**Server or both releases** — edit `version.properties`:
 ```
-VERSION_MAJOR=2
-VERSION_MINOR=1
-VERSION_PATCH=0
+VERSION_MAJOR=X
+VERSION_MINOR=Y
+VERSION_PATCH=Z
 ```
 
-### 8b. Insert new section into `CHANGELOG.md`
+**Plugin-only or both releases** — edit `claude-plugins/task-orchestrator/.claude-plugin/plugin.json`
+and `.claude-plugin/marketplace.json`:
+- Update the `version` field in `plugin.json`
+- Update the `plugins[name="task-orchestrator"].version` field in `marketplace.json`
+- Both must carry the same version string
+
+**Also update** the version table in `claude-plugins/CLAUDE.md` to reflect the new plugin version.
+
+### 9b. Insert new section into `CHANGELOG.md`
 
 Read `CHANGELOG.md`. Find the first `## [` versioned entry (after the header). Insert the
 new section **immediately above** it, with a trailing `---` separator and a blank line:
@@ -182,20 +256,49 @@ new section **immediately above** it, with a trailing `---` separator and a blan
 ## [previous version] ...
 ```
 
+For plugin-only releases, prefix the version with "Plugin " in the changelog header:
+```markdown
+## [Plugin X.Y.Z] - YYYY-MM-DD
+```
+
 Do not modify any existing entries.
 
-### 8c. Stage, commit, and push
+### 9c. Stage, commit, and push
 
+Stage only the files that changed:
+
+**Server release:**
 ```bash
 git add version.properties CHANGELOG.md
-git status   # confirm only these two files are staged
-git commit -m "release: bump to vX.Y.Z"
-git push origin release/vX.Y.Z
+```
+
+**Plugin-only release:**
+```bash
+git add claude-plugins/task-orchestrator/.claude-plugin/plugin.json \
+        .claude-plugin/marketplace.json \
+        claude-plugins/CLAUDE.md \
+        CHANGELOG.md
+```
+
+**Both:**
+```bash
+git add version.properties \
+        claude-plugins/task-orchestrator/.claude-plugin/plugin.json \
+        .claude-plugin/marketplace.json \
+        claude-plugins/CLAUDE.md \
+        CHANGELOG.md
+```
+
+Then:
+```bash
+git status   # confirm only expected files are staged
+git commit -m "release: bump to <TAG>"
+git push origin release/<TAG>
 ```
 
 ---
 
-## Step 9 — Pre-PR Checklist
+## Step 10 — Pre-PR Checklist
 
 Before creating the PR, verify these README items and fix any that are stale. If fixes are
 needed, add `README.md` to the staged files and amend the commit before pushing.
@@ -211,17 +314,16 @@ Every Docker image reference must use `:latest` — never a branch name or hardc
 **Version badge** (line ~7 in README):
 
 Both `/github/v/tag/` and `/github/v/release/` badge endpoints work — the CI workflow
-creates a git tag and a GitHub release on every deploy. No change needed unless the URL
-is broken.
+creates a GitHub release on every deploy. No change needed unless the URL is broken.
 
 ---
 
-## Step 10 — Create the PR
+## Step 11 — Create the PR
 
 ```bash
 gh pr create \
   --base main \
-  --title "release: vX.Y.Z — <one-line summary of most significant change>" \
+  --title "release: <TAG> — <one-line summary of most significant change>" \
   --body "$(cat <<'EOF'
 ## Summary
 
@@ -231,9 +333,10 @@ gh pr create \
 
 ## Version
 
-<CURRENT> → <NEW>
+**Release type:** <server | plugin-only | both>
+<CURRENT> -> <NEW>
 
-🤖 Prepared with /prepare-release
+Prepared with /prepare-release
 EOF
 )"
 ```
@@ -245,21 +348,66 @@ code block instead of executing it.
 
 ---
 
-## Step 11 — Print Summary and Trigger Command
+## Step 12 — Print Summary
 
 Output this block after the PR is created:
 
 ```
-Release prepared: CURRENT → vX.Y.Z  (<bump level>)
-Branch:           release/vX.Y.Z
+Release prepared: CURRENT -> <TAG>  (<bump level>)
+Release type:     <server | plugin-only | both>
+Branch:           release/<TAG>
 PR:               <URL from gh pr create>
 
-After merging the PR, trigger the Docker build and GitHub release:
+After you merge the PR, I'll tag the release and CI will handle the rest.
+```
 
-  gh workflow run docker-publish.yml --ref main
+**Stop and wait for the user to merge the PR.**
 
-Or use the Actions tab:
-  https://github.com/jpicklyk/task-orchestrator/actions/workflows/docker-publish.yml
+---
+
+## Step 13 — Tag and Release
+
+After the user confirms the PR is merged:
+
+```bash
+git checkout main
+git pull origin main --tags
+git tag <TAG>
+git push origin <TAG>
+```
+
+Where `<TAG>` is:
+- `vX.Y.Z` for **server** or **both** releases — triggers `docker-publish.yml`
+- `plugin-vX.Y.Z` for **plugin-only** releases — triggers `plugin-release.yml`
+
+Confirm the workflow started:
+
+```bash
+gh run list --workflow=<workflow-file> --limit 1
+```
+
+Output the final status based on release type:
+
+**Server or both:**
+```
+Tag pushed: vX.Y.Z
+CI workflow: https://github.com/jpicklyk/task-orchestrator/actions/workflows/docker-publish.yml
+
+The workflow will:
+  ✓ Verify tag matches version.properties
+  ✓ Build and push Docker image (amd64 + arm64)
+  ✓ Create GitHub Release with auto-generated notes
+  ✓ Run Trivy vulnerability scan
+```
+
+**Plugin-only:**
+```
+Tag pushed: plugin-vX.Y.Z
+CI workflow: https://github.com/jpicklyk/task-orchestrator/actions/workflows/plugin-release.yml
+
+The workflow will:
+  ✓ Verify tag matches plugin.json and marketplace.json
+  ✓ Create GitHub Release with auto-generated notes
 ```
 
 ---
@@ -272,8 +420,16 @@ Or use the Actions tab:
 | minor | New capability, no breaking change | X.Y+1.0 |
 | patch | Bug fix, docs, refactor | X.Y.Z+1 |
 
+| Release type | Tag scheme | CI workflow | Version files |
+|-------------|------------|-------------|--------------|
+| server | `vX.Y.Z` | `docker-publish.yml` | `version.properties` |
+| plugin-only | `plugin-vX.Y.Z` | `plugin-release.yml` | `plugin.json` + `marketplace.json` |
+| both | `vX.Y.Z` | `docker-publish.yml` | All three |
+
 **Common mistakes to avoid:**
 - Do not include raw commit hashes or internal file paths in the changelog
 - Do not bump version without confirmation from the user
-- Do not stage files other than `version.properties`, `CHANGELOG.md` (and `README.md` if fixes were needed)
+- Do not stage files other than the expected version/changelog files for the release type
 - Do not create the PR if there are no commits ahead of the last tag
+- Do not use `v*` tags for plugin-only releases — use `plugin-v*`
+- For **both** releases, ensure `plugin.json` and `marketplace.json` versions match each other

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,7 +1,9 @@
 name: Build, Publish, and Release
 
 on:
-  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
 
 env:
   REGISTRY: ghcr.io
@@ -53,21 +55,14 @@ jobs:
         echo "version=${VERSION}" >> $GITHUB_OUTPUT
         echo "Building version: ${VERSION}"
 
-    - name: Check version tag does not exist
+    - name: Verify tag matches version.properties
       run: |
         VERSION=${{ steps.version.outputs.version }}
-        if git ls-remote --tags origin "refs/tags/v${VERSION}" | grep -q "v${VERSION}"; then
-          echo "ERROR: Tag v${VERSION} already exists. Run /bump-version to increment the version before merging."
+        TAG_VERSION="${GITHUB_REF_NAME#v}"
+        if [ "$VERSION" != "$TAG_VERSION" ]; then
+          echo "ERROR: Tag ${GITHUB_REF_NAME} does not match version.properties (${VERSION})"
           exit 1
         fi
-
-    - name: Create and push version tag
-      run: |
-        VERSION=${{ steps.version.outputs.version }}
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git tag "v${VERSION}"
-        git push origin "v${VERSION}"
 
     - name: Extract Docker metadata
       id: meta
@@ -95,8 +90,8 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create "v${{ steps.version.outputs.version }}" \
-          --title "v${{ steps.version.outputs.version }}" \
+        gh release create "${{ github.ref_name }}" \
+          --title "${{ github.ref_name }}" \
           --generate-notes \
           --verify-tag
 

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -1,0 +1,51 @@
+name: Plugin Release
+
+on:
+  push:
+    tags:
+      - 'plugin-v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Extract plugin version from tag
+      id: version
+      run: |
+        TAG_VERSION="${GITHUB_REF_NAME#plugin-v}"
+        echo "version=${TAG_VERSION}" >> $GITHUB_OUTPUT
+        echo "Plugin release version: ${TAG_VERSION}"
+
+    - name: Verify tag matches plugin.json
+      run: |
+        PLUGIN_VERSION=$(jq -r '.version' claude-plugins/task-orchestrator/.claude-plugin/plugin.json)
+        TAG_VERSION="${GITHUB_REF_NAME#plugin-v}"
+        if [ "$PLUGIN_VERSION" != "$TAG_VERSION" ]; then
+          echo "ERROR: Tag ${GITHUB_REF_NAME} does not match plugin.json version (${PLUGIN_VERSION})"
+          exit 1
+        fi
+
+    - name: Verify marketplace.json matches
+      run: |
+        MARKETPLACE_VERSION=$(jq -r '.plugins[] | select(.name=="task-orchestrator") | .version' .claude-plugin/marketplace.json)
+        TAG_VERSION="${GITHUB_REF_NAME#plugin-v}"
+        if [ "$MARKETPLACE_VERSION" != "$TAG_VERSION" ]; then
+          echo "ERROR: marketplace.json version (${MARKETPLACE_VERSION}) does not match tag ${GITHUB_REF_NAME}"
+          exit 1
+        fi
+
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release create "${{ github.ref_name }}" \
+          --title "Plugin ${{ github.ref_name }}" \
+          --generate-notes \
+          --verify-tag


### PR DESCRIPTION
## Summary

- Changed `docker-publish.yml` trigger from `workflow_dispatch` to `push: tags: v*` — releases now happen automatically when a tag is pushed
- Added `plugin-release.yml` workflow for `plugin-v*` tags — creates a GitHub Release without building Docker images
- Rewrote `/prepare-release` skill with release type detection (server, plugin-only, or both) that branches version bumping, tag scheme, and CI workflow accordingly

## Release flow

| Type | Tag | CI | Artifacts |
|------|-----|-----|-----------|
| server | `vX.Y.Z` | `docker-publish.yml` | Docker image + GitHub Release |
| plugin-only | `plugin-vX.Y.Z` | `plugin-release.yml` | GitHub Release only |
| both | `vX.Y.Z` | `docker-publish.yml` | Docker + GitHub Release (plugin version bumped in same commit) |

## Test plan

- [ ] Verify `docker-publish.yml` YAML is valid and triggers correctly on `v*` tag push
- [ ] Verify `plugin-release.yml` YAML is valid and triggers correctly on `plugin-v*` tag push
- [ ] Run `/prepare-release` on a server-only change set and confirm correct detection
- [ ] Run `/prepare-release` on a plugin-only change set and confirm correct detection

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>