### PR TITLE
feat: MCP SDK 0.9.0 upgrade, cascade gate enforcement, session retrospective

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -47,7 +47,7 @@ review cleaner.
 
 ## Step 2 — Prepare the Branch
 
-Sync main before any implementation begins.
+Sync local main before any implementation begins.
 
 ```bash
 git checkout main
@@ -55,16 +55,20 @@ git pull origin main --tags
 ```
 
 **If NOT using worktree isolation** (orchestrator implements directly or dispatches
-a single non-isolated agent), create a working branch:
+a single non-isolated agent), create a local working branch:
 
 ```bash
 git checkout -b <branch-name>
 ```
 
-**If using worktree isolation**, skip branch creation — each worktree agent gets
-its own isolated branch automatically. See Worktree Isolation below.
+This branch stays local — it will be squash-merged into local `main` after
+review, not pushed directly to origin. See Step 6 for the squash-merge flow.
 
-**Branch naming** (for manually created branches):
+**If using worktree isolation**, skip branch creation — each worktree agent gets
+its own isolated branch automatically. See Worktree Isolation below. Worktree
+branches are also local-only and get squash-merged into `main` after review.
+
+**Branch naming** (for local working branches):
 - `feat/<short-description>` — feature-implementation items
 - `fix/<short-description>` — bug-fix items
 - `fix/<grouped-description>` — batch of related bug fixes
@@ -196,20 +200,21 @@ from. Automatically retrying hides these signals.
 
 ---
 
-## Step 6 — Commit and PR
+## Step 6 — Commit and Squash-Merge to Main
 
-After review passes, commit the changes and create a PR.
+After review passes, commit the changes and squash-merge into local `main`.
+PRs to GitHub are batched — multiple completed items accumulate on local `main`
+before a single PR is created.
 
-**If using worktree isolation**, all commands in this step run from the worktree:
+### Commit on the working branch
+
+**If using worktree isolation**, commit from the worktree:
 ```bash
 git -C <worktree-path> add <specific-files>
-git -C <worktree-path> commit ...
-git -C <worktree-path> push origin <worktree-branch>
+git -C <worktree-path> commit -m "..."
 ```
 
-**If NOT using worktree isolation**, run from the working branch as normal.
-
-### Commit
+**If NOT using worktree isolation**, commit on the local working branch as normal.
 
 Stage only the files related to the implementation. Do not stage unrelated changes
 that happen to be in the working tree.
@@ -229,13 +234,31 @@ EOF
 **Commit types:** `feat` for features, `fix` for bugs, `refactor` for tech debt,
 `perf` for performance, `test` for test-only changes, `chore` for maintenance.
 
-For batch work with multiple items in one branch, use a single commit or logical
-commits per item — whichever tells a clearer story in the git log.
+### Squash-merge into local main
 
-### Push and PR
+After committing on the working branch (or worktree branch), squash-merge into
+local `main`:
 
 ```bash
-git push origin <branch-name>
+git checkout main
+git merge --squash <branch-name>       # or: git merge --squash <worktree-branch>
+git commit -m "<type>(<scope>): <description>"
+git branch -D <branch-name>            # delete the local working branch
+```
+
+For worktree branches, use the branch name returned by the Agent tool. The
+worktree directory is cleaned up automatically after the branch is deleted.
+
+Local `main` now has the squashed change. Repeat for more items — they accumulate.
+
+### Push and PR (batched)
+
+When ready to publish one or more accumulated changes to GitHub, create a PR
+branch from local `main`:
+
+```bash
+git checkout -b <pr-branch-name>       # e.g., feat/batch-validation-improvements
+git push -u origin <pr-branch-name>
 ```
 
 Create the PR:
@@ -263,6 +286,18 @@ EOF
 )"
 ```
 
+After the GitHub PR is merged, sync local main:
+```bash
+git checkout main
+git pull origin main
+git branch -D <pr-branch-name>         # delete the local PR branch
+```
+
+**When to create a PR** — use judgment:
+- After completing a logical unit of work (a feature, a batch of fixes)
+- When local `main` has accumulated enough changes to warrant publishing
+- The user may explicitly request a PR at any point
+
 ### Advance to terminal
 
 After the PR is created:
@@ -283,11 +318,13 @@ When processing multiple items autonomously:
 2. **Parallel execution** — use worktree isolation for independent work streams.
    Sequential execution for items with dependency edges between them.
 3. **Per-item pipeline** — each worktree goes through Steps 4-6 independently:
-   implementation → capture worktree metadata → simplify → review (in worktree) → PR
+   implementation → capture worktree metadata → simplify → review (in worktree) → squash-merge to main
 4. **Track all worktrees** — maintain a table mapping item UUID → worktree path →
-   branch → status (implementing / reviewing / PR created / failed)
-5. **Report at the end** — summarize all PRs created, any items that couldn't be
-   processed, and any review failures that need user attention
+   branch → status (implementing / reviewing / squash-merged / failed)
+5. **Squash-merge each** — after review passes, squash-merge each worktree branch
+   into local `main`. Run the full test suite after each merge to catch integration issues.
+6. **Report at the end** — summarize items completed, any review failures, and whether
+   a PR to GitHub is ready
 
 If any item in the batch hits a review failure, continue processing other items
 and report all failures together at the end.
@@ -303,8 +340,8 @@ real branch that survives the agent's lifecycle.
 
 **When to use worktrees:**
 - Parallel dispatch of multiple implementation agents (prevents file conflicts)
-- Any implementation dispatch where you need the changes on a reviewable branch
-- When you want the implementation agent to commit and push independently
+- Any implementation dispatch where you need the changes on an isolated branch
+- When you want the implementation agent to commit independently
 
 **When NOT to use worktrees:**
 - Tasks that depend on each other's file changes (use sequential dispatch instead)
@@ -331,8 +368,8 @@ Agent(
 
 ### Worktree lifecycle
 
-The worktree branch is the PR branch. Review and PR creation happen on that
-branch — do NOT merge worktree branches back before review.
+Review happens in the worktree. After review passes, squash-merge into local
+`main` — do NOT push worktree branches to origin.
 
 ```
 1. Orchestrator dispatches agent with isolation: "worktree"
@@ -342,7 +379,7 @@ branch — do NOT merge worktree branches back before review.
 5. Orchestrator spot-checks diffs: git -C <worktree-path> diff main --stat
 6. Orchestrator runs /simplify in the worktree (or dispatches agent to do so)
 7. Review agent dispatched INTO the worktree (reads files and runs tests there)
