### PR TITLE
docs(workflow): add repo-local authority evidence pack

### DIFF
--- a/pm-workflow-pack/00-scan-scope-and-method.md
+++ b/pm-workflow-pack/00-scan-scope-and-method.md
@@ -1,0 +1,148 @@
+# PM Workflow Pack: Scan Scope and Method
+
+## Scope
+
+This pack was produced from repo-local evidence in `/Users/hue/code/task-orchestrator` only.
+
+Primary directories searched:
+- `current/src/main/kotlin`
+- `current/src/main/resources`
+- `current/src/test/kotlin`
+- `current/docs`
+- `clockwork/src/main/kotlin`
+- `clockwork/src/test/kotlin`
+- `clockwork/docs`
+- `claude-plugins/task-orchestrator`
+- `.claude-plugin`
+- `scripts`
+- `.github`
+
+Primary runtime/config selectors inspected:
+- `settings.gradle.kts`
+- `build.gradle.kts`
+- `docker-compose.yml`
+- `Dockerfile`
+- `scripts/docker-build.sh`
+- `CLAUDE.md`
+- `AGENTS.md`
+
+## Commands Used
+
+Representative inspection commands:
+
+```bash
+git branch --show-current
+git rev-parse HEAD
+git status --short
+
+rg --files current/src/main/kotlin current/src/main/resources current/src/test/kotlin \
+  clockwork/src/main/kotlin clockwork/src/test/kotlin \
+  claude-plugins/task-orchestrator .claude-plugin scripts .github
+
+nl -ba settings.gradle.kts | sed -n '1,40p'
+nl -ba build.gradle.kts | sed -n '1,40p'
+nl -ba docker-compose.yml | sed -n '1,140p'
+nl -ba Dockerfile | sed -n '1,160p'
+nl -ba scripts/docker-build.sh | sed -n '1,140p'
+
+nl -ba current/src/main/kotlin/.../CurrentMain.kt | sed -n '9,46p'
+nl -ba current/src/main/kotlin/.../CurrentMcpServer.kt | sed -n '38,223p'
+nl -ba current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql | sed -n '1,140p'
+nl -ba current/src/main/resources/db/migration/V2__Work_Item_Field_Updates.sql | sed -n '1,140p'
+
+nl -ba current/src/main/kotlin/.../RoleTransitionHandler.kt | sed -n '74,370p'
+nl -ba current/src/main/kotlin/.../AdvanceItemTool.kt | sed -n '120,387p'
+nl -ba current/src/main/kotlin/.../GetNextItemTool.kt | sed -n '77,225p'
+nl -ba current/src/main/kotlin/.../GetBlockedItemsTool.kt | sed -n '101,310p'
+nl -ba current/src/main/kotlin/.../GetNextStatusTool.kt | sed -n '60,141p'
+nl -ba current/src/main/kotlin/.../GetContextTool.kt | sed -n '106,400p'
+nl -ba current/src/main/kotlin/.../ManageItemsTool.kt | sed -n '163,520p'
+nl -ba current/src/main/kotlin/.../ManageNotesTool.kt | sed -n '128,280p'
+nl -ba current/src/main/kotlin/.../ManageDependenciesTool.kt | sed -n '241,340p'
+nl -ba current/src/main/kotlin/.../CompleteTreeTool.kt | sed -n '160,340p'
+nl -ba current/src/main/kotlin/.../CreateWorkTreeTool.kt | sed -n '13,307p'
+nl -ba current/src/main/kotlin/.../SQLiteWorkTreeService.kt | sed -n '23,166p'
+
+nl -ba clockwork/DEPRECATED.md | sed -n '1,140p'
+nl -ba clockwork/src/main/kotlin/Main.kt | sed -n '1,102p'
+nl -ba clockwork/src/main/kotlin/.../McpServer.kt | sed -n '108,319p'
+nl -ba clockwork/src/main/kotlin/.../RequestTransitionTool.kt | sed -n '21,160p'
+nl -ba clockwork/src/main/kotlin/.../QueryRoleTransitionsTool.kt | sed -n '14,140p'
+```
+
+Negative-evidence searches are recorded in `99-evidence-index.md`.
+
+## Search Terms
+
+Targeted search terms included:
+- `role`, `status`, `transition`, `advance_item`, `request_transition`
+- `blocked`, `dependency`, `unblockAt`, `get_next_item`, `get_blocked_items`
+- `note`, `schema`, `guidancePointer`, `get_context`
+- `decision`, `progress`, `comment`, `chronicle`, `timeline`, `event store`
+- `CurrentMcpServer`, `CurrentMain`, `clockwork`, `runtime-v2`, `runtime-current`
+- `AGENT_CONFIG_DIR`, `.taskorchestrator/config.yaml`, `default-config.yaml`
+
+## Files and Types Inspected
+
+File types inspected:
+- Kotlin runtime code (`.kt`)
+- SQL migrations (`.sql`)
+- Markdown docs and runbooks (`.md`)
+- JSON plugin/hook config (`.json`)
+- Shell scripts (`.sh`)
+- GitHub workflow YAML (`.yml`)
+
+Priority order during inspection:
+1. Runtime/build selectors
+2. Active module code under `current/`
+3. Database schema and repositories
+4. Tests covering workflow behavior
+5. Archived `clockwork/` code for variant analysis
+6. Plugin/hook/config docs for exposed seams
+
+## Runtime / Config Selectors Examined
+
+Selectors used to determine active vs archived paths:
+- `settings.gradle.kts:6-10`
+- `build.gradle.kts:1-3`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/CurrentMain.kt:10-12`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt:41-45`
+- `clockwork/DEPRECATED.md:3-5,73`
+- `docker-compose.yml:2-24,36-102`
+- `Dockerfile:31-33,82-92`
+- `scripts/docker-build.sh:5-13,57-68`
+
+## Limitations
+
+- The active/current implementation was inspected statically; no server process was started.
+- Targeted Gradle tests were attempted but not executed successfully:
+
+```bash
+./gradlew :current:test --tests "*RoleTransitionHandlerTest" --tests "*SchemaGatedLifecycleTest" \
+  --tests "*GetNextItemToolTest" --tests "*GetBlockedItemsToolTest" --tests "*GetContextToolTest"
+```
+
+Observed failure:
+- `./gradlew` was not executable in this environment.
+
+Retry:
+
+```bash
+bash ./gradlew :current:test --tests "*RoleTransitionHandlerTest" --tests "*SchemaGatedLifecycleTest" \
+  --tests "*GetNextItemToolTest" --tests "*GetBlockedItemsToolTest" --tests "*GetContextToolTest"
+```
+
+Observed failure:
+- no Java runtime was installed (`Unable to locate a Java Runtime.`)
+
+- `AGENTS.md` is untracked in this checkout, but it was still repo-local and inspected as local guidance, not as higher authority than code.
+
+## Negative-Evidence Method
+
+Negative claims in this pack use this method:
+- define a bounded scan scope
+- run explicit `rg` queries against that scope
+- record exact commands and results in `99-evidence-index.md`
+- label the result as `absent/no evidence found`, not as impossibility
+
+Where code and docs disagree, code/build/runtime selectors were treated as higher authority than prose.

