### PR TITLE
style: fix ktlint violations from v2.5.2 refactoring

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/SchemaEntryJsonBuilder.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/SchemaEntryJsonBuilder.kt
@@ -60,9 +60,7 @@ fun buildExpectedNotesJson(
  *
  * @param schema Schema entries, or null if no schema matches
  */
-fun buildSchemaResponseFields(
-    schema: List<NoteSchemaEntry>?
-): SchemaResponseFields =
+fun buildSchemaResponseFields(schema: List<NoteSchemaEntry>?): SchemaResponseFields =
     SchemaResponseFields(
         schemaMatch = schema != null,
         expectedNotes = buildExpectedNotesJson(schema)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
@@ -352,9 +352,10 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
         val idToRef = treeResult.refToId.entries.associate { (ref, id) -> id to ref }
 
         val rootResultItem = treeResult.items.first()
-        val rootSchemaFields = buildSchemaResponseFields(
-            context.noteSchemaService().getSchemaForTags(rootResultItem.tagList())
-        )
+        val rootSchemaFields =
+            buildSchemaResponseFields(
+                context.noteSchemaService().getSchemaForTags(rootResultItem.tagList())
+            )
         val rootJson =
             buildJsonObject {
                 put("id", JsonPrimitive(rootResultItem.id.toString()))
@@ -370,9 +371,10 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
             JsonArray(
                 treeResult.items.drop(1).map { item ->
                     val ref = idToRef[item.id] ?: "unknown"
-                    val childSchemaFields = buildSchemaResponseFields(
-                        context.noteSchemaService().getSchemaForTags(item.tagList())
-                    )
+                    val childSchemaFields =
+                        buildSchemaResponseFields(
+                            context.noteSchemaService().getSchemaForTags(item.tagList())
+                        )
                     buildJsonObject {
                         put("ref", JsonPrimitive(ref))
                         put("id", JsonPrimitive(item.id.toString()))

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -454,11 +454,12 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                 val existingKeys = notesByKey.keys
 
                 // Build expectedNotes: schema entries matching the new role (tool-specific, includes "exists")
-                expectedNotesJson = buildExpectedNotesJson(
-                    schema = schema,
-                    existingNoteKeys = existingKeys,
-                    filterRole = targetRole
-                )
+                expectedNotesJson =
+                    buildExpectedNotesJson(
+                        schema = schema,
+                        existingNoteKeys = existingKeys,
+                        filterRole = targetRole
+                    )
 
                 // Use shared PhaseNoteContext for guidancePointer and noteProgress
                 val phaseContext = computePhaseNoteContext(targetRole, schema, notesByKey)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
@@ -162,11 +162,12 @@ Parameters:
 
         // Build schema list with exists/filled status
         val filledKeys = notes.filter { it.body.isNotBlank() }.map { it.key }.toSet()
-        val schemaEntriesArray = buildExpectedNotesJson(
-            schema = schema,
-            existingNoteKeys = notesByKey.keys,
-            filledNoteKeys = filledKeys
-        )
+        val schemaEntriesArray =
+            buildExpectedNotesJson(
+                schema = schema,
+                existingNoteKeys = notesByKey.keys,
+                filledNoteKeys = filledKeys
+            )
 
         // Gate status for current phase — uses shared computation
         val phaseContext = computePhaseNoteContext(item.role, schema, notesByKey)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt
@@ -67,34 +67,38 @@ class YamlNoteSchemaService(
             return SchemaLoadResult(emptyMap(), warnings)
         }
 
-        val schemas = try {
-            val yaml = Yaml()
-            FileReader(configPath.toFile()).use { reader ->
-                val root = yaml.load<Map<String, Any>>(reader)
-                    ?: return@use emptyMap<String, List<NoteSchemaEntry>>()
+        val schemas =
+            try {
+                val yaml = Yaml()
+                FileReader(configPath.toFile()).use { reader ->
+                    val root =
+                        yaml.load<Map<String, Any>>(reader)
+                            ?: return@use emptyMap<String, List<NoteSchemaEntry>>()
 
-                if (!root.containsKey("note_schemas")) {
-                    warnings.add("Config file is missing 'note_schemas' key; no schemas loaded")
-                    return@use emptyMap()
-                }
-
-                val noteSchemas = root["note_schemas"] as? Map<String, Any>
-                    ?: return@use emptyMap<String, List<NoteSchemaEntry>>()
-
-                noteSchemas.entries.associate { (schemaName, rawEntries) ->
-                    val entryList = rawEntries as? List<Map<String, Any>> ?: emptyList()
-                    val entries = entryList.mapIndexedNotNull { index, raw ->
-                        parseEntry(raw, schemaName, index, warnings)
+                    if (!root.containsKey("note_schemas")) {
+                        warnings.add("Config file is missing 'note_schemas' key; no schemas loaded")
+                        return@use emptyMap()
                     }
-                    schemaName to entries
+
+                    val noteSchemas =
+                        root["note_schemas"] as? Map<String, Any>
+                            ?: return@use emptyMap<String, List<NoteSchemaEntry>>()
+
+                    noteSchemas.entries.associate { (schemaName, rawEntries) ->
+                        val entryList = rawEntries as? List<Map<String, Any>> ?: emptyList()
+                        val entries =
+                            entryList.mapIndexedNotNull { index, raw ->
+                                parseEntry(raw, schemaName, index, warnings)
+                            }
+                        schemaName to entries
+                    }
                 }
+            } catch (e: Exception) {
+                val msg = "Failed to load note schemas from '$configPath': ${e.message}"
+                warnings.add(msg)
+                logger.warn(msg)
+                emptyMap()
             }
-        } catch (e: Exception) {
-            val msg = "Failed to load note schemas from '${configPath}': ${e.message}"
-            warnings.add(msg)
-            logger.warn(msg)
-            emptyMap()
-        }
 
         val totalEntries = schemas.values.sumOf { it.size }
         warnings.forEach { w -> logger.warn(w) }
@@ -138,14 +142,15 @@ class YamlNoteSchemaService(
         }
 
         val requiredRaw = raw["required"]
-        val required = if (requiredRaw != null && requiredRaw !is Boolean) {
-            warnings.add(
-                "Schema '$schemaName' entry (key='$key') has non-boolean 'required' value '$requiredRaw'; defaulting to false"
-            )
-            false
-        } else {
-            requiredRaw as? Boolean ?: false
-        }
+        val required =
+            if (requiredRaw != null && requiredRaw !is Boolean) {
+                warnings.add(
+                    "Schema '$schemaName' entry (key='$key') has non-boolean 'required' value '$requiredRaw'; defaulting to false"
+                )
+                false
+            } else {
+                requiredRaw as? Boolean ?: false
+            }
 
         val description = raw["description"] as? String ?: ""
         val guidance = raw["guidance"] as? String

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/NoteSchemaServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/NoteSchemaServiceTest.kt
@@ -34,7 +34,7 @@ class NoteSchemaServiceTest {
     // --- Gap M8: default method hasReviewPhase on NoOpNoteSchemaService ---
 
     @Test
-    fun `NoOp hasReviewPhase default method returns false via getSchemaForTags returning null`(): Unit {
+    fun `NoOp hasReviewPhase default method returns false via getSchemaForTags returning null`() {
         // The hasReviewPhase default method on NoteSchemaService calls getSchemaForTags and
         // checks if any entry has role=REVIEW. When getSchemaForTags returns null (as NoOp does),
         // the elvis operator returns false. This test verifies the default method contract.
@@ -43,12 +43,13 @@ class NoteSchemaServiceTest {
     }
 
     @Test
-    fun `NoOp returns null which causes hasReviewPhase to return false via default implementation`(): Unit {
+    fun `NoOp returns null which causes hasReviewPhase to return false via default implementation`() {
         // Verify that a custom NoteSchemaService returning null also gets false from the default
         // hasReviewPhase — confirming the default method logic is correct.
-        val customService = object : NoteSchemaService {
-            override fun getSchemaForTags(tags: List<String>) = null
-        }
+        val customService =
+            object : NoteSchemaService {
+                override fun getSchemaForTags(tags: List<String>) = null
+            }
         assertFalse(customService.hasReviewPhase(listOf("tag1")))
         assertFalse(customService.hasReviewPhase(emptyList()))
     }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/SchemaEntryJsonBuilderTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/SchemaEntryJsonBuilderTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test
 import kotlin.test.*
 
 class SchemaEntryJsonBuilderTest {
-
     // ──────────────────────────────────────────────
     // buildExpectedNotesJson
     // ──────────────────────────────────────────────
@@ -26,10 +25,11 @@ class SchemaEntryJsonBuilderTest {
 
     @Test
     fun `schema with entries and no existing notes has all exists false`() {
-        val schema = listOf(
-            NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec desc"),
-            NoteSchemaEntry(key = "impl", role = Role.WORK, required = false, description = "Impl desc")
-        )
+        val schema =
+            listOf(
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec desc"),
+                NoteSchemaEntry(key = "impl", role = Role.WORK, required = false, description = "Impl desc")
+            )
 
         val result = buildExpectedNotesJson(schema = schema)
 
@@ -49,15 +49,17 @@ class SchemaEntryJsonBuilderTest {
 
     @Test
     fun `schema with existingNoteKeys reflects exists state correctly`() {
-        val schema = listOf(
-            NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec"),
-            NoteSchemaEntry(key = "impl", role = Role.WORK, required = false, description = "Impl")
-        )
+        val schema =
+            listOf(
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec"),
+                NoteSchemaEntry(key = "impl", role = Role.WORK, required = false, description = "Impl")
+            )
 
-        val result = buildExpectedNotesJson(
-            schema = schema,
-            existingNoteKeys = setOf("spec")
-        )
+        val result =
+            buildExpectedNotesJson(
+                schema = schema,
+                existingNoteKeys = setOf("spec")
+            )
 
         assertEquals(2, result.size)
         val specEntry = result[0].jsonObject
@@ -69,16 +71,18 @@ class SchemaEntryJsonBuilderTest {
 
     @Test
     fun `filledNoteKeys adds filled field and reflects state correctly`() {
-        val schema = listOf(
-            NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec"),
-            NoteSchemaEntry(key = "impl", role = Role.WORK, required = false, description = "Impl")
-        )
+        val schema =
+            listOf(
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec"),
+                NoteSchemaEntry(key = "impl", role = Role.WORK, required = false, description = "Impl")
+            )
 
-        val result = buildExpectedNotesJson(
-            schema = schema,
-            existingNoteKeys = setOf("spec", "impl"),
-            filledNoteKeys = setOf("spec")
-        )
+        val result =
+            buildExpectedNotesJson(
+                schema = schema,
+                existingNoteKeys = setOf("spec", "impl"),
+                filledNoteKeys = setOf("spec")
+            )
 
         assertEquals(2, result.size)
         val specEntry = result[0].jsonObject
@@ -94,16 +98,18 @@ class SchemaEntryJsonBuilderTest {
 
     @Test
     fun `filterRole only includes entries matching the specified role`() {
-        val schema = listOf(
-            NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec"),
-            NoteSchemaEntry(key = "impl", role = Role.WORK, required = false, description = "Impl"),
-            NoteSchemaEntry(key = "review-notes", role = Role.REVIEW, required = true, description = "Review")
-        )
+        val schema =
+            listOf(
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec"),
+                NoteSchemaEntry(key = "impl", role = Role.WORK, required = false, description = "Impl"),
+                NoteSchemaEntry(key = "review-notes", role = Role.REVIEW, required = true, description = "Review")
+            )
 
-        val result = buildExpectedNotesJson(
-            schema = schema,
-            filterRole = Role.WORK
-        )
+        val result =
+            buildExpectedNotesJson(
+                schema = schema,
+                filterRole = Role.WORK
+            )
 
         assertEquals(1, result.size)
         val entry = result[0].jsonObject
@@ -113,23 +119,26 @@ class SchemaEntryJsonBuilderTest {
 
     @Test
     fun `filterRole with no matching entries returns empty array`() {
-        val schema = listOf(
-            NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec")
-        )
+        val schema =
+            listOf(
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec")
+            )
 
-        val result = buildExpectedNotesJson(
-            schema = schema,
-            filterRole = Role.REVIEW
-        )
+        val result =
+            buildExpectedNotesJson(
+                schema = schema,
+                filterRole = Role.REVIEW
+            )
 
         assertEquals(0, result.size)
     }
 
     @Test
     fun `entry with null guidance omits guidance field`() {
-        val schema = listOf(
-            NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec", guidance = null)
-        )
+        val schema =
+            listOf(
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec", guidance = null)
+            )
 
         val result = buildExpectedNotesJson(schema = schema)
 
@@ -140,9 +149,10 @@ class SchemaEntryJsonBuilderTest {
 
     @Test
     fun `entry with non-null guidance includes guidance field`() {
-        val schema = listOf(
-            NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec", guidance = "Do it this way")
-        )
+        val schema =
+            listOf(
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec", guidance = "Do it this way")
+            )
 
         val result = buildExpectedNotesJson(schema = schema)
 
@@ -154,15 +164,17 @@ class SchemaEntryJsonBuilderTest {
 
     @Test
     fun `null filledNoteKeys means no filled field on any entry`() {
-        val schema = listOf(
-            NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec")
-        )
+        val schema =
+            listOf(
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec")
+            )
 
-        val result = buildExpectedNotesJson(
-            schema = schema,
-            existingNoteKeys = setOf("spec"),
-            filledNoteKeys = null
-        )
+        val result =
+            buildExpectedNotesJson(
+                schema = schema,
+                existingNoteKeys = setOf("spec"),
+                filledNoteKeys = null
+            )
 
         assertEquals(1, result.size)
         val entry = result[0].jsonObject
@@ -184,9 +196,10 @@ class SchemaEntryJsonBuilderTest {
 
     @Test
     fun `buildSchemaResponseFields with non-null schema returns schemaMatch true`() {
-        val schema = listOf(
-            NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec")
-        )
+        val schema =
+            listOf(
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec")
+            )
 
         val result = buildSchemaResponseFields(schema = schema)
 
@@ -204,10 +217,11 @@ class SchemaEntryJsonBuilderTest {
 
     @Test
     fun `buildSchemaResponseFields entries have exists false`() {
-        val schema = listOf(
-            NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec"),
-            NoteSchemaEntry(key = "impl", role = Role.WORK, required = false, description = "Impl")
-        )
+        val schema =
+            listOf(
+                NoteSchemaEntry(key = "spec", role = Role.QUEUE, required = true, description = "Spec"),
+                NoteSchemaEntry(key = "impl", role = Role.WORK, required = false, description = "Impl")
+            )
 
         val result = buildSchemaResponseFields(schema = schema)
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/WorkTreeServiceIntegrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/WorkTreeServiceIntegrationTest.kt
@@ -361,45 +361,49 @@ class WorkTreeServiceIntegrationTest {
     // ──────────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `duplicate item UUID causes full transaction rollback`(): Unit = runBlocking {
-        val sharedId = UUID.randomUUID()
-        val firstItem = WorkItem(
-            id = sharedId,
-            title = "First Item",
-            role = Role.QUEUE,
-            depth = 0,
-            parentId = null,
-            priority = Priority.MEDIUM
-        )
-        // Second item intentionally reuses the same UUID — will trigger a PK violation
-        val secondItem = WorkItem(
-            id = sharedId,
-            title = "Duplicate ID Item",
-            role = Role.QUEUE,
-            depth = 1,
-            parentId = firstItem.id,
-            priority = Priority.MEDIUM
-        )
+    fun `duplicate item UUID causes full transaction rollback`(): Unit =
+        runBlocking {
+            val sharedId = UUID.randomUUID()
+            val firstItem =
+                WorkItem(
+                    id = sharedId,
+                    title = "First Item",
+                    role = Role.QUEUE,
+                    depth = 0,
+                    parentId = null,
+                    priority = Priority.MEDIUM
+                )
+            // Second item intentionally reuses the same UUID — will trigger a PK violation
+            val secondItem =
+                WorkItem(
+                    id = sharedId,
+                    title = "Duplicate ID Item",
+                    role = Role.QUEUE,
+                    depth = 1,
+                    parentId = firstItem.id,
+                    priority = Priority.MEDIUM
+                )
 
-        val input = WorkTreeInput(
-            items = listOf(firstItem, secondItem),
-            refToItem = mapOf("first" to firstItem, "second" to secondItem),
-            deps = emptyList(),
-            notes = emptyList()
-        )
+            val input =
+                WorkTreeInput(
+                    items = listOf(firstItem, secondItem),
+                    refToItem = mapOf("first" to firstItem, "second" to secondItem),
+                    deps = emptyList(),
+                    notes = emptyList()
+                )
 
-        // The duplicate PK insert must propagate an exception
-        assertThrows(Exception::class.java) {
-            runBlocking { service.execute(input) }
+            // The duplicate PK insert must propagate an exception
+            assertThrows(Exception::class.java) {
+                runBlocking { service.execute(input) }
+            }
+
+            // Neither item should be present — the whole transaction was rolled back
+            val fetchedFirst = workItemRepository.getById(sharedId)
+            assertTrue(
+                fetchedFirst is Result.Error,
+                "Item with duplicate UUID should NOT be in DB after rollback; got: $fetchedFirst"
+            )
         }
-
-        // Neither item should be present — the whole transaction was rolled back
-        val fetchedFirst = workItemRepository.getById(sharedId)
-        assertTrue(
-            fetchedFirst is Result.Error,
-            "Item with duplicate UUID should NOT be in DB after rollback; got: $fetchedFirst"
-        )
-    }
 
     // ──────────────────────────────────────────────────────────────────────────
     // Test H2: Happy path with notes — items, dependency, AND notes all committed
@@ -410,51 +414,57 @@ class WorkTreeServiceIntegrationTest {
     @Test
     fun `happy path with notes - items, dependency, and notes committed atomically`(): Unit =
         runBlocking {
-            val rootItem = WorkItem(
-                id = UUID.randomUUID(),
-                title = "Root With Notes",
-                role = Role.QUEUE,
-                depth = 0,
-                parentId = null,
-                priority = Priority.MEDIUM
-            )
-            val childItem = WorkItem(
-                id = UUID.randomUUID(),
-                title = "Child With Notes",
-                role = Role.QUEUE,
-                depth = 1,
-                parentId = rootItem.id,
-                priority = Priority.MEDIUM
-            )
+            val rootItem =
+                WorkItem(
+                    id = UUID.randomUUID(),
+                    title = "Root With Notes",
+                    role = Role.QUEUE,
+                    depth = 0,
+                    parentId = null,
+                    priority = Priority.MEDIUM
+                )
+            val childItem =
+                WorkItem(
+                    id = UUID.randomUUID(),
+                    title = "Child With Notes",
+                    role = Role.QUEUE,
+                    depth = 1,
+                    parentId = rootItem.id,
+                    priority = Priority.MEDIUM
+                )
 
-            val note1 = io.github.jpicklyk.mcptask.current.domain.model.Note(
-                id = UUID.randomUUID(),
-                itemId = rootItem.id,
-                key = "requirements",
-                role = "queue",
-                body = "Root requirements note"
-            )
-            val note2 = io.github.jpicklyk.mcptask.current.domain.model.Note(
-                id = UUID.randomUUID(),
-                itemId = childItem.id,
-                key = "approach",
-                role = "work",
-                body = "Child approach note"
-            )
+            val note1 =
+                io.github.jpicklyk.mcptask.current.domain.model.Note(
+                    id = UUID.randomUUID(),
+                    itemId = rootItem.id,
+                    key = "requirements",
+                    role = "queue",
+                    body = "Root requirements note"
+                )
+            val note2 =
+                io.github.jpicklyk.mcptask.current.domain.model.Note(
+                    id = UUID.randomUUID(),
+                    itemId = childItem.id,
+                    key = "approach",
+                    role = "work",
+                    body = "Child approach note"
+                )
 
-            val input = WorkTreeInput(
-                items = listOf(rootItem, childItem),
-                refToItem = mapOf("root" to rootItem, "child" to childItem),
-                deps = listOf(
-                    TreeDepSpec(
-                        fromRef = "root",
-                        toRef = "child",
-                        type = DependencyType.BLOCKS,
-                        unblockAt = null
-                    )
-                ),
-                notes = listOf(note1, note2)
-            )
+            val input =
+                WorkTreeInput(
+                    items = listOf(rootItem, childItem),
+                    refToItem = mapOf("root" to rootItem, "child" to childItem),
+                    deps =
+                        listOf(
+                            TreeDepSpec(
+                                fromRef = "root",
+                                toRef = "child",
+                                type = DependencyType.BLOCKS,
+                                unblockAt = null
+                            )
+                        ),
+                    notes = listOf(note1, note2)
+                )
 
             val result = service.execute(input)
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaServiceTest.kt
@@ -593,7 +593,7 @@ other_config:
     // --- Gap M1: lazy init triggered by first call ---
 
     @Test
-    fun `schema loading is lazy — entry with typo role is skipped even on first call`(): Unit {
+    fun `schema loading is lazy — entry with typo role is skipped even on first call`() {
         val tempDir = createTempConfigDir()
         writeConfig(
             tempDir,
@@ -622,7 +622,7 @@ note_schemas:
     }
 
     @Test
-    fun `lazy init produces consistent results across multiple calls`(): Unit {
+    fun `lazy init produces consistent results across multiple calls`() {
         val tempDir = createTempConfigDir()
         writeConfig(
             tempDir,
@@ -655,7 +655,7 @@ note_schemas:
     // --- Gap M2: note_schemas value is wrong type (list instead of map) ---
 
     @Test
-    fun `note_schemas as list instead of map returns null without crashing`(): Unit {
+    fun `note_schemas as list instead of map returns null without crashing`() {
         val tempDir = createTempConfigDir()
         writeConfig(
             tempDir,
@@ -674,7 +674,7 @@ note_schemas:
     }
 
     @Test
-    fun `note_schemas as list does not crash on empty tag list`(): Unit {
+    fun `note_schemas as list does not crash on empty tag list`() {
         val tempDir = createTempConfigDir()
         writeConfig(
             tempDir,


### PR DESCRIPTION
## Summary

- Fixed multiline-expression-wrapping violations in SchemaEntryJsonBuilder, CreateWorkTreeTool, AdvanceItemTool, GetContextTool, YamlNoteSchemaService
- Fixed string-template redundant curly braces in YamlNoteSchemaService
- Auto-formatted via `ktlintFormat` — all tests pass

Fixes the "Lint check" CI failure on main since v2.5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)