### PR TITLE
feat: short hex prefix resolution for all WorkItem ID parameters

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/BaseToolDefinition.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/BaseToolDefinition.kt
@@ -1,6 +1,7 @@
 package io.github.jpicklyk.mcptask.current.application.tools
 
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import kotlinx.serialization.json.*
 import org.slf4j.LoggerFactory
 import java.time.Instant
@@ -375,6 +376,203 @@ abstract class BaseToolDefinition : ToolDefinition {
         } catch (_: IllegalArgumentException) {
             throw ToolValidationException("Parameter $name must be a valid UUID, got: $content")
         }
+    }
+
+    // ──────────────────────────────────────────────
+    // Short-ID prefix resolution
+    // ──────────────────────────────────────────────
+
+    companion object {
+        /** Minimum hex prefix length for short-ID resolution. */
+        const val MIN_PREFIX_LENGTH = 4
+
+        /** Regex for a valid hex string (UUID prefix). */
+        val HEX_PATTERN: Regex = Regex("^[0-9a-fA-F]+$")
+    }
+
+    /**
+     * Validates that a raw string value is either a full UUID or a valid hex prefix.
+     * Use this in [validateParams] for array elements or extracted strings.
+     *
+     * @param value The string value to validate
+     * @param fieldLabel Human-readable field label for error messages (e.g. "transitions[0].itemId")
+     * @throws ToolValidationException if the value is neither a valid UUID nor a valid hex prefix
+     */
+    protected fun validateIdStringOrPrefix(
+        value: String,
+        fieldLabel: String
+    ) {
+        if (value.length == 36) {
+            try {
+                UUID.fromString(value)
+            } catch (_: IllegalArgumentException) {
+                throw ToolValidationException("$fieldLabel must be a valid UUID or hex prefix, got: $value")
+            }
+            return
+        }
+        if (!value.matches(HEX_PATTERN)) {
+            throw ToolValidationException(
+                "$fieldLabel must be a UUID or hex prefix ($MIN_PREFIX_LENGTH-35 chars), got: $value"
+            )
+        }
+        if (value.length < MIN_PREFIX_LENGTH) {
+            throw ToolValidationException(
+                "ID prefix too short for $fieldLabel: minimum $MIN_PREFIX_LENGTH hex characters required, got ${value.length}"
+            )
+        }
+    }
+
+    /**
+     * Validates that a string parameter is either a full UUID or a valid hex prefix.
+     * Use this in [validateParams] for top-level parameters that accept short IDs.
+     * Delegates to [validateIdStringOrPrefix] after extracting the value.
+     *
+     * @param params The input parameters
+     * @param name The parameter name
+     * @param required If true, throws when the parameter is missing
+     * @throws ToolValidationException if the value is neither a valid UUID nor a valid hex prefix
+     */
+    protected fun validateIdOrPrefix(
+        params: JsonElement,
+        name: String,
+        required: Boolean = true
+    ) {
+        val paramsObj =
+            params as? JsonObject
+                ?: throw ToolValidationException("Parameters must be a JSON object")
+
+        val value = paramsObj[name] as? JsonPrimitive
+        if (value == null) {
+            if (required) throw ToolValidationException("Missing required parameter: $name")
+            return
+        }
+        if (!value.isString) throw ToolValidationException("Parameter $name must be a string")
+
+        val content = value.content
+        if (content.isBlank()) {
+            if (required) throw ToolValidationException("Required parameter $name cannot be empty")
+            return
+        }
+
+        validateIdStringOrPrefix(content, name)
+    }
+
+    /**
+     * Resolves a raw ID string that may be a full UUID or a short hex prefix.
+     * Tries full UUID parse first (fast path), then falls back to prefix resolution
+     * via [WorkItemRepository.findByIdPrefix]. Use this for array elements or
+     * pre-extracted strings.
+     *
+     * @param idStr The ID string to resolve
+     * @param context The tool execution context (for repository access)
+     * @return A pair of (UUID?, errorResponse?) — exactly one will be non-null
+     */
+    protected suspend fun resolveIdString(
+        idStr: String,
+        context: ToolExecutionContext
+    ): Pair<UUID?, JsonElement?> {
+        // Fast path: full UUID (36 chars)
+        if (idStr.length == 36) {
+            return try {
+                Pair(UUID.fromString(idStr), null)
+            } catch (_: IllegalArgumentException) {
+                Pair(null, errorResponse("Invalid UUID format: $idStr", ErrorCodes.VALIDATION_ERROR))
+            }
+        }
+
+        // Prefix resolution path
+        if (!idStr.matches(HEX_PATTERN)) {
+            return Pair(
+                null,
+                errorResponse(
+                    "Invalid ID format: must be a UUID or hex prefix ($MIN_PREFIX_LENGTH-35 chars), got: $idStr",
+                    ErrorCodes.VALIDATION_ERROR
+                )
+            )
+        }
+        if (idStr.length < MIN_PREFIX_LENGTH) {
+            return Pair(
+                null,
+                errorResponse(
+                    "ID prefix too short: minimum $MIN_PREFIX_LENGTH hex characters required, got ${idStr.length}",
+                    ErrorCodes.VALIDATION_ERROR
+                )
+            )
+        }
+
+        return when (val result = context.workItemRepository().findByIdPrefix(idStr)) {
+            is Result.Success -> {
+                val matches = result.data
+                when {
+                    matches.isEmpty() ->
+                        Pair(
+                            null,
+                            errorResponse("No WorkItem found matching prefix: $idStr", ErrorCodes.RESOURCE_NOT_FOUND)
+                        )
+                    matches.size > 1 ->
+                        Pair(
+                            null,
+                            errorResponse(
+                                "Ambiguous prefix: $idStr matches ${matches.size} items",
+                                ErrorCodes.VALIDATION_ERROR,
+                                additionalData =
+                                    buildJsonObject {
+                                        put("prefix", JsonPrimitive(idStr))
+                                        put(
+                                            "matches",
+                                            JsonArray(
+                                                matches.map { match ->
+                                                    buildJsonObject {
+                                                        put("id", JsonPrimitive(match.id.toString()))
+                                                        put("title", JsonPrimitive(match.title))
+                                                    }
+                                                }
+                                            )
+                                        )
+                                    }
+                            )
+                        )
+                    else -> Pair(matches.first().id, null)
+                }
+            }
+            is Result.Error ->
+                Pair(
+                    null,
+                    errorResponse("Failed to resolve ID prefix: ${result.error.message}", ErrorCodes.INTERNAL_ERROR)
+                )
+        }
+    }
+
+    /**
+     * Resolves an item ID parameter that may be a full UUID or a short hex prefix.
+     * Extracts the value from [params] and delegates to [resolveIdString].
+     *
+     * @param params The input parameters
+     * @param name The parameter name
+     * @param context The tool execution context (for repository access)
+     * @param required If true, returns an error response when the parameter is missing
+     * @return A pair of (UUID?, errorResponse?) — exactly one will be non-null on success/failure,
+     *         or both null if the parameter is absent and not required
+     */
+    protected suspend fun resolveItemId(
+        params: JsonElement,
+        name: String,
+        context: ToolExecutionContext,
+        required: Boolean = true
+    ): Pair<UUID?, JsonElement?> {
+        val paramsObj =
+            params as? JsonObject
+                ?: return Pair(null, errorResponse("Parameters must be a JSON object", ErrorCodes.VALIDATION_ERROR))
+
+        val value = paramsObj[name] as? JsonPrimitive
+        if (value == null || !value.isString || value.content.isBlank()) {
+            if (required) {
+                return Pair(null, errorResponse("Missing required parameter: $name", ErrorCodes.VALIDATION_ERROR))
+            }
+            return Pair(null, null)
+        }
+
+        return resolveIdString(value.content, context)
     }
 
     // ──────────────────────────────────────────────

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt
@@ -80,7 +80,9 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
                             put("type", JsonPrimitive("string"))
                             put(
                                 "description",
-                                JsonPrimitive("UUID of root item whose descendants should be completed. Mutually exclusive with itemIds.")
+                                JsonPrimitive(
+                                    "UUID or hex prefix (4+ chars) of root item whose descendants should be completed. Mutually exclusive with itemIds."
+                                )
                             )
                         }
                     )
