### PR TITLE
refactor: make NoteSchemaEntry.role type-safe with Role enum

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NoteSchemaService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NoteSchemaService.kt
@@ -1,6 +1,7 @@
 package io.github.jpicklyk.mcptask.current.application.service
 
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.Role
 
 /**
  * Provides note schemas derived from `.taskorchestrator/config.yaml`.
@@ -23,7 +24,7 @@ interface NoteSchemaService {
      * Used to determine whether `start` from WORK should advance to REVIEW or jump to TERMINAL.
      * Returns false when no schema matches (schema-free mode — skip REVIEW).
      */
-    fun hasReviewPhase(tags: List<String>): Boolean = getSchemaForTags(tags)?.any { it.role == "review" } ?: false
+    fun hasReviewPhase(tags: List<String>): Boolean = getSchemaForTags(tags)?.any { it.role == Role.REVIEW } ?: false
 }
 
 /**

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/PhaseNoteContext.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/PhaseNoteContext.kt
@@ -43,8 +43,7 @@ fun computePhaseNoteContext(
 ): PhaseNoteContext? {
     if (role == Role.TERMINAL || schema == null) return null
 
-    val roleStr = role.name.lowercase()
-    val required = schema.filter { it.role == roleStr && it.required }
+    val required = schema.filter { it.role == role && it.required }
     val missing =
         required.filter { entry ->
             val note = notesByKey[entry.key]

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
@@ -311,7 +311,7 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                         Note(
                             itemId = item.id,
                             key = entry.key,
-                            role = entry.role,
+                            role = entry.role.toJsonString(),
                             body = ""
                         )
                     )
@@ -368,7 +368,7 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                                 schemaEntries.map { entry ->
                                     buildJsonObject {
                                         put("key", JsonPrimitive(entry.key))
-                                        put("role", JsonPrimitive(entry.role))
+                                        put("role", JsonPrimitive(entry.role.toJsonString()))
                                         put("required", JsonPrimitive(entry.required))
                                         put("description", JsonPrimitive(entry.description))
                                         entry.guidance?.let { put("guidance", JsonPrimitive(it)) }
@@ -402,7 +402,7 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                                         schemaEntries.map { entry ->
                                             buildJsonObject {
                                                 put("key", JsonPrimitive(entry.key))
-                                                put("role", JsonPrimitive(entry.role))
+                                                put("role", JsonPrimitive(entry.role.toJsonString()))
                                                 put("required", JsonPrimitive(entry.required))
                                                 put("description", JsonPrimitive(entry.description))
                                                 entry.guidance?.let { put("guidance", JsonPrimitive(it)) }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/CreateItemHandler.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/CreateItemHandler.kt
@@ -158,7 +158,7 @@ class CreateItemHandler(
                                             schemaEntries.map { entry ->
                                                 buildJsonObject {
                                                     put("key", JsonPrimitive(entry.key))
-                                                    put("role", JsonPrimitive(entry.role))
+                                                    put("role", JsonPrimitive(entry.role.toJsonString()))
                                                     put("required", JsonPrimitive(entry.required))
                                                     put("description", JsonPrimitive(entry.description))
                                                     entry.guidance?.let { put("guidance", JsonPrimitive(it)) }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -224,8 +224,7 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
             if (trigger == "start") {
                 val schema = noteSchemaService.getSchemaForTags(itemTags)
                 if (schema != null) {
-                    val currentRoleStr = item.role.toJsonString()
-                    val requiredForCurrentPhase = schema.filter { it.role == currentRoleStr && it.required }
+                    val requiredForCurrentPhase = schema.filter { it.role == item.role && it.required }
                     if (requiredForCurrentPhase.isNotEmpty()) {
                         val notesResult = context.noteRepository().findByItemId(item.id)
                         val existingNotes =
@@ -242,7 +241,7 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                                 buildErrorResult(
                                     itemId,
                                     trigger,
-                                    "Gate check failed: required notes not filled for $currentRoleStr phase: ${missingKeys.joinToString()}",
+                                    "Gate check failed: required notes not filled for ${item.role.toJsonString()} phase: ${missingKeys.joinToString()}",
                                     missingNotes = NoteSchemaJsonHelpers.buildMissingNotesArray(missingEntries)
                                 )
                             )
@@ -435,8 +434,6 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
 
             // Schema-driven response fields: expectedNotes, guidancePointer, noteProgress
             val schema = noteSchemaService.getSchemaForTags(itemTags)
-            val newRoleStr = targetRole.toJsonString()
-
             // Only query notes when a schema exists (avoids unnecessary DB call)
             val expectedNotesJson: JsonArray
             val guidancePointer: String?
@@ -456,13 +453,13 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                 val existingKeys = notesByKey.keys
 
                 // Build expectedNotes: schema entries matching the new role (tool-specific, includes "exists")
-                val forNewRole = schema.filter { it.role == newRoleStr }
+                val forNewRole = schema.filter { it.role == targetRole }
                 expectedNotesJson =
                     JsonArray(
                         forNewRole.map { entry ->
                             buildJsonObject {
                                 put("key", JsonPrimitive(entry.key))
-                                put("role", JsonPrimitive(entry.role))
+                                put("role", JsonPrimitive(entry.role.toJsonString()))
                                 put("required", JsonPrimitive(entry.required))
                                 put("description", JsonPrimitive(entry.description))
                                 entry.guidance?.let { put("guidance", JsonPrimitive(it)) }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
@@ -158,7 +158,6 @@ Parameters:
                 is Result.Error -> emptyList()
             }
         val notesByKey = notes.associateBy { it.key }
-        val currentRoleStr = item.role.toJsonString()
 
         // Build schema list with exists/filled status
         val schemaEntries =
@@ -166,7 +165,7 @@ Parameters:
                 val note = notesByKey[entry.key]
                 buildJsonObject {
                     put("key", JsonPrimitive(entry.key))
-                    put("role", JsonPrimitive(entry.role))
+                    put("role", JsonPrimitive(entry.role.toJsonString()))
                     put("required", JsonPrimitive(entry.required))
                     put("description", JsonPrimitive(entry.description))
                     entry.guidance?.let { put("guidance", JsonPrimitive(it)) }
@@ -214,7 +213,7 @@ Parameters:
                         // Terminal items can never advance; schema-free items always can; schema items need all notes filled
                         val isTerminal = item.role == Role.TERMINAL
                         put("canAdvance", JsonPrimitive(!isTerminal && missingForPhase.isEmpty()))
-                        put("phase", JsonPrimitive(currentRoleStr))
+                        put("phase", JsonPrimitive(item.role.toJsonString()))
                         put("missing", JsonArray(missingForPhase.map { JsonPrimitive(it) }))
                     }
                 )

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/NoteSchemaEntry.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/NoteSchemaEntry.kt
@@ -26,14 +26,14 @@ package io.github.jpicklyk.mcptask.current.domain.model
  * ```
  *
  * @property key Unique identifier for the note within a schema (e.g., "acceptance-criteria")
- * @property role Workflow phase this note belongs to: "queue", "work", or "review"
+ * @property role Workflow phase this note belongs to (QUEUE, WORK, or REVIEW)
  * @property required Whether this note must be filled before advancing past its phase
  * @property description Human-readable description of what the note should contain
  * @property guidance Optional detailed instructions for filling the note
  */
 data class NoteSchemaEntry(
     val key: String,
-    val role: String,
+    val role: Role,
     val required: Boolean = false,
     val description: String = "",
     val guidance: String? = null

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt
@@ -2,6 +2,7 @@ package io.github.jpicklyk.mcptask.current.infrastructure.config
 
 import io.github.jpicklyk.mcptask.current.application.service.NoteSchemaService
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.Role
 import org.slf4j.LoggerFactory
 import org.yaml.snakeyaml.Yaml
 import java.io.FileReader
@@ -75,19 +76,31 @@ class YamlNoteSchemaService(
         val key = raw["key"] as? String ?: return null
         val role = raw["role"] as? String ?: return null
 
-        if (role !in VALID_SCHEMA_ROLES) {
-            logger.warn("Skipping schema entry '{}': invalid role '{}' (valid: {})", key, role, VALID_SCHEMA_ROLES)
+        val parsedRole = VALID_SCHEMA_ROLES[role]
+        if (parsedRole == null) {
+            logger.warn("Skipping schema entry '{}': invalid role '{}' (valid: {})", key, role, VALID_SCHEMA_ROLES.keys)
             return null
         }
 
         val required = raw["required"] as? Boolean ?: false
         val description = raw["description"] as? String ?: ""
         val guidance = raw["guidance"] as? String
-        return NoteSchemaEntry(key = key, role = role, required = required, description = description, guidance = guidance)
+        return NoteSchemaEntry(
+            key = key,
+            role = parsedRole,
+            required = required,
+            description = description,
+            guidance = guidance,
+        )
     }
 
     companion object {
-        private val VALID_SCHEMA_ROLES = setOf("queue", "work", "review")
+        private val VALID_SCHEMA_ROLES =
+            mapOf(
+                "queue" to Role.QUEUE,
+                "work" to Role.WORK,
+                "review" to Role.REVIEW,
+            )
 
         fun resolveDefaultConfigPath(): java.nio.file.Path {
             val projectRoot =

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/PhaseNoteContextTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/PhaseNoteContextTest.kt
@@ -23,7 +23,7 @@ class PhaseNoteContextTest {
     fun `returns null for terminal items`() {
         val schema =
             listOf(
-                NoteSchemaEntry(key = "spec", role = "queue", required = true, guidance = "Write spec")
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, guidance = "Write spec")
             )
         val result = computePhaseNoteContext(Role.TERMINAL, schema, emptyMap())
         assertNull(result)
@@ -39,8 +39,8 @@ class PhaseNoteContextTest {
     fun `computes correct counts with no notes filled`() {
         val schema =
             listOf(
-                NoteSchemaEntry(key = "spec", role = "queue", required = true, guidance = "Write spec"),
-                NoteSchemaEntry(key = "design", role = "queue", required = true, guidance = "Write design")
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, guidance = "Write spec"),
+                NoteSchemaEntry(key = "design", role = Role.QUEUE, required = true, guidance = "Write design")
             )
         val result = computePhaseNoteContext(Role.QUEUE, schema, emptyMap())
 
@@ -56,9 +56,9 @@ class PhaseNoteContextTest {
     fun `computes correct counts with some notes filled`() {
         val schema =
             listOf(
-                NoteSchemaEntry(key = "spec", role = "queue", required = true, guidance = "Write spec"),
-                NoteSchemaEntry(key = "design", role = "queue", required = true, guidance = "Write design"),
-                NoteSchemaEntry(key = "risks", role = "queue", required = true, guidance = "List risks")
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, guidance = "Write spec"),
+                NoteSchemaEntry(key = "design", role = Role.QUEUE, required = true, guidance = "Write design"),
+                NoteSchemaEntry(key = "risks", role = Role.QUEUE, required = true, guidance = "List risks")
             )
         val notesByKey = mapOf("spec" to note("spec"))
         val result = computePhaseNoteContext(Role.QUEUE, schema, notesByKey)
@@ -75,7 +75,7 @@ class PhaseNoteContextTest {
     fun `all notes filled gives null guidancePointer`() {
         val schema =
             listOf(
-                NoteSchemaEntry(key = "spec", role = "queue", required = true, guidance = "Write spec")
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, guidance = "Write spec")
             )
         val notesByKey = mapOf("spec" to note("spec"))
         val result = computePhaseNoteContext(Role.QUEUE, schema, notesByKey)
@@ -92,7 +92,7 @@ class PhaseNoteContextTest {
     fun `blank body does not count as filled`() {
         val schema =
             listOf(
-                NoteSchemaEntry(key = "spec", role = "queue", required = true, guidance = "Write spec")
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, guidance = "Write spec")
             )
         val notesByKey = mapOf("spec" to note("spec", body = ""))
         val result = computePhaseNoteContext(Role.QUEUE, schema, notesByKey)
@@ -107,8 +107,8 @@ class PhaseNoteContextTest {
     fun `only considers notes for the current role`() {
         val schema =
             listOf(
-                NoteSchemaEntry(key = "spec", role = "queue", required = true, guidance = "Queue guidance"),
-                NoteSchemaEntry(key = "impl", role = "work", required = true, guidance = "Work guidance")
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, guidance = "Queue guidance"),
+                NoteSchemaEntry(key = "impl", role = Role.WORK, required = true, guidance = "Work guidance")
             )
         // Item is in WORK phase — should only consider work-role notes
         val result = computePhaseNoteContext(Role.WORK, schema, emptyMap())
@@ -125,8 +125,8 @@ class PhaseNoteContextTest {
     fun `non-required notes are excluded from counts`() {
         val schema =
             listOf(
-                NoteSchemaEntry(key = "spec", role = "queue", required = true, guidance = "Required"),
-                NoteSchemaEntry(key = "optional-notes", role = "queue", required = false, guidance = "Optional")
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, guidance = "Required"),
+                NoteSchemaEntry(key = "optional-notes", role = Role.QUEUE, required = false, guidance = "Optional")
             )
         val result = computePhaseNoteContext(Role.QUEUE, schema, emptyMap())
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeToolTest.kt
@@ -179,7 +179,7 @@ class CompleteTreeToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Acceptance criteria"
                     )
@@ -243,7 +243,7 @@ class CompleteTreeToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Acceptance criteria"
                     )
@@ -673,7 +673,7 @@ class CompleteTreeToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Acceptance criteria"
                     )
@@ -751,7 +751,7 @@ class CompleteTreeToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Acceptance criteria"
                     )
@@ -811,7 +811,7 @@ class CompleteTreeToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Acceptance criteria"
                     )
@@ -875,7 +875,7 @@ class CompleteTreeToolTest {
                             listOf(
                                 NoteSchemaEntry(
                                     key = "acceptance-criteria",
-                                    role = "queue",
+                                    role = Role.QUEUE,
                                     required = true,
                                     description = "AC"
                                 )

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolTest.kt
@@ -8,6 +8,7 @@ import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
 import io.github.jpicklyk.mcptask.current.application.tools.ToolValidationException
 import io.github.jpicklyk.mcptask.current.domain.model.Dependency
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.repository.RepositoryError
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
@@ -216,7 +217,7 @@ class CreateWorkTreeToolTest {
         runBlocking {
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "acceptance-criteria", role = "queue", required = true)
+                    NoteSchemaEntry(key = "acceptance-criteria", role = Role.QUEUE, required = true)
                 )
             val noteSchemaService =
                 object : NoteSchemaService {
@@ -696,14 +697,14 @@ class CreateWorkTreeToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Criteria for acceptance",
                         guidance = "List each criterion as a bullet"
                     ),
                     NoteSchemaEntry(
                         key = "implementation-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = false,
                         description = "Notes on implementation approach"
                     )
@@ -772,7 +773,7 @@ class CreateWorkTreeToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "test-plan",
-                        role = "review",
+                        role = Role.REVIEW,
                         required = true,
                         description = "Test plan for this child"
                     )

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsToolTest.kt
@@ -4,6 +4,7 @@ import io.github.jpicklyk.mcptask.current.application.service.NoteSchemaService
 import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
 import io.github.jpicklyk.mcptask.current.application.tools.ToolValidationException
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
@@ -376,11 +377,16 @@ class ManageItemsToolTest {
                             listOf(
                                 NoteSchemaEntry(
                                     key = "requirements",
-                                    role = "queue",
+                                    role = Role.QUEUE,
                                     required = true,
                                     description = "Requirements for this item"
                                 ),
-                                NoteSchemaEntry(key = "done-criteria", role = "work", required = true, description = "Definition of done")
+                                NoteSchemaEntry(
+                                    key = "done-criteria",
+                                    role = Role.WORK,
+                                    required = true,
+                                    description = "Definition of done"
+                                )
                             )
                         } else {
                             null
@@ -1346,7 +1352,7 @@ class ManageItemsToolTest {
                             listOf(
                                 NoteSchemaEntry(
                                     key = "requirements",
-                                    role = "queue",
+                                    role = Role.QUEUE,
                                     required = true,
                                     description = "Requirements for this item",
                                     guidance = "List all functional and non-functional requirements"
@@ -1399,7 +1405,7 @@ class ManageItemsToolTest {
                             listOf(
                                 NoteSchemaEntry(
                                     key = "requirements",
-                                    role = "queue",
+                                    role = Role.QUEUE,
                                     required = true,
                                     description = "Requirements for this item",
                                     guidance = null

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesToolTest.kt
@@ -503,8 +503,8 @@ class ManageNotesToolTest {
         runBlocking {
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "spec", role = "queue", required = true, guidance = "Write the spec"),
-                    NoteSchemaEntry(key = "design", role = "queue", required = true, guidance = "Write the design")
+                    NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, guidance = "Write the spec"),
+                    NoteSchemaEntry(key = "design", role = Role.QUEUE, required = true, guidance = "Write the design")
                 )
             val schemaContext = contextWithSchema(schemaEntries, "test-schema")
             val itemId = createTestItemWithTags(tags = "test-schema")
@@ -545,7 +545,7 @@ class ManageNotesToolTest {
         runBlocking {
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "spec", role = "queue", required = true, guidance = "Write the spec")
+                    NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, guidance = "Write the spec")
                 )
             val schemaContext = contextWithSchema(schemaEntries, "test-schema")
             val itemId = createTestItemWithTags(tags = "test-schema")
@@ -614,7 +614,7 @@ class ManageNotesToolTest {
         runBlocking {
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "spec", role = "queue", required = true, guidance = "Write the spec")
+                    NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, guidance = "Write the spec")
                 )
             val schemaContext = contextWithSchema(schemaEntries, "test-schema")
             val itemId = createTestItemWithTags(tags = "test-schema")
@@ -652,7 +652,7 @@ class ManageNotesToolTest {
         runBlocking {
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "spec", role = "queue", required = true, guidance = "Write the spec")
+                    NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, guidance = "Write the spec")
                 )
             val schemaContext = contextWithSchema(schemaEntries, "test-schema")
             val itemId1 = createTestItemWithTags(title = "Item 1", tags = "test-schema")
@@ -726,7 +726,7 @@ class ManageNotesToolTest {
         runBlocking {
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "spec", role = "queue", required = true, guidance = "Write the spec")
+                    NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, guidance = "Write the spec")
                 )
             val schemaContext = contextWithSchema(schemaEntries, "test-schema")
             val itemId = createTestItemWithTags(tags = "test-schema", role = Role.TERMINAL)
@@ -761,7 +761,7 @@ class ManageNotesToolTest {
         runBlocking {
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "spec", role = "queue", required = true, guidance = "Write the spec")
+                    NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, guidance = "Write the spec")
                 )
             val schemaContext = contextWithSchema(schemaEntries, "test-schema")
             val validItemId = createTestItemWithTags(tags = "test-schema")
@@ -806,9 +806,9 @@ class ManageNotesToolTest {
         runBlocking {
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "spec", role = "queue", required = true, guidance = "Write the spec"),
-                    NoteSchemaEntry(key = "design", role = "queue", required = true, guidance = "Write the design"),
-                    NoteSchemaEntry(key = "risks", role = "queue", required = true, guidance = "List the risks")
+                    NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, guidance = "Write the spec"),
+                    NoteSchemaEntry(key = "design", role = Role.QUEUE, required = true, guidance = "Write the design"),
+                    NoteSchemaEntry(key = "risks", role = Role.QUEUE, required = true, guidance = "List the risks")
                 )
             val schemaContext = contextWithSchema(schemaEntries, "test-schema")
             val itemId = createTestItemWithTags(tags = "test-schema")

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
@@ -994,13 +994,13 @@ class AdvanceItemToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Acceptance criteria"
                     ),
                     NoteSchemaEntry(
                         key = "implementation-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = true,
                         description = "Implementation notes"
                     )
@@ -1040,7 +1040,7 @@ class AdvanceItemToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Acceptance criteria"
                     )
@@ -1087,7 +1087,7 @@ class AdvanceItemToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Acceptance criteria"
                     )
@@ -1131,7 +1131,7 @@ class AdvanceItemToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Acceptance criteria"
                     )
@@ -1180,14 +1180,14 @@ class AdvanceItemToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Acceptance criteria for this task",
                         guidance = "List each criterion as a bullet point"
                     ),
                     NoteSchemaEntry(
                         key = "scope-definition",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Scope definition",
                         guidance = "Describe what is in and out of scope"
@@ -1237,7 +1237,7 @@ class AdvanceItemToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Acceptance criteria for this task",
                         guidance = null // no guidance
@@ -1281,14 +1281,14 @@ class AdvanceItemToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Acceptance criteria",
                         guidance = "List each criterion"
                     ),
                     NoteSchemaEntry(
                         key = "implementation-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = true,
                         description = "Implementation notes",
                         guidance = null
@@ -1424,21 +1424,21 @@ class AdvanceItemToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Acceptance criteria",
                         guidance = "List criteria"
                     ),
                     NoteSchemaEntry(
                         key = "design-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = true,
                         description = "Design notes",
                         guidance = "Do X"
                     ),
                     NoteSchemaEntry(
                         key = "implementation-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = true,
                         description = "Implementation notes",
                         guidance = "Do Y"
@@ -1494,21 +1494,21 @@ class AdvanceItemToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Acceptance criteria",
                         guidance = "List criteria"
                     ),
                     NoteSchemaEntry(
                         key = "design-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = true,
                         description = "Design notes",
                         guidance = "Do X"
                     ),
                     NoteSchemaEntry(
                         key = "implementation-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = true,
                         description = "Implementation notes",
                         guidance = "Do Y"
@@ -1569,14 +1569,14 @@ class AdvanceItemToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Acceptance criteria",
                         guidance = "List criteria"
                     ),
                     NoteSchemaEntry(
                         key = "design-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = true,
                         description = "Design notes",
                         guidance = "Do X"
@@ -1661,7 +1661,7 @@ class AdvanceItemToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "optional-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = false,
                         description = "Optional notes",
                         guidance = "Write if you want"

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolTest.kt
@@ -132,7 +132,12 @@ class GetContextToolTest {
 
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "implementation-notes", role = "work", required = true, description = "Notes on implementation")
+                    NoteSchemaEntry(
+                        key = "implementation-notes",
+                        role = Role.WORK,
+                        required = true,
+                        description = "Notes on implementation"
+                    )
                 )
             every { noteSchemaService.getSchemaForTags(listOf("feature-task")) } returns schemaEntries
 
@@ -175,7 +180,12 @@ class GetContextToolTest {
 
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "implementation-notes", role = "work", required = true, description = "Notes on implementation")
+                    NoteSchemaEntry(
+                        key = "implementation-notes",
+                        role = Role.WORK,
+                        required = true,
+                        description = "Notes on implementation"
+                    )
                 )
             every { noteSchemaService.getSchemaForTags(listOf("feature-task")) } returns schemaEntries
 
@@ -679,14 +689,14 @@ class GetContextToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "AC for the task",
                         guidance = "List each criterion as a bullet"
                     ),
                     NoteSchemaEntry(
                         key = "effort-estimate",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Estimate effort",
                         guidance = "Use T-shirt sizing: XS/S/M/L/XL"
@@ -720,14 +730,14 @@ class GetContextToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "AC for the task",
                         guidance = "List each criterion as a bullet"
                     ),
                     NoteSchemaEntry(
                         key = "effort-estimate",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Estimate effort",
                         guidance = "Use T-shirt sizing: XS/S/M/L/XL"
@@ -770,14 +780,14 @@ class GetContextToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "AC for the task",
                         guidance = "List each criterion as a bullet"
                     ),
                     NoteSchemaEntry(
                         key = "effort-estimate",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "Estimate effort",
                         guidance = "Use T-shirt sizing: XS/S/M/L/XL"
@@ -822,7 +832,7 @@ class GetContextToolTest {
                     // Queue phase note (filled — item advanced past queue)
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "AC",
                         guidance = "Queue-phase guidance — must NOT appear after advancing"
@@ -830,7 +840,7 @@ class GetContextToolTest {
                     // Work phase note (missing — should be the guidancePointer)
                     NoteSchemaEntry(
                         key = "implementation-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = true,
                         description = "Impl notes",
                         guidance = "Work-phase guidance — this should be the pointer"
@@ -880,14 +890,14 @@ class GetContextToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "AC",
                         guidance = "Queue guidance"
                     ),
                     NoteSchemaEntry(
                         key = "implementation-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = true,
                         description = "Impl",
                         guidance = "Work guidance"
@@ -954,7 +964,13 @@ class GetContextToolTest {
 
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "acceptance-criteria", role = "queue", required = true, description = "AC", guidance = "Guidance")
+                    NoteSchemaEntry(
+                        key = "acceptance-criteria",
+                        role = Role.QUEUE,
+                        required = true,
+                        description = "AC",
+                        guidance = "Guidance"
+                    )
                 )
             every { noteSchemaService.getSchemaForTags(listOf("feature-task")) } returns schemaEntries
 
@@ -992,7 +1008,7 @@ class GetContextToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "implementation-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = true,
                         description = "Impl notes",
                         guidance = "Write the implementation approach here"
@@ -1038,7 +1054,7 @@ class GetContextToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "implementation-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = true,
                         description = "Impl notes",
                         guidance = null
@@ -1076,7 +1092,7 @@ class GetContextToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "implementation-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = true,
                         description = "Impl notes",
                         guidance = "Describe the implementation"
@@ -1122,14 +1138,14 @@ class GetContextToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "implementation-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = true,
                         description = "Impl notes",
                         guidance = "First guidance"
                     ),
                     NoteSchemaEntry(
                         key = "effort-estimate",
-                        role = "work",
+                        role = Role.WORK,
                         required = true,
                         description = "Effort",
                         guidance = "Second guidance"
@@ -1182,7 +1198,7 @@ class GetContextToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "implementation-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = true,
                         description = "Impl",
                         guidance = "Write impl"
@@ -1236,7 +1252,7 @@ class GetContextToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "implementation-notes",
-                        role = "work",
+                        role = Role.WORK,
                         required = true,
                         description = "Impl",
                         guidance = "Write impl"
@@ -1281,7 +1297,7 @@ class GetContextToolTest {
                 listOf(
                     NoteSchemaEntry(
                         key = "acceptance-criteria",
-                        role = "queue",
+                        role = Role.QUEUE,
                         required = true,
                         description = "AC for the task",
                         guidance = null
@@ -1319,9 +1335,9 @@ class GetContextToolTest {
 
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "impl-notes", role = "work", required = true, description = "Impl notes"),
-                    NoteSchemaEntry(key = "design-notes", role = "work", required = true, description = "Design notes"),
-                    NoteSchemaEntry(key = "test-plan", role = "work", required = true, description = "Test plan")
+                    NoteSchemaEntry(key = "impl-notes", role = Role.WORK, required = true, description = "Impl notes"),
+                    NoteSchemaEntry(key = "design-notes", role = Role.WORK, required = true, description = "Design notes"),
+                    NoteSchemaEntry(key = "test-plan", role = Role.WORK, required = true, description = "Test plan")
                 )
             every { noteSchemaService.getSchemaForTags(listOf("feature-task")) } returns schemaEntries
 
@@ -1349,9 +1365,9 @@ class GetContextToolTest {
 
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "impl-notes", role = "work", required = true, description = "Impl notes"),
-                    NoteSchemaEntry(key = "design-notes", role = "work", required = true, description = "Design notes"),
-                    NoteSchemaEntry(key = "test-plan", role = "work", required = true, description = "Test plan")
+                    NoteSchemaEntry(key = "impl-notes", role = Role.WORK, required = true, description = "Impl notes"),
+                    NoteSchemaEntry(key = "design-notes", role = Role.WORK, required = true, description = "Design notes"),
+                    NoteSchemaEntry(key = "test-plan", role = Role.WORK, required = true, description = "Test plan")
                 )
             every { noteSchemaService.getSchemaForTags(listOf("feature-task")) } returns schemaEntries
 
@@ -1401,7 +1417,7 @@ class GetContextToolTest {
 
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "impl-notes", role = "work", required = true, description = "Impl notes")
+                    NoteSchemaEntry(key = "impl-notes", role = Role.WORK, required = true, description = "Impl notes")
                 )
             every { noteSchemaService.getSchemaForTags(listOf("feature-task")) } returns schemaEntries
 
@@ -1426,9 +1442,9 @@ class GetContextToolTest {
 
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "impl-notes", role = "work", required = true, description = "Impl notes"),
-                    NoteSchemaEntry(key = "design-notes", role = "work", required = true, description = "Design notes"),
-                    NoteSchemaEntry(key = "optional-context", role = "work", required = false, description = "Optional context")
+                    NoteSchemaEntry(key = "impl-notes", role = Role.WORK, required = true, description = "Impl notes"),
+                    NoteSchemaEntry(key = "design-notes", role = Role.WORK, required = true, description = "Design notes"),
+                    NoteSchemaEntry(key = "optional-context", role = Role.WORK, required = false, description = "Optional context")
                 )
             every { noteSchemaService.getSchemaForTags(listOf("feature-task")) } returns schemaEntries
 
@@ -1456,9 +1472,9 @@ class GetContextToolTest {
 
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "impl-notes", role = "work", required = true, description = "Impl notes"),
-                    NoteSchemaEntry(key = "review-checklist", role = "review", required = true, description = "Review checklist"),
-                    NoteSchemaEntry(key = "review-feedback", role = "review", required = true, description = "Review feedback")
+                    NoteSchemaEntry(key = "impl-notes", role = Role.WORK, required = true, description = "Impl notes"),
+                    NoteSchemaEntry(key = "review-checklist", role = Role.REVIEW, required = true, description = "Review checklist"),
+                    NoteSchemaEntry(key = "review-feedback", role = Role.REVIEW, required = true, description = "Review feedback")
                 )
             every { noteSchemaService.getSchemaForTags(listOf("feature-task")) } returns schemaEntries
 
@@ -1486,7 +1502,7 @@ class GetContextToolTest {
 
             val schemaEntries =
                 listOf(
-                    NoteSchemaEntry(key = "impl-notes", role = "work", required = true, description = "Impl notes")
+                    NoteSchemaEntry(key = "impl-notes", role = Role.WORK, required = true, description = "Impl notes")
                 )
             every { noteSchemaService.getSchemaForTags(listOf("feature-task")) } returns schemaEntries
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/SchemaGatedLifecycleTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/SchemaGatedLifecycleTest.kt
@@ -42,19 +42,19 @@ class SchemaGatedLifecycleTest {
                             listOf(
                                 NoteSchemaEntry(
                                     key = "specification",
-                                    role = "queue",
+                                    role = Role.QUEUE,
                                     required = true,
                                     description = "Problem statement, approach, and implementation plan."
                                 ),
                                 NoteSchemaEntry(
                                     key = "implementation-notes",
-                                    role = "work",
+                                    role = Role.WORK,
                                     required = true,
                                     description = "Context handoff for downstream agents."
                                 ),
                                 NoteSchemaEntry(
                                     key = "review-checklist",
-                                    role = "review",
+                                    role = Role.REVIEW,
                                     required = true,
                                     description = "Quality gate - plan alignment, test quality, and simplification review."
                                 )
@@ -63,19 +63,19 @@ class SchemaGatedLifecycleTest {
                             listOf(
                                 NoteSchemaEntry(
                                     key = "diagnosis",
-                                    role = "queue",
+                                    role = Role.QUEUE,
                                     required = true,
                                     description = "Reproduction, root cause, and fix approach."
                                 ),
                                 NoteSchemaEntry(
                                     key = "implementation-notes",
-                                    role = "work",
+                                    role = Role.WORK,
                                     required = true,
                                     description = "Context handoff for downstream agents."
                                 ),
                                 NoteSchemaEntry(
                                     key = "review-checklist",
-                                    role = "review",
+                                    role = Role.REVIEW,
                                     required = true,
                                     description = "Quality gate - fix alignment, test quality, and simplification review."
                                 )
@@ -85,40 +85,40 @@ class SchemaGatedLifecycleTest {
                                 // Queue phase: one required, one optional
                                 NoteSchemaEntry(
                                     key = "requirements",
-                                    role = "queue",
+                                    role = Role.QUEUE,
                                     required = true,
                                     description = "Required requirements."
                                 ),
-                                NoteSchemaEntry(key = "context", role = "queue", required = false, description = "Optional context."),
+                                NoteSchemaEntry(key = "context", role = Role.QUEUE, required = false, description = "Optional context."),
                                 // Work phase: one required, two optional
                                 NoteSchemaEntry(
                                     key = "design-decisions",
-                                    role = "work",
+                                    role = Role.WORK,
                                     required = true,
                                     description = "Required design decisions."
                                 ),
                                 NoteSchemaEntry(
                                     key = "alternatives",
-                                    role = "work",
+                                    role = Role.WORK,
                                     required = false,
                                     description = "Optional alternatives considered."
                                 ),
                                 NoteSchemaEntry(
                                     key = "open-questions",
-                                    role = "work",
+                                    role = Role.WORK,
                                     required = false,
                                     description = "Optional open questions."
                                 ),
                                 // Review phase: only optional (no required notes)
                                 NoteSchemaEntry(
                                     key = "review-notes",
-                                    role = "review",
+                                    role = Role.REVIEW,
                                     required = false,
                                     description = "Optional review observations."
                                 ),
                                 NoteSchemaEntry(
                                     key = "follow-ups",
-                                    role = "review",
+                                    role = Role.REVIEW,
                                     required = false,
                                     description = "Optional follow-up items."
                                 )
@@ -156,10 +156,10 @@ class SchemaGatedLifecycleTest {
     private suspend fun createNote(
         itemId: UUID,
         key: String,
-        role: String,
+        role: Role,
         body: String = "Filled content for $key"
     ): Note {
-        val note = Note(itemId = itemId, key = key, role = role, body = body)
+        val note = Note(itemId = itemId, key = key, role = role.name.lowercase(), body = body)
         val result = context.noteRepository().upsert(note)
         return (result as Result.Success).data
     }
@@ -264,7 +264,7 @@ class SchemaGatedLifecycleTest {
             assertGateRejection(start1, "specification")
 
             // Fill the queue-phase note
-            createNote(item.id, key = "specification", role = "queue")
+            createNote(item.id, key = "specification", role = Role.QUEUE)
 
             // Retry QUEUE -> WORK -> success
             val start2 =
@@ -283,7 +283,7 @@ class SchemaGatedLifecycleTest {
             assertGateRejection(start3, "implementation-notes")
 
             // Fill the work-phase note
-            createNote(item.id, key = "implementation-notes", role = "work")
+            createNote(item.id, key = "implementation-notes", role = Role.WORK)
 
             // Retry WORK -> REVIEW -> success
             val start4 =
@@ -302,7 +302,7 @@ class SchemaGatedLifecycleTest {
             assertGateRejection(start5, "review-checklist")
 
             // Fill the review-phase note
-            createNote(item.id, key = "review-checklist", role = "review")
+            createNote(item.id, key = "review-checklist", role = Role.REVIEW)
 
             // Retry REVIEW -> TERMINAL -> success
             val start6 =
@@ -335,7 +335,7 @@ class SchemaGatedLifecycleTest {
             assertGateRejection(start1, "diagnosis")
 
             // Fill the queue-phase note
-            createNote(item.id, key = "diagnosis", role = "queue")
+            createNote(item.id, key = "diagnosis", role = Role.QUEUE)
 
             // Retry QUEUE -> WORK -> success
             val start2 =
@@ -354,7 +354,7 @@ class SchemaGatedLifecycleTest {
             assertGateRejection(start3, "implementation-notes")
 
             // Fill the work-phase note
-            createNote(item.id, key = "implementation-notes", role = "work")
+            createNote(item.id, key = "implementation-notes", role = Role.WORK)
 
             // Retry WORK -> REVIEW -> success
             val start4 =
@@ -373,7 +373,7 @@ class SchemaGatedLifecycleTest {
             assertGateRejection(start5, "review-checklist")
 
             // Fill the review-phase note
-            createNote(item.id, key = "review-checklist", role = "review")
+            createNote(item.id, key = "review-checklist", role = Role.REVIEW)
 
             // Retry REVIEW -> TERMINAL -> success
             val start6 =
@@ -428,7 +428,7 @@ class SchemaGatedLifecycleTest {
             val item = createItem("Feature with empty note", tags = "feature-implementation")
 
             // Create a note with empty body
-            createNote(item.id, key = "specification", role = "queue", body = "")
+            createNote(item.id, key = "specification", role = Role.QUEUE, body = "")
 
             // Attempt QUEUE -> WORK -> gate rejection (empty body should not satisfy)
             val start1 =
@@ -457,7 +457,7 @@ class SchemaGatedLifecycleTest {
             assertGateRejection(complete1, "specification")
 
             // Fill only the queue-phase note
-            createNote(item.id, key = "specification", role = "queue")
+            createNote(item.id, key = "specification", role = Role.QUEUE)
 
             // Attempt complete again -> still fails (work and review notes missing)
             val complete2 =
@@ -468,8 +468,8 @@ class SchemaGatedLifecycleTest {
             assertGateRejection(complete2, "implementation-notes")
 
             // Fill all 3 notes
-            createNote(item.id, key = "implementation-notes", role = "work")
-            createNote(item.id, key = "review-checklist", role = "review")
+            createNote(item.id, key = "implementation-notes", role = Role.WORK)
+            createNote(item.id, key = "review-checklist", role = Role.REVIEW)
 
             // Attempt complete -> succeeds, role is TERMINAL
             val complete3 =
@@ -499,7 +499,7 @@ class SchemaGatedLifecycleTest {
             val child = createItem("Child feature", tags = "feature-implementation", parentId = parent.id)
 
             // Fill child's queue-phase note so it can advance
-            createNote(child.id, key = "specification", role = "queue")
+            createNote(child.id, key = "specification", role = Role.QUEUE)
 
             // Advance child: queue -> work (should cascade parent: queue -> work)
             val result =
@@ -539,7 +539,7 @@ class SchemaGatedLifecycleTest {
 
             // Child with schema tag
             val child = createItem("Schema child", tags = "feature-implementation", parentId = parent.id)
-            createNote(child.id, key = "specification", role = "queue")
+            createNote(child.id, key = "specification", role = Role.QUEUE)
 
             // Advance child: should cascade parent to WORK
             // The cascade trigger is "cascade" not "start", so the gate check at line 196
@@ -565,7 +565,7 @@ class SchemaGatedLifecycleTest {
         runBlocking {
             // Item A: has spec note filled (should pass gate)
             val itemA = createItem("Batch item A", tags = "feature-implementation")
-            createNote(itemA.id, key = "specification", role = "queue")
+            createNote(itemA.id, key = "specification", role = Role.QUEUE)
 
             // Item B: missing spec note (should fail gate)
             val itemB = createItem("Batch item B", tags = "feature-implementation")
@@ -637,7 +637,7 @@ class SchemaGatedLifecycleTest {
             assertEquals(Role.QUEUE, getItem(parent.id).role) // no cascade on failure
 
             // Step 2: Fill spec, advance queue→work (cascades parent)
-            createNote(child.id, key = "specification", role = "queue")
+            createNote(child.id, key = "specification", role = Role.QUEUE)
             val r2 =
                 transitionTool.execute(
                     buildTransitionParams(transitionObj(child.id, "start")),
@@ -659,7 +659,7 @@ class SchemaGatedLifecycleTest {
             assertEquals(Role.WORK, getItem(child.id).role) // unchanged
 
             // Step 4: Fill impl notes, advance work→review
-            createNote(child.id, key = "implementation-notes", role = "work")
+            createNote(child.id, key = "implementation-notes", role = Role.WORK)
             val r4 =
                 transitionTool.execute(
                     buildTransitionParams(transitionObj(child.id, "start")),
@@ -680,7 +680,7 @@ class SchemaGatedLifecycleTest {
             assertEquals(Role.REVIEW, getItem(child.id).role) // unchanged
 
             // Step 6: Fill review note, advance review→terminal
-            createNote(child.id, key = "review-checklist", role = "review")
+            createNote(child.id, key = "review-checklist", role = Role.REVIEW)
             val r6 =
                 transitionTool.execute(
                     buildTransitionParams(transitionObj(child.id, "start")),
@@ -707,7 +707,7 @@ class SchemaGatedLifecycleTest {
             // Rapid sequence: fill + advance, fill + advance, fill + advance
             // No pause between operations — tests that responses stay consistent
 
-            createNote(item.id, key = "diagnosis", role = "queue")
+            createNote(item.id, key = "diagnosis", role = Role.QUEUE)
             val r1 =
                 transitionTool.execute(
                     buildTransitionParams(transitionObj(item.id, "start")),
@@ -716,7 +716,7 @@ class SchemaGatedLifecycleTest {
             assertTransitionSuccess(r1, "work")
             assertResponseMatchesDb(r1, item.id)
 
-            createNote(item.id, key = "implementation-notes", role = "work")
+            createNote(item.id, key = "implementation-notes", role = Role.WORK)
             val r2 =
                 transitionTool.execute(
                     buildTransitionParams(transitionObj(item.id, "start")),
@@ -725,7 +725,7 @@ class SchemaGatedLifecycleTest {
             assertTransitionSuccess(r2, "review")
             assertResponseMatchesDb(r2, item.id)
 
-            createNote(item.id, key = "review-checklist", role = "review")
+            createNote(item.id, key = "review-checklist", role = Role.REVIEW)
             val r3 =
                 transitionTool.execute(
                     buildTransitionParams(transitionObj(item.id, "start")),
@@ -752,8 +752,8 @@ class SchemaGatedLifecycleTest {
             val untagged = createItem("Untagged child", parentId = parent.id)
 
             // Fill required notes for each
-            createNote(feature.id, key = "specification", role = "queue")
-            createNote(bugfix.id, key = "diagnosis", role = "queue")
+            createNote(feature.id, key = "specification", role = Role.QUEUE)
+            createNote(bugfix.id, key = "diagnosis", role = Role.QUEUE)
 
             // Batch advance all three children: queue → work
             val r1 =
@@ -796,15 +796,15 @@ class SchemaGatedLifecycleTest {
             assertEquals(Role.WORK, getItem(parent.id).role)
 
             // Complete feature child through full lifecycle
-            createNote(feature.id, key = "implementation-notes", role = "work")
+            createNote(feature.id, key = "implementation-notes", role = Role.WORK)
             transitionTool.execute(buildTransitionParams(transitionObj(feature.id, "start")), context) // → review
-            createNote(feature.id, key = "review-checklist", role = "review")
+            createNote(feature.id, key = "review-checklist", role = Role.REVIEW)
             transitionTool.execute(buildTransitionParams(transitionObj(feature.id, "start")), context) // → terminal
 
             // Complete bugfix child through full lifecycle
-            createNote(bugfix.id, key = "implementation-notes", role = "work")
+            createNote(bugfix.id, key = "implementation-notes", role = Role.WORK)
             transitionTool.execute(buildTransitionParams(transitionObj(bugfix.id, "start")), context) // → review
-            createNote(bugfix.id, key = "review-checklist", role = "review")
+            createNote(bugfix.id, key = "review-checklist", role = Role.REVIEW)
             val rLast =
                 transitionTool.execute(
                     buildTransitionParams(transitionObj(bugfix.id, "start")),
@@ -842,7 +842,7 @@ class SchemaGatedLifecycleTest {
             assertEquals(Role.QUEUE, getItem(item.id).role)
 
             // Fill only the required note (skip optional "context")
-            createNote(item.id, key = "requirements", role = "queue")
+            createNote(item.id, key = "requirements", role = Role.QUEUE)
 
             // Advance should succeed — optional "context" note is NOT required
             val r2 =
@@ -866,12 +866,12 @@ class SchemaGatedLifecycleTest {
             val item = createItem("Optional review item", tags = "mixed-schema")
 
             // Fill required queue note and advance to work
-            createNote(item.id, key = "requirements", role = "queue")
+            createNote(item.id, key = "requirements", role = Role.QUEUE)
             transitionTool.execute(buildTransitionParams(transitionObj(item.id, "start")), context)
             assertEquals(Role.WORK, getItem(item.id).role)
 
             // Fill required work note and advance to review
-            createNote(item.id, key = "design-decisions", role = "work")
+            createNote(item.id, key = "design-decisions", role = Role.WORK)
             transitionTool.execute(buildTransitionParams(transitionObj(item.id, "start")), context)
             assertEquals(Role.REVIEW, getItem(item.id).role)
 
@@ -906,8 +906,8 @@ class SchemaGatedLifecycleTest {
             assertGateRejection(r1, "requirements")
 
             // Fill only the two required notes (skip all optional)
-            createNote(item.id, key = "requirements", role = "queue")
-            createNote(item.id, key = "design-decisions", role = "work")
+            createNote(item.id, key = "requirements", role = Role.QUEUE)
+            createNote(item.id, key = "design-decisions", role = Role.WORK)
 
             // Complete should succeed — no required notes in review phase
             val r2 =
@@ -931,7 +931,7 @@ class SchemaGatedLifecycleTest {
             val item = createItem("Optional not enough", tags = "mixed-schema")
 
             // Fill only the optional queue note, skip the required one
-            createNote(item.id, key = "context", role = "queue", body = "Optional context filled")
+            createNote(item.id, key = "context", role = Role.QUEUE, body = "Optional context filled")
 
             // Advance should still fail — "requirements" (required) is missing
             val r =
@@ -1053,9 +1053,9 @@ class SchemaGatedLifecycleTest {
         runBlocking {
             // Parent with schema tag — fill ALL required notes upfront
             val parent = createItem("Fully noted parent", tags = "feature-implementation")
-            createNote(parent.id, key = "specification", role = "queue")
-            createNote(parent.id, key = "implementation-notes", role = "work")
-            createNote(parent.id, key = "review-checklist", role = "review")
+            createNote(parent.id, key = "specification", role = Role.QUEUE)
+            createNote(parent.id, key = "implementation-notes", role = Role.WORK)
+            createNote(parent.id, key = "review-checklist", role = Role.REVIEW)
 
             // Single child (schema-free)
             val child = createItem("Only child", parentId = parent.id)
@@ -1090,7 +1090,7 @@ class SchemaGatedLifecycleTest {
         runBlocking {
             // Parent with schema tag — fill only ONE of three required notes
             val parent = createItem("Partial parent", tags = "feature-implementation")
-            createNote(parent.id, key = "specification", role = "queue")
+            createNote(parent.id, key = "specification", role = Role.QUEUE)
             // Missing: implementation-notes, review-checklist
 
             // Single child (schema-free)

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaServiceTest.kt
@@ -1,5 +1,6 @@
 package io.github.jpicklyk.mcptask.current.infrastructure.config
 
+import io.github.jpicklyk.mcptask.current.domain.model.Role
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.Test
@@ -60,7 +61,7 @@ note_schemas:
         assertNotNull(schema)
         assertEquals(1, schema.size)
         assertEquals("acceptance-criteria", schema[0].key)
-        assertEquals("queue", schema[0].role)
+        assertEquals(Role.QUEUE, schema[0].role)
         assertEquals(true, schema[0].required)
         assertEquals("Acceptance criteria", schema[0].description)
     }
@@ -193,9 +194,9 @@ note_schemas:
         assertNotNull(schema)
         assertEquals(2, schema.size)
         assertEquals("note-one", schema[0].key)
-        assertEquals("queue", schema[0].role)
+        assertEquals(Role.QUEUE, schema[0].role)
         assertEquals("note-two", schema[1].key)
-        assertEquals("work", schema[1].role)
+        assertEquals(Role.WORK, schema[1].role)
         assertEquals("Detailed guidance here", schema[1].guidance)
     }
 
@@ -252,7 +253,7 @@ note_schemas:
         assertNotNull(schema)
         assertEquals(1, schema.size)
         assertEquals("good-note", schema[0].key)
-        assertEquals("queue", schema[0].role)
+        assertEquals(Role.QUEUE, schema[0].role)
     }
 
     @Test
@@ -311,9 +312,9 @@ note_schemas:
         assertNotNull(schema)
         assertEquals(2, schema.size)
         assertEquals("implementation-notes", schema[0].key)
-        assertEquals("work", schema[0].role)
+        assertEquals(Role.WORK, schema[0].role)
         assertEquals("review-checklist", schema[1].key)
-        assertEquals("review", schema[1].role)
+        assertEquals(Role.REVIEW, schema[1].role)
     }
 
     @Test

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/test/TestNoteSchemaService.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/test/TestNoteSchemaService.kt
@@ -2,6 +2,7 @@ package io.github.jpicklyk.mcptask.current.test
 
 import io.github.jpicklyk.mcptask.current.application.service.NoteSchemaService
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.Role
 
 /**
  * Test-only NoteSchemaService backed by an in-memory map.
@@ -21,15 +22,25 @@ class TestNoteSchemaService(
                 mapOf(
                     "feature-implementation" to
                         listOf(
-                            NoteSchemaEntry(key = "requirements", role = "queue", required = true, description = "Functional requirements"),
-                            NoteSchemaEntry(key = "design", role = "queue", required = true, description = "Design decisions"),
+                            NoteSchemaEntry(
+                                key = "requirements",
+                                role = Role.QUEUE,
+                                required = true,
+                                description = "Functional requirements",
+                            ),
+                            NoteSchemaEntry(
+                                key = "design",
+                                role = Role.QUEUE,
+                                required = true,
+                                description = "Design decisions",
+                            ),
                             NoteSchemaEntry(
                                 key = "implementation-notes",
-                                role = "work",
+                                role = Role.WORK,
                                 required = true,
                                 description = "Implementation details"
                             ),
-                            NoteSchemaEntry(key = "review-checklist", role = "review", required = true, description = "Review findings")
+                            NoteSchemaEntry(key = "review-checklist", role = Role.REVIEW, required = true, description = "Review findings")
                         )
                 )
             )
@@ -42,25 +53,25 @@ class TestNoteSchemaService(
                         listOf(
                             NoteSchemaEntry(
                                 key = "task-scope",
-                                role = "queue",
+                                role = Role.QUEUE,
                                 required = true,
                                 description = "What to build — target files, acceptance criteria, constraints"
                             ),
                             NoteSchemaEntry(
                                 key = "implementation-notes",
-                                role = "work",
+                                role = Role.WORK,
                                 required = true,
                                 description = "Context handoff — deviations, surprises, decisions"
                             ),
                             NoteSchemaEntry(
                                 key = "review-checklist",
-                                role = "review",
+                                role = Role.REVIEW,
                                 required = true,
                                 description = "Task-level quality gate — scope alignment and test coverage"
                             ),
                             NoteSchemaEntry(
                                 key = "session-tracking",
-                                role = "work",
+                                role = Role.WORK,
                                 required = true,
                                 description = "Session context for retrospective"
                             )
@@ -74,8 +85,18 @@ class TestNoteSchemaService(
                 mapOf(
                     "bug-fix" to
                         listOf(
-                            NoteSchemaEntry(key = "root-cause", role = "queue", required = true, description = "Root cause analysis"),
-                            NoteSchemaEntry(key = "fix-details", role = "work", required = true, description = "Fix implementation details")
+                            NoteSchemaEntry(
+                                key = "root-cause",
+                                role = Role.QUEUE,
+                                required = true,
+                                description = "Root cause analysis",
+                            ),
+                            NoteSchemaEntry(
+                                key = "fix-details",
+                                role = Role.WORK,
+                                required = true,
+                                description = "Fix implementation details",
+                            )
                         )
                 )
             )


### PR DESCRIPTION
## Summary

- Changed `NoteSchemaEntry.role` from `String` to `Role` enum, eliminating stringly-typed comparisons across the schema gate layer
- Parse-time conversion in `YamlNoteSchemaService` now maps validated strings to `Role` values
- All comparison sites use direct enum equality instead of `role.name.lowercase()` intermediaries
- JSON serialization sites use `entry.role.toJsonString()` for wire format

## Test Results

- 1240+ tests passing
- ktlint clean
- No migrations required

## MCP Items

- `b938fe1f` — [optimization] Stringly-typed role comparisons (completed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)