### PR TITLE
fix: include childCounts and traits in scoped overview children

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
@@ -572,7 +572,26 @@ Operations: get, search, overview
             buildJsonObject {
                 put("item", item.toFullJson())
                 put("childCounts", roleCountToJson(childCounts))
-                put("children", JsonArray(children.map { it.toMinimalJson() }))
+                put(
+                    "children",
+                    JsonArray(
+                        children.map { child ->
+                            val grandchildCounts =
+                                when (val result = context.workItemRepository().countChildrenByRole(child.id)) {
+                                    is Result.Success -> result.data
+                                    is Result.Error -> emptyMap()
+                                }
+                            val childTraits = PropertiesHelper.extractTraits(child.properties)
+                            buildJsonObject {
+                                child.toMinimalJson().forEach { (k, v) -> put(k, v) }
+                                put("childCounts", roleCountToJson(grandchildCounts))
+                                if (childTraits.isNotEmpty()) {
+                                    put("traits", JsonArray(childTraits.map { JsonPrimitive(it) }))
+                                }
+                            }
+                        }
+                    )
+                )
             }
 
         return successResponse(data)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
@@ -572,26 +572,7 @@ Operations: get, search, overview
             buildJsonObject {
                 put("item", item.toFullJson())
                 put("childCounts", roleCountToJson(childCounts))
-                put(
-                    "children",
-                    JsonArray(
-                        children.map { child ->
-                            val grandchildCounts =
-                                when (val result = context.workItemRepository().countChildrenByRole(child.id)) {
-                                    is Result.Success -> result.data
-                                    is Result.Error -> emptyMap()
-                                }
-                            val childTraits = PropertiesHelper.extractTraits(child.properties)
-                            buildJsonObject {
-                                child.toMinimalJson().forEach { (k, v) -> put(k, v) }
-                                put("childCounts", roleCountToJson(grandchildCounts))
-                                if (childTraits.isNotEmpty()) {
-                                    put("traits", JsonArray(childTraits.map { JsonPrimitive(it) }))
-                                }
-                            }
-                        }
-                    )
-                )
+                put("children", JsonArray(children.map { enrichChildJson(it, context) }))
             }
 
         return successResponse(data)
@@ -636,26 +617,7 @@ Operations: get, search, overview
                                 is Result.Success -> result.data
                                 is Result.Error -> emptyList()
                             }
-                        put(
-                            "children",
-                            JsonArray(
-                                children.map { child ->
-                                    val grandchildCounts =
-                                        when (val result = context.workItemRepository().countChildrenByRole(child.id)) {
-                                            is Result.Success -> result.data
-                                            is Result.Error -> emptyMap()
-                                        }
-                                    val childTraits = PropertiesHelper.extractTraits(child.properties)
-                                    buildJsonObject {
-                                        child.toMinimalJson().forEach { (k, v) -> put(k, v) }
-                                        put("childCounts", roleCountToJson(grandchildCounts))
-                                        if (childTraits.isNotEmpty()) {
-                                            put("traits", JsonArray(childTraits.map { JsonPrimitive(it) }))
-                                        }
-                                    }
-                                }
-                            )
-                        )
+                        put("children", JsonArray(children.map { enrichChildJson(it, context) }))
                     }
                 }
             }
@@ -667,5 +629,28 @@ Operations: get, search, overview
             }
 
         return successResponse(data)
+    }
+
+    /**
+     * Enriches a child WorkItem with childCounts and traits for overview responses.
+     * Shared by both scoped and global overview to keep child rendering consistent.
+     */
+    private suspend fun enrichChildJson(
+        child: WorkItem,
+        context: ToolExecutionContext
+    ): JsonObject {
+        val grandchildCounts =
+            when (val result = context.workItemRepository().countChildrenByRole(child.id)) {
+                is Result.Success -> result.data
+                is Result.Error -> emptyMap()
+            }
+        val childTraits = PropertiesHelper.extractTraits(child.properties)
+        return buildJsonObject {
+            child.toMinimalJson().forEach { (k, v) -> put(k, v) }
+            put("childCounts", roleCountToJson(grandchildCounts))
+            if (childTraits.isNotEmpty()) {
+                put("traits", JsonArray(childTraits.map { JsonPrimitive(it) }))
+            }
+        }
     }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolTest.kt