@@ -88,7 +90,12 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
                         "itemIds",
                         buildJsonObject {
                             put("type", JsonPrimitive("array"))
-                            put("description", JsonPrimitive("Explicit list of item UUIDs to complete. Mutually exclusive with rootId."))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "Item UUIDs or hex prefixes (4+ chars) to complete. Mutually exclusive with rootId."
+                                )
+                            )
                             put(
                                 "items",
                                 buildJsonObject {
@@ -148,15 +155,11 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
         if (hasRootId) {
             val prim =
                 rootId as? JsonPrimitive
-                    ?: throw ToolValidationException("rootId must be a string UUID")
+                    ?: throw ToolValidationException("rootId must be a string")
             if (!prim.isString || prim.content.isBlank()) {
-                throw ToolValidationException("rootId must be a non-empty string UUID")
+                throw ToolValidationException("rootId must be a non-empty string")
             }
-            try {
-                UUID.fromString(prim.content)
-            } catch (_: IllegalArgumentException) {
-                throw ToolValidationException("rootId must be a valid UUID, got: ${prim.content}")
-            }
+            validateIdStringOrPrefix(prim.content, "rootId")
         }
 
         if (hasItemIds) {
@@ -166,15 +169,11 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
             arr.forEachIndexed { index, element ->
                 val prim =
                     element as? JsonPrimitive
-                        ?: throw ToolValidationException("itemIds[$index] must be a string UUID")
+                        ?: throw ToolValidationException("itemIds[$index] must be a string")
                 if (!prim.isString || prim.content.isBlank()) {
-                    throw ToolValidationException("itemIds[$index] must be a non-empty string UUID")
+                    throw ToolValidationException("itemIds[$index] must be a non-empty string")
                 }
-                try {
-                    UUID.fromString(prim.content)
-                } catch (_: IllegalArgumentException) {
-                    throw ToolValidationException("itemIds[$index] must be a valid UUID, got: ${prim.content}")
-                }
+                validateIdStringOrPrefix(prim.content, "itemIds[$index]")
             }
         }
 
@@ -538,7 +537,12 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
     ): Pair<List<WorkItem>, WorkItem?> {
         val rootIdElem = paramsObj["rootId"]
         if (rootIdElem != null && rootIdElem !is JsonNull) {
-            val rootId = UUID.fromString((rootIdElem as JsonPrimitive).content)
+            val rootIdStr = (rootIdElem as JsonPrimitive).content
+            val (resolvedRootId, rootIdErr) = resolveIdString(rootIdStr, context)
+            if (rootIdErr != null || resolvedRootId == null) {
+                throw ToolValidationException("Could not resolve rootId: $rootIdStr")
+            }
+            val rootId = resolvedRootId
             val descendants =
                 when (val result = context.workItemRepository().findDescendants(rootId)) {
                     is Result.Success -> result.data
@@ -558,8 +562,12 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
         val itemIdsElem = paramsObj["itemIds"] as? JsonArray ?: return Pair(emptyList(), null)
         val items = mutableListOf<WorkItem>()
         for (element in itemIdsElem) {
-            val id = UUID.fromString((element as JsonPrimitive).content)
-            when (val result = context.workItemRepository().getById(id)) {
+            val idStr = (element as JsonPrimitive).content
+            val (resolvedId, idErr) = resolveIdString(idStr, context)
+            if (idErr != null || resolvedId == null) {
+                throw ToolValidationException("Could not resolve itemId: $idStr")
+            }
+            when (val result = context.workItemRepository().getById(resolvedId)) {
                 is Result.Success -> items.add(result.data)
                 is Result.Error -> { /* skip missing items */ }
             }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
@@ -85,7 +85,12 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                         "parentId",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("UUID of existing parent item. Root depth = parent.depth + 1 if provided."))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "UUID or hex prefix (4+ chars) of existing parent item. Root depth = parent.depth + 1 if provided."
+                                )
+                            )
                         }
                     )
                     put(
@@ -196,7 +201,8 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
         val paramsObj = params as JsonObject
 
         // ── 1. Parse parentId (optional) ──────────────────────────────────────
-        val parentId = extractUUID(params, "parentId", required = false)
+        val (parentId, parentIdError) = resolveItemId(params, "parentId", context, required = false)
+        if (parentIdError != null) return parentIdError
 
         // ── 2. Compute root depth from parent ──────────────────────────────────
         val rootDepth =

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/dependency/ManageDependenciesTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/dependency/ManageDependenciesTool.kt
@@ -88,35 +88,50 @@ Unified write operations for WorkItem dependencies (create, delete).
                         "itemIds",
                         buildJsonObject {
                             put("type", JsonPrimitive("array"))
-                            put("description", JsonPrimitive("Ordered item IDs for linear pattern"))
+                            put(
+                                "description",
+                                JsonPrimitive("Ordered item IDs (UUIDs or hex prefixes 4+ chars) for linear pattern")
+                            )
                         }
                     )
                     put(
                         "source",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("Source item UUID for fan-out pattern"))
+                            put(
+                                "description",
+                                JsonPrimitive("Source item UUID or hex prefix (4+ chars) for fan-out pattern")
+                            )
                         }
                     )
                     put(
                         "targets",
                         buildJsonObject {
                             put("type", JsonPrimitive("array"))
-                            put("description", JsonPrimitive("Target item UUIDs for fan-out pattern"))
+                            put(
+                                "description",
+                                JsonPrimitive("Target item UUIDs or hex prefixes (4+ chars) for fan-out pattern")
+                            )
                         }
                     )
                     put(
                         "sources",
                         buildJsonObject {
                             put("type", JsonPrimitive("array"))
-                            put("description", JsonPrimitive("Source item UUIDs for fan-in pattern"))
+                            put(
+                                "description",
+                                JsonPrimitive("Source item UUIDs or hex prefixes (4+ chars) for fan-in pattern")
+                            )
                         }
                     )
                     put(
                         "target",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("Target item UUID for fan-in pattern"))
+                            put(
+                                "description",
+                                JsonPrimitive("Target item UUID or hex prefix (4+ chars) for fan-in pattern")
+                            )
                         }
                     )
                     put(
@@ -152,14 +167,20 @@ Unified write operations for WorkItem dependencies (create, delete).
                         "fromItemId",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("Source item UUID for delete by relationship"))
+                            put(
+                                "description",
+                                JsonPrimitive("Source item UUID or hex prefix (4+ chars) for delete by relationship")
+                            )
                         }
                     )
                     put(
                         "toItemId",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("Target item UUID for delete by relationship"))
