### PR TITLE
chore: add project-level skills and fix release tagging workflow

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: implement
+description: End-to-end workflow for taking MCP work items from backlog to merged PR. Handles git branching, schema-driven planning, implementation, independent review, and PR creation. Composes spec-quality, review-quality, and schema-workflow skills into a single pipeline. Use when a user says "implement this", "work on this item", "fix these bugs", "pick up the next task", "create a PR for this", "go through the backlog", or references specific MCP item IDs for implementation.
+user-invocable: true
+---
+
+# Implement
+
+End-to-end workflow for taking MCP work items from queue to PR. This skill composes
+the schema-driven planning (spec-quality), implementation, review (review-quality),
+and git/PR workflow into a single pipeline.
+
+**Usage:**
+- `/implement <item-id>` — work on a specific item
+- `/implement` — with context about what to work on
+- Can process single items or multiple items in batch
+
+---
+
+## Step 1 — Assess the Work
+
+Load the item(s) and determine the operating mode.
+
+For each item, call `get_context(itemId=...)` to understand:
+- Current role and gate status
+- Schema tag (feature-implementation, bug-fix, etc.)
+- Existing notes already filled
+- Dependencies and blocked status
+
+**Mode determination:**
+
+| Signal | Mode |
+|--------|------|
+| User says "work with me on", "let's plan", or similar collaborative language | **Collaborative** — user participates in planning and key decisions |
+| Single large feature with multiple child items or significant blast radius | **Collaborative** — too much risk for autonomous execution |
+| Small bug fix, tech debt cleanup, or isolated change with clear scope | **Autonomous** — agent handles the full pipeline |
+| Multiple bug fixes or small items | **Autonomous batch** — agent groups related items and processes them |
+| Unclear scope or ambiguous complexity | **Ask the user** |
+
+When processing multiple items, evaluate whether related items (e.g., bugs in the
+same module, fixes that touch the same files) should be grouped into a single branch
+and PR. Group when the changes are cohesive and independent fixes would create
+merge conflicts. Keep items separate when they're unrelated or when isolation makes
+review cleaner.
+
+---
+
+## Step 2 — Prepare the Branch
+
+Sync main and create a working branch before any implementation begins.
+
+```bash
+git checkout main
+git pull origin main --tags
+git checkout -b <branch-name>
+```
+
+**Branch naming:**
+- `feat/<short-description>` — feature-implementation items
+- `fix/<short-description>` — bug-fix items
+- `fix/<grouped-description>` — batch of related bug fixes
+- `chore/<short-description>` — tech debt, refactoring, observations
+
+For autonomous batch work with unrelated items, create separate branches. Use
+worktree isolation (`isolation: "worktree"` on the Agent tool) when dispatching
+multiple implementation agents in parallel to prevent file conflicts.
+
+---
+
+## Step 3 — Queue Phase: Planning
+
+Progress through the queue phase using the item's schema-defined gates. The existing
+orchestration skills handle the specifics — this step composes them.
+
+Use `get_context(itemId=...)` to see the item's `expectedNotes` and `guidancePointer`
+for the current phase. These are driven by the schema configuration and will reflect
+whatever notes are required at the queue gate.
+
+**Collaborative mode:**
+1. Tell the user the item is ready for planning and ask them to enter plan mode.
+   The `pre-plan-workflow` and `post-plan-workflow` hooks fire automatically on
+   plan mode entry and exit, handling context gathering and materialization.
+2. During planning, follow the `guidancePointer` for each required note — this
+   will reference the spec-quality skill where applicable.
+3. After plan approval and post-plan materialization, advance the item:
+   `advance_item(trigger="start")`
+
+**Autonomous mode:**
+1. Read and follow the `pre-plan-workflow` skill — gather existing MCP state,
+   check schema requirements, and understand the definition floor.
+2. Research the codebase — explore relevant files, understand current state.
+3. Fill all queue-phase notes following the `guidancePointer` for each. The
+   spec-quality framework applies regardless of mode.
+4. Read and follow the `post-plan-workflow` skill — materialize child items
+   if the plan calls for them.
+5. Advance the item: `advance_item(trigger="start")`
+
+The gate will reject advancement if required notes are missing. If rejected, fill
+the missing notes and retry.
+
+---
+
+## Step 4 — Work Phase: Implementation
+
+Implement the changes and fill the work-phase notes required by the schema.
+
+Use `get_context(itemId=...)` to see the work-phase `expectedNotes` and their
+`guidancePointer` values. Fill each required note following its guidance.
+
+Follow the delegation model from your output style (model selection, return formats,
+UUID inclusion). The key decisions at this step are:
+
+- **Single item, simple change:** delegate to one implementation subagent or
+  implement directly.
+- **Multiple child tasks, independent:** dispatch parallel subagents with worktree
+  isolation (see Worktree Isolation below).
+- **Multiple child tasks, dependent:** dispatch sequentially — wait for each agent
+  to return before dispatching the next.
+
+**After implementation completes:**
+1. Run the `/simplify` skill on the changed code to check for reuse, quality, and
+   efficiency — this is a cleanup pass before review, not a review itself
+2. **If `/simplify` made changes**, write or update tests to cover them. The simplify
+   pass is still part of the work phase — all code changes require test coverage
+   before advancing to review.
+3. **Log findings as work items** — any issues surfaced by `/simplify` or during
+   implementation that are not immediately addressed (pre-existing tech debt,
+   optimization opportunities, related bugs) must be logged via
+   `/task-orchestrator:create-item` before moving on. Do not discard findings.
+4. Fill all work-phase notes following their `guidancePointer` — focus on context
+   that downstream agents need to know
+5. Advance the item: `advance_item(trigger="start")` to move to review
+
+---
+
+## Step 5 — Review Phase: Independent Review
+
+Dispatch a **separate** review agent. The agent that implemented the code must not
+review its own work.
+
+The review agent:
+1. Reads the review-quality skill
+2. Uses `get_context(itemId=...)` to load the item's notes and review-phase requirements
+3. Reads the changed files directly
+4. Runs the test suite
+5. Evaluates plan alignment, test quality, and simplification
+6. Fills the review-phase notes per `guidancePointer` with a verdict
+
+**Handling the verdict:**
+
+| Verdict | Action |
+|---------|--------|
+| **Pass** | Proceed to Step 6 |
+| **Pass with observations** | Proceed to Step 6; log observations for follow-up |
+| **Fail — blocking issues** | Stop and report to the user with the full findings. Do not attempt to fix autonomously — bring the human into the loop. |
+
+Review failures surface issues that may indicate systemic problems worth learning
+from. Automatically retrying hides these signals.
+
+---
+
+## Step 6 — Commit and PR
+
+After review passes, commit the changes and create a PR.
+
+### Commit
+
+Stage only the files related to the implementation. Do not stage unrelated changes
+that happen to be in the working tree.
+
+```bash
+git add <specific-files>
+git commit -m "$(cat <<'EOF'
+<type>(<scope>): <description>
+
+<body — what changed and why, referencing the MCP item>
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+**Commit types:** `feat` for features, `fix` for bugs, `refactor` for tech debt,
+`perf` for performance, `test` for test-only changes, `chore` for maintenance.
+
+For batch work with multiple items in one branch, use a single commit or logical
+commits per item — whichever tells a clearer story in the git log.
+
+### Push and PR
+
+```bash
+git push origin <branch-name>
+```
+
+Create the PR:
+```bash
+gh pr create \
+  --base main \
+  --title "<type>(<scope>): <short description>" \
+  --body "$(cat <<'EOF'
+## Summary
+
+<2-4 bullets covering what changed and why>
+
+## Test Results
+
+<test count, pass/fail, new tests added>
+
+## Review
+
+<review verdict summary — plan alignment confirmed, test quality verified>
+
+## MCP Items
+
+<list of MCP item IDs addressed by this PR>
+EOF
+)"
+```
+
+### Advance to terminal
+
+After the PR is created:
+```bash
+advance_item(transitions=[{ itemId: "<uuid>", trigger: "start" }])
+```
+
+Report the PR URL and a summary of what was done.
+
+---
+
+## Autonomous Batch Processing
+
+When processing multiple items autonomously:
+
+1. **Group assessment** — evaluate all items, identify which can be grouped and which
+   need separate branches
+2. **Parallel execution** — use worktree isolation for independent work streams.
+   Sequential execution for items with dependency edges between them.
+3. **Per-group pipeline** — each group goes through Steps 2-6 independently
+4. **Report at the end** — summarize all PRs created, any items that couldn't be
+   processed, and any review failures that need user attention
+
+If any item in the batch hits a review failure, continue processing other items
+and report all failures together at the end.
+
+---
+
+## Worktree Isolation
+
+When dispatching multiple implementation agents in parallel, use `isolation: "worktree"`
+on the Agent tool. Each agent gets an isolated copy of the repository, preventing file
+conflicts, accidental cross-cutting changes, and test baseline contamination.
+
+**Dispatch pattern:**
+```
+Agent(
+  prompt="...",
+  model="sonnet",
+  isolation="worktree",
+  subagent_type="general-purpose"
+)
+```
+
+**Scoping rules — include in every parallel subagent prompt:**
+- "Only modify files directly related to your task"
+- "Do not bump versions, modify shared config, or edit files outside your scope"
+- Cross-cutting changes (version bumps, shared config) are handled by the
+  orchestrator after all agents return
+
+**Validation after agents return:**
+1. Review each worktree's changes — the Agent tool returns the worktree path and
+   branch when changes are made
+2. Spot-check at least 2 diffs for insertion errors, scope violations, or unintended
+   modifications
+3. Merge worktree branches sequentially into the working branch, resolving any conflicts
+4. Run the full test suite once after all merges to catch integration issues
+5. Worktrees with no changes are automatically cleaned up; merged worktrees should be
+   removed after successful integration
+
+**When NOT to use worktrees:**
+- Single-agent dispatch (no isolation needed)
+- Tasks that depend on each other's file changes (use sequential dispatch instead)
+- Pure MCP operations with no file modifications (e.g., materialization subagents)
+
+---
+
+## Resuming In-Progress Work
+
+If an item is already past the queue phase (e.g., previously planned but not
+implemented), the skill picks up from the current state:
+
+| Current role | Resume from |
+|-------------|-------------|
+| queue (notes filled) | Step 3 — advance and proceed |
+| queue (notes missing) | Step 3 — fill missing notes |
+| work (in progress) | Step 4 — check implementation state |
+| work (notes filled) | Step 4 — advance to review |
+| review | Step 5 — run review |
+| terminal | Already done — report status |
+
+Always call `get_context(itemId=...)` first to determine exact state before
+resuming.

--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -321,7 +321,7 @@ code block instead of executing it.
 
 ---
 
-## Step 11 — Print Summary and Trigger Command
+## Step 11 — Print Summary and Post-Merge Tag Command
 
 Output this block after the PR is created:
 
@@ -330,13 +330,36 @@ Release prepared: CURRENT → vX.Y.Z  (<bump level>)
 Branch:           release/vX.Y.Z
 PR:               <URL from gh pr create>
 
-After merging the PR, trigger the Docker build and GitHub release:
+After merging the PR, create the release tag to trigger CI:
 
-  gh workflow run docker-publish.yml --ref main
+  git checkout main && git pull origin main
+  git tag vX.Y.Z
+  git push origin vX.Y.Z
 
-Or use the Actions tab:
-  https://github.com/jpicklyk/task-orchestrator/actions/workflows/docker-publish.yml
+This triggers the "Build, Publish, and Release" workflow (docker-publish.yml)
+which builds the Docker image and creates a GitHub Release.
+
+Monitor: https://github.com/jpicklyk/task-orchestrator/actions/workflows/docker-publish.yml
 ```