@@ -1191,6 +1191,107 @@ class QueryItemsToolTest {
         }
 
     // ──────────────────────────────────────────────
+    // Scoped overview — child enrichment (TDD tests for childCounts + traits bug)
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `scoped overview children include childCounts`(): Unit =
+        runBlocking {
+            // 3-level hierarchy: root -> child -> 2 grandchildren (1 queue, 1 work)
+            val rootId = createItem("Scoped Root")
+            val childId = createItem("Scoped Child", parentId = rootId, role = "queue")
+            createItem("Grandchild Queue", parentId = childId, role = "queue")
+            val grandchildWorkId = createItem("Grandchild Work", parentId = childId, role = "queue")
+
+            // Advance one grandchild to work role
+            advanceTool.execute(
+                buildJsonObject {
+                    put(
+                        "transitions",
+                        JsonArray(
+                            listOf(
+                                buildJsonObject {
+                                    put("itemId", JsonPrimitive(grandchildWorkId))
+                                    put("trigger", JsonPrimitive("start"))
+                                }
+                            )
+                        )
+                    )
+                },
+                context
+            )
+
+            // Scoped overview on the root
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("overview"),
+                        "itemId" to JsonPrimitive(rootId)
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            val children = data["children"]!!.jsonArray
+            assertEquals(1, children.size)
+
+            val child = children[0].jsonObject
+            assertEquals(childId, child["id"]!!.jsonPrimitive.content)
+
+            // childCounts must be present with correct grandchild role distribution
+            val childCounts = child["childCounts"]
+            assertNotNull(childCounts, "Scoped overview child should include childCounts")
+            val childCountsObj = childCounts!!.jsonObject
+            assertEquals(1, childCountsObj["queue"]!!.jsonPrimitive.int, "Should have 1 grandchild in queue")
+            assertEquals(1, childCountsObj["work"]!!.jsonPrimitive.int, "Should have 1 grandchild in work")
+        }
+
+    @Test
+    fun `scoped overview children include traits when set`(): Unit =
+        runBlocking {
+            val rootId = createItem("Traits Root")
+            createItem(
+                "Child With Traits",
+                parentId = rootId,
+                role = "queue",
+                properties = """{"traits":["needs-perf-review"]}"""
+            )
+            createItem("Child Without Traits", parentId = rootId, role = "queue")
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("overview"),
+                        "itemId" to JsonPrimitive(rootId)
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            val children = data["children"]!!.jsonArray
+            assertEquals(2, children.size)
+
+            val withTraits =
+                children
+                    .first {
+                        it.jsonObject["title"]!!.jsonPrimitive.content == "Child With Traits"
+                    }.jsonObject
+            assertTrue(withTraits.containsKey("traits"), "Child with traits should include traits array")
+            val traits = withTraits["traits"]!!.jsonArray
+            assertEquals(1, traits.size)
+            assertEquals("needs-perf-review", traits[0].jsonPrimitive.content)
+
+            val withoutTraits =
+                children
+                    .first {
+                        it.jsonObject["title"]!!.jsonPrimitive.content == "Child Without Traits"
+                    }.jsonObject
+            assertFalse(withoutTraits.containsKey("traits"), "Child without traits should omit traits key")
+        }
+
+    // ──────────────────────────────────────────────
     // Validation
     // ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `query_items(operation="overview", itemId=...)` (scoped overview) now includes `childCounts` and `traits` on each child entry
- Previously children were rendered with only `toMinimalJson()` fields — consumers couldn't detect grandchildren
- Now matches the enrichment already present in `executeGlobalOverview` with `includeChildren=true`

## Root cause
`executeScopedOverview` line 575 used `children.map { it.toMinimalJson() }` while `executeGlobalOverview` lines 623-637 explicitly computed `countChildrenByRole()` and extracted traits for each child.

## Test plan
- [x] TDD: 2 tests written first, verified failing (red), then fix applied (green)
  - `scoped overview children include childCounts` — 3-level hierarchy, verifies grandchild role counts
  - `scoped overview children include traits when set` — verifies traits array present/absent
- [x] All 1137 tests pass, ktlint clean

Fixes observation item `624c1e15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)