+                            put(
+                                "description",
+                                JsonPrimitive("Target item UUID or hex prefix (4+ chars) for delete by relationship")
+                            )
                         }
                     )
                     put(
@@ -304,7 +325,7 @@ Unified write operations for WorkItem dependencies (create, delete).
     // Create operation
     // ──────────────────────────────────────────────
 
-    private fun executeCreate(
+    private suspend fun executeCreate(
         params: JsonElement,
         context: ToolExecutionContext
     ): JsonElement {
@@ -328,9 +349,9 @@ Unified write operations for WorkItem dependencies (create, delete).
         val dependencies: List<Dependency> =
             try {
                 if (depsArray != null) {
-                    parseDependenciesArray(depsArray, sharedType, sharedUnblockAt)
+                    parseDependenciesArray(depsArray, sharedType, sharedUnblockAt, context)
                 } else {
-                    generateFromPattern(params, pattern!!, sharedType, sharedUnblockAt)
+                    generateFromPattern(params, pattern!!, sharedType, sharedUnblockAt, context)
                 }
             } catch (e: ToolValidationException) {
                 val failedCount = depsArray?.size ?: 1
@@ -372,12 +393,14 @@ Unified write operations for WorkItem dependencies (create, delete).
         }
     }
 
-    private fun parseDependenciesArray(
+    private suspend fun parseDependenciesArray(
         depsArray: JsonArray,
         sharedType: DependencyType,
-        sharedUnblockAt: String?
-    ): List<Dependency> =
-        depsArray.mapIndexed { index, element ->
+        sharedUnblockAt: String?,
+        context: ToolExecutionContext
+    ): List<Dependency> {
+        val result = mutableListOf<Dependency>()
+        for ((index, element) in depsArray.withIndex()) {
             val depObj =
                 element as? JsonObject
                     ?: throw ToolValidationException("Dependency at index $index must be a JSON object")
@@ -389,18 +412,18 @@ Unified write operations for WorkItem dependencies (create, delete).
                 extractItemString(depObj, "toItemId")
                     ?: throw ToolValidationException("Dependency at index $index: 'toItemId' is required")
 
-            val fromItemId =
-                try {
-                    UUID.fromString(fromItemIdStr)
-                } catch (_: IllegalArgumentException) {
-                    throw ToolValidationException("Dependency at index $index: 'fromItemId' is not a valid UUID: $fromItemIdStr")
-                }
-            val toItemId =
-                try {
-                    UUID.fromString(toItemIdStr)
-                } catch (_: IllegalArgumentException) {
-                    throw ToolValidationException("Dependency at index $index: 'toItemId' is not a valid UUID: $toItemIdStr")
-                }
+            val (fromItemId, fromErr) = resolveIdString(fromItemIdStr, context)
+            if (fromErr != null || fromItemId == null) {
+                throw ToolValidationException(
+                    "Dependency at index $index: 'fromItemId' could not be resolved: $fromItemIdStr"
+                )
+            }
+            val (toItemId, toErr) = resolveIdString(toItemIdStr, context)
+            if (toErr != null || toItemId == null) {
+                throw ToolValidationException(
+                    "Dependency at index $index: 'toItemId' could not be resolved: $toItemIdStr"
+                )
+            }
 
             val typeStr = extractItemString(depObj, "type")
             val type =
@@ -415,83 +438,80 @@ Unified write operations for WorkItem dependencies (create, delete).
 
             val unblockAt = extractItemString(depObj, "unblockAt") ?: sharedUnblockAt
 
-            // Dependency constructor validates (self-reference, RELATES_TO+unblockAt, valid thresholds)
             try {
-                Dependency(fromItemId = fromItemId, toItemId = toItemId, type = type, unblockAt = unblockAt)
+                result.add(Dependency(fromItemId = fromItemId, toItemId = toItemId, type = type, unblockAt = unblockAt))
             } catch (e: ValidationException) {
                 throw ToolValidationException("Dependency at index $index: ${e.message}")
             }
         }
+        return result
+    }
 
-    private fun generateFromPattern(
+    private suspend fun generateFromPattern(
         params: JsonElement,
         pattern: String,
         sharedType: DependencyType,
-        sharedUnblockAt: String?
+        sharedUnblockAt: String?,
+        context: ToolExecutionContext
     ): List<Dependency> =
         when (pattern) {
             "linear" -> {
                 val itemIdsArray = requireJsonArray(params, "itemIds")
-                val itemIds =
-                    itemIdsArray.map { element ->
-                        val str =
-                            (element as? JsonPrimitive)?.content
-                                ?: throw ToolValidationException("Each itemId must be a string UUID")
-                        try {
-                            UUID.fromString(str)
-                        } catch (_: IllegalArgumentException) {
-                            throw ToolValidationException("Invalid UUID in itemIds: $str")
-                        }
+                val itemIds = mutableListOf<UUID>()
+                for (element in itemIdsArray) {
+                    val str =
+                        (element as? JsonPrimitive)?.content
+                            ?: throw ToolValidationException("Each itemId must be a string")
+                    val (resolved, err) = resolveIdString(str, context)
+                    if (err != null || resolved == null) {
+                        throw ToolValidationException("Could not resolve itemId: $str")
                     }
-                // Generate chain: A→B, B→C, C→D
+                    itemIds.add(resolved)
+                }
                 itemIds.zipWithNext().map { (from, to) ->
                     Dependency(fromItemId = from, toItemId = to, type = sharedType, unblockAt = sharedUnblockAt)
                 }
             }
             "fan-out" -> {
                 val sourceStr = requireString(params, "source")
-                val sourceId =
-                    try {
-                        UUID.fromString(sourceStr)
-                    } catch (_: IllegalArgumentException) {
-                        throw ToolValidationException("'source' is not a valid UUID: $sourceStr")
-                    }
+                val (sourceId, sourceErr) = resolveIdString(sourceStr, context)
+                if (sourceErr != null || sourceId == null) {
+                    throw ToolValidationException("Could not resolve 'source': $sourceStr")
+                }
                 val targetsArray = requireJsonArray(params, "targets")
-                val targetIds =
-                    targetsArray.map { element ->
-                        val str =
-                            (element as? JsonPrimitive)?.content
-                                ?: throw ToolValidationException("Each target must be a string UUID")
-                        try {
-                            UUID.fromString(str)
-                        } catch (_: IllegalArgumentException) {
-                            throw ToolValidationException("Invalid UUID in targets: $str")
-                        }
+                val targetIds = mutableListOf<UUID>()
+                for (element in targetsArray) {
+                    val str =
+                        (element as? JsonPrimitive)?.content
+                            ?: throw ToolValidationException("Each target must be a string")
+                    val (resolved, err) = resolveIdString(str, context)
+                    if (err != null || resolved == null) {
+                        throw ToolValidationException("Could not resolve target: $str")
                     }
+                    targetIds.add(resolved)
+                }
                 targetIds.map { targetId ->
                     Dependency(fromItemId = sourceId, toItemId = targetId, type = sharedType, unblockAt = sharedUnblockAt)
                 }
             }
             "fan-in" -> {
                 val targetStr = requireString(params, "target")
-                val targetId =
-                    try {
-                        UUID.fromString(targetStr)
-                    } catch (_: IllegalArgumentException) {
-                        throw ToolValidationException("'target' is not a valid UUID: $targetStr")
-                    }
+                val (targetId, targetErr) = resolveIdString(targetStr, context)
+                if (targetErr != null || targetId == null) {
+                    throw ToolValidationException("Could not resolve 'target': $targetStr")
+                }
                 val sourcesArray = requireJsonArray(params, "sources")
-                val sourceIds =
-                    sourcesArray.map { element ->
-                        val str =
-                            (element as? JsonPrimitive)?.content
-                                ?: throw ToolValidationException("Each source must be a string UUID")
-                        try {
-                            UUID.fromString(str)
-                        } catch (_: IllegalArgumentException) {
-                            throw ToolValidationException("Invalid UUID in sources: $str")
-                        }
+                val sourceIds = mutableListOf<UUID>()
+                for (element in sourcesArray) {
+                    val str =
+                        (element as? JsonPrimitive)?.content
+                            ?: throw ToolValidationException("Each source must be a string")
+                    val (resolved, err) = resolveIdString(str, context)
+                    if (err != null || resolved == null) {
+                        throw ToolValidationException("Could not resolve source: $str")
                     }
+                    sourceIds.add(resolved)
+                }
                 sourceIds.map { sourceId ->
                     Dependency(fromItemId = sourceId, toItemId = targetId, type = sharedType, unblockAt = sharedUnblockAt)
                 }
@@ -503,14 +523,16 @@ Unified write operations for WorkItem dependencies (create, delete).
     // Delete operation
     // ──────────────────────────────────────────────
 
-    private fun executeDelete(
+    private suspend fun executeDelete(
         params: JsonElement,
         context: ToolExecutionContext
     ): JsonElement {
         val repo = context.dependencyRepository()
         val id = extractUUID(params, "id", required = false)
-        val fromItemId = extractUUID(params, "fromItemId", required = false)
-        val toItemId = extractUUID(params, "toItemId", required = false)
+        val (fromItemId, fromError) = resolveItemId(params, "fromItemId", context, required = false)
+        if (fromError != null) return fromError
+        val (toItemId, toError) = resolveItemId(params, "toItemId", context, required = false)
+        if (toError != null) return toError
         val deleteAll = optionalBoolean(params, "deleteAll", false)
         val typeFilter = optionalString(params, "type")
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/dependency/QueryDependenciesTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/dependency/QueryDependenciesTool.kt
@@ -55,7 +55,7 @@ Returns dependencies with counts breakdown and optional graph traversal data.
                         "itemId",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("WorkItem UUID to query dependencies for (required)"))
+                            put("description", JsonPrimitive("WorkItem UUID or hex prefix (4+ chars)"))
                         }
                     )
                     put(
@@ -99,7 +99,7 @@ Returns dependencies with counts breakdown and optional graph traversal data.
         )
 
     override fun validateParams(params: JsonElement) {
-        extractUUID(params, "itemId", required = true)
+        validateIdOrPrefix(params, "itemId", required = true)
 
         val direction = optionalString(params, "direction")
         if (direction != null && direction !in listOf("incoming", "outgoing", "all")) {
@@ -117,7 +117,9 @@ Returns dependencies with counts breakdown and optional graph traversal data.
         params: JsonElement,
         context: ToolExecutionContext
     ): JsonElement {
-        val itemId = requireUUID(params, "itemId")
+        val (resolvedItemId, idError) = resolveItemId(params, "itemId", context)
+        if (idError != null) return idError
+        val itemId = resolvedItemId!!
         val direction = optionalString(params, "direction") ?: "all"
         val typeFilter = optionalString(params, "type")?.let { DependencyType.fromString(it) }
         val includeItemInfo = optionalBoolean(params, "includeItemInfo", defaultValue = false)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt
@@ -114,7 +114,7 @@ Unified write operations for WorkItems (create, update, delete).
                         "parentId",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("Shared default parent ID for create"))
+                            put("description", JsonPrimitive("Shared default parent ID for create (UUID or hex prefix 4+ chars)"))
                         }
                     )
                     put(
@@ -199,13 +199,16 @@ Unified write operations for WorkItems (create, update, delete).
     ): JsonElement {
         val operation = requireString(params, "operation")
         return when (operation) {
-            "create" ->
+            "create" -> {
+                val (parentId, parentIdError) = resolveItemId(params, "parentId", context, required = false)
+                if (parentIdError != null) return parentIdError
                 createHandler.execute(
                     requireJsonArray(params, "items"),
-                    extractUUID(params, "parentId", required = false),
+                    parentId,
                     optionalString(params, "traits"),
                     context
                 )
+            }
             "update" ->
                 updateHandler.execute(
                     requireJsonArray(params, "items"),

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
@@ -82,14 +82,14 @@ Operations: get, search, overview
                         "itemId",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("Item UUID or short hex prefix (min 4 chars) for scoped overview"))
+                            put("description", JsonPrimitive("Item UUID or hex prefix (4+ chars) for scoped overview"))
                         }
                     )
                     put(
                         "parentId",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("Filter by parent ID (UUID or short hex prefix, min 4 chars)"))
+                            put("description", JsonPrimitive("Filter by parent ID (UUID or hex prefix 4+ chars)"))
                         }
                     )
                     put(

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
@@ -18,13 +18,6 @@ import kotlinx.serialization.json.*
  * - **overview**: Hierarchical summary view (scoped to an item, or global root items)
  */
 class QueryItemsTool : BaseToolDefinition() {
-    companion object {
-        /** Minimum hex characters required for prefix resolution (avoids excessive ambiguity). */
-        private const val MIN_PREFIX_LENGTH = 4
-
-        private val HEX_PATTERN = Regex("^[0-9a-fA-F]+$")
-    }
-
     override val name = "query_items"
 
     override val description =
@@ -89,14 +82,14 @@ Operations: get, search, overview
                         "itemId",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("Item UUID for scoped overview"))
+                            put("description", JsonPrimitive("Item UUID or short hex prefix (min 4 chars) for scoped overview"))
                         }
                     )
                     put(
                         "parentId",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("Filter by parent ID"))
+                            put("description", JsonPrimitive("Filter by parent ID (UUID or short hex prefix, min 4 chars)"))
                         }
                     )
                     put(
@@ -242,7 +235,7 @@ Operations: get, search, overview
     override fun validateParams(params: JsonElement) {
         val operation = requireString(params, "operation")
         when (operation) {
-            "get" -> requireString(params, "id") // Accept any string; UUID vs prefix validation happens in executeGet
+            "get" -> validateIdOrPrefix(params, "id")
             "search", "overview" -> { /* all parameters are optional */ }
             else -> throw ToolValidationException("Invalid operation: $operation. Must be one of: get, search, overview")
         }
@@ -339,83 +332,22 @@ Operations: get, search, overview
         params: JsonElement,
         context: ToolExecutionContext
     ): JsonElement {
-        val idStr = requireString(params, "id")
+        val (resolvedId, idError) = resolveItemId(params, "id", context)
+        if (idError != null) return idError
+        val itemId = resolvedId!!
         val includeAncestors = optionalBoolean(params, "includeAncestors", false)
 
-        // Try parsing as a full UUID first (fast path — avoids prefix resolution overhead)
         val item =
-            if (idStr.length == 36) {
-                val id =
-                    try {
-                        java.util.UUID.fromString(idStr)
-                    } catch (_: IllegalArgumentException) {
-                        return errorResponse("Invalid UUID format: $idStr", ErrorCodes.VALIDATION_ERROR)
-                    }
-                when (val result = context.workItemRepository().getById(id)) {
-                    is Result.Success -> result.data
-                    is Result.Error -> return errorResponse(
-                        "WorkItem not found",
-                        ErrorCodes.RESOURCE_NOT_FOUND,
-                        additionalData =
-                            buildJsonObject {
-                                put("requestedId", JsonPrimitive(idStr))
-                            }
-                    )
-                }
-            } else {
-                // Prefix resolution path
-                if (!idStr.matches(HEX_PATTERN)) {
-                    return errorResponse(
-                        "Invalid ID format: must be a UUID or hex prefix ($MIN_PREFIX_LENGTH-35 chars), got: $idStr",
-                        ErrorCodes.VALIDATION_ERROR
-                    )
-                }
-                if (idStr.length < MIN_PREFIX_LENGTH) {
-                    return errorResponse(
-                        "ID prefix too short: minimum $MIN_PREFIX_LENGTH hex characters required, got ${idStr.length}",
-                        ErrorCodes.VALIDATION_ERROR
-                    )
-                }
-
-                when (val result = context.workItemRepository().findByIdPrefix(idStr)) {
-                    is Result.Success -> {
-                        val matches = result.data
-                        when {
-                            matches.isEmpty() -> return errorResponse(
-                                "No WorkItem found matching prefix: $idStr",
-                                ErrorCodes.RESOURCE_NOT_FOUND,
-                                additionalData =
-                                    buildJsonObject {
-                                        put("prefix", JsonPrimitive(idStr))
-                                    }
-                            )
-                            matches.size > 1 -> return errorResponse(
-                                "Ambiguous prefix: $idStr matches ${matches.size} items",
-                                ErrorCodes.VALIDATION_ERROR,
-                                additionalData =
-                                    buildJsonObject {
-                                        put("prefix", JsonPrimitive(idStr))
-                                        put(
-                                            "matches",
-                                            JsonArray(
-                                                matches.map { match ->
-                                                    buildJsonObject {
-                                                        put("id", JsonPrimitive(match.id.toString()))
-                                                        put("title", JsonPrimitive(match.title))
-                                                    }
-                                                }
-                                            )
-                                        )
-                                    }
-                            )
-                            else -> matches.first()
+            when (val result = context.workItemRepository().getById(itemId)) {
+                is Result.Success -> result.data
+                is Result.Error -> return errorResponse(
+                    "WorkItem not found",
+                    ErrorCodes.RESOURCE_NOT_FOUND,
+                    additionalData =
+                        buildJsonObject {
+                            put("requestedId", JsonPrimitive(itemId.toString()))
                         }
-                    }
-                    is Result.Error -> return errorResponse(
-                        "Failed to resolve prefix: ${result.error.message}",
-                        ErrorCodes.DATABASE_ERROR
-                    )
-                }
+                )
             }
 
         val itemJson = item.toFullJson()
@@ -442,7 +374,8 @@ Operations: get, search, overview
         params: JsonElement,
         context: ToolExecutionContext
     ): JsonElement {
-        val parentId = extractUUID(params, "parentId", required = false)
+        val (parentId, parentIdError) = resolveItemId(params, "parentId", context, required = false)
+        if (parentIdError != null) return parentIdError
         val depth = optionalInt(params, "depth")
         val roleStr = optionalString(params, "role")
         val priorityStr = optionalString(params, "priority")
@@ -591,7 +524,8 @@ Operations: get, search, overview
         params: JsonElement,
         context: ToolExecutionContext
     ): JsonElement {
-        val itemId = extractUUID(params, "itemId", required = false)
+        val (itemId, itemIdError) = resolveItemId(params, "itemId", context, required = false)
+        if (itemIdError != null) return itemIdError
 
         return if (itemId != null) {
             executeScopedOverview(itemId, context)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesTool.kt
@@ -78,7 +78,10 @@ Unified write operations for Notes (upsert, delete).
                         "itemId",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("WorkItem UUID — delete all notes for this item"))
+                            put(
+                                "description",
+                                JsonPrimitive("WorkItem UUID or hex prefix (4+ chars) — delete all notes for this item")
+                            )
                         }
                     )
                     put(
@@ -182,12 +185,11 @@ Unified write operations for Notes (upsert, delete).
                         ?: throw ToolValidationException("Note at index $index: 'role' is required")
                 val body = extractNoteString(noteObj, "body") ?: ""
 
-                val itemId =
-                    try {
-                        UUID.fromString(itemIdStr)
-                    } catch (_: IllegalArgumentException) {
-                        throw ToolValidationException("Note at index $index: 'itemId' is not a valid UUID: $itemIdStr")
-                    }
+                val (resolvedItemId, itemIdErr) = resolveIdString(itemIdStr, context)
+                if (itemIdErr != null || resolvedItemId == null) {
+                    throw ToolValidationException("Note at index $index: could not resolve 'itemId': $itemIdStr")
+                }
+                val itemId = resolvedItemId
 
                 // Validate that the WorkItem exists (cache for itemContext reuse)
                 if (itemId !in validatedItems) {
@@ -385,15 +387,9 @@ Unified write operations for Notes (upsert, delete).
 
         // Delete by itemId (+ optional key)
         if (itemIdStr != null) {
-            val itemId =
-                try {
-                    UUID.fromString(itemIdStr)
-                } catch (_: IllegalArgumentException) {
-                    return errorResponse(
-                        "Parameter 'itemId' is not a valid UUID: $itemIdStr",
-                        ErrorCodes.VALIDATION_ERROR
-                    )
-                }
+            val (resolvedItemId, itemIdErr) = resolveIdString(itemIdStr, context)
+            if (itemIdErr != null) return itemIdErr
+            val itemId = resolvedItemId!!
 
             if (key != null) {
                 // Delete specific note by (itemId, key)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/QueryNotesTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/QueryNotesTool.kt
@@ -66,7 +66,7 @@ Read-only query operations for Notes (get, list).
                         "itemId",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("WorkItem UUID (required for list)"))
+                            put("description", JsonPrimitive("WorkItem UUID or hex prefix (4+ chars), required for list"))
                         }
                     )
                     put(
@@ -94,7 +94,7 @@ Read-only query operations for Notes (get, list).
                 extractUUID(params, "id", required = true)
             }
             "list" -> {
-                extractUUID(params, "itemId", required = true)
+                validateIdOrPrefix(params, "itemId", required = true)
                 val role = optionalString(params, "role")
                 if (role != null) {
                     val validRoles = setOf("queue", "work", "review")
@@ -178,7 +178,9 @@ Read-only query operations for Notes (get, list).
         params: JsonElement,
         context: ToolExecutionContext
     ): JsonElement {
-        val itemId = requireUUID(params, "itemId")
+        val (resolvedItemId, idError) = resolveItemId(params, "itemId", context)
+        if (idError != null) return idError
+        val itemId = resolvedItemId!!
         val role = optionalString(params, "role")
         val includeBody = optionalBoolean(params, "includeBody", defaultValue = true)
         val noteRepo = context.noteRepository()

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -39,7 +39,7 @@ class AdvanceItemTool : BaseToolDefinition() {
 Trigger-based role transitions for WorkItems with validation, cascade detection, and unblock reporting.
 
 **Parameters:**
-- `transitions` (required array): Each element: `{ itemId (required UUID), trigger (required string), summary? (optional string) }`
+- `transitions` (required array): Each element: `{ itemId (required UUID or short hex prefix, min 4 chars), trigger (required string), summary? (optional string) }`
 - Valid triggers: start, complete, block, hold, resume, cancel, reopen
 
 **Trigger effects:**
@@ -121,11 +121,7 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
             if (!itemIdPrim.isString || itemIdPrim.content.isBlank()) {
                 throw ToolValidationException("transitions[$index].itemId must be a non-empty string")
             }
-            try {
-                UUID.fromString(itemIdPrim.content)
-            } catch (_: IllegalArgumentException) {
-                throw ToolValidationException("transitions[$index].itemId must be a valid UUID")
-            }
+            validateIdStringOrPrefix(itemIdPrim.content, "transitions[$index].itemId")
             val triggerPrim =
                 obj["trigger"] as? JsonPrimitive
                     ?: throw ToolValidationException("transitions[$index] missing required field: trigger")
@@ -151,7 +147,20 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
 
         for (element in transitions) {
             val obj = element as JsonObject
-            val itemId = UUID.fromString((obj["itemId"] as JsonPrimitive).content)
+            val itemIdStr = (obj["itemId"] as JsonPrimitive).content
+            val (resolvedItemId, idError) = resolveIdString(itemIdStr, context)
+            if (idError != null) {
+                failCount++
+                resultsList.add(
+                    buildJsonObject {
+                        put("itemId", JsonPrimitive(itemIdStr))
+                        put("applied", JsonPrimitive(false))
+                        put("error", JsonPrimitive("Failed to resolve item ID: $itemIdStr"))
+                    }
+                )
+                continue
+            }
+            val itemId = resolvedItemId!!
             val trigger = (obj["trigger"] as JsonPrimitive).content.lowercase()
             val summary =
                 (obj["summary"] as? JsonPrimitive)?.let {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsTool.kt
@@ -89,7 +89,10 @@ Items in TERMINAL role are never included.
                         "parentId",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("Scope results to items under this parent UUID"))
+                            put(
+                                "description",
+                                JsonPrimitive("Scope to items under this parent (UUID or hex prefix 4+ chars)")
+                            )
                         }
                     )
                     put(
@@ -119,7 +122,8 @@ Items in TERMINAL role are never included.
         params: JsonElement,
         context: ToolExecutionContext
     ): JsonElement {
-        val parentId = extractUUID(params, "parentId", required = false)
+        val (parentId, parentIdError) = resolveItemId(params, "parentId", context, required = false)
+        if (parentIdError != null) return parentIdError
         val includeDetails = optionalBoolean(params, "includeItemDetails", false)
         val includeAncestors = optionalBoolean(params, "includeAncestors", false)
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
@@ -70,7 +70,7 @@ Parameters:
                         "itemId",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("UUID of a WorkItem for item context mode"))
+                            put("description", JsonPrimitive("UUID or hex prefix (4+ chars) of a WorkItem for item context mode"))
                         }
                     )
                     put(
@@ -105,8 +105,8 @@ Parameters:
         )
 
     override fun validateParams(params: JsonElement) {
-        // Validate itemId if present
-        extractUUID(params, "itemId", required = false)
+        // Validate itemId if present — accepts full UUID or short hex prefix
+        validateIdOrPrefix(params, "itemId", required = false)
         // Validate since if present
         parseInstant(params, "since")
     }
@@ -115,7 +115,8 @@ Parameters:
         params: JsonElement,
         context: ToolExecutionContext
     ): JsonElement {
-        val itemId = extractUUID(params, "itemId", required = false)
+        val (itemId, idError) = resolveItemId(params, "itemId", context, required = false)
+        if (idError != null) return idError
         val sinceInstant = parseInstant(params, "since")
         val includeAncestors = optionalBoolean(params, "includeAncestors", false)
         val transitionLimit =

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
@@ -52,7 +52,10 @@ Parameters:
                         "parentId",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("Scope recommendations to items under this parent (UUID)"))
+                            put(
+                                "description",
+                                JsonPrimitive("Scope to items under this parent (UUID or hex prefix 4+ chars)")
+                            )
                         }
                     )
                     put(
@@ -87,7 +90,7 @@ Parameters:
 
     override fun validateParams(params: JsonElement) {
         // All parameters are optional — just validate types if present
-        extractUUID(params, "parentId", required = false)
+        validateIdOrPrefix(params, "parentId", required = false)
         val limit = optionalInt(params, "limit")
         if (limit != null && (limit < 1 || limit > 20)) {
             throw ToolValidationException("limit must be between 1 and 20, got: $limit")
@@ -98,7 +101,8 @@ Parameters:
         params: JsonElement,
         context: ToolExecutionContext
     ): JsonElement {
-        val parentId = extractUUID(params, "parentId", required = false)
+        val (parentId, parentIdError) = resolveItemId(params, "parentId", context, required = false)
+        if (parentIdError != null) return parentIdError
         val limit = optionalInt(params, "limit") ?: 1
         val includeDetails = optionalBoolean(params, "includeDetails", defaultValue = false)
         val includeAncestors = optionalBoolean(params, "includeAncestors", false)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextStatusTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextStatusTool.kt
@@ -52,7 +52,7 @@ Read-only status progression recommendation for a WorkItem.
                         "itemId",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("UUID of the WorkItem to analyze"))
+                            put("description", JsonPrimitive("UUID or hex prefix (4+ chars) of the WorkItem to analyze"))
                         }
                     )
                 },
@@ -60,14 +60,16 @@ Read-only status progression recommendation for a WorkItem.
         )
 
     override fun validateParams(params: JsonElement) {
-        extractUUID(params, "itemId", required = true)
+        validateIdOrPrefix(params, "itemId", required = true)
     }
 
     override suspend fun execute(
         params: JsonElement,
         context: ToolExecutionContext
     ): JsonElement {
-        val itemId = requireUUID(params, "itemId")
+        val (resolvedItemId, idError) = resolveItemId(params, "itemId", context)
+        if (idError != null) return idError
+        val itemId = resolvedItemId!!
 
         // Fetch the WorkItem
         val itemResult = context.workItemRepository().getById(itemId)

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/BaseToolDefinitionTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/BaseToolDefinitionTest.kt
@@ -1,6 +1,12 @@
 package io.github.jpicklyk.mcptask.current.application.tools
 
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.RepositoryError
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.test.MockRepositoryProvider
+import io.mockk.coEvery
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.*
 import java.time.Instant
 import java.util.UUID
@@ -100,6 +106,19 @@ class BaseToolDefinitionTest {
                 msg: String,
                 code: String = ErrorCodes.VALIDATION_ERROR
             ) = errorResponse(msg, code)
+
+            fun testValidateIdOrPrefix(
+                params: JsonElement,
+                name: String,
+                required: Boolean = true
+            ) = validateIdOrPrefix(params, name, required)
+
+            suspend fun testResolveItemId(
+                params: JsonElement,
+                name: String,
+                context: ToolExecutionContext,
+                required: Boolean = true
+            ) = resolveItemId(params, name, context, required)
         }
 
     /** Helper to build a JsonObject from pairs. */