+
+**Standalone plugin release** — use a `plugin-v` prefixed tag instead:
+
+```
+After merging the PR, create the plugin release tag to trigger CI:
+
+  git checkout main && git pull origin main
+  git tag plugin-vX.Y.Z
+  git push origin plugin-vX.Y.Z
+
+This triggers the "Plugin Release" workflow (plugin-release.yml)
+which verifies version consistency and creates a GitHub Release.
+
+Monitor: https://github.com/jpicklyk/task-orchestrator/actions/workflows/plugin-release.yml
+```
+
+**IMPORTANT:** Do NOT use `gh workflow run` — the CI workflows are triggered by tag
+pushes (`v*` and `plugin-v*`), not manual dispatch. The tag must be created on main
+after the release PR is merged.
 
 ---
 

--- a/.claude/skills/review-quality/SKILL.md
+++ b/.claude/skills/review-quality/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: review-quality
+description: Review quality framework for the work-to-review transition gate. Guides verification of plan alignment, test quality, and code simplification before marking implementation complete. Referenced by schema guidance fields during review-phase note filling. Read this skill when filling review-checklist notes or when asked to review completed implementation work.
+user-invocable: false
+---
+
+# Review Quality Framework
+
+This skill defines what a reviewer must verify before implementation work advances to
+completion. It applies whether the reviewer is the orchestrator directly or a delegated
+subagent.
+
+The review gate exists because implementation agents optimize for getting things working,
+not for verifying they built the right thing. Without a structured review checkpoint,
+planned work gets silently dropped, tests get written to pass rather than to verify, and
+unnecessary complexity accumulates. The review is where these failure modes get caught.
+
+**Critical separation of concerns:** The reviewer must not be the same agent that wrote
+the code or the tests. An agent reviewing its own work will rationalize rather than
+evaluate. The reviewer reads, runs, and reports — it never fixes. If issues are found,
+they go back to the implementation agent for resolution.
+
+---
+
+## Getting Started
+
+The reviewer is given an MCP item ID. Use MCP tools and codebase access to gather what
+you need — do not expect context to be pre-loaded for you.
+
+1. **Load the item's notes** — `query_notes(itemId=..., includeBody=true)` to retrieve
+   the `specification` and `implementation-notes`.
+2. **Read the changed files** — use the implementation notes to identify which files were
+   modified, then read them directly. Review the actual code, not just summaries.
+3. **Run the test suite** — execute the project's test command and capture the results.
+   Do not assume tests pass because the implementation agent said they did.
+
+If the specification or implementation notes are missing, the review cannot proceed.
+Report this as a blocking issue.
+
+---
+
+## Review Areas
+
+These four areas form the minimum review. Each one catches a different class of failure.
+If the review surfaces additional concerns, include them — this is a floor, not a ceiling.
+
+### 1. Test Suite Verification
+
+Run the test suite before anything else. Everything downstream depends on knowing the
+actual state of the tests.
+
+Run `./gradlew :current:test` and capture the output. Record the total test count and
+the pass/fail breakdown.
+
+**If tests fail:** Document every failure — test name, assertion message, and the file
+where the test lives. Do not attempt to fix failures. Do not speculate about whether
+failures are pre-existing or new. Report what you observe. Test failures are a blocking
+issue — the item cannot advance with a failing test suite.
+
+**If tests pass:** Record the count and move on.
+
+### 2. Plan Alignment
+
+Compare what was built against the specification. The goal is to catch drift in both
+directions — work that was planned but not done, and work that was done but not planned.
+
+**Check each acceptance criterion.** Walk through the acceptance criteria from the
+specification one by one. For each criterion, identify the specific code change that
+satisfies it. If a criterion has no corresponding implementation, flag it — either the
+work is incomplete or the criterion was intentionally descoped (which should appear in
+the implementation notes).
+
+**Check for unplanned changes.** Review the changed files for modifications that don't
+trace back to any acceptance criterion. Unplanned changes aren't automatically wrong —
+sometimes implementation reveals necessary adjacent work. But they should be
+acknowledged and justified in the implementation notes, not silent.
+
+**Check non-goals weren't violated.** Review the specification's non-goals list. If the
+implementation touched areas that were explicitly scoped out, flag it.
+
+### 3. Test Quality
+
+The specification's test strategy defined what should be tested — happy paths, failure
+paths, and edge cases. The reviewer verifies that the tests actually deliver on that
+strategy, not just that they exist and pass.
+
+This is where the separation of concerns matters most. The agent that wrote the tests
+has an inherent bias toward believing they're correct. An independent reviewer can
+evaluate whether the tests verify real behavior or just confirm that code runs.
+
+**Map tests to the test strategy.** For each scenario in the specification's test
+strategy, identify the corresponding test. Missing coverage is a gap to report.
+
+**Evaluate test substance.** Watch for these patterns that produce green results
+without catching real bugs:
+
+- **Tautological assertions** — asserting something equals itself, or that a non-null
+  value is not null, without verifying the actual value is correct.
+- **Mock-heavy tests that verify nothing real** — every dependency mocked, test only
+  confirms mocks were called in order. Mocks are fine for isolation, but the test must
+  still assert something meaningful about the unit's output or state change.
+- **Happy-path-only coverage** — if the test strategy called for failure paths, those
+  tests need to exist and need to verify the failure behavior is correct (right
+  exception type, right error message, right fallback behavior).
+- **Overly broad assertions** — `result != null` or `list.isNotEmpty()` when specific
+  values, sizes, or contents should be checked. These pass even when the implementation
+  is wrong.
+
+**Check edge cases.** Verify each boundary condition from the test strategy has a
+corresponding test. If implementation notes documented new edge cases discovered during
+development, check whether tests were added for those too.
+
+### 4. Simplification
+
+Run the `/simplify` skill on the changed files and document its findings. The reviewer
+records what simplify identifies — it does not apply fixes.
+
+Document each finding from simplify with:
+- The file and area affected
+- What simplify identified (duplication, unnecessary complexity, over-engineering)
+- Whether it's minor (style/preference) or substantive (affects maintainability)
+
+Simplification findings are not blocking unless they indicate a structural problem
+that would make the code difficult to maintain or extend.
+
+---
+
+## Review Output
+
+The review produces a `review-checklist` note on the MCP item. Structure the note
+around findings, not process.
+
+### Verdict
+
+Every review must end with a clear verdict:
+
+- **Pass** — all acceptance criteria met, tests pass and have substance, no blocking
+  issues. The item can advance.
+- **Fail — blocking issues** — test failures, missing acceptance criteria, or critical
+  gaps in test coverage. The item must go back for fixes before it can advance. List
+  every blocking issue.
+- **Pass with observations** — no blocking issues, but simplification findings or
+  minor test quality concerns worth addressing. The item can advance, but the
+  observations should be tracked for follow-up.
+
+### Findings Format
+
+For each finding, state:
+- **What was expected** (from the specification or test strategy)
+- **What was found** (in the code or test output)
+- **Severity** (blocking or observation)
+
+Be specific. "Tests could be better" is not actionable. "Test `testCreateItem` asserts
+only that the result is not null — it should verify the item's title and status match
+the input parameters" is actionable.
+
+### Gate Enforcement
+
+The reviewer does not advance the item. It fills the `review-checklist` note and
+reports the verdict. The orchestrator reads the verdict and decides whether to:
+- Advance the item (pass or pass-with-observations)
+- Send the item back to the implementation agent with the blocking issues list (fail)
+
+A failing verdict with clear findings gives the implementation agent exactly what to
+fix without ambiguity.

