### PR TITLE
release: plugin v2.5.1 — fix subagent guidance ordering

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "task-orchestrator",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "description": "Skills, hooks, and workflows for MCP Task Orchestrator. Schema-aware context, note-driven workflow, and session hooks.",
       "author": {
         "name": "Jeff Picklyk",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.1] - 2026-03-05 (plugin-only)
+
+### Fixed
+- Fixed subagent-start hook to enforce transition-before-guidance ordering — agents now call `advance_item(start)` before `get_context`, ensuring they receive work-phase `guidancePointer` instead of stale queue-phase guidance
+- Bumped plugin version to 2.5.1
+
+---
+
 ## [2.2.0] - 2026-03-05
 
 ### New Features

--- a/claude-plugins/CLAUDE.md
+++ b/claude-plugins/CLAUDE.md
@@ -10,7 +10,7 @@ removing and re-adding the marketplace in Claude Code. No version bump is needed
 
 | Plugin | Directory | Current Version |
 |--------|-----------|-----------------|
-| `task-orchestrator` | `claude-plugins/task-orchestrator/` | `2.5.0` |
+| `task-orchestrator` | `claude-plugins/task-orchestrator/` | `2.5.1` |
 
 > Updated automatically by `/prepare-release`. Do not bump manually.
 

--- a/claude-plugins/task-orchestrator/.claude-plugin/plugin.json
+++ b/claude-plugins/task-orchestrator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "task-orchestrator",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Claude Code integration for MCP Task Orchestrator — schema-aware context, note-driven workflow",
   "skills": "./skills",
   "hooks": "./hooks/hooks-config.json",


### PR DESCRIPTION
## Summary

- Fixed subagent-start hook to enforce transition-before-guidance ordering — agents now receive work-phase `guidancePointer` instead of stale queue-phase guidance
- Plugin-only release (no project version changes)

## Version

Plugin: 2.5.0 → 2.5.1

🤖 Prepared with /prepare-release