### PR TITLE
chore: read runtime version from Gradle build

### DIFF
--- a/current/build.gradle.kts
+++ b/current/build.gradle.kts
@@ -22,6 +22,20 @@ tasks.register("printTagVersion") {
     doLast { println(baseVersion) }
 }
 
+// Generate build-info resource so the app can read its version at runtime
+val generateBuildInfo = tasks.register("generateBuildInfo") {
+    val outputDir = layout.buildDirectory.dir("generated/resources/build-info")
+    val versionValue = version.toString()
+    inputs.property("version", versionValue)
+    outputs.dir(outputDir)
+    doLast {
+        val dir = outputDir.get().asFile.resolve("build-info")
+        dir.mkdirs()
+        dir.resolve("version.properties").writeText("version=$versionValue\n")
+    }
+}
+sourceSets.main { resources.srcDir(generateBuildInfo) }
+
 group = "io.github.jpicklyk"
 
 repositories {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/CurrentMain.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/CurrentMain.kt
@@ -4,13 +4,14 @@ import io.github.jpicklyk.mcptask.current.infrastructure.shutdown.ShutdownCoordi
 import io.github.jpicklyk.mcptask.current.infrastructure.shutdown.SignalHandler
 import io.github.jpicklyk.mcptask.current.interfaces.mcp.CurrentMcpServer
 import org.slf4j.LoggerFactory
+import java.util.Properties
 
 /**
  * Entry point for the Current (v3) MCP Task Orchestrator application.
  */
 fun main() {
     val logger = LoggerFactory.getLogger("CurrentMain")
-    val version = "0.1.0-alpha-01"
+    val version = loadVersion()
 
     logger.info("Starting Current (v3) MCP Task Orchestrator v$version")
 
@@ -42,5 +43,20 @@ fun main() {
         // Don't use exitProcess(1) — it bypasses shutdown hooks.
         // Throwing from main() will cause the JVM to exit with code 1.
         throw e
+    }
+}
+
+/**
+ * Reads the application version from the build-generated resource file.
+ * Falls back to "unknown" if the resource is missing (e.g., running from IDE without a build).
+ */
+private fun loadVersion(): String {
+    val props = Properties()
+    val stream = object {}.javaClass.getResourceAsStream("/build-info/version.properties")
+    return if (stream != null) {
+        stream.use { props.load(it) }
+        props.getProperty("version", "unknown")
+    } else {
+        "unknown"
     }
 }


### PR DESCRIPTION
## Summary

- Replaces hardcoded `0.1.0-alpha-01` version string in `CurrentMain.kt` with a build-generated resource
- Adds `generateBuildInfo` Gradle task that writes `build-info/version.properties` into the JAR
- `loadVersion()` reads the resource at startup; falls back to `"unknown"` if absent (IDE without build)
- After rebuild, Docker containers will report `v2.2.0` instead of `v0.1.0-alpha-01`

## Files Changed

- `current/build.gradle.kts` — new `generateBuildInfo` task + source set wiring
- `current/src/main/kotlin/.../CurrentMain.kt` — `loadVersion()` replaces hardcoded string

## Test Results

- Full suite: BUILD SUCCESSFUL, no regressions
- Verified `build-info/version.properties` present in JAR with correct content (`version=2.2.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)