--- a/.claude/skills/spec-quality/SKILL.md
+++ b/.claude/skills/spec-quality/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: spec-quality
+description: Specification quality framework for planning. Defines the minimum bar for what a plan must address — alternatives, non-goals, blast radius, risk flags, and test strategy. Referenced by schema guidance fields during queue-phase note filling. Read this skill whenever filling requirements or design notes for any MCP work item.
+user-invocable: false
+---
+
+# Specification Quality Framework
+
+This skill defines the minimum thinking floor for plans and specifications. The sections
+below represent what every plan must address. They are not a ceiling — if the problem
+demands additional analysis, add it. But these areas must not be skipped.
+
+The value of a spec is entirely in the thinking it forces before code is written. If a
+section doesn't change how you'd approach implementation, it isn't earning its place.
+Every sentence should either prevent a mistake or force a decision.
+
+---
+
+## Specification Disciplines
+
+These are the required areas of analysis. Each one exists because skipping it leads to
+a specific, recurring class of failure.
+
+### Alternatives Considered
+
+Evaluate at least two real approaches. "Do nothing" always counts as one. For each
+alternative, state what it would look like and the specific trade-off that led to its
+rejection. If you can only think of one approach, you haven't explored the solution
+space — step back and look for a fundamentally different angle.
+
+The point is not to document alternatives for posterity. It's to catch yourself before
+committing to an approach that has a better option sitting next to it.
+
+*Anti-pattern: strawman alternatives.* "Alternative: rewrite everything from scratch.
+Rejected: too much work." This doesn't force any real thinking.
+
+### Non-Goals
+
+Name what someone might reasonably expect this work to include but that is deliberately
+excluded. If you cannot name a single non-goal, the scope is not tight enough.
+
+Non-goals prevent scope creep during implementation. Without them, agents tend to
+gold-plate — adding adjacent improvements that weren't asked for and that introduce
+unplanned risk.
+
+### Blast Radius
+
+Identify every module, file, and interface affected by the change. Trace downstream
+consumers — if you change a repository method signature, what tools call it? If you
+change a domain model default, what tests assume the old value?
+
+This analysis exists to catch "I didn't realize changing X breaks Y" before it happens.
+Read `references/project-concerns.md` for cross-cutting constraints specific to this
+codebase that frequently expand blast radius in non-obvious ways.
+
+### Risk Flags
+
+Call out the one or two things most likely to go wrong. These might be areas of tight
+coupling, migration complexity, concurrency concerns, or simply parts of the codebase
+you don't fully understand yet.
+
+The purpose is to focus review attention where it matters and to make uncertainty
+explicit rather than hidden.
+
+### Test Strategy
+
+Every plan must include a concrete test strategy. This is not "add tests" — it's a
+specific accounting of what will be verified and how.
+
+**Required coverage areas:**
+
+- **Happy paths** — the primary use cases the change enables. These confirm the feature
+  works as intended under normal conditions.
+- **Failure paths** — what happens when inputs are invalid, dependencies are missing, or
+  operations fail. These confirm the system fails gracefully rather than silently
+  corrupting state or throwing unhandled exceptions.
+- **Edge cases** — boundary conditions specific to the change. Examples: empty collections,
+  null/optional fields, maximum depth limits, circular references, concurrent access.
+  Think about what a user or caller could do that you didn't explicitly design for.
+
+For each area, name the specific scenarios you'll test. "Test edge cases" is not a
+strategy. "Test that circular parent references are detected and rejected with a clear
+error" is.
+
+If the change modifies shared interfaces (domain models, repository contracts, tool
+parameters), note which existing tests may break and how you'll handle that — update
+them, or confirm they still pass with the new behavior.
+
+---
+
+## Using This Framework
+
+This framework sets a floor. The disciplines above are the minimum required analysis.
+Depending on the complexity of the work, additional analysis may be warranted —
+performance implications, migration strategies, API compatibility concerns, or
+anything else that would change the implementation approach if examined carefully.
+
+Add whatever the problem demands. The goal is a plan that lets someone implement the
+change confidently, understanding not just what to build but why this approach was
+chosen and what to watch out for.