-8. PR created from the worktree branch
+8. After review passes: squash-merge worktree branch into local main
 9. Worktrees with no changes are automatically cleaned up
 ```
 
@@ -355,7 +392,7 @@ When an agent returns from worktree isolation, the Agent tool result includes:
 Record these alongside the MCP item ID. You need them for:
 - Running `git -C <path> diff main --name-only` to get the changed files list
 - Pointing the review agent at the correct directory
-- Pushing the branch and creating the PR
+- Squash-merging the branch into local `main` after review
 
 ### Parallel worktree validation
 
@@ -365,11 +402,9 @@ When multiple agents return from parallel worktrees:
 2. Spot-check at least 2 diffs for insertion errors, scope violations, or
    unintended modifications
 3. Run each worktree's test suite independently (or delegate to review agents)
-4. Each worktree branch gets its own PR — do not merge them together unless
-   the items were intentionally grouped
-
-If items were grouped into a single working branch (Step 2), merge reviewed
-worktree branches into that branch sequentially AFTER review passes for each.
+4. Squash-merge each reviewed worktree branch into local `main` sequentially
+5. Run the full test suite after all merges to catch integration issues
+6. Delete worktree branches after successful squash-merge
 
 ---
 

--- a/.claude/skills/session-retrospective/SKILL.md
+++ b/.claude/skills/session-retrospective/SKILL.md
@@ -1,0 +1,347 @@
+---
+name: session-retrospective
+description: "Analyze the current implementation run — evaluate schema effectiveness, delegation alignment, note quality, plan-to-execution fit. Captures cross-session trends and proposes improvements when patterns repeat. Use after implementation runs, or when user says 'retrospective', 'session review', 'what did we learn', 'analyze this run', 'how did that go', 'evaluate our process', 'wrap up', 'end of session review'. Also use when the output style's retrospective nudge fires after complete_tree."
+argument-hint: "[optional: --dry-run to preview without creating items]"
+---
+
+# Session Retrospective
+
+Structured post-implementation analysis. Evaluates the current run across five dimensions, persists findings in MCP, and maintains cross-session trend memory to surface actionable improvement proposals.
+
+---
+
+## Step 0 — Mode Check
+
+If `$ARGUMENTS` contains `--dry-run`, set **DRY_RUN = true**. In dry-run mode, perform steps 1-4 and render the report (step 9) but skip steps 5-8 (no MCP item creation, no memory updates). Announce at the top of the report: `**Dry run** — no items created, no memory updated.`
+
+---
+
+## Step 1 — Load the Manifest
+
+Search for the run manifest session task:
+
+```
+TaskList — scan for tasks named `run-manifest:*`
+TaskGet — read the most recent one
+```
+
+Parse the JSON manifest. Extract: `runId`, `scope`, `delegations`, `schemaInteractions`, `observations`, `friction`, `extensions`.
+
+**If no manifest exists (fallback):** Query MCP for recently active items:
+
+```
+get_context() — active, blocked, stalled items
+query_items(operation="search", role="terminal", sortBy="modifiedAt", sortOrder="desc", limit=20) — recently completed items
+```
+
+Build a synthetic scope from items modified today (compare `modifiedAt` to current date). Discard items that appear stale. Note in the report: `**Fallback mode** — no run manifest found. Analysis based on MCP state queries.`
+
+**If neither manifest nor fallback produces any items in scope:** Exit early with:
+```
+◆ No implementation run data found. Nothing to retrospect — run `/implement` first, then try again.
+```
+
+---
+
+## Step 2 — Gather Retrospective Data
+
+Run these calls in parallel:
+
+1. For each item in `scope.preExistingItems` + `scope.adHocItems` (up to 20):
+   ```
+   query_notes(itemId="<uuid>", includeBody=true)
+   ```
+2. `get_context()` — current state snapshot
+
+Cross-reference:
+- Match `delegations[].itemId` to items — verify outcomes
+- Match `schemaInteractions[].itemId` to notes — evaluate content quality
+- Identify items in scope with no delegation entry → self-implemented
+- Identify items with delegations but no notes → incomplete work
+
+---
+
+## Step 3 — Evaluate Across Dimensions
+
+### 3a. Schema Effectiveness
+
+For each `schemaInteraction` entry:
+- Was `guidanceFollowed: true` for all notes?
+- Token count per note: **<50 = sparse** (flag), **50-500 = appropriate**, **>500 = potentially verbose** (flag for status-type notes; specification notes are exempt from the upper bound)
+- Were gate failures recorded? What caused them?
+- **Score:** Fraction of notes where guidance was followed and content was appropriately sized
+
+### 3b. Delegation Alignment
+
+Cross-reference `delegations[]` against the output style delegation table:
+
+| Task type | Expected model |
+|-----------|---------------|
+| MCP bulk ops, materialization, simple queries | `haiku` |
+| Code reading, implementation, test writing | `sonnet` |
+| Architecture, complex tradeoffs, multi-file synthesis | `opus` |
+
+- Flag misalignments (e.g., opus for bulk MCP ops, haiku for architecture)
+- Flag `selfImplemented: true` entries — the orchestrator should delegate, not implement directly
+- **Score:** Fraction of delegations matching expected model for their rationale
+
+### 3c. Note Effectiveness
+
+For items with both queue-phase notes (specs) and work-phase notes (implementation):
+- Compare spec content themes to implementation note themes
+- If implementation notes mention "deviated from spec", "unexpected", or "assumption was wrong" → flag as a spec gap
+- If work-phase notes are nearly empty (<30 tokens) → flag as context loss for downstream agents
+- **Score:** Qualitative (effective / mixed / ineffective)
+
+### 3d. Plan-to-Execution Alignment
+
+From `scope`:
+- `adHocItems` not in `preExistingItems` = scope change (may be necessary or scope creep)
+- Items in `preExistingItems` still in queue role = planned but skipped
+- **Score:** Fraction of planned items that reached terminal
+
+### 3e. Friction Synthesis
+
+Group `friction[]` entries and `observations[]` by type:
+- `tool-error` — MCP or tool failures
+- `excessive-roundtrips` — more calls than necessary
+- `workaround` — agent had to work around a limitation
+- `api-confusion` — unclear API semantics
+
+Identify themes across entries (e.g., "3 friction entries related to gate failures on items without schemas").
+
+---
+
+## Step 4 — Check Trend Memory
+
+Read the trend memory file `memory/retrospectives.md` from the auto memory directory (file read, not MCP call). The auto memory path is shown at session start — typically `~/.claude/projects/<project-key>/memory/`.
+
+**If the file does not exist:** This is the first retrospective. Skip trend comparison — all findings are new baselines.
+
+**If the file exists:** For each dimension finding from step 3:
+- Search existing trend entries for matches (same schema note, same delegation pattern, same friction type)
+- If a finding matches an existing trend, note the incremented session count
+- If a finding is new, mark it as a candidate for the trends section
+
+---
+
+## Step 5 — Persist the Retrospective
+
+**Skip entirely in dry-run mode.**
+
+### 5a. Find or create container
+
+```
+query_items(operation="search", query="Session Retrospectives", depth=0, limit=5)
+```
+
+If no match with that exact title at depth 0, create it:
+
+```
+manage_items(operation="create", items=[{
+  title: "Session Retrospectives",
+  summary: "Container for structured post-implementation analyses.",
+  priority: "low"
+}])
+```
+
+### 5b. Create retrospective item
+
+```
+manage_items(operation="create", items=[{
+  title: "Retrospective — <root-item-title> — <YYYY-MM-DD>",
+  summary: "<one-sentence summary of key findings>",
+  tags: "session-retrospective",
+  parentId: "<container-uuid>"
+}])
+```
+
+### 5c. Fill schema notes
+
+All three notes are queue-role. Fill them in a single batch:
+
+```
+manage_notes(operation="upsert", notes=[
+  {
+    itemId: "<retro-uuid>",
+    key: "session-metrics",
+    role: "queue",
+    body: "<Step 3 quantitative data: item counts, delegation breakdown, schema usage, token estimates>"
+  },
+  {
+    itemId: "<retro-uuid>",
+    key: "workflow-evaluation",
+    role: "queue",
+    body: "<Step 3 qualitative assessment: per-dimension scores and key findings>"
+  },
+  {
+    itemId: "<retro-uuid>",
+    key: "improvement-signals",
+    role: "queue",
+    body: "<Step 4 trend analysis: new trends, reinforced trends, proposals, extension promotions>"
+  }
+])
+```
+
+### 5d. Advance to terminal
+
+The retrospective is a write-once artifact — all notes are queue-phase, so after filling them there are no further gates. Complete directly:
+
+```
+complete_tree(itemIds=["<retro-uuid>"], trigger="complete")
+```
+
+---
+
+## Step 6 — Update Trend Memory
+
+**Skip entirely in dry-run mode.**
+
+Read `memory/retrospectives.md` from the auto memory directory. Update each section:
+
+- **Schema Effectiveness:** Add or update entries from dimension 3a findings. Format: `- <schema-note-key>: <observation>. Sessions: N. Last seen: YYYY-MM-DD`
+- **Delegation Patterns:** Add or update from dimension 3b. Format: `- <pattern>. Sessions: N. Last seen: YYYY-MM-DD`
+- **Note Quality:** Add or update from dimension 3c. Format: `- <note-key>: <observation>. Sessions: N. Last seen: YYYY-MM-DD`
+- **Extension Candidates:** Add entries from `manifest.extensions[]` that appeared in this run. Format: `- <key>: <value pattern>. Sessions: N. Promoted: no`
+- **Improvement Proposals:** Add new proposal references if created in step 7.
+
+Write the updated file.
+
+---
+
+## Step 7 — Create Improvement Proposals
+
+**Skip entirely in dry-run mode.**
+
+Check the updated trend memory (from step 6). For each trend with **Sessions >= 2**:
+
+### 7a. Find or create proposals container
+
+```
+query_items(operation="search", query="Improvement Proposals", depth=0, limit=5)
+```
+
+Create if missing (same pattern as 5a).
+
+### 7b. Create proposal items
+
+For each graduating trend:
+
+```
+manage_items(operation="create", items=[{
+  title: "Proposal: <concrete change description>",
+  summary: "<what to change and why — reference retrospective item IDs that surfaced the trend>",
+  tags: "improvement-proposal",
+  parentId: "<proposals-container-uuid>",
+  priority: "low"
+}])
+```
+
+The proposal should include a **concrete suggestion** — not just "this is a problem" but the specific change:
+- Schema edits: include the exact YAML to add/modify
+- Skill updates: reference the section and describe the change
+- Output style adjustments: specify the zone and content
+- Hook additions: specify the event, matcher, and purpose
+
+### 7c. Extension promotions
+
+If any `extensions[]` keys from the trend memory have `Sessions >= 2`:
+- Create a proposal item with the proposed JSON schema addition (field name, type, enum values if applicable)
+- Note which runs used the extension and what values they recorded
+
+Update the Extension Candidates section in trend memory: set `Promoted: yes` for graduated entries.
+
+---
+
+## Step 8 — Meta-Evaluation
+
+**Skip entirely in dry-run mode.**
+
+Query prior retrospectives:
+
+```
+query_items(operation="search", tags="session-retrospective", limit=20)
+```
+
+**If 3+ retrospectives exist**, evaluate:
+
+1. **Trend durability:** Did previously identified trends get addressed? Check if improvement proposals in terminal state exist for prior trends.
+2. **Proposal staleness:** Any proposals created 3+ retrospectives ago with no movement (still in queue)?
+3. **Self-quality:** Are retrospective notes converging on useful patterns, or repeating the same observations without resolution? Are notes too verbose (>800 tokens each) or too shallow (<100 tokens)?
+
+If meta-findings warrant it, add a brief note to the current retrospective's `improvement-signals` note via:
+
+```
+manage_notes(operation="upsert", notes=[{
+  itemId: "<current-retro-uuid>",
+  key: "improvement-signals",
+  role: "queue",
+  body: "<updated body with meta-evaluation appended>"
+}])
+```
+
+---
+
+## Step 9 — Report
+
+Render a dashboard using the output style visual conventions:
+
+```
+## ◆ Session Retrospective — <root-item-title>
+
+**<YYYY-MM-DD> · <N> items · <N> delegations · <N> schemas used**
+
+### Dimension Scores
+
+| Dimension | Score | Key Finding |
+|-----------|-------|-------------|
+| Schema effectiveness | <fraction or qualitative> | <one-line summary> |
+| Delegation alignment | <fraction> | <one-line summary> |
+| Note effectiveness | <qualitative> | <one-line summary> |
+| Plan-to-execution | <fraction> | <one-line summary> |
+| Friction | <count> entries, <N> themes | <top theme> |
+
+### Trends
+
+| Pattern | Sessions | Status |
+|---------|----------|--------|
+| <trend description> | N | new / reinforced / addressed |
+
+### Improvement Proposals Created
+
+| ID | Proposal | Trigger |
+|----|----------|---------|
+| `<short-id>` | <description> | <trend that graduated> |
+
+### Extension Promotions
+
+| Key | Value Pattern | Sessions | Recommendation |
+|-----|---------------|----------|----------------|
+| <key> | <typical value> | N | promote to core / keep observing |
+```
+
+**Conditional prefixes:**
+- Dry-run: `**Dry run** — no items created, no memory updated.`
+- Fallback: `**Fallback mode** — no run manifest found. Analysis based on MCP state queries.`
+
+Omit sections with no data (e.g., no extension promotions → omit that table).
+
+---
+
+## Troubleshooting
+
+**No manifest found**
+- Cause: Implementation run did not maintain a run manifest (output style not active, or short session)
+- Solution: Skill falls back to MCP queries. Less precise but functional. The report notes fallback mode.
+
+**Schema not recognized (`expectedNotes` empty)**
+- Cause: `session-retrospective` tag not in `.taskorchestrator/config.yaml`, or MCP not reconnected after config edit
+- Solution: Run `/mcp` to reconnect, verify config has the schema
+
+**Trend memory file missing**
+- Cause: First retrospective ever run
+- Solution: Skill creates the file at step 6 with initial structure. No action needed.
+
+**Container not found**
+- Cause: First time creating retrospectives or improvement proposals
+- Solution: Skill creates containers lazily at steps 5a and 7a. No action needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,9 @@ Two skill systems — do not confuse them:
 
 ## Git Workflow
 
-- Main branch: `main` — follow conventional commits, reference issue numbers
+**Local-first squash flow** — work stays local on branches, squash-merged into `main`, batched PRs to GitHub. See the `/implement` skill for the full step-by-step process.
+
+- Follow conventional commits, reference issue numbers
 - All tests must pass before committing
+- Never force-push `main` — use PR branches to sync with origin
 - Database migrations require special attention

--- a/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
+++ b/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
@@ -62,6 +62,81 @@ Every delegation prompt must include: entity IDs, exact tool operations, expecte
 
 Session tasks are ephemeral — they exist for the current session only. Do NOT use them for items that need to persist across sessions.
 
+## Implementation Run Manifest
+
+During any implementation run (triggered by `/implement` or `post-plan-workflow`), maintain a structured run manifest as a **session task** using `TaskCreate`/`TaskUpdate`. This provides durable in-session storage that survives context compaction.
+
+**Lifecycle:**
+1. At run start, `TaskCreate` a session task named `run-manifest:<root-item-short-id>` with the initial JSON
+2. After each delegation return, `TaskUpdate` to append to `delegations[]`
+3. After each schema interaction (note fill, gate failure), `TaskUpdate` to append to `schemaInteractions[]`
+4. After each observation logged, `TaskUpdate` to append the UUID to `observations[]`
+5. When friction is encountered, `TaskUpdate` to append to `friction[]`
+6. For data worth tracking that does not fit core fields, append to `extensions[]` with a reason
+
+**Manifest schema (fixed core + extensions):**
+
+```json
+{
+  "runId": "<root-item-uuid>",
+  "startedAt": "<ISO-8601>",
+  "scope": {
+    "rootItemId": "<uuid>",
+    "rootItemTitle": "<string>",
+    "preExistingItems": ["<uuid>"],
+    "adHocItems": ["<uuid>"]
+  },
+  "delegations": [
+    {
+      "itemId": "<uuid>",
+      "model": "sonnet | haiku | opus",
+      "rationale": "bulk-mcp-ops | code-implementation | test-writing | architecture-review | research | materialization",
+      "isolation": "worktree | none",
+      "selfImplemented": false,
+      "outcome": "success | failure | partial"
+    }
+  ],
+  "schemaInteractions": [
+    {
+      "itemId": "<uuid>",
+      "schemaTag": "<string>",
+      "notesFilled": [
+        { "key": "<string>", "phase": "queue | work | review", "approxTokens": 0, "guidanceFollowed": true }
+      ],
+      "gateFailures": 0
+    }
+  ],
+  "observations": ["<observation-uuid>"],
+  "friction": [
+    { "type": "tool-error | excessive-roundtrips | workaround | api-confusion", "brief": "<string>" }
+  ],
+  "extensions": [
+    {
+      "key": "<agent-suggested-key>",
+      "value": "<typed value>",
+      "reason": "<why this was worth tracking>",
+      "sessionCount": 1
+    }
+  ]
+}
+```
+
+**Rules:**
+- `model` and `rationale` use closed enums. Unknown rationales go in `extensions[]`.
+- `selfImplemented: true` when the orchestrator implements directly instead of delegating.
+- The manifest is consumed by `/session-retrospective` — do not display it to the user directly.
+- If no implementation run is active, do not create a manifest.
+
+## Retrospective Nudge
+
+After `complete_tree` completes, or when 3+ items transition to terminal during a session, append a one-line suggestion:
+
+```
+↳ Implementation run complete. Consider running `/session-retrospective` to capture learnings.
+```
+
+Do NOT auto-invoke the skill. Show the nudge at most once per implementation run.
+
 ## Visual Conventions
 
 Status symbols: `✓` terminal · `◉` work/review · `⊘` blocked · `○` queue · `—` cancelled

--- a/current/build.gradle.kts
+++ b/current/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
 
     // Testing
     testImplementation(libs.kotlin.test)
+    testImplementation(libs.mcp.sdk.testing)
     testImplementation(libs.mockk)
     testImplementation(libs.junit.api)
     testImplementation(libs.junit.params)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -208,21 +208,14 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                             is Result.Success -> notesResult.data
                             is Result.Error -> emptyList()
                         }
-                        val filledKeys = existingNotes.filter { it.body.isNotBlank() }.map { it.key }.toSet()
+                        val filledKeys = NoteSchemaJsonHelpers.buildFilledKeys(existingNotes)
                         val missingEntries = requiredForCurrentPhase.filter { it.key !in filledKeys }
-                        val missingKeys = missingEntries.map { it.key }
-                        if (missingKeys.isNotEmpty()) {
-                            val missingNotesJson = JsonArray(missingEntries.map { entry ->
-                                buildJsonObject {
-                                    put("key", JsonPrimitive(entry.key))
-                                    put("description", JsonPrimitive(entry.description))
-                                    entry.guidance?.let { put("guidance", JsonPrimitive(it)) }
-                                }
-                            })
+                        if (missingEntries.isNotEmpty()) {
+                            val missingKeys = missingEntries.map { it.key }
                             failCount++
                             resultsList.add(buildErrorResult(itemId, trigger,
                                 "Gate check failed: required notes not filled for ${currentRoleStr} phase: ${missingKeys.joinToString()}",
-                                missingNotes = missingNotesJson))
+                                missingNotes = NoteSchemaJsonHelpers.buildMissingNotesArray(missingEntries)))
                             continue
                         }
                     }
@@ -240,21 +233,14 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                             is Result.Success -> notesResult.data
                             is Result.Error -> emptyList()
                         }
-                        val filledKeys = existingNotes.filter { it.body.isNotBlank() }.map { it.key }.toSet()
+                        val filledKeys = NoteSchemaJsonHelpers.buildFilledKeys(existingNotes)
                         val missingEntries = allRequired.filter { it.key !in filledKeys }
-                        val missingKeys = missingEntries.map { it.key }
-                        if (missingKeys.isNotEmpty()) {
-                            val missingNotesJson = JsonArray(missingEntries.map { entry ->
-                                buildJsonObject {
-                                    put("key", JsonPrimitive(entry.key))
-                                    put("description", JsonPrimitive(entry.description))
-                                    entry.guidance?.let { put("guidance", JsonPrimitive(it)) }
-                                }
-                            })
+                        if (missingEntries.isNotEmpty()) {
+                            val missingKeys = missingEntries.map { it.key }
                             failCount++
                             resultsList.add(buildErrorResult(itemId, trigger,
                                 "Gate check failed: required notes not filled: ${missingKeys.joinToString()}",
-                                missingNotes = missingNotesJson))
+                                missingNotes = NoteSchemaJsonHelpers.buildMissingNotesArray(missingEntries)))
                             continue
                         }
                     }
@@ -295,6 +281,36 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                     val parentItem = when (parentResult) {
                         is Result.Success -> parentResult.data
                         is Result.Error -> break
+                    }
+
+                    // Gate check: cascade-to-TERMINAL requires all required notes (like "complete" trigger)
+                    if (event.targetRole == Role.TERMINAL) {
+                        val parentTags = parentItem.tagList()
+                        val parentSchema = noteSchemaService.getSchemaForTags(parentTags)
+                        if (parentSchema != null) {
+                            val allRequired = parentSchema.filter { it.required }
+                            if (allRequired.isNotEmpty()) {
+                                val parentNotes = when (val nr = context.noteRepository().findByItemId(parentItem.id)) {
+                                    is Result.Success -> nr.data
+                                    is Result.Error -> emptyList()
+                                }
+                                val filledKeys = NoteSchemaJsonHelpers.buildFilledKeys(parentNotes)
+                                val missingEntries = allRequired.filter { it.key !in filledKeys }
+                                if (missingEntries.isNotEmpty()) {
+                                    // Block cascade — report gate failure in cascade event
+                                    cascadeJsonList.add(buildJsonObject {
+                                        put("itemId", JsonPrimitive(event.itemId.toString()))
+                                        put("title", JsonPrimitive(parentItem.title))
+                                        put("previousRole", JsonPrimitive(event.currentRole.toJsonString()))
+                                        put("targetRole", JsonPrimitive(event.targetRole.toJsonString()))
+                                        put("applied", JsonPrimitive(false))
+                                        put("gateBlocked", JsonPrimitive(true))
+                                        put("missingNotes", NoteSchemaJsonHelpers.buildMissingNotesArray(missingEntries))
+                                    })
+                                    break // Stop cascading up the tree
+                                }
+                            }
+                        }
                     }
 
                     val cascadeApply = handler.applyTransition(

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/NoteSchemaJsonHelpers.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/NoteSchemaJsonHelpers.kt
@@ -31,6 +31,19 @@ object NoteSchemaJsonHelpers {
     }
 
     /**
+     * Builds a JSON array describing which required notes are missing (unfilled).
+     * Used by gate checks in [AdvanceItemTool] for start, complete, and cascade triggers.
+     */
+    fun buildMissingNotesArray(missingEntries: List<NoteSchemaEntry>): JsonArray =
+        JsonArray(missingEntries.map { entry ->
+            buildJsonObject {
+                put("key", JsonPrimitive(entry.key))
+                put("description", JsonPrimitive(entry.description))
+                entry.guidance?.let { put("guidance", JsonPrimitive(it)) }
+            }
+        })
+
+    /**
      * Builds a `noteProgress` JSON object with `{filled, remaining, total}` counts
      * for required notes in the given role. Callers should guard for null schema
      * before calling — this function always returns a non-null object.

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
@@ -159,7 +159,7 @@ class CurrentMcpServer(
         }
 
         try {
-            server.connect(transport)
+            server.createSession(transport)
             logger.info("Current (v3) MCP server running as '$serverName' v$version with $toolCount tools")
             done.join()
         } catch (e: Exception) {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/McpToolAdapter.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/McpToolAdapter.kt
@@ -4,6 +4,7 @@ import io.github.jpicklyk.mcptask.current.application.tools.ResponseUtil
 import io.github.jpicklyk.mcptask.current.application.tools.ToolDefinition
 import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
 import io.github.jpicklyk.mcptask.current.application.tools.ToolValidationException
+import io.modelcontextprotocol.kotlin.sdk.server.ClientConnection
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
@@ -48,6 +49,9 @@ class McpToolAdapter {
             description = toolDefinition.description,
             inputSchema = toolDefinition.parameterSchema
         ) { request ->
+            // 'this' is ClientConnection — provides sessionId, createMessage, listRoots,
+            // sendLoggingMessage, and other server-to-client capabilities from SDK 0.9.0.
+            val clientConnection = this@addTool
             try {
                 val preprocessedParams = preprocessParameters(request.arguments ?: JsonObject(emptyMap()))
 
@@ -81,7 +85,7 @@ class McpToolAdapter {
                     structuredContent = structuredData
                 )
             } catch (e: Exception) {
-                val message = "Internal error in '${toolDefinition.name}': ${e.message}"
+                val message = "Internal error in '${toolDefinition.name}' (session ${clientConnection.sessionId}): ${e.message}"
                 logger.error(message, e)
                 CallToolResult(
                     content = listOf(TextContent(text = message)),

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/SchemaGatedLifecycleTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/SchemaGatedLifecycleTest.kt
@@ -849,4 +849,149 @@ class SchemaGatedLifecycleTest {
         assertResponseMatchesDb(r4, item.id)
         assertEquals(Role.WORK, getItem(item.id).role)
     }
+
+    // ──────────────────────────────────────────────
+    // 17. Cascade-to-TERMINAL blocked by parent's
+    //     schema gate (missing required notes)
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `cascade to terminal blocked when parent has schema with unfilled required notes`(): Unit = runBlocking {
+        // Parent with schema tag — has required notes across all phases
+        val parent = createItem("Gated parent", tags = "feature-implementation")
+        // Do NOT fill any parent notes
+
+        // Single child (schema-free, advances freely)
+        val child = createItem("Only child", parentId = parent.id)
+
+        // Advance child through to TERMINAL
+        transitionTool.execute(buildTransitionParams(transitionObj(child.id, "start")), context)
+        assertEquals(Role.WORK, getItem(child.id).role)
+        // Parent should have start-cascaded to WORK
+        assertEquals(Role.WORK, getItem(parent.id).role)
+
+        val rComplete = transitionTool.execute(
+            buildTransitionParams(transitionObj(child.id, "start")),
+            context
+        )
+        assertTransitionSuccess(rComplete, "terminal")
+        assertEquals(Role.TERMINAL, getItem(child.id).role)
+
+        // Parent should NOT have cascaded to TERMINAL (gate blocked)
+        assertEquals(Role.WORK, getItem(parent.id).role)
+
+        // Verify cascade event reports gate block
+        val results = extractResults(rComplete)
+        val r = results[0].jsonObject
+        val cascades = r["cascadeEvents"]!!.jsonArray
+        assertTrue(cascades.isNotEmpty(), "Expected a cascade event for parent")
+        val cascade = cascades[0].jsonObject
+        assertEquals(parent.id.toString(), cascade["itemId"]!!.jsonPrimitive.content)
+        assertFalse(cascade["applied"]!!.jsonPrimitive.boolean, "Cascade should not have been applied")
+        assertTrue(cascade["gateBlocked"]!!.jsonPrimitive.boolean, "Cascade should report gateBlocked")
+        val missingNotes = cascade["missingNotes"]!!.jsonArray
+        assertTrue(missingNotes.isNotEmpty(), "Should report missing notes")
+        // All three required notes should be listed
+        val missingKeys = missingNotes.map { it.jsonObject["key"]!!.jsonPrimitive.content }.toSet()
+        assertTrue(missingKeys.contains("specification"), "Should list specification as missing")
+        assertTrue(missingKeys.contains("implementation-notes"), "Should list implementation-notes as missing")
+        assertTrue(missingKeys.contains("review-checklist"), "Should list review-checklist as missing")
+    }
+
+    // ──────────────────────────────────────────────
+    // 18. Cascade-to-TERMINAL succeeds when parent's
+    //     required notes are all filled
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `cascade to terminal succeeds when parent has all required notes filled`(): Unit = runBlocking {
+        // Parent with schema tag — fill ALL required notes upfront
+        val parent = createItem("Fully noted parent", tags = "feature-implementation")
+        createNote(parent.id, key = "specification", role = "queue")
+        createNote(parent.id, key = "implementation-notes", role = "work")
+        createNote(parent.id, key = "review-checklist", role = "review")
+
+        // Single child (schema-free)
+        val child = createItem("Only child", parentId = parent.id)
+
+        // Advance child to TERMINAL
+        transitionTool.execute(buildTransitionParams(transitionObj(child.id, "start")), context)
+        val rComplete = transitionTool.execute(
+            buildTransitionParams(transitionObj(child.id, "start")),
+            context
+        )
+        assertTransitionSuccess(rComplete, "terminal")
+        assertEquals(Role.TERMINAL, getItem(child.id).role)
+
+        // Parent SHOULD have cascaded to TERMINAL (all notes filled)
+        assertEquals(Role.TERMINAL, getItem(parent.id).role)
+
+        // Verify cascade event reports success
+        val results = extractResults(rComplete)
+        val cascade = results[0].jsonObject["cascadeEvents"]!!.jsonArray[0].jsonObject
+        assertTrue(cascade["applied"]!!.jsonPrimitive.boolean, "Cascade should have been applied")
+        assertNull(cascade["gateBlocked"], "Should not have gateBlocked field")
+    }
+
+    // ──────────────────────────────────────────────
+    // 19. Cascade-to-TERMINAL blocked with partially
+    //     filled notes on parent
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `cascade to terminal blocked when parent has only some required notes filled`(): Unit = runBlocking {
+        // Parent with schema tag — fill only ONE of three required notes
+        val parent = createItem("Partial parent", tags = "feature-implementation")
+        createNote(parent.id, key = "specification", role = "queue")
+        // Missing: implementation-notes, review-checklist
+
+        // Single child (schema-free)
+        val child = createItem("Only child", parentId = parent.id)
+
+        // Advance child to TERMINAL
+        transitionTool.execute(buildTransitionParams(transitionObj(child.id, "start")), context)
+        val rComplete = transitionTool.execute(
+            buildTransitionParams(transitionObj(child.id, "start")),
+            context
+        )
+        assertTransitionSuccess(rComplete, "terminal")
+
+        // Parent should NOT cascade to TERMINAL (missing notes)
+        assertEquals(Role.WORK, getItem(parent.id).role)
+
+        // Verify the cascade event reports exactly the missing notes
+        val cascade = extractResults(rComplete)[0].jsonObject["cascadeEvents"]!!.jsonArray[0].jsonObject
+        assertFalse(cascade["applied"]!!.jsonPrimitive.boolean)
+        assertTrue(cascade["gateBlocked"]!!.jsonPrimitive.boolean)
+        val missingKeys = cascade["missingNotes"]!!.jsonArray.map { it.jsonObject["key"]!!.jsonPrimitive.content }.toSet()
+        assertEquals(setOf("implementation-notes", "review-checklist"), missingKeys)
+    }
+
+    // ──────────────────────────────────────────────
+    // 20. Schema-free parent still cascades freely
+    //     (regression guard)
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `schema-free parent cascades to terminal without gate check`(): Unit = runBlocking {
+        // Parent with NO schema tag
+        val parent = createItem("Schema-free parent")
+
+        // Single child (also schema-free)
+        val child = createItem("Child task", parentId = parent.id)
+
+        // Advance child to TERMINAL
+        transitionTool.execute(buildTransitionParams(transitionObj(child.id, "start")), context)
+        val rComplete = transitionTool.execute(
+            buildTransitionParams(transitionObj(child.id, "start")),
+            context
+        )
+        assertTransitionSuccess(rComplete, "terminal")
+
+        // Parent should cascade to TERMINAL freely (no schema = no gate)
+        assertEquals(Role.TERMINAL, getItem(parent.id).role)
+
+        val cascade = extractResults(rComplete)[0].jsonObject["cascadeEvents"]!!.jsonArray[0].jsonObject
+        assertTrue(cascade["applied"]!!.jsonPrimitive.boolean)
+    }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/McpToolAdapterIntegrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/McpToolAdapterIntegrationTest.kt
@@ -1,0 +1,301 @@
+package io.github.jpicklyk.mcptask.current.interfaces.mcp
+
+import io.github.jpicklyk.mcptask.current.application.tools.*
+import io.modelcontextprotocol.kotlin.sdk.client.Client
+import io.modelcontextprotocol.kotlin.sdk.client.ClientOptions
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.testing.ChannelTransport
+import io.modelcontextprotocol.kotlin.sdk.types.*
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests that exercise tools through the full MCP protocol stack:
+ * Client → ChannelTransport → Server → McpToolAdapter → ToolDefinition → response.
+ *
+ * Uses the SDK 0.9.0 kotlin-sdk-testing module with in-process channel transport.
+ */
+class McpToolAdapterIntegrationTest {
+
+    private lateinit var server: Server
+    private lateinit var client: Client
+    private lateinit var adapter: McpToolAdapter
+
+    @BeforeEach
+    fun setUp(): Unit = runBlocking {
+        server = Server(
+            serverInfo = Implementation(name = "test-server", version = "1.0.0"),
+            options = ServerOptions(
+                capabilities = ServerCapabilities(
+                    tools = ServerCapabilities.Tools(listChanged = true)
+                )
+            )
+        )
+
+        adapter = McpToolAdapter()
+
+        val (clientTransport, serverTransport) = ChannelTransport.createLinkedPair()
+
+        client = Client(
+            clientInfo = Implementation(name = "test-client", version = "1.0.0"),
+            options = ClientOptions(
+                capabilities = ClientCapabilities()
+            )
+        )
+
+        server.createSession(serverTransport)
+        client.connect(clientTransport)
+    }
+
+    @AfterEach
+    fun tearDown(): Unit = runBlocking {
+        client.close()
+        server.close()
+    }
+
+    // ──────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────
+
+    /** A minimal ToolDefinition for testing that echoes its input. */
+    private fun echoTool(): ToolDefinition = object : ToolDefinition {
+        override val name = "echo"
+        override val description = "Echoes input back"
+        override val parameterSchema = ToolSchema(
+            properties = buildJsonObject {
+                put("message", buildJsonObject {
+                    put("type", JsonPrimitive("string"))
+                    put("description", JsonPrimitive("Message to echo"))
+                })
+            },
+            required = listOf("message")
+        )
+        override val category = ToolCategory.SYSTEM
+
+        override fun validateParams(params: JsonElement) {
+            val obj = params as? JsonObject
+                ?: throw ToolValidationException("Expected JSON object")
+            if (obj["message"] == null) {
+                throw ToolValidationException("Missing required parameter: message")
+            }
+        }
+
+        override suspend fun execute(params: JsonElement, context: ToolExecutionContext): JsonElement {
+            val message = (params as JsonObject)["message"]?.jsonPrimitive?.content ?: ""
+            return buildJsonObject {
+                put("status", JsonPrimitive("success"))
+                put("message", JsonPrimitive("Echo: $message"))
+                put("data", buildJsonObject {
+                    put("echoed", JsonPrimitive(message))
+                })
+            }
+        }
+    }
+
+    /** A tool that always throws an exception during execution. */
+    private fun failingTool(): ToolDefinition = object : ToolDefinition {
+        override val name = "failing_tool"
+        override val description = "Always fails"
+        override val parameterSchema = ToolSchema()
+        override val category = ToolCategory.SYSTEM
+
+        override suspend fun execute(params: JsonElement, context: ToolExecutionContext): JsonElement {
+            throw RuntimeException("Intentional test failure")
+        }
+    }
+
+    private val dummyContext = ToolExecutionContext(
+        repositoryProvider = io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider(
+            io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager(
+                org.jetbrains.exposed.v1.jdbc.Database.connect(
+                    "jdbc:h2:mem:integration_${System.nanoTime()};DB_CLOSE_DELAY=-1",
+                    driver = "org.h2.Driver"
+                )
+            ).also {
+                io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager()
+                    .updateSchema()
+            }
+        )
+    )
+
+    // ──────────────────────────────────────────────
+    // Tool listing through MCP protocol
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `listTools returns registered tool`(): Unit = runBlocking {
+        adapter.registerToolWithServer(server, echoTool(), dummyContext)
+
+        val result = client.listTools()
+        val tools = result.tools
+        assertEquals(1, tools.size)
+        assertEquals("echo", tools[0].name)
+        assertEquals("Echoes input back", tools[0].description)
+    }
+
+    // ──────────────────────────────────────────────
+    // Successful tool call through MCP protocol
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `callTool executes tool and returns result`(): Unit = runBlocking {
+        adapter.registerToolWithServer(server, echoTool(), dummyContext)
+
+        val result = client.callTool(
+            name = "echo",
+            arguments = mapOf("message" to "hello world")
+        )
+
+        // Should not be an error
+        assertTrue(result.isError != true, "Expected successful result but got error")
+
+        // Content should contain the user summary
+        val textContent = result.content.filterIsInstance<TextContent>()
+        assertTrue(textContent.isNotEmpty(), "Expected at least one TextContent")
+        assertTrue(textContent[0].text.contains("Echo: hello world"), "Summary should contain echo message")
+    }
+
+    // ──────────────────────────────────────────────
+    // Validation error propagation
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `callTool returns validation error when required param missing`(): Unit = runBlocking {
+        adapter.registerToolWithServer(server, echoTool(), dummyContext)
+
+        val result = client.callTool(
+            name = "echo",
+            arguments = emptyMap()
+        )
+
+        // Should be flagged as error
+        assertEquals(true, result.isError)
+
+        // Error message should contain validation info
+        val textContent = result.content.filterIsInstance<TextContent>()
+        assertTrue(textContent.isNotEmpty())
+        assertTrue(textContent[0].text.contains("Validation error"), "Should contain validation error message")
+        assertTrue(textContent[0].text.contains("message"), "Should reference the missing parameter")
+    }
+
+    // ──────────────────────────────────────────────
+    // Internal error propagation
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `callTool returns internal error when tool throws exception`(): Unit = runBlocking {
+        adapter.registerToolWithServer(server, failingTool(), dummyContext)
+
+        val result = client.callTool(
+            name = "failing_tool",
+            arguments = emptyMap()
+        )
+
+        assertEquals(true, result.isError)
+
+        val textContent = result.content.filterIsInstance<TextContent>()
+        assertTrue(textContent.isNotEmpty())
+        assertTrue(textContent[0].text.contains("Internal error"), "Should contain internal error message")
+        assertTrue(textContent[0].text.contains("Intentional test failure"), "Should contain exception message")
+    }
+
+    // ──────────────────────────────────────────────
+    // Boolean preprocessing through MCP stack
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `callTool preprocesses string booleans`(): Unit = runBlocking {
+        // Tool that checks a boolean parameter
+        val boolTool = object : ToolDefinition {
+            override val name = "bool_check"
+            override val description = "Checks boolean preprocessing"
+            override val parameterSchema = ToolSchema(
+                properties = buildJsonObject {
+                    put("flag", buildJsonObject {
+                        put("type", JsonPrimitive("boolean"))
+                    })
+                    put("message", buildJsonObject {
+                        put("type", JsonPrimitive("string"))
+                    })
+                }
+            )
+            override val category = ToolCategory.SYSTEM
+
+            override suspend fun execute(params: JsonElement, context: ToolExecutionContext): JsonElement {
+                val flag = (params as JsonObject)["flag"]
+                // After preprocessing, "true" string should become boolean true
+                val isBooleanTrue = flag is JsonPrimitive && !flag.isString && flag.boolean
+                return buildJsonObject {
+                    put("status", JsonPrimitive("success"))
+                    put("message", JsonPrimitive("flag=$isBooleanTrue"))
+                    put("data", buildJsonObject {
+                        put("isBooleanTrue", JsonPrimitive(isBooleanTrue))
+                    })
+                }
+            }
+        }
+
+        adapter.registerToolWithServer(server, boolTool, dummyContext)
+
+        // Send "true" as a string — MCP clients often do this
+        val result = client.callTool(
+            name = "bool_check",
+            arguments = mapOf("flag" to "true", "message" to "test")
+        )
+
+        assertTrue(result.isError != true, "Expected successful result")
+        val textContent = result.content.filterIsInstance<TextContent>()
+        assertTrue(textContent[0].text.contains("flag=true"), "Boolean preprocessing should convert string 'true' to boolean")
+    }
+
+    // ──────────────────────────────────────────────
+    // Multiple tool registration
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `registerToolsWithServer registers multiple tools`(): Unit = runBlocking {
+        adapter.registerToolsWithServer(server, listOf(echoTool(), failingTool()), dummyContext)
+
+        val result = client.listTools()
+        assertEquals(2, result.tools.size)
+
+        val names = result.tools.map { it.name }.toSet()
+        assertTrue("echo" in names)
+        assertTrue("failing_tool" in names)
+    }
+
+    // ──────────────────────────────────────────────
+    // Real tool through MCP stack
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `callTool with real ManageItemsTool creates item`(): Unit = runBlocking {
+        val manageTool = io.github.jpicklyk.mcptask.current.application.tools.items.ManageItemsTool()
+        adapter.registerToolWithServer(server, manageTool, dummyContext)
+
+        val result = client.callTool(
+            name = "manage_items",
+            arguments = mapOf(
+                "operation" to "create",
+                "items" to listOf(mapOf("title" to "Integration test item"))
+            )
+        )
+
+        assertTrue(result.isError != true, "Expected successful item creation, got: ${result.content}")
+        val textContent = result.content.filterIsInstance<TextContent>()
+        assertTrue(textContent.isNotEmpty())
+        // The summary should indicate items were created
+        assertTrue(
+            textContent[0].text.contains("created", ignoreCase = true) ||
+                textContent[0].text.contains("1", ignoreCase = true),
+            "Summary should indicate item creation: ${textContent[0].text}"
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlinCoroutines = "1.8.0"
 kotlinSerialization = "1.8.0"
 
 # MCP SDK
-mcpSdk = "0.8.4"
+mcpSdk = "0.9.0"
 
 # Ktor (version-aligned with MCP SDK's transitive dependency)
 ktor = "3.2.3"
@@ -35,6 +35,7 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 
 # MCP SDK
 mcp-sdk = { module = "io.modelcontextprotocol:kotlin-sdk", version.ref = "mcpSdk" }
+mcp-sdk-testing = { module = "io.modelcontextprotocol:kotlin-sdk-testing", version.ref = "mcpSdk" }
 
 # Ktor
 ktor-bom        = { module = "io.ktor:ktor-bom",        version.ref = "ktor" }


### PR DESCRIPTION
## Summary
- **MCP Kotlin SDK 0.9.0** — upgrade from 0.8.4, adopt `ClientConnection` and `kotlin-sdk-testing`, add `McpToolAdapterIntegrationTest`
- **Cascade gate enforcement** — fix cascade-to-TERMINAL bypassing note schema gates; parent items with schema tags now require all required notes filled before auto-completing; schema-free parents unaffected
- **Session retrospective skill** — post-implementation analysis skill with run manifest tracking
- **Documentation** — local-first squash flow documented in `/implement` skill and `CLAUDE.md`

## Test plan
- [x] All 20 `SchemaGatedLifecycleTest` tests pass (4 new cascade gate tests)
- [x] `AdvanceItemToolTest` and `WorkflowIntegrationTest` pass
- [x] Full `:current:test` suite passes
- [x] New `McpToolAdapterIntegrationTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)