@@ -547,4 +566,385 @@ class BaseToolDefinitionTest {
         val error = response["error"]!!.jsonObject
         assertEquals(ErrorCodes.VALIDATION_ERROR, error["code"]!!.jsonPrimitive.content)
     }
+
+    // ────────────────────────────────────────────────────────
+    // validateIdOrPrefix — full UUID
+    // ────────────────────────────────────────────────────────
+
+    @Test
+    fun `validateIdOrPrefix accepts valid full UUID`() {
+        val uuid = UUID.randomUUID()
+        val p = params("id" to JsonPrimitive(uuid.toString()))
+        // Should not throw
+        tool.testValidateIdOrPrefix(p, "id")
+    }
+
+    @Test
+    fun `validateIdOrPrefix rejects malformed 36-char string`() {
+        val p = params("id" to JsonPrimitive("not-a-uuid-but-exactly-36-chars-long"))
+        assertFailsWith<ToolValidationException> {
+            tool.testValidateIdOrPrefix(p, "id")
+        }
+    }
+
+    // ────────────────────────────────────────────────────────
+    // validateIdOrPrefix — hex prefix
+    // ────────────────────────────────────────────────────────
+
+    @Test
+    fun `validateIdOrPrefix accepts 8-char hex prefix`() {
+        val p = params("id" to JsonPrimitive("abcd1234"))
+        tool.testValidateIdOrPrefix(p, "id")
+    }
+
+    @Test
+    fun `validateIdOrPrefix accepts minimum 4-char hex prefix`() {
+        val p = params("id" to JsonPrimitive("abcd"))
+        tool.testValidateIdOrPrefix(p, "id")
+    }
+
+    @Test
+    fun `validateIdOrPrefix accepts uppercase hex prefix`() {
+        val p = params("id" to JsonPrimitive("ABCD1234"))
+        tool.testValidateIdOrPrefix(p, "id")
+    }
+
+    @Test
+    fun `validateIdOrPrefix accepts mixed case hex prefix`() {
+        val p = params("id" to JsonPrimitive("aBcD1234"))
+        tool.testValidateIdOrPrefix(p, "id")
+    }
+
+    @Test
+    fun `validateIdOrPrefix rejects prefix shorter than 4 chars`() {
+        val p = params("id" to JsonPrimitive("abc"))
+        val ex =
+            assertFailsWith<ToolValidationException> {
+                tool.testValidateIdOrPrefix(p, "id")
+            }
+        assertTrue(ex.message!!.contains("minimum"))
+    }
+
+    @Test
+    fun `validateIdOrPrefix rejects single hex char`() {
+        val p = params("id" to JsonPrimitive("a"))
+        assertFailsWith<ToolValidationException> {
+            tool.testValidateIdOrPrefix(p, "id")
+        }
+    }
+
+    @Test
+    fun `validateIdOrPrefix rejects non-hex characters`() {
+        val p = params("id" to JsonPrimitive("ghij1234"))
+        val ex =
+            assertFailsWith<ToolValidationException> {
+                tool.testValidateIdOrPrefix(p, "id")
+            }
+        assertTrue(ex.message!!.contains("hex prefix"))
+    }
+
+    @Test
+    fun `validateIdOrPrefix rejects special characters`() {
+        val p = params("id" to JsonPrimitive("ab-cd-ef"))
+        assertFailsWith<ToolValidationException> {
+            tool.testValidateIdOrPrefix(p, "id")
+        }
+    }
+
+    // ────────────────────────────────────────────────────────
+    // validateIdOrPrefix — missing/blank/type errors
+    // ────────────────────────────────────────────────────────
+
+    @Test
+    fun `validateIdOrPrefix throws when required and missing`() {
+        val p = params()
+        assertFailsWith<ToolValidationException> {
+            tool.testValidateIdOrPrefix(p, "id", required = true)
+        }
+    }
+
+    @Test
+    fun `validateIdOrPrefix returns silently when not required and missing`() {
+        val p = params()
+        // Should not throw
+        tool.testValidateIdOrPrefix(p, "id", required = false)
+    }
+
+    @Test
+    fun `validateIdOrPrefix throws when required and blank`() {
+        val p = params("id" to JsonPrimitive(""))
+        assertFailsWith<ToolValidationException> {
+            tool.testValidateIdOrPrefix(p, "id", required = true)
+        }
+    }
+
+    @Test
+    fun `validateIdOrPrefix returns silently when not required and blank`() {
+        val p = params("id" to JsonPrimitive(""))
+        tool.testValidateIdOrPrefix(p, "id", required = false)
+    }
+
+    @Test
+    fun `validateIdOrPrefix throws on non-string type`() {
+        val p = params("id" to JsonPrimitive(12345))
+        assertFailsWith<ToolValidationException> {
+            tool.testValidateIdOrPrefix(p, "id")
+        }
+    }
+
+    @Test
+    fun `validateIdOrPrefix throws when params is not a JsonObject`() {
+        assertFailsWith<ToolValidationException> {
+            tool.testValidateIdOrPrefix(JsonPrimitive("not an object"), "id")
+        }
+    }
+
+    // ────────────────────────────────────────────────────────
+    // resolveItemId — helper to build mock context
+    // ────────────────────────────────────────────────────────
+
+    private fun makeWorkItem(
+        id: UUID = UUID.randomUUID(),
+        title: String = "Test Item"
+    ): WorkItem = WorkItem(id = id, title = title)
+
+    // ────────────────────────────────────────────────────────
+    // resolveItemId — full UUID path
+    // ────────────────────────────────────────────────────────
+
+    @Test
+    fun `resolveItemId resolves full UUID without hitting repository`(): Unit =
+        runBlocking {
+            val uuid = UUID.randomUUID()
+            val mocks = MockRepositoryProvider()
+            val p = params("id" to JsonPrimitive(uuid.toString()))
+
+            val (resolved, error) = tool.testResolveItemId(p, "id", mocks.context())
+
+            assertEquals(uuid, resolved)
+            assertNull(error)
+        }
+
+    @Test
+    fun `resolveItemId returns error for malformed 36-char string`(): Unit =
+        runBlocking {
+            val mocks = MockRepositoryProvider()
+            val p = params("id" to JsonPrimitive("not-a-uuid-but-exactly-36-chars-long"))
+
+            val (resolved, error) = tool.testResolveItemId(p, "id", mocks.context())
+
+            assertNull(resolved)
+            assertNotNull(error)
+            assertFalse(error.jsonObject["success"]!!.jsonPrimitive.boolean)
+        }
+
+    // ────────────────────────────────────────────────────────
+    // resolveItemId — prefix resolution path
+    // ────────────────────────────────────────────────────────
+
+    @Test
+    fun `resolveItemId resolves 8-char prefix to unique item`(): Unit =
+        runBlocking {
+            val item = makeWorkItem(title = "Prefix Match")
+            val mocks = MockRepositoryProvider()
+            coEvery { mocks.workItemRepo.findByIdPrefix(any(), any()) } returns Result.Success(listOf(item))
+            val prefix = item.id.toString().substring(0, 8)
+            val p = params("id" to JsonPrimitive(prefix))
+
+            val (resolved, error) = tool.testResolveItemId(p, "id", mocks.context())
+
+            assertEquals(item.id, resolved)
+            assertNull(error)
+        }
+
+    @Test
+    fun `resolveItemId resolves 4-char prefix to unique item`(): Unit =
+        runBlocking {
+            val item = makeWorkItem(title = "Short Prefix Match")
+            val mocks = MockRepositoryProvider()
+            coEvery { mocks.workItemRepo.findByIdPrefix(any(), any()) } returns Result.Success(listOf(item))
+            val prefix = item.id.toString().substring(0, 4)
+            val p = params("id" to JsonPrimitive(prefix))
+
+            val (resolved, error) = tool.testResolveItemId(p, "id", mocks.context())
+
+            assertEquals(item.id, resolved)
+            assertNull(error)
+        }
+
+    @Test
+    fun `resolveItemId returns not-found error when prefix matches nothing`(): Unit =
+        runBlocking {
+            val mocks = MockRepositoryProvider()
+            coEvery { mocks.workItemRepo.findByIdPrefix(any(), any()) } returns Result.Success(emptyList())
+            val p = params("id" to JsonPrimitive("dead0000"))
+
+            val (resolved, error) = tool.testResolveItemId(p, "id", mocks.context())
+
+            assertNull(resolved)
+            assertNotNull(error)
+            val errorObj = error.jsonObject["error"]!!.jsonObject
+            assertTrue(errorObj["message"]!!.jsonPrimitive.content.contains("No WorkItem found"))
+            assertEquals(ErrorCodes.RESOURCE_NOT_FOUND, errorObj["code"]!!.jsonPrimitive.content)
+        }
+
+    @Test
+    fun `resolveItemId returns ambiguous error when prefix matches multiple items`(): Unit =
+        runBlocking {
+            val item1 = makeWorkItem(title = "Item One")
+            val item2 = makeWorkItem(title = "Item Two")
+            val mocks = MockRepositoryProvider()
+            coEvery {
+                mocks.workItemRepo.findByIdPrefix(any(), any())
+            } returns Result.Success(listOf(item1, item2))
+            val p = params("id" to JsonPrimitive("abcd1234"))
+
+            val (resolved, error) = tool.testResolveItemId(p, "id", mocks.context())
+
+            assertNull(resolved)
+            assertNotNull(error)
+            val errorObj = error.jsonObject["error"]!!.jsonObject
+            assertTrue(errorObj["message"]!!.jsonPrimitive.content.contains("Ambiguous prefix"))
+            val additionalData = error.jsonObject["data"]!!.jsonObject
+            val matches = additionalData["matches"]!!.jsonArray
+            assertEquals(2, matches.size)
+        }
+
+    @Test
+    fun `resolveItemId returns error when repository fails`(): Unit =
+        runBlocking {
+            val mocks = MockRepositoryProvider()
+            coEvery {
+                mocks.workItemRepo.findByIdPrefix(any(), any())
+            } returns
+                Result.Error(RepositoryError.DatabaseError("Database connection failed"))
+            val p = params("id" to JsonPrimitive("abcd1234"))
+
+            val (resolved, error) = tool.testResolveItemId(p, "id", mocks.context())
+
+            assertNull(resolved)
+            assertNotNull(error)
+            val errorObj = error.jsonObject["error"]!!.jsonObject
+            assertTrue(errorObj["message"]!!.jsonPrimitive.content.contains("Failed to resolve"))
+            assertEquals(ErrorCodes.INTERNAL_ERROR, errorObj["code"]!!.jsonPrimitive.content)
+        }
+
+    // ────────────────────────────────────────────────────────
+    // resolveItemId — validation errors (bad format)
+    // ────────────────────────────────────────────────────────
+
+    @Test
+    fun `resolveItemId returns error for non-hex characters in prefix`(): Unit =
+        runBlocking {
+            val mocks = MockRepositoryProvider()
+            val p = params("id" to JsonPrimitive("ghij1234"))
+
+            val (resolved, error) = tool.testResolveItemId(p, "id", mocks.context())
+
+            assertNull(resolved)
+            assertNotNull(error)
+            val errorMsg =
+                error.jsonObject["error"]!!
+                    .jsonObject["message"]!!
+                    .jsonPrimitive.content
+            assertTrue(errorMsg.contains("Invalid ID format"))
+        }
+
+    @Test
+    fun `resolveItemId returns error for prefix shorter than 4 chars`(): Unit =
+        runBlocking {
+            val mocks = MockRepositoryProvider()
+            val p = params("id" to JsonPrimitive("abc"))
+
+            val (resolved, error) = tool.testResolveItemId(p, "id", mocks.context())
+
+            assertNull(resolved)
+            assertNotNull(error)
+            val errorMsg =
+                error.jsonObject["error"]!!
+                    .jsonObject["message"]!!
+                    .jsonPrimitive.content
+            assertTrue(errorMsg.contains("prefix too short"))
+        }
+
+    @Test
+    fun `resolveItemId returns error for special characters in prefix`() {
+        runBlocking {
+            val mocks = MockRepositoryProvider()
+            val p = params("id" to JsonPrimitive("ab-cd-ef"))
+
+            val (resolved, error) = tool.testResolveItemId(p, "id", mocks.context())
+
+            assertNull(resolved)
+            assertNotNull(error)
+        }
+    }
+
+    // ────────────────────────────────────────────────────────
+    // resolveItemId — missing/blank/optional
+    // ────────────────────────────────────────────────────────
+
+    @Test
+    fun `resolveItemId returns error when required and missing`(): Unit =
+        runBlocking {
+            val mocks = MockRepositoryProvider()
+            val p = params()
+
+            val (resolved, error) = tool.testResolveItemId(p, "id", mocks.context(), required = true)
+
+            assertNull(resolved)
+            assertNotNull(error)
+            val errorMsg =
+                error.jsonObject["error"]!!
+                    .jsonObject["message"]!!
+                    .jsonPrimitive.content
+            assertTrue(errorMsg.contains("Missing required"))
+        }
+
+    @Test
+    fun `resolveItemId returns both null when not required and missing`(): Unit =
+        runBlocking {
+            val mocks = MockRepositoryProvider()
+            val p = params()
+
+            val (resolved, error) = tool.testResolveItemId(p, "id", mocks.context(), required = false)
+
+            assertNull(resolved)
+            assertNull(error)
+        }
+
+    @Test
+    fun `resolveItemId returns both null when not required and blank`(): Unit =
+        runBlocking {
+            val mocks = MockRepositoryProvider()
+            val p = params("id" to JsonPrimitive(""))
+
+            val (resolved, error) = tool.testResolveItemId(p, "id", mocks.context(), required = false)
+
+            assertNull(resolved)
+            assertNull(error)
+        }
+
+    @Test
+    fun `resolveItemId returns error when required and blank`(): Unit =
+        runBlocking {
+            val mocks = MockRepositoryProvider()
+            val p = params("id" to JsonPrimitive(""))
+
+            val (resolved, error) = tool.testResolveItemId(p, "id", mocks.context(), required = true)
+
+            assertNull(resolved)
+            assertNotNull(error)
+        }
+
+    @Test
+    fun `resolveItemId returns error when params is not a JsonObject`(): Unit =
+        runBlocking {
+            val mocks = MockRepositoryProvider()
+
+            val (resolved, error) = tool.testResolveItemId(JsonPrimitive("not an object"), "id", mocks.context())
+
+            assertNull(resolved)
+            assertNotNull(error)
+        }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeToolTest.kt
@@ -992,4 +992,127 @@ class CompleteTreeToolTest {
             // Hardcoded "cancelled" from resolution.statusLabel takes precedence over config "dropped"
             assertEquals("cancelled", r["statusLabel"]!!.jsonPrimitive.content)
         }