--- a/pm-workflow-pack/01-entity-and-persistence-model.md
+++ b/pm-workflow-pack/01-entity-and-persistence-model.md
@@ -1,0 +1,65 @@
+# PM Workflow Pack: Entity and Persistence Model
+
+## Active Baseline
+
+`Implemented behavior:` the root Gradle selectors mark `:current` as the active module and `:clockwork` as archived, so the entity/persistence model below is grounded first in `current/`. `settings.gradle.kts:6-10`, `build.gradle.kts:1-3`
+
+## Core Workflow Entities
+
+### 1. WorkItem
+
+`Implemented behavior:` `WorkItem` is the core persisted workflow object. It stores hierarchy (`parentId`, `depth`), canonical workflow state (`role`), optional display state (`statusLabel`), suspension state (`previousRole`), prioritization (`priority`, `complexity`), verification flag (`requiresVerification`), metadata/tags, timestamps, and an optimistic-lock version. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/WorkItem.kt:7-25`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/Role.kt:4-6`, `current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql:4-25`, `current/src/main/resources/db/migration/V2__Work_Item_Field_Updates.sql:4-26`
+
+`Implemented behavior:` the Exposed table definition matches the migration-level fields, including `requires_verification`, `role_changed_at`, and `version`. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/WorkItemsTable.kt:6-32`
+
+`Implemented behavior:` repository reads/writes for `WorkItem` are centralized through `WorkItemRepository`, with create/update/delete, filter queries, tree queries, and ancestor-chain lookup. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt:9-98`
+
+`Implemented behavior:` the active MCP server exposes both direct CRUD surfaces and workflow surfaces over `WorkItem` state by registering `manage_items`, `query_items`, `advance_item`, `get_next_status`, `get_next_item`, `get_blocked_items`, `complete_tree`, `create_work_tree`, and `get_context`. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt:87-110,220`
+
+### 2. Note
+
+`Implemented behavior:` `Note` is a role-scoped accountability artifact attached to a `WorkItem`. It is unique by `(itemId, key)` and constrained to `queue`, `work`, or `review` roles. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/Note.kt:7-12,13-33`
+
+`Implemented behavior:` notes are persisted in a dedicated `notes` table with timestamps and a unique index on `(work_item_id, key)`. `current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql:33-46`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/NotesTable.kt:7-20`
+
+`Implemented behavior:` note persistence is exposed through `NoteRepository`, including upsert, delete, per-item queries, and batch lookup by item IDs. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/NoteRepository.kt:6-13`
+
+`Implemented behavior:` the active write surface for notes is `manage_notes`, which validates `itemId` existence before upsert and preserves existing note IDs on `(itemId, key)` collisions. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesTool.kt:128-177`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepository.kt:39-74`
+
+### 3. Dependency
+
+`Implemented behavior:` `Dependency` is a directed edge between `WorkItem`s. It supports `BLOCKS`, `IS_BLOCKED_BY`, and `RELATES_TO`, and can carry an `unblockAt` threshold for blocking semantics. Self-loops and invalid thresholds are rejected in the domain model. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/Dependency.kt:7-19,25-46`
+
+`Implemented behavior:` dependencies are persisted in a dedicated `dependencies` table with uniqueness on `(from_item_id, to_item_id, type)`. `current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql:48-61`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/DependenciesTable.kt:7-20`
+
+`Implemented behavior:` dependency persistence is exposed through `DependencyRepository`, including single writes, batch writes, graph lookup, delete, and cycle checks. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/DependencyRepository.kt:6-30`
+
+`Implemented behavior:` `manage_dependencies` is the active external write surface. It routes creates into `createBatch`, which applies duplicate and cycle validation atomically. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/dependency/ManageDependenciesTool.kt:12-21,241-296`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteDependencyRepository.kt:35-60,97-149,151-202`
+
+### 4. RoleTransition
+
+`Implemented behavior:` `RoleTransition` is a persisted audit record for workflow state changes. It stores `fromRole`, `toRole`, optional status labels, the trigger, summary, and the transition timestamp. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/RoleTransition.kt:6-23`
+
+`Implemented behavior:` the audit records are stored in a dedicated `role_transitions` table with indexes by item and time. `current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql:63-77`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/RoleTransitionsTable.kt:7-21`
+
+`Implemented behavior:` the repository surface supports create, per-item reads, time-range reads, `findSince`, and delete-by-item. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/RoleTransitionRepository.kt:7-12`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteRoleTransitionRepository.kt:27-40,46-54,87-103`
+
+## Relationships
+
+`Implemented behavior:` `WorkItem` is self-referential through `parentId`, which creates a bounded depth hierarchy rather than separate project/feature/task tables in the active/current module. `current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql:4-25`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt:21-23,27-29,192-247`
+
+`Implemented behavior:` `Note`, `Dependency`, and `RoleTransition` all reference `WorkItem` rows directly; notes and role transitions are deleted on item deletion, and dependencies cascade on either endpoint deletion. `current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql:33-77`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/NotesTable.kt:15-20`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/DependenciesTable.kt:14-20`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/RoleTransitionsTable.kt:17-20`
+
+## Readers and Writers
+
+`Implemented behavior:` the active/current tool layer reaches persistence through `ToolExecutionContext`, which exposes typed repository access for work items, notes, dependencies, role transitions, note schemas, and atomic work-tree execution. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt:12-44`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/RepositoryProvider.kt:9-20`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/DefaultRepositoryProvider.kt:18-31`
+
+`Implemented behavior:` the canonical SQLite-backed implementations are wired by `DefaultRepositoryProvider`, so `current` owns direct persistence for all four core entity types in the active runtime. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/DefaultRepositoryProvider.kt:18-31`
+
+`Inferred capability:` because `create_work_tree` delegates to `WorkTreeExecutor`, and `DefaultRepositoryProvider` binds that interface to `SQLiteWorkTreeService`, the active/current module also owns an atomic multi-entity writer that can create items, dependencies, and notes in one transaction. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt:292-307`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/WorkTreeExecutor.kt:33-39`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/DefaultRepositoryProvider.kt:24-31`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/service/SQLiteWorkTreeService.kt:26-33,38-130`
+
+## Absent / No Evidence Found
+
+`Absent/no evidence found:` no separate `Comment` entity or `CommentRepository` was found in the active/current scan scope (`current/src/main/kotlin`, `current/src/main/resources`, `current/src/test/kotlin`). Search: `rg -n --ignore-case 'class Comment|data class Comment|CommentRepository|comments table|comment_id' current/src/main/kotlin current/src/main/resources current/src/test/kotlin` returned no matches. See `99-evidence-index.md`, negative search `N2`.
+
+`Absent/no evidence found:` no dedicated decision or progress persistence layer was found in the active/current scan scope. Search: `rg -n --ignore-case 'decision_id|decision table|progress table|progress record|decision record|decision repository|progress repository' current/src/main/kotlin current/src/main/resources current/src/test/kotlin` returned no matches. See `99-evidence-index.md`, negative search `N1`.

--- a/pm-workflow-pack/02-workflow-legality-and-transition-analysis.md
+++ b/pm-workflow-pack/02-workflow-legality-and-transition-analysis.md
@@ -1,0 +1,61 @@
+# PM Workflow Pack: Workflow Legality and Transition Analysis
+
+## Repo-Local Verdict
+
+`Implemented behavior:` the active/current module implements a real workflow legality layer. The legality model is explicit in code: resolve trigger to target role, validate the move against dependency gates, then apply the state change and persist an audit record. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandler.kt:53-63,81-188,199-273,306-370`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt:121-265`
+
+`Implemented behavior:` that legality layer is not the only writer. The same repository also exposes direct mutation paths that can change `role` and `statusLabel` without going through transition validation or transition-audit recording. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt:181-187,249-288,361-516`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt:81-118`
+
+## State Model and Transition Rules
+
+`Implemented behavior:` the canonical active/current workflow roles are `QUEUE`, `WORK`, `REVIEW`, `BLOCKED`, and `TERMINAL`. The code treats roles as canonical state, treats statuses as optional display labels, defines sequential progression as `QUEUE -> WORK -> REVIEW -> TERMINAL`, and treats `BLOCKED` as orthogonal. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/Role.kt:3-31`
+
+`Implemented behavior:` validated trigger handling supports `start`, `complete`, `block`, `hold`, `resume`, and `cancel`. `start` moves `QUEUE -> WORK`, `WORK -> REVIEW` or `WORK -> TERMINAL` depending on schema-driven review presence, and `REVIEW -> TERMINAL`; `complete` jumps to `TERMINAL`; `block`/`hold` move to `BLOCKED`; `resume` restores `previousRole`; `cancel` moves to `TERMINAL` with status `"cancelled"`. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandler.kt:66-68,81-119,121-184`
+
+`Implemented behavior:` targeted tests exercise the role-resolution logic and confirm that terminal and blocked items reject invalid forward moves. `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandlerTest.kt:49-110`
+
+## Dependency-Based Legality
+
+`Implemented behavior:` forward progressions are validated against incoming blocking dependencies. For each dependency, the handler resolves the effective unblock threshold, loads the blocker item, and rejects the transition if the blocker has not reached the required role. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandler.kt:190-273`
+
+`Implemented behavior:` transitions to `BLOCKED` bypass dependency checks, and items already in `TERMINAL` cannot transition further. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandler.kt:205-216`
+
+`Implemented behavior:` repository-level dependency writes also apply duplicate and cycle checks, so dependency legality is constrained both at creation time and at transition time. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteDependencyRepository.kt:35-60,97-149,151-202`
+
+`Implemented behavior:` tests cover satisfied dependencies, unsatisfied blockers, blocked-transition bypass, and multi-dependency gating. `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandlerTest.kt:245-310`, `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/WorkflowIntegrationTest.kt:665-706`
+
+## Note / Schema Gating
+
+`Implemented behavior:` note-schema gating is conditional, not universal. The note-schema service returns `null`/`false` in schema-free mode, which means transitions proceed without note-based gate enforcement when no config file exists or no schema matches the item tags. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NoteSchemaService.kt:5-13,20-29,31-37`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt:13-30,48-71,83-89`
+
+`Implemented behavior:` `advance_item` enforces required notes for the current phase on `start`, and all required notes across all phases on `complete`. Missing required notes are returned as a failed gate result instead of silently ignored. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt:195-257`
+
+`Implemented behavior:` `complete_tree` applies the same gate concept during batch completion and skips downstream dependents when a required-note gate fails. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt:12-18,160-178,246-267,316-330`
+
+`Implemented behavior:` integration tests show queue/work/review note gates in schema-backed flows and schema-free advancement when no schema tag exists. `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/SchemaGatedLifecycleTest.kt:18-22,234-291,297-318,324-337`
+
+## Validated Transition Path
+
+`Implemented behavior:` the main validated write path is `advance_item`. It fetches the item, resolves the trigger, validates dependencies, checks note gates, applies the transition, records cascade and unblock side effects, and returns the next-role expected notes. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt:121-265,274-387`
+
+`Implemented behavior:` `applyTransition` writes both the updated `WorkItem` and a `RoleTransition` audit entry, preserving `previousRole` on block/hold and clearing it on resume. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandler.kt:294-370`
+
+`Implemented behavior:` tests confirm that `applyTransition` updates the item and writes an audit transition, including previous-role persistence across block/resume. `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandlerTest.kt:385-456`
+
+## Direct Mutation Bypasses
+
+`Implemented behavior:` `manage_items(create)` accepts caller-supplied `role` and `statusLabel` values and persists them directly through `WorkItemRepository.create`. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt:38-45,176-188,249-290`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt:52-79`
+
+`Implemented behavior:` `manage_items(update)` accepts caller-supplied `role`, `statusLabel`, `priority`, `complexity`, and other fields, then writes them through `repo.update(updatedItem)` without invoking the transition handler. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt:391-502`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt:81-118`
+
+`Absent/no evidence found:` no `RoleTransitionHandler`, `roleTransitionRepository`, or `applyTransition` call was found in `ManageItemsTool.kt`. Search: `rg -n 'RoleTransitionHandler|roleTransitionRepository|applyTransition|advance_item' current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt` returned no matches. See `99-evidence-index.md`, negative search `N9`.
+
+`Implemented behavior:` `create_work_tree` also bypasses transition validation for its initial writes by delegating to `WorkTreeExecutor`, and the active implementation inserts `work_items`, `dependencies`, and `notes` directly inside one transaction. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt:13-20,292-307`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/WorkTreeExecutor.kt:33-39`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/service/SQLiteWorkTreeService.kt:23-33,38-123`
+
+## Assessment
+
+`Inferred capability:` repo-local workflow legality in active/current is best described as a dual-path model:
+- validated transitions through `advance_item` and `complete_tree`
+- direct item/state mutation through `manage_items` and direct work-tree creation
+
+That means legality enforcement is real, but it is not the only mutation path. If a caller needs dependency validation, note gates, and transition audit records, it must use the validated transition path rather than raw item updates. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt:121-265`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt:160-340`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt:361-516`

