### PR TITLE
fix(plugin): enforce transition-before-guidance ordering in subagent hook

### DIFF
--- a/claude-plugins/task-orchestrator/hooks/subagent-start.mjs
+++ b/claude-plugins/task-orchestrator/hooks/subagent-start.mjs
@@ -5,12 +5,17 @@ const output = {
     hookEventName: "SubagentStart",
     additionalContext: `## Implementation Agent — Current (v3) Protocol
 
-**Required actions for implementation agents:**
-1. Call \`advance_item(trigger="start")\` on your assigned item UUID at the beginning
-2. Do the work
-3. **Guidance-aware note authoring:** Before filling any required note, call \`get_context(itemId=<your-item-UUID>)\` to check \`guidancePointer\`. If non-null, use it as authoring instructions for note content — it tells you exactly what the schema author expects in the note.
-4. Fill any required notes with \`manage_notes(operation="upsert")\`
-5. Call \`advance_item(trigger="complete")\` when done (gate enforcement will verify notes)
+**IMPORTANT — transition FIRST, then read guidance, then implement.**
+
+Guidance is phase-gated: \`get_context\` returns authoring instructions for the item's *current* phase only. If you skip the \`start\` transition, you will see queue-phase guidance (meant for planning) instead of work-phase guidance (meant for implementation). The correct sequence is:
+
+1. **Transition immediately:** Call \`advance_item(transitions=[{itemId: "<your-item-UUID>", trigger: "start"}])\` — this moves the item from queue to work phase
+2. **Read work-phase guidance:** Call \`get_context(itemId="<your-item-UUID>")\` — now returns work-phase \`expectedNotes\` and \`guidancePointer\` with authoring instructions for implementation notes
+3. **Implement:** Do the work, guided by what \`guidancePointer\` told you the schema author expects
+4. **Fill required notes:** Call \`manage_notes(operation="upsert")\` for each work-phase note listed in \`expectedNotes\`, following the \`guidancePointer\` authoring instructions
+5. **Complete:** Call \`advance_item(transitions=[{itemId: "<your-item-UUID>", trigger: "complete"}])\` — gate enforcement verifies all required notes are filled
+
+Do NOT defer steps 1-2 until after implementation — you need the guidance *before* you start coding.
 
 **Returning results:** Report files changed (with line counts), test results, and any blockers. Do not echo back the task description.`
   }


### PR DESCRIPTION
## Summary

- Subagents were deferring `advance_item(start)` until the end of their work, which meant they never saw work-phase `guidancePointer` values
- Root cause: `get_context` returns guidance for the item's **current phase only** — if `start` isn't called first, the item is still in `queue` role and agents see queue-phase guidance (planning notes) instead of work-phase guidance (implementation notes)
- The old hook said "call start at the beginning" but didn't explain **why**, so agents treated it as bookkeeping and deferred it

## Changes

Rewrote `subagent-start.mjs` to:
1. Lead with the reason — "Guidance is phase-gated"
2. Restructure steps: transition → read guidance → implement (not: implement → transition)
3. Add explicit prohibition: "Do NOT defer steps 1-2 until after implementation"

## Test plan

- [ ] Dispatch a subagent with a schema-tagged item and verify it calls `advance_item(start)` before `get_context`
- [ ] Confirm the subagent receives work-phase `guidancePointer` (not queue-phase)
- [ ] Verify note content follows the guidance instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)