### PR TITLE
ci: verify CI green on main before pushing release tag

### DIFF
--- a/.claude/skills/prepare-release.md
+++ b/.claude/skills/prepare-release.md
@@ -372,6 +372,27 @@ After the user confirms the PR is merged:
 ```bash
 git checkout main
 git pull origin main --tags
+```
+
+**Verify CI is green before tagging.** The test workflow runs on every push to `main` —
+releasing before it passes risks tagging broken code.
+
+```bash
+gh run list --workflow=test.yml --branch=main --limit 1 --json status,conclusion,headSha
+```
+
+Check the result:
+- If `conclusion` is `"success"` and `headSha` matches `HEAD` on main → proceed to tag
+- If `status` is `"in_progress"` or `"queued"` → wait and re-check:
+  ```bash
+  gh run watch --exit-status
+  ```
+- If `conclusion` is `"failure"` → **stop**. Do not tag. Inform the user that tests
+  failed on main and the release cannot proceed until they pass.
+
+After CI is confirmed green:
+
+```bash
 git tag <TAG>
 git push origin <TAG>
 ```


### PR DESCRIPTION
## Summary

- Step 13 of `/prepare-release` now checks the test workflow status on main before pushing a release tag
- If tests are in progress, waits with `gh run watch`
- If tests failed, stops and alerts the user
- Prevents tagging code that hasn't passed CI

Follow-up to #46.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>