--- a/.claude/skills/spec-quality/references/project-concerns.md
+++ b/.claude/skills/spec-quality/references/project-concerns.md
@@ -1,0 +1,60 @@
+# Project-Specific Concerns: MCP Task Orchestrator
+
+These are cross-cutting constraints specific to this codebase. When assessing blast
+radius and risk flags, check each area that your change might touch.
+
+This is an awareness list, not a set of rules. The right approach depends on the
+specific change — these items flag where non-obvious coupling or complexity tends
+to hide.
+
+---
+
+## ToolExecutionContext Coupling
+
+`ToolExecutionContext` is constructed in `CurrentMcpServer.kt` and passed to every
+tool. Adding a new service dependency means updating both the context class and
+the server construction site. If your change introduces a new service that tools
+need, this is part of the blast radius.
+
+## DirectDatabaseSchemaManager Table Ordering
+
+Maintains a manually-ordered list of tables in foreign-key dependency order. New
+tables must be inserted at the correct position — the compiler cannot detect wrong
+ordering. If your change adds a database table, verify the insertion position against
+FK relationships.
+
+## SQLite Migration Constraints
+
+Flyway migrations are append-only — never modify an existing migration file. SQLite
+has no `ALTER COLUMN`, so schema changes that modify existing columns require table
+recreation (create new, copy data, drop old, rename). Migration files live in
+`current/src/main/resources/db/migration/`.
+
+## Domain Model Defaults and Test Impact
+
+Changing a default value on a domain model field (e.g., `priority: Priority = Priority.MEDIUM`
+to `Priority? = null`) will break tests across the codebase that construct instances
+without specifying that field. When assessing blast radius for model changes, search
+for all test files that instantiate the affected model.
+
+## MCP Tool Registration
+
+New tools must extend `BaseToolDefinition` and be registered in
+`CurrentMcpServer.kt::createTools()`. The tool count is not hardcoded anywhere —
+but forgetting registration means the tool exists in code but is invisible to clients.
+
+## Exposed ORM Patterns
+
+The project uses Exposed ORM with SQLite. Key patterns to be aware of:
+- All database operations must run inside `transaction {}` blocks
+- Repository methods that are called from suspend contexts need appropriate coroutine
+  handling
+- H2 in-memory database is used for repository tests, which may behave differently
+  from SQLite in edge cases (e.g., case sensitivity, type coercion)
+
+## Repository Interface Contracts
+
+Repository interfaces live in `domain/repository/` and their SQLite implementations
+in `infrastructure/repository/`. Adding a method to a repository interface requires
+updating the implementation, and any mocks in test files that use that repository.
+Search for `mockk<RepositoryName>` across test files to find affected mocks.


### PR DESCRIPTION
## Summary

- Added `/implement` skill — end-to-end workflow from MCP backlog items to merged PR (schema-driven planning, worktree isolation, independent review)
- Added `/review-quality` skill — review framework for plan alignment, test quality, and simplification verification
- Added `/spec-quality` skill — specification quality framework with minimum bar for alternatives, blast radius, risk flags, and test strategy
- Fixed `/prepare-release` Step 11 to use tag-based CI triggers (`git tag vX.Y.Z && git push`) instead of incorrect `gh workflow run` which doesn't work (workflows are tag-triggered, not dispatch-triggered)

## Files

| File | Change |
|------|--------|
| `.claude/skills/implement/SKILL.md` | New skill |
| `.claude/skills/review-quality/SKILL.md` | New skill |
| `.claude/skills/spec-quality/SKILL.md` | New skill |
| `.claude/skills/spec-quality/references/project-concerns.md` | Reference doc |
| `.claude/skills/prepare-release/SKILL.md` | Fix Step 11 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)