--- a/pm-workflow-pack/03-gates-actions-and-progress.md
+++ b/pm-workflow-pack/03-gates-actions-and-progress.md
@@ -1,0 +1,53 @@
+# PM Workflow Pack: Gates, Actions, and Progress
+
+## Capability Classification
+
+### Dependency Gates
+
+Classification: `partially authoritative`
+
+`Implemented behavior:` dependency thresholds are authoritative on the validated transition path. `RoleTransitionHandler.validateTransition` blocks forward progress when blocker items have not reached their required `unblockAt` role, and `complete_tree` depends on the same transition machinery after gate checks. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandler.kt:190-273`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt:270-304`
+
+`Implemented behavior:` dependency creation is also constrained at write time through duplicate and cycle checks in the dependency repository. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteDependencyRepository.kt:35-60,97-149,151-202`
+
+`Inferred capability:` dependency gates are only partially authoritative at the repo level because `manage_items(update)` can still mutate `role` directly without invoking dependency validation. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt:391-502`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt:81-118`
+
+### Blockers
+
+Classification: `derived`
+
+`Implemented behavior:` explicit blocked state is stored as `Role.BLOCKED`, but the blocked-items surface itself is computed. `get_blocked_items` scans `BLOCKED`, `QUEUE`, `WORK`, and `REVIEW` items, resolves blocker details from dependency edges, and returns items either explicitly blocked or dependency-blocked. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsTool.kt:14-25,101-220`
+
+`Implemented behavior:` `get_next_status` also derives a `Blocked` recommendation from either explicit blocked state or unsatisfied dependency validation. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextStatusTool.kt:11-19,75-141`
+
+`Implemented behavior:` tests confirm both explicit and dependency-derived blocked cases. `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsToolTest.kt:156-169,188-247`
+
+### Note / Comment Gates
+
+Classification: `partially authoritative`
+
+`Implemented behavior:` note gates are authoritative only when an item’s tags match a configured note schema. In that mode, `advance_item(start)` requires current-phase notes, `advance_item(complete)` requires all required notes, and `get_context` reports gate status and missing notes. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NoteSchemaService.kt:5-13,20-29`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt:13-30,48-71,83-89`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt:195-257`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt:120-192,352-400`
+
+`Implemented behavior:` schema-free mode disables note gating entirely. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NoteSchemaService.kt:11-13`, `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/SchemaGatedLifecycleTest.kt:297-318`
+
+`Absent/no evidence found:` no separate comment entity, comment repository, or comment-driven gate was found in the active/current scan scope (`current/src/main/kotlin`, `current/src/main/resources`, `current/src/test/kotlin`). Search: `rg -n --ignore-case 'class Comment|data class Comment|CommentRepository|comments table|comment_id' current/src/main/kotlin current/src/main/resources current/src/test/kotlin` returned no matches. See `99-evidence-index.md`, negative search `N2`.
+
+### Next-Action Computation
+
+Classification: `advisory`
+
+`Implemented behavior:` `get_next_item` computes recommendations by selecting `QUEUE` items, filtering blocked candidates, sorting by priority then complexity, and returning the top results. It does not mutate state. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt:10-18,77-145,174-225`
+
+`Implemented behavior:` `get_next_status` computes a `Ready`, `Blocked`, or `Terminal` recommendation for a single item based on its current role, note-schema review phase, and dependency validation. It also does not mutate state. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextStatusTool.kt:11-19,60-141`
+
+`Implemented behavior:` tests verify ordering, blocker exclusion, threshold handling, and downstream visibility after blocker completion. `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolTest.kt:128-149,188-269`, `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/WorkflowIntegrationTest.kt:747-770`
+
+### Decisions / Progress Tracking
+
+Classification: `absent/no evidence found` for dedicated decision/progress records
+
+`Implemented behavior:` the repo does persist workflow progression state indirectly through `role`, `statusLabel`, `roleChangedAt`, `requiresVerification`, and `role_transitions`, and `get_context(session-resume)` surfaces recent transitions. `current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql:11-24,63-77`, `current/src/main/resources/db/migration/V2__Work_Item_Field_Updates.sql:17-18`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt:202-275`
+
+`Absent/no evidence found:` no dedicated decision repository, decision table, progress repository, or progress table was found in the active/current scan scope. Search: `rg -n --ignore-case 'decision_id|decision table|progress table|progress record|decision record|decision repository|progress repository' current/src/main/kotlin current/src/main/resources current/src/test/kotlin` returned no matches. See `99-evidence-index.md`, negative search `N1`.
+
+`Absent/no evidence found:` no dedicated decision subsystem was found in the same scope. Search: `rg -n --ignore-case 'decision|decisions' current/src/main/kotlin current/src/main/resources current/src/test/kotlin` returned only incidental references, not a decision-tracking component. See `99-evidence-index.md`, negative search `N4`.

--- a/pm-workflow-pack/04-audit-history-and-chronicle.md
+++ b/pm-workflow-pack/04-audit-history-and-chronicle.md
@@ -1,0 +1,46 @@
+# PM Workflow Pack: Audit, History, and Chronicle
+
+## Transition Audit Trail
+
+`Implemented behavior:` validated workflow transitions are persisted in `role_transitions`, which stores `fromRole`, `toRole`, optional status labels, the triggering action, an optional summary, and `transitioned_at`. `current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql:63-77`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/RoleTransition.kt:6-23`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/RoleTransitionsTable.kt:7-21`
+
+`Implemented behavior:` the validated transition path writes an audit entry every time `applyTransition` succeeds. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandler.kt:294-355`
+
+`Implemented behavior:` tests confirm that applying a transition updates the item and creates a corresponding role-transition audit record. `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandlerTest.kt:385-413`
+
+`Implemented behavior:` the active/current repository exposes internal reads over this audit trail through `findByItemId`, `findByTimeRange`, and `findSince`. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/RoleTransitionRepository.kt:7-12`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteRoleTransitionRepository.kt:46-57,59-98`
+
+## Exposed History Surfaces
+
+`Implemented behavior:` `get_context(session-resume)` exposes recent transitions since a supplied timestamp alongside active and stalled items. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt:202-275`
+
+`Implemented behavior:` `get_context(health-check)` exposes active, blocked, and stalled read models, but it does not emit a full transition log. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt:282-345`
+
+`Implemented behavior:` tests cover the session-resume and health-check response shapes. `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolTest.kt:207-245`
+
+`Absent/no evidence found:` the active/current MCP tool surface does not include a dedicated `query_role_transitions` tool. The registered current tool list is fixed at 13 tools and does not name that surface, and an explicit search in the current module found no `RequestTransitionTool`, `QueryRoleTransitionsTool`, `request_transition`, or `query_role_transitions` symbols. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt:87-110,220`, search `rg -n 'RequestTransitionTool|QueryRoleTransitionsTool|request_transition|query_role_transitions' current/src/main/kotlin current/src/test/kotlin` returned no matches; see `99-evidence-index.md`, negative search `N6`.
+
+## Notes as Supporting Records
+
+`Implemented behavior:` notes carry their own `createdAt` and `modifiedAt` timestamps and are persisted independently from role transitions. They are operational records for gate satisfaction and context, not merely ephemeral annotations. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/Note.kt:13-20`, `current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql:33-46`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepository.kt:39-74,94-143`
+
+`Implemented behavior:` `get_context(item)` reads notes and reports whether schema-defined notes exist and are filled; `findStalledItems` derives stalled status from missing required notes in the current phase. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt:120-192,352-400`
+
+`Inferred capability:` notes are part of the operational workflow record because they can block advancement, but they are not a full chronology of all actions. The note model records current content and timestamps, not an append-only sequence of note edits. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/Note.kt:7-20`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepository.kt:39-74`
+
+## Chronicle / Event-Store Assessment
+
+`Absent/no evidence found:` no general event store, timeline subsystem, chronicle store, or journal-like history service was found in the active/current scan scope (`current/src/main/kotlin`, `current/src/main/resources`, `current/src/test/kotlin`). Search: `rg -n --ignore-case 'event store|event_log|event log|timeline|chronicle|journal' current/src/main/kotlin current/src/main/resources current/src/test/kotlin` returned only SQLite `journal_mode=WAL` comments in `DatabaseManager.kt`. See `99-evidence-index.md`, negative search `N3`.
+
+`Implemented behavior:` the only repo-local `journal` evidence in current is SQLite WAL configuration for database concurrency, not an application-level history model. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseManager.kt:64-78`
+
+`Absent/no evidence found:` no separate comment subsystem was found, so there is no evidence of a comment timeline or comment-driven audit trail beyond notes and role transitions. Search: `rg -n --ignore-case '\\bcomment\\b|comments' current/src/main/kotlin current/src/main/resources current/src/test/kotlin` returned no matches. See `99-evidence-index.md`, negative search `N5`.
+
+## Repo-Local Assessment
+
+`Inferred capability:` active/current maintains a bounded workflow history model:
+- canonical operational transition history in `role_transitions`
+- timestamped supporting workflow notes in `notes`
+- derived session/health read models in `get_context`
+
+It does not implement a general-purpose chronicle or event-sourcing system in the scanned scope. `current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql:33-77`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt:202-345`