+
+    // ──────────────────────────────────────────────
+    // Short prefix resolution
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `rootId accepts short hex prefix and resolves`(): Unit =
+        runBlocking {
+            val item = makeItem(title = "Prefix Root", role = Role.QUEUE)
+            val prefix = item.id.toString().substring(0, 8)
+
+            coEvery { workItemRepo.findByIdPrefix(prefix, any()) } returns Result.Success(listOf(item))
+            coEvery { workItemRepo.findDescendants(item.id) } returns Result.Success(emptyList())
+            coEvery { workItemRepo.getById(item.id) } returns Result.Success(item)
+            coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+            coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+            every { depRepo.findByToItemId(item.id) } returns emptyList()
+
+            val params =
+                buildJsonObject {
+                    put("rootId", JsonPrimitive(prefix))
+                    put("trigger", JsonPrimitive("complete"))
+                }
+            val result = tool.execute(params, context)
+
+            val data = extractData(result)
+            assertNotNull(data["summary"])
+        }
+
+    @Test
+    fun `rootId with unresolvable prefix throws validation error`(): Unit =
+        runBlocking {
+            coEvery { workItemRepo.findByIdPrefix("dead0000", any()) } returns Result.Success(emptyList())
+
+            val params =
+                buildJsonObject {
+                    put("rootId", JsonPrimitive("dead0000"))
+                    put("trigger", JsonPrimitive("complete"))
+                }
+            val ex =
+                assertFailsWith<ToolValidationException> {
+                    tool.execute(params, context)
+                }
+            assertTrue(ex.message!!.contains("resolve"))
+        }
+
+    @Test
+    fun `itemIds accepts short hex prefixes and resolves`(): Unit =
+        runBlocking {
+            val item = makeItem(title = "Prefix Item", role = Role.QUEUE)
+            val prefix = item.id.toString().substring(0, 8)
+
+            coEvery { workItemRepo.findByIdPrefix(prefix, any()) } returns Result.Success(listOf(item))
+            coEvery { workItemRepo.getById(item.id) } returns Result.Success(item)
+            coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+            coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+            every { depRepo.findByToItemId(item.id) } returns emptyList()
+
+            val params =
+                buildJsonObject {
+                    put(
+                        "itemIds",
+                        buildJsonArray { add(JsonPrimitive(prefix)) }
+                    )
+                    put("trigger", JsonPrimitive("complete"))
+                }
+            val result = tool.execute(params, context)
+
+            val data = extractData(result)
+            assertNotNull(data["summary"])
+        }
+
+    @Test
+    fun `itemIds with unresolvable prefix throws validation error`(): Unit =
+        runBlocking {
+            coEvery { workItemRepo.findByIdPrefix("dead0000", any()) } returns Result.Success(emptyList())
+
+            val params =
+                buildJsonObject {
+                    put(
+                        "itemIds",
+                        buildJsonArray { add(JsonPrimitive("dead0000")) }
+                    )
+                    put("trigger", JsonPrimitive("complete"))
+                }
+            val ex =
+                assertFailsWith<ToolValidationException> {
+                    tool.execute(params, context)
+                }
+            assertTrue(ex.message!!.contains("resolve"))
+        }
+
+    @Test
+    fun `validateParams accepts short hex prefix in rootId`() {
+        tool.validateParams(
+            buildJsonObject {
+                put("rootId", JsonPrimitive("abcd1234"))
+            }
+        )
+    }
+
+    @Test
+    fun `validateParams accepts short hex prefix in itemIds`() {
+        tool.validateParams(
+            buildJsonObject {
+                put(
+                    "itemIds",
+                    buildJsonArray { add(JsonPrimitive("abcd1234")) }
+                )
+            }
+        )
+    }
+
+    @Test
+    fun `validateParams rejects too-short prefix in rootId`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(
+                buildJsonObject {
+                    put("rootId", JsonPrimitive("abc"))
+                }
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- All 13 MCP tools that accept WorkItem ID parameters now support short hex prefixes (min 4 chars) in addition to full UUIDs
- Shared helpers in `BaseToolDefinition`: `validateIdStringOrPrefix`, `validateIdOrPrefix`, `resolveIdString`, `resolveItemId`
- Replaces the inline prefix resolution that only existed in `QueryItemsTool.executeGet()` with consistent shared infrastructure
- Non-WorkItem IDs (Note UUID, Dependency UUID) correctly kept as `extractUUID`

## Tools updated
`get_context`, `get_next_status`, `get_next_item`, `get_blocked_items`, `advance_item`, `query_items`, `query_notes`, `query_dependencies`, `manage_items`, `manage_notes`, `manage_dependencies`, `create_work_tree`, `complete_tree`

## Test plan
- [x] 27 unit tests for shared helpers (`validateIdOrPrefix`, `validateIdStringOrPrefix`, `resolveItemId`, `resolveIdString`) covering full UUID, prefix, ambiguous, not-found, repo-error, missing/blank/optional paths
- [x] 7 integration tests for `CompleteTreeTool` prefix resolution (happy path + error surfacing for both `rootId` and `itemIds[]`)
- [x] Existing `QueryItemsToolPrefixTest` (6 tests) continues to pass
- [x] All 1135 tests pass, ktlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)