--- a/pm-workflow-pack/05-runtime-variants-and-local-split-brain-risks.md
+++ b/pm-workflow-pack/05-runtime-variants-and-local-split-brain-risks.md
@@ -1,0 +1,115 @@
+# PM Workflow Pack: Runtime Variants and Local Split-Brain Risks
+
+## Baseline
+
+`Implemented behavior:` the repo declares `:current` as the active module and `:clockwork` as archived. `settings.gradle.kts:6-10`, `build.gradle.kts:1-3`, `clockwork/DEPRECATED.md:3-5,73`
+
+The risks below exist because other repo-local runtime selectors still compete with that declaration.
+
+## Risk 1: Active Build Selectors vs Default Docker Runtime
+
+Pattern:
+- build selectors say `current` is active
+- default container selectors still point to `clockwork`/`runtime-v2`
+
+Systems/components involved:
+- `settings.gradle.kts`
+- `build.gradle.kts`
+- `docker-compose.yml`
+- `Dockerfile`
+- `scripts/docker-build.sh`
+
+Why this is a local split-brain risk:
+- a reader following the root Gradle/build signals lands on `current`
+- a reader following the default docker-compose service or default docker build script lands on `clockwork`
+- both paths are repo-local and both are still runnable/buildable
+
+Evidence:
+- `settings.gradle.kts:6-10`
+- `build.gradle.kts:1-3`
+- `docker-compose.yml:2-24` defaults `mcp-task-orchestrator` to `runtime-v2`
+- `docker-compose.yml:36-102` exposes `current` only behind the `current` and `current-http` profiles
+- `Dockerfile:31-33` builds only `:current:jar` by default, but still defines both `runtime-v2` and `runtime-current` targets at `Dockerfile:82-92`
+- `scripts/docker-build.sh:5-13,15-19,57-68` defaults to a v2 image unless `--current` or `--all` is passed
+
+## Risk 2: Competing Workflow/Object Models (`current` vs `clockwork`)
+
+Pattern:
+- active/current uses a unified `WorkItem` graph
+- archived/clockwork uses a `Project -> Feature -> Task` hierarchy with a different tool surface
+
+Systems/components involved:
+- `current` runtime and domain model
+- `clockwork` runtime and tool registration
+
+Why this is a local split-brain risk:
+- the two variants expose materially different entities, transition tools, and audit/query affordances
+- the repo still contains both implementations and both runtime targets
+
+Evidence:
+- `current` documents and persists a unified `WorkItem` model. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/WorkItem.kt:7-25`, `current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql:4-25`
+- `current` registers 13 tools centered on `manage_items`, `advance_item`, `get_context`, and related read models. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt:87-110,220`
+- `clockwork/DEPRECATED.md` describes the v2 `Project -> Feature -> Task` model and its larger tool surface. `clockwork/DEPRECATED.md:10-20,24-34`
+- `clockwork` still registers a different 14-tool MCP surface including `GetNextTaskTool`, `GetBlockedTasksTool`, `RequestTransitionTool`, and `QueryRoleTransitionsTool`. `clockwork/src/main/kotlin/io/github/jpicklyk/mcptask/interfaces/mcp/McpServer.kt:268-302`
+- `clockwork` transition handling is exposed through `request_transition` over `task`, `feature`, and `project` containers. `clockwork/src/main/kotlin/io/github/jpicklyk/mcptask/application/tools/status/RequestTransitionTool.kt:21-42,43-45`
+- `clockwork` exposes a dedicated audit query tool that current does not expose. `clockwork/src/main/kotlin/io/github/jpicklyk/mcptask/application/tools/status/QueryRoleTransitionsTool.kt:14-20,21-32`
+
+## Risk 3: Competing Writers Inside `current`
+
+Pattern:
+- validated transition writer: `advance_item` / `complete_tree`
+- direct state writer: `manage_items`
+- direct bulk writer: `create_work_tree` via `SQLiteWorkTreeService`
+
+Systems/components involved:
+- `AdvanceItemTool`
+- `CompleteTreeTool`
+- `ManageItemsTool`
+- `CreateWorkTreeTool`
+- `SQLiteWorkItemRepository`
+- `SQLiteWorkTreeService`
+
+Why this is a local split-brain risk:
+- the repo contains both a legality-enforcing state transition path and bypass writers that can alter persisted workflow state without the same validation/audit sequence
+- consumers can reach different correctness guarantees depending on which write surface they call
+
+Evidence:
+- validated transition path uses `RoleTransitionHandler` resolve/validate/apply and writes audit entries. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt:121-265`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandler.kt:53-63,199-273,306-355`
+- `complete_tree` also uses the validated transition handler after gate checks. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt:270-304`
+- `manage_items(update)` can write `role` and `statusLabel` directly through repository update. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt:391-502`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt:81-118`
+- `create_work_tree` writes items, dependencies, and notes atomically through a direct table-writing executor. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt:299-307`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/service/SQLiteWorkTreeService.kt:32-130`
+- no transition-handler usage was found in `ManageItemsTool.kt`. Search: `rg -n 'RoleTransitionHandler|roleTransitionRepository|applyTransition|advance_item' current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt` returned no matches. See `99-evidence-index.md`, negative search `N9`.
+
+## Risk 4: Config Path Drift Between Docs and Runtime
+
+Pattern:
+- runtime code resolves `.taskorchestrator/config.yaml`
+- root docs also describe `.taskorchestrator/config.yaml`
+- `CLAUDE.md` and `AGENTS.md` still point at a non-existent bundled `default-config.yaml`
+
+Systems/components involved:
+- `YamlNoteSchemaService`
+- `NoteSchemaService`
+- `current/docs/*`
+- `CLAUDE.md`
+- `AGENTS.md`
+
+Why this is a local ambiguity risk:
+- repo-local guidance names two different config locations for the same workflow-gating system
+- a reader following the stale root table path would look for a config file that is not present in the scanned resources
+
+Evidence:
+- runtime code resolves `.taskorchestrator/config.yaml` from `AGENT_CONFIG_DIR` or `user.dir`. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt:13-16,83-89`
+- note-schema interface docs describe `.taskorchestrator/config.yaml` and schema-free mode when absent. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NoteSchemaService.kt:5-13`
+- current docs use `.taskorchestrator/config.yaml` as the workflow config location. `current/docs/workflow-guide.md:79-83,694-700`, `current/docs/quick-start.md:267-271,331-335`
+- `CLAUDE.md` and `AGENTS.md` still point to `current/src/main/resources/configuration/default-config.yaml`. `CLAUDE.md:124-132`, `AGENTS.md:124-132`
+- no bundled config/configuration/yaml file was found under `current/src/main/resources`, and no repo-local `.taskorchestrator/` directory was found. Searches: `rg --files current/src/main/resources | rg 'config|configuration|yaml'` and `rg --files . | rg '^\\.taskorchestrator/'` returned no matches. See `99-evidence-index.md`, negative search `N7`.
+
+## Assessment
+
+`Inferred capability:` the highest local split-brain risk is not just legacy code remaining in-tree. The bigger problem is selector disagreement:
+- root build files say `current`
+- default docker surfaces still prefer `clockwork`
+- `current` itself contains both validated and bypass write paths
+
+That combination makes “what this repo actually enforces” depend on which local runtime and write surface a caller chooses. `settings.gradle.kts:6-10`, `docker-compose.yml:2-24,36-102`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt:121-265`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt:361-516`

--- a/pm-workflow-pack/06-integration-seams.md
+++ b/pm-workflow-pack/06-integration-seams.md
@@ -1,0 +1,70 @@
+# PM Workflow Pack: Integration Seams
+
+## 1. Active MCP Server Surface
+
+`Implemented behavior:` the active/current runtime starts from `CurrentMain`, constructs `CurrentMcpServer`, and exposes MCP tools over either stdio or streamable HTTP depending on `MCP_TRANSPORT`. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/CurrentMain.kt:10-18,23-38`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt:41-45,61-80,114-120,163-200`
+
+`Implemented behavior:` the active/current MCP tool surface is 13 tools:
+- `manage_items`
+- `query_items`
+- `manage_notes`
+- `query_notes`
+- `manage_dependencies`
+- `query_dependencies`
+- `advance_item`
+- `get_next_status`
+- `get_next_item`
+- `get_blocked_items`
+- `complete_tree`
+- `create_work_tree`
+- `get_context`
+
+Evidence: `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt:87-110,206-220`
+
+`Implemented behavior:` when HTTP transport is selected, the current server exposes the MCP stream on `/mcp` with host/port controlled by `MCP_HTTP_HOST` and `MCP_HTTP_PORT`. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt:163-200`
+
+## 2. Container / Runtime Entry Seams
+
+`Implemented behavior:` repo-local container entry points are defined in `docker-compose.yml`, with one default service targeting `runtime-v2` and two profile-gated current services targeting `runtime-current` (stdio and HTTP). `docker-compose.yml:2-24,36-102`
+
+`Implemented behavior:` the Dockerfile defines both `runtime-v2` and `runtime-current` targets, while the builder stage only builds the current JAR by default. `Dockerfile:31-33,82-92`
+
+`Implemented behavior:` the shell build wrapper is an operator-facing seam that defaults to a v2 image unless `--current` or `--all` is supplied. `scripts/docker-build.sh:5-13,15-19,57-68`
+
+`Implemented behavior:` runtime configuration is environment-driven: `DATABASE_PATH`, `USE_FLYWAY`, `LOG_LEVEL`, `AGENT_CONFIG_DIR`, and HTTP transport variables are read from environment rather than from a compiled config object. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseConfig.kt:7-51`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt:83-120,163-166`
+
+## 3. Project-Local Workflow Extension Surface
+
+`Implemented behavior:` note-schema configuration is a repo-local extension seam. The runtime resolves `.taskorchestrator/config.yaml` from `AGENT_CONFIG_DIR` or `user.dir`, and the note-schema service changes gate behavior based on that file. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt:13-16,31-46,48-71,83-89`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NoteSchemaService.kt:5-13`
+
+`Implemented behavior:` current docs instruct operators to mount or create `.taskorchestrator/config.yaml`, which means external consumers can change gate requirements without changing Kotlin code. `current/docs/workflow-guide.md:79-83,694-700`, `current/docs/quick-start.md:267-271,331-335`
+
+## 4. Plugin / Hook Surfaces
+
+`Implemented behavior:` the repo ships a Claude plugin marketplace entry for `task-orchestrator`, pointing at `./claude-plugins/task-orchestrator` with `strict: true`. `.claude-plugin/marketplace.json:1-29`
+
+`Implemented behavior:` plugin hook config registers four client-side hook events:
+- `SessionStart`
+- `PreToolUse` on `EnterPlanMode`
+- `PostToolUse` on `ExitPlanMode`
+- `SubagentStart`
+
+Evidence: `claude-plugins/task-orchestrator/hooks/hooks-config.json:1-52`
+
+`Implemented behavior:` the hook scripts inject operational guidance that explicitly references current MCP tools such as `get_context`, `advance_item`, `create_work_tree`, and `complete_tree`. `claude-plugins/task-orchestrator/hooks/session-start.mjs:2-19`, `claude-plugins/task-orchestrator/hooks/pre-plan.mjs:2-9`, `claude-plugins/task-orchestrator/hooks/post-plan.mjs:2-9`, `claude-plugins/task-orchestrator/hooks/subagent-start.mjs:2-23`
+
+`Documented intent:` these plugin hooks are integration aids for MCP clients, not evidence of server-side legality enforcement by themselves. The runtime authority still comes from the server/tool code, not the hook prose. `claude-plugins/task-orchestrator/hooks/session-start.mjs:2-19`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt:87-110`
+
+## 5. Archived Variant Surface
+
+`Implemented behavior:` the archived `clockwork` runtime still exposes a separate MCP surface over stdio only, including `request_transition` and `query_role_transitions`. `clockwork/src/main/kotlin/io/github/jpicklyk/mcptask/interfaces/mcp/McpServer.kt:108-114,273-302`, `clockwork/src/main/kotlin/io/github/jpicklyk/mcptask/application/tools/status/RequestTransitionTool.kt:21-42,43-45`, `clockwork/src/main/kotlin/io/github/jpicklyk/mcptask/application/tools/status/QueryRoleTransitionsTool.kt:14-20,21-32`
+
+`Inferred capability:` that archived surface remains an external integration seam because docker/build defaults can still route operators toward v2 unless they explicitly select the current runtime. `docker-compose.yml:2-24`, `scripts/docker-build.sh:57-68`
+
+## 6. Absent / No Evidence Found
+
+`Absent/no evidence found:` no dedicated workflow CLI parser or subcommand framework was found in the scanned Kotlin sources (`current/src/main/kotlin`, `current/src/test/kotlin`, `clockwork/src/main/kotlin`, `clockwork/src/test/kotlin`). Search: `rg -n 'Clikt|picocli|kotlinx\\.cli|CommandLine\\.|ArgParser|subcommand|option\\(' current/src/main/kotlin current/src/test/kotlin clockwork/src/main/kotlin clockwork/src/test/kotlin` returned no matches. The repo exposes startup entrypoints and shell scripts, but not a separate repo-local workflow CLI. See `99-evidence-index.md`, negative search `N10`.
+
+`Absent/no evidence found:` no dedicated REST controller layer was found in the scanned Kotlin sources. Search: `rg -n '@(Get|Post|Put|Delete)Mapping|routing\\s*\\{|route\\(|install\\(Routing\\)' current/src/main/kotlin clockwork/src/main/kotlin` returned no matches. The only HTTP evidence in active/current is the MCP stream transport in `CurrentMcpServer`. See `99-evidence-index.md`, negative search `N11`.
+
+`Absent/no evidence found:` no dedicated import/export tool or class was found in the scanned runtime/plugin/script scope. Search: `rg -n 'override val name = \"(import|export)|class (Import|Export)|\\b(import|export)_' current/src/main/kotlin clockwork/src/main/kotlin claude-plugins/task-orchestrator .claude-plugin scripts .github` returned no matches. See `99-evidence-index.md`, negative search `N12`.

--- a/pm-workflow-pack/07-repo-local-authority-verdict.md
+++ b/pm-workflow-pack/07-repo-local-authority-verdict.md
@@ -1,0 +1,71 @@
+# PM Workflow Pack: Repo-Local Authority Verdict
+
+## Hard Verdict
+
+`Implemented behavior:` in the active/current module, this repository is authoritative for its own persisted workflow graph:
+- `WorkItem`
+- `Note`
+- `Dependency`
+- `RoleTransition`
+
+Those objects are persisted in the active/current SQLite schema and are wired into the current runtime through the repository provider and MCP server. `current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql:4-77`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/DefaultRepositoryProvider.kt:18-31`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt:76-110`
+
+## What This Repo Is Authoritative For
+
+`Implemented behavior:` the repo owns the active/current role-based workflow model itself: canonical roles, trigger resolution, dependency validation, role-transition audit writes, and note-schema gate enforcement when a schema matches an item’s tags. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/Role.kt:3-31`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandler.kt:53-63,81-188,199-273,306-370`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt:121-265`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NoteSchemaService.kt:5-13`
+
+`Implemented behavior:` the repo also owns the advisory workflow computations derived from that graph: next-item recommendation, next-status recommendation, blocked-item detection, stalled-item detection, cascade detection, and unblock detection. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt:10-18,77-145,174-225`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextStatusTool.kt:11-19,60-141`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsTool.kt:14-25,101-220`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt:202-345,352-400`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/CascadeDetector.kt:29-43,168-240`
+
+`Implemented behavior:` the repo owns its own SQLite-backed operational record for validated workflow transitions through `role_transitions`. `current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql:63-77`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandler.kt:341-355`
+
+## What This Repo Appears Designed to Enforce
+
+`Documented intent:` root docs and the active/current code agree that the repo is meant to enforce a v3/current `WorkItem` workflow with note-schema gates, dependency-aware progression, and MCP-first integration. `CLAUDE.md:33-36,61-66`, `current/docs/Home.md:5`, `current/docs/workflow-guide.md:75-92`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt:206-220`
+
+`Implemented behavior:` that design intent is materially reflected in the active/current runtime, not only in prose, because the server registers the workflow tools and the legality logic exists in executable code plus tests. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt:87-110`, `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandlerTest.kt:49-110,245-310,385-456`, `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/SchemaGatedLifecycleTest.kt:18-22,234-318`
+
+## What It Computes
+
+`Implemented behavior:` the repo computes:
+- trigger-to-role resolution and legality outcomes
+- dependency blocker satisfaction
+- note-gate satisfaction
+- next-item and next-status recommendations
+- blocked-item lists
+- stalled-item lists
+- cascade events and unblock events
+- session-resume and health snapshots
+
+Evidence: `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandler.kt:81-188,199-273`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt:157-257,274-387`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt:86-145`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsTool.kt:109-220`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt:202-345,352-400`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/CascadeDetector.kt:29-43,168-240`
+
+## What It Stores
+
+`Implemented behavior:` the active/current module stores only four first-class operational record types in its own schema:
+- work items
+- notes
+- dependencies
+- role transitions
+
+Evidence: `current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql:4-77`, `current/src/main/resources/db/migration/V2__Work_Item_Field_Updates.sql:4-53`
+
+`Implemented behavior:` the database is a local SQLite file by default (`data/current-tasks.db`) unless `DATABASE_PATH` overrides it. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseConfig.kt:7-22`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseManager.kt:30-84`
+
+## What It Does Not Own Based on Repo-Local Evidence
+
+`Absent/no evidence found:` no dedicated decision-tracking subsystem was found in the active/current scan scope. Search: `rg -n --ignore-case 'decision|decisions' current/src/main/kotlin current/src/main/resources current/src/test/kotlin` returned only incidental references, not a decision-tracking component. See `99-evidence-index.md`, negative search `N4`.
+
+`Absent/no evidence found:` no dedicated progress-record subsystem was found in the same scope. Search: `rg -n --ignore-case 'decision_id|decision table|progress table|progress record|decision record|decision repository|progress repository' current/src/main/kotlin current/src/main/resources current/src/test/kotlin` returned no matches. See `99-evidence-index.md`, negative search `N1`.
+
+`Absent/no evidence found:` no comment system, general chronicle/event store, or standalone timeline subsystem was found in the active/current scope. Searches `N2`, `N3`, and `N5` in `99-evidence-index.md` cover those negative results.
+
+`Inferred capability:` the repo does not own a single unambiguous workflow surface across all repo-local runtime selectors, because `clockwork` remains present and some default container selectors still point at it. `settings.gradle.kts:6-10`, `docker-compose.yml:2-24,36-102`, `scripts/docker-build.sh:57-68`, `clockwork/DEPRECATED.md:3-5`
+
+## What External Integrators Must Not Bypass
+
+`Implemented behavior:` if an integrator wants the repo’s legality model, it must not bypass `advance_item` / `complete_tree` by mutating `WorkItem.role` or `statusLabel` through `manage_items` or lower-level repository writes. The validated path is the only path that combines dependency validation, note gates, `previousRole` handling, and transition-audit recording. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt:121-265`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt:160-340`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt:361-516`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandler.kt:294-370`
+
+`Implemented behavior:` if an integrator depends on note gates, it must also supply the runtime with a `.taskorchestrator/config.yaml` that matches the intended workflow. Without that config, the repo falls back to schema-free mode and note gating disappears. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NoteSchemaService.kt:11-13`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt:50-53,83-89`
+
+## Final Repo-Local Verdict
+
+`Inferred capability:` this repository is best described as a workflow engine plus workflow-state store for its own entities in the active/current module, with advisory read models layered on top. It enforces legality only on the validated transition path, not on every writer present in the repo. It stores workflow state and transition audit data, but it does not implement dedicated decision tracking, progress records, comments, or a general chronicle subsystem in the scanned scope. `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt:87-110`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandler.kt:53-63,199-273,306-370`, `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt:361-516`, `current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql:4-77`

--- a/pm-workflow-pack/99-evidence-index.md
+++ b/pm-workflow-pack/99-evidence-index.md
@@ -1,0 +1,337 @@
+# PM Workflow Pack: Evidence Index
+
+## Primary Source Index
+
+### Module / Runtime Selectors
+
+- `settings.gradle.kts:6-10` — active `:current`, archived `:clockwork`
+- `build.gradle.kts:1-3` — root build comments repeat current-active / clockwork-archived split
+- `docker-compose.yml:2-24` — default service targets `runtime-v2`
+- `docker-compose.yml:36-102` — `current` services are profile-gated
+- `Dockerfile:31-33,82-92` — builder builds current by default, runtime targets include both v2 and current
+- `scripts/docker-build.sh:5-13,57-68` — default build path is v2 unless `--current` / `--all`
+
+### Active Current Runtime
+
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/CurrentMain.kt:10-18,23-38` — active/current entrypoint
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt:41-45,61-80,87-120,163-220` — transport selection, repository/tool wiring, HTTP `/mcp`, tool list
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt:12-44` — tool access to repositories and note schema service
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/RepositoryProvider.kt:9-20` — repository/provider contract
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/DefaultRepositoryProvider.kt:18-31` — active SQLite repository bindings
+
+### Persistence Schema
+
+- `current/src/main/resources/db/migration/V1__Current_Initial_Schema.sql:4-77` — `work_items`, `notes`, `dependencies`, `role_transitions`
+- `current/src/main/resources/db/migration/V2__Work_Item_Field_Updates.sql:4-53` — nullable `complexity`, added `requires_verification`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/WorkItemsTable.kt:6-32`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/NotesTable.kt:7-20`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/DependenciesTable.kt:7-20`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/RoleTransitionsTable.kt:7-21`
+
+### Domain Model
+
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/Role.kt:3-31` — canonical role semantics and progression ordering
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/WorkItem.kt:7-54` — workflow entity fields and validation
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/Note.kt:7-33` — note semantics and role restriction
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/Dependency.kt:7-46` — dependency semantics and threshold validation
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/RoleTransition.kt:6-23` — transition audit record shape
+
+### Repository / Storage Logic
+
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt:9-98`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/NoteRepository.kt:6-13`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/DependencyRepository.kt:6-30`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/RoleTransitionRepository.kt:7-12`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt:52-127`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepository.kt:39-143`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteDependencyRepository.kt:27-202`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteRoleTransitionRepository.kt:27-103`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseConfig.kt:7-51`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseManager.kt:30-124,127-170`
+
+### Workflow Legality / Read Models
+
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NoteSchemaService.kt:5-37`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt:10-90`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandler.kt:53-63,81-188,190-273,294-370`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/CascadeDetector.kt:29-43,55-70,168-240`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt:13-28,31-49,121-387`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt:10-18,77-145,174-225`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsTool.kt:14-25,101-220,243-310`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextStatusTool.kt:11-19,60-141`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt:13-18,106-196,202-345,352-400`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt:14-23,33-56,163-320,361-516`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesTool.kt:12-18,128-215,222-280`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/dependency/ManageDependenciesTool.kt:12-21,241-340`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt:12-27,160-345`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt:13-20,32-55,263-307`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/WorkTreeExecutor.kt:33-39`
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/service/SQLiteWorkTreeService.kt:23-33,38-130,133-166`
+
+### Tests Used as Executable Intent
+
+- `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandlerTest.kt:49-110,245-310,385-456`
+- `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/SchemaGatedLifecycleTest.kt:18-22,234-318,324-337`
+- `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolTest.kt:128-149,188-269`
+- `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsToolTest.kt:156-169,188-247`
+- `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolTest.kt:95-119,125-200,207-245`
+- `current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/WorkflowIntegrationTest.kt:631-657,665-706,713-740,747-770`
+
+### Archived Variant / Drift Evidence
+
+- `clockwork/DEPRECATED.md:3-5,10-34,37-73`
+- `clockwork/src/main/kotlin/Main.kt:8-22,35-44,62-68,82-99`
+- `clockwork/src/main/kotlin/io/github/jpicklyk/mcptask/interfaces/mcp/McpServer.kt:108-114,163-179,273-319`
+- `clockwork/src/main/kotlin/io/github/jpicklyk/mcptask/application/tools/status/RequestTransitionTool.kt:21-42,43-45`
+- `clockwork/src/main/kotlin/io/github/jpicklyk/mcptask/application/tools/status/QueryRoleTransitionsTool.kt:14-20,21-32,36-43`
+- `CLAUDE.md:124-132`
+- `AGENTS.md:124-132`
+- `current/docs/workflow-guide.md:79-83,694-700`
+- `current/docs/quick-start.md:267-271,331-335`
+
+### Plugin / Hook Seams
+
+- `.claude-plugin/marketplace.json:1-29`
+- `claude-plugins/task-orchestrator/hooks/hooks-config.json:1-52`
+- `claude-plugins/task-orchestrator/hooks/session-start.mjs:2-19`
+- `claude-plugins/task-orchestrator/hooks/pre-plan.mjs:2-9`
+- `claude-plugins/task-orchestrator/hooks/post-plan.mjs:2-9`
+- `claude-plugins/task-orchestrator/hooks/subagent-start.mjs:2-23`
+
+## Negative-Evidence Searches
+
+Each search below was run from `/Users/hue/code/task-orchestrator`.
+
+### N1. No dedicated decision/progress persistence
+
+Command:
+
+```bash
+rg -n --ignore-case 'decision_id|decision table|progress table|progress record|decision record|decision repository|progress repository' \
+  current/src/main/kotlin current/src/main/resources current/src/test/kotlin
+```
+
+Scope:
+- `current/src/main/kotlin`
+- `current/src/main/resources`
+- `current/src/test/kotlin`
+
+Result:
+- no matches
+
+### N2. No separate comment entity or repository
+
+Command:
+
+```bash
+rg -n --ignore-case 'class Comment|data class Comment|CommentRepository|comments table|comment_id' \
+  current/src/main/kotlin current/src/main/resources current/src/test/kotlin
+```
+
+Scope:
+- `current/src/main/kotlin`
+- `current/src/main/resources`
+- `current/src/test/kotlin`
+
+Result:
+- no matches
+
+### N3. No general event store / chronicle / timeline subsystem
+
+Command:
+
+```bash
+rg -n --ignore-case 'event store|event_log|event log|timeline|chronicle|journal' \
+  current/src/main/kotlin current/src/main/resources current/src/test/kotlin
+```
+
+Scope:
+- `current/src/main/kotlin`
+- `current/src/main/resources`
+- `current/src/test/kotlin`
+
+Result:
+- only:
+  - `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseManager.kt:66`
+  - `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseManager.kt:74`
+  - `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseManager.kt:75`
+
+Interpretation:
+- only SQLite journal-mode comments and PRAGMA usage were found, not an application-level event/chronicle subsystem
+
+### N4. No dedicated decision subsystem in active/current
+
+Command:
+
+```bash
+rg -n --ignore-case 'decision|decisions' \
+  current/src/main/kotlin current/src/main/resources current/src/test/kotlin
+```
+
+Scope:
+- `current/src/main/kotlin`
+- `current/src/main/resources`
+- `current/src/test/kotlin`
+
+Result:
+- only incidental references, including schema/test text such as `design-decisions`; no dedicated decision service/repository/tool
+
+### N5. No comment usage in active/current scope
+
+Command:
+
+```bash
+rg -n --ignore-case '\\bcomment\\b|comments' \
+  current/src/main/kotlin current/src/main/resources current/src/test/kotlin
+```
+
+Scope:
+- `current/src/main/kotlin`
+- `current/src/main/resources`
+- `current/src/test/kotlin`
+
+Result:
+- no matches
+
+### N6. No `request_transition` or `query_role_transitions` in active/current
+
+Command:
+
+```bash
+rg -n 'RequestTransitionTool|QueryRoleTransitionsTool|request_transition|query_role_transitions' \
+  current/src/main/kotlin current/src/test/kotlin
+```
+
+Scope:
+- `current/src/main/kotlin`
+- `current/src/test/kotlin`
+
+Result:
+- no matches
+
+### N7. No bundled default workflow config file in active/current resources
+
+Commands:
+
+```bash
+rg --files current/src/main/resources | rg 'config|configuration|yaml'
+rg --files . | rg '^\\.taskorchestrator/'
+```
+
+Scope:
+- `current/src/main/resources`
+- repo root file list
+
+Result:
+- no matches for either command
+
+### N8. Config-path drift evidence
+
+Command:
+
+```bash
+rg -n 'default-config.yaml|\\.taskorchestrator/config.yaml|AGENT_CONFIG_DIR' \
+  current/docs CLAUDE.md AGENTS.md current/src/main/kotlin
+```
+
+Scope:
+- `current/docs`
+- `CLAUDE.md`
+- `AGENTS.md`
+- `current/src/main/kotlin`
+
+Result:
+- root docs refer to both `AGENT_CONFIG_DIR` and `.taskorchestrator/config.yaml`
+- `CLAUDE.md:131` and `AGENTS.md:131` also refer to `current/src/main/resources/configuration/default-config.yaml`
+- runtime code resolves `.taskorchestrator/config.yaml`
+
+### N9. No transition-handler usage in `ManageItemsTool`
+
+Command:
+
+```bash
+rg -n 'RoleTransitionHandler|roleTransitionRepository|applyTransition|advance_item' \
+  current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt
+```
+
+Scope:
+- `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt`
+
+Result:
+- no matches
+
+### N10. No dedicated CLI parser / subcommand framework
+
+Command:
+
+```bash
+rg -n 'Clikt|picocli|kotlinx\\.cli|CommandLine\\.|ArgParser|subcommand|option\\(' \
+  current/src/main/kotlin current/src/test/kotlin clockwork/src/main/kotlin clockwork/src/test/kotlin
+```
+
+Scope:
+- `current/src/main/kotlin`
+- `current/src/test/kotlin`
+- `clockwork/src/main/kotlin`
+- `clockwork/src/test/kotlin`
+
+Result:
+- no matches
+
+### N11. No dedicated REST/controller layer
+
+Command:
+
+```bash
+rg -n '@(Get|Post|Put|Delete)Mapping|routing\\s*\\{|route\\(|install\\(Routing\\)' \
+  current/src/main/kotlin clockwork/src/main/kotlin
+```
+
+Scope:
+- `current/src/main/kotlin`
+- `clockwork/src/main/kotlin`
+
+Result:
+- no matches
+
+### N12. No dedicated import/export workflow surface
+
+Command:
+
+```bash
+rg -n 'override val name = \"(import|export)|class (Import|Export)|\\b(import|export)_' \
+  current/src/main/kotlin clockwork/src/main/kotlin claude-plugins/task-orchestrator .claude-plugin scripts .github
+```
+
+Scope:
+- `current/src/main/kotlin`
+- `clockwork/src/main/kotlin`
+- `claude-plugins/task-orchestrator`
+- `.claude-plugin`
+- `scripts`
+- `.github`
+
+Result:
+- no matches
+
+## Validation Attempts
+
+Attempted targeted test run:
+
+```bash
+./gradlew :current:test --tests "*RoleTransitionHandlerTest" --tests "*SchemaGatedLifecycleTest" \
+  --tests "*GetNextItemToolTest" --tests "*GetBlockedItemsToolTest" --tests "*GetContextToolTest"
+```
+
+Observed result:
+- failed because `./gradlew` was not executable in this environment
+
+Retry:
+
+```bash
+bash ./gradlew :current:test --tests "*RoleTransitionHandlerTest" --tests "*SchemaGatedLifecycleTest" \
+  --tests "*GetNextItemToolTest" --tests "*GetBlockedItemsToolTest" --tests "*GetContextToolTest"
+```
+
+Observed result:
+- failed because no Java runtime was installed (`Unable to locate a Java Runtime.`)


### PR DESCRIPTION
## What changed
- add a repo-local workflow authority extraction pack under `pm-workflow-pack/`
- document the entities, persistence model, legality rules, gates, history surfaces, runtime variants, integration seams, and a repo-local authority verdict
- include explicit negative-evidence searches and scan scope so absence claims remain auditable

## Pack contents
- `00-scan-scope-and-method.md`
- `01-entity-and-persistence-model.md`
- `02-workflow-legality-and-transition-analysis.md`
- `03-gates-actions-and-progress.md`
- `04-audit-history-and-chronicle.md`
- `05-runtime-variants-and-local-split-brain-risks.md`
- `06-integration-seams.md`
- `07-repo-local-authority-verdict.md`
- `99-evidence-index.md`

## Key findings
- `current/` is the active implementation baseline according to build wiring and runtime entrypoints.
- Workflow legality is implemented, but direct mutation paths also exist, so legality enforcement is not uniform across all writers.
- Dependency and blocker handling exists, but blocker views are derived rather than first-class persisted authority.
- Next-action computation exists and is advisory.
- No dedicated decision/progress subsystem, comment subsystem, or chronicle/event-store was found in the scanned repo-local scope.
- `clockwork/` remains a legacy/archived path and a local split-brain risk when compared with `current/`.

## Validation
- verified output scope and file set under `pm-workflow-pack/`
- verified citations are present across `01` through `07`
- verified negative-evidence searches are recorded in `99-evidence-index.md`
- attempted targeted Gradle tests, but this environment does not have a Java runtime installed

## Notes
- This PR is evidence-first and repo-local only. It does not make cross-repo authority claims.
- Unrelated local untracked artifacts were intentionally excluded from the commit.

@codex
@clauee
@copilot
