### PR TITLE
fix: align plugin and project skills to single-phase agent model

### DIFF
--- a/.claude/skills/feature-implementation/SKILL.md
+++ b/.claude/skills/feature-implementation/SKILL.md
@@ -110,8 +110,10 @@ as `parentId`. Dispatch implementation subagents with each child item UUID.
 
 Each subagent must:
 - Call `advance_item(trigger="start")` on their item to enter work phase
-- Call `advance_item(trigger="start")` again to advance to review before returning
-- Do NOT call `advance_item(trigger="complete")` — the orchestrator handles terminal transitions
+- Fill work-phase notes following the JIT progression loop (the subagent-start hook
+  provides guidance via `guidancePointer` and `skillPointer`)
+- Return to the orchestrator — do NOT call `advance_item` again. The orchestrator
+  handles all further transitions.
 
 ### 2b. Fill `implementation-notes`
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -189,20 +189,34 @@ branch if not):
    `/task-orchestrator:create-item` before moving on. Do not discard findings.
 4. Fill all work-phase notes following their `guidancePointer` — focus on context
    that downstream agents need to know
-5. Advance the item to review: when delegating to a subagent, the agent calls
-   `advance_item(trigger="start")` to move work→review before returning (per the
-   agent-owned-phase model). When implementing directly, the orchestrator calls
-   `advance_item(trigger="start")` itself.
+5. After implementation completes:
+   - **Subagent delegation:** The agent returns after filling work-phase notes.
+     The orchestrator then calls `advance_item(trigger="start")` to advance
+     the item to the next phase.
+   - **Direct implementation:** The orchestrator calls `advance_item(trigger="start")`
+     itself after filling work-phase notes.
+   In both cases, inspect `newRole` in the response to determine what comes next
+   (see Step 5).
 
 ---
 
 ## Step 5 — Review Phase
 
+Before dispatching or performing review, check the item's current role. Inspect
+`newRole` from the `advance_item` response in the previous step:
+
+- **If `newRole` is `terminal`:** The item's schema has no review phase (lightweight
+  lifecycle). Review dispatch is not needed — the item completed through its natural
+  lifecycle. Proceed to Step 6.
+- **If `newRole` is `review`:** Continue with review per tier below.
+
 This step is **tier-conditional**:
 
 **Direct tier:** Perform an inline review. Read the diff, verify correctness, confirm
-tests pass. Write a brief review note: "Inline review: pass. [one-line rationale]."
-Advance to terminal: `advance_item(trigger="start")`. No separate review agent —
+tests pass. If the review-phase note has a `skillPointer` (visible in the `advance_item`
+response or via `get_context`), invoke that skill for the evaluation framework before
+filling the review note. Write the review note, then advance to terminal:
+`advance_item(trigger="start")`. No separate review agent —
 the overhead exceeds the risk for 1-2 file changes with known fixes.
 
 **Delegated and Parallel tiers:** Dispatch a **separate** review agent. The agent

--- a/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
+++ b/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
@@ -51,12 +51,14 @@ Before starting any work, classify it into one of three execution tiers. This de
 | Implementation | orchestrator direct | single subagent | parallel worktree agents |
 | Review | inline (orchestrator) | separate agent | separate agent |
 
+Review applies when the item's schema declares review-phase notes. Items whose schema has no review phase advance directly from work to terminal — the orchestrator observes this via the `newRole` field and skips review dispatch.
+
 ## Workflow Principles
 
 1. **Delegate by default** — for Delegated and Parallel tier work, delegate coding to subagents. For Direct tier work (1-2 files, known fix, no migration), implement, test, and review inline
 2. **Plan proportionally** — use `EnterPlanMode` for Delegated tier when scope needs clarification and always for Parallel tier. Direct tier skips plan mode
 3. **Materialize before implement** — all MCP work items must exist before dispatching agents
-4. **Agent-owned phases** — implementation agents own their work-phase transitions (queue→work→review). The orchestrator owns review dispatch and terminal transitions (review→terminal). Skills define the specific sequencing
+4. **Agent-owned phases** — implementation agents enter their assigned phase (one `advance_item(start)` call), fill its required notes, and return. The orchestrator owns all subsequent transitions — it advances the item, inspects `newRole` to determine the next phase (review or terminal, depending on the item's schema), and dispatches the appropriate agent. Skills referenced by `skillPointer` provide evaluation frameworks to whoever fills the note
 5. **Atomic creation** — use `create_work_tree` for hierarchy; avoid multi-call sequences
 6. **Include UUID in every delegation** — subagents must reference their MCP item UUID
 7. **Always know current state** — query MCP before making decisions

--- a/claude-plugins/task-orchestrator/skills/post-plan-workflow/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/post-plan-workflow/SKILL.md
@@ -28,7 +28,7 @@ Dispatch subagents to execute the plan:
 - Each subagent **owns one MCP item** — include the item UUID in the delegation prompt
 - If `expectedNotes` entries include `guidance`, embed it in the delegation prompt as authoring instructions when filling notes
 - If `expectedNotes` entries include a `skill` field, include in the delegation prompt: "Before filling the `<key>` note, invoke `/<skill>` and follow its framework." This ensures subagents receive deterministic skill routing rather than relying on guidance prose
-- **Agents own their work-phase transitions** — each agent calls `advance_item(trigger="start")` to enter work, and `advance_item(trigger="start")` again to advance to review before returning. Agents do NOT call `advance_item(trigger="complete")` — the orchestrator handles terminal transitions
+- **Agents own phase entry only** — each agent calls `advance_item(trigger="start")` once to enter work phase, fills work-phase notes, and returns. The orchestrator handles all further transitions (work→review or work→terminal depending on schema). Agents do NOT call `advance_item` a second time
 - Fill work-phase notes (`implementation-notes`, `test-results`, etc.) as the agent works
 - Respect dependency ordering — do not dispatch an agent for a blocked item until its blockers complete
 - **Between waves:** call `get_blocked_items(parentId=...)` to confirm upstream items completed — dependency gating implicitly verifies agents transitioned their items. If downstream items are still blocked, investigate the upstream blocker

--- a/claude-plugins/task-orchestrator/skills/schema-workflow/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/schema-workflow/SKILL.md
@@ -144,16 +144,18 @@ rather than assuming specific keys exist.
 **Orchestrator** (this skill's primary user):
 - Fills queue-phase notes (requirements, design) during planning
 - Dispatches implementation agents with the item UUID
-- Dispatches review agents after the item reaches review phase (implementation agent advances work→review before returning)
+- After implementation agents return, advances the item via `advance_item(start)` and inspects `newRole`:
+  - If `review`: dispatches review agents or performs inline review
+  - If `terminal`: item completed through a lightweight lifecycle (no review-phase notes in schema)
 - Performs the final terminal transition (review→terminal) after the review verdict
 - Uses this skill for queue-phase note filling and terminal advancement
 
 **Implementation agents** (agent-owned-phase model):
 - Receive the full phase-aware protocol automatically via the `subagent-start` hook
-- Call `advance_item(start)` to enter work phase (queue→work)
-- Fill work-phase notes using the JIT progression loop described in the hook protocol
-- Call `advance_item(start)` again to advance to review (work→review) before returning
-- Do NOT call `advance_item(trigger="complete")` — the orchestrator handles terminal transitions
+- Call `advance_item(start)` once to enter work phase (queue→work)
+- Fill work-phase notes using the JIT progression loop (guidancePointer + skillPointer)
+- Return to the orchestrator — do NOT call `advance_item` again
+- The orchestrator advances the item to the next phase and handles all further routing
 
 **Review agents** (dispatched into an item already in review):
 - Receive the `subagent-start` hook, which tells them to call `advance_item(start)`
@@ -162,7 +164,7 @@ rather than assuming specific keys exist.
 - Fill review-phase notes (e.g., review-checklist), report verdict, return
 - Do NOT call `advance_item` again — the orchestrator handles the terminal transition
 
-**Key invariant:** Implementation agents own queue→work and work→review transitions. The orchestrator owns review→terminal. Review agents do not advance items — they evaluate and report.
+**Key invariant:** Agents own phase entry (one `advance_item(start)` call to enter their assigned phase). The orchestrator owns all phase-to-phase transitions — advancing the item, inspecting the schema to determine the next phase (review or terminal), and dispatching phase-appropriate agents. Review agents fill review-phase notes and return — they do not advance items.
 
 ---
 

--- a/claude-plugins/task-orchestrator/skills/status-progression/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/status-progression/SKILL.md
@@ -358,7 +358,7 @@ Result:
       test-results (work, required)
 ```
 
-The `expectedNotes` in the response shows what must be filled during the work phase before the next `start` will succeed. Fill these notes as implementation progresses, then call `advance_item(trigger="start")` again to move to review or terminal.
+The `expectedNotes` in the response shows what must be filled during the work phase before the next `start` will succeed. Fill these notes as implementation progresses, then return control to the orchestrator. The orchestrator calls `advance_item(trigger="start")` to advance the item to the next phase (review if the schema has review-phase notes, or terminal otherwise).
 
 ---
 

--- a/current/docs/integration-guides/bare-mcp.md
+++ b/current/docs/integration-guides/bare-mcp.md
@@ -97,10 +97,12 @@ Use `get_next_item(parentId="<uuid>")` to scope recommendations to a specific su
 
 1. Create the feature with `create_work_tree` (root + 3 children, linear dependencies)
 2. Start the first child: `advance_item(trigger="start")` → queue→work
-3. Do the work, then advance again: `advance_item(trigger="start")` → work→review→terminal
-4. The next child auto-unblocks — check with `get_blocked_items(parentId="<root-uuid>")`
-5. Use `get_next_item(parentId="<root-uuid>")` to find what's ready
-6. When all children complete, the parent auto-cascades to terminal
+3. Do the work, fill work-phase notes
+4. Advance: `advance_item(trigger="start")` — moves to review (if schema has review-phase notes) or terminal (if not)
+5. If in review: fill review notes, then `advance_item(trigger="start")` → terminal
+6. The next child auto-unblocks — check with `get_blocked_items(parentId="<root-uuid>")`
+7. Use `get_next_item(parentId="<root-uuid>")` to find what's ready
+8. When all children complete, the parent auto-cascades to terminal
 
 ## Key Tool Patterns
 

--- a/current/docs/integration-guides/output-styles.md
+++ b/current/docs/integration-guides/output-styles.md
@@ -68,11 +68,11 @@ Phase transitions follow a strict ownership model:
 
 | Transition | Owner | Mechanism |
 |-----------|-------|-----------|
-| queue → work | Implementation agent | `advance_item(trigger="start")` at task start |
-| work → review | Implementation agent | `advance_item(trigger="start")` before returning |
+| queue → work | Implementation agent | `advance_item(trigger="start")` — phase entry |
+| work → review/terminal | Orchestrator | `advance_item(trigger="start")` — routes based on schema |
 | review → terminal | Orchestrator | `advance_item(trigger="start")` after review verdict |
 
-Implementation agents own their lifecycle through review. The orchestrator performs the final terminal transition after reviewing the verdict.
+Implementation agents enter their assigned phase and fill its notes. The orchestrator owns all subsequent transitions — it advances the item and inspects `newRole` to determine the next phase. If the schema has review-phase notes, the item moves to review and a reviewer is dispatched. If not, the item moves directly to terminal.
 
 ---
 
@@ -143,9 +143,9 @@ Feature: "Refactor authentication into three components"
 1. **Plan:** Enter plan mode. Pre-plan hook gathers MCP state. Write plan with three tasks. User approves.
 2. **Materialize:** Post-plan creates root item + three children with fan-out dependencies.
 3. **Dispatch:** Three worktree agents in parallel. Each gets a child UUID + target files. Each creates a session task.
-4. **Self-advance:** Each agent calls `advance_item(trigger="start")` twice — queue→work at start, work→review before returning.
-5. **Review:** Orchestrator dispatches review agents into each worktree path.
-6. **Terminal:** Orchestrator advances each item review→terminal after review passes.
+4. **Phase entry:** Each agent calls `advance_item(trigger="start")` once — queue→work at start. Fills work-phase notes and returns.
+5. **Orchestrator advances:** Calls `advance_item(trigger="start")` on each item. Items with review-phase notes move to review; lightweight items move to terminal.
+6. **Review:** For items now in review, orchestrator dispatches review agents into each worktree path. After review passes, advances review→terminal.
 7. **Cascade:** Parent auto-cascades to terminal when all children reach terminal.
 8. **Merge:** Squash-merge each worktree branch into local `main`. Run tests after each merge.
 

--- a/current/docs/integration-guides/plugin-skills-hooks.md
+++ b/current/docs/integration-guides/plugin-skills-hooks.md
@@ -226,7 +226,7 @@ Queue-phase notes (specification / task-scope) are filled before dispatching.
 - Commits changes
 - Returns to the orchestrator
 
-**7. Orchestrator reviews each item** — calls `advance_item(trigger="start")` to move work→review, fills review-checklist, then advances review→terminal.
+**7. Orchestrator advances each item** — calls `advance_item(trigger="start")`. If `newRole` is `review` (schema has review-phase notes): dispatches a reviewer or fills review notes inline, then advances review→terminal. If `newRole` is `terminal` (no review phase): item is complete.
 
 **8. Parent auto-cascades** — when all four children reach terminal, the root item cascades to terminal automatically. The `cascadeEvents` field in the response confirms the cascade.
 


### PR DESCRIPTION
## Summary

- Resolved a direct contradiction between the `subagent-start` hook (correct: agents enter one phase and return) and 12 locations across skills, output styles, and integration docs that told agents to call `advance_item(start)` twice
- Added lifecycle-awareness to `/implement` Step 5 — the orchestrator now inspects `newRole` before dispatching review, skipping review dispatch for lightweight schemas (no review-phase notes)
- Added `skillPointer` guidance to Direct tier inline review — the orchestrator invokes the skill for evaluation framework before filling the review note

## Context

Triggered by a bug report (MCP item `b97e9331`) observing that subagents could self-terminalize on schema-free items. Investigation found the tool layer (`RoleTransitionHandler.resolveStart()`) is working as designed — the mismatch was in the plugin layer's unconditional assumption that all items pass through a review gate.

## Files changed (9)

| Category | Files |
|----------|-------|
| Plugin output style | `workflow-orchestrator.md` |
| Plugin skills | `schema-workflow`, `post-plan-workflow`, `status-progression` |
| Project skills | `feature-implementation`, `implement` |
| Integration docs | `output-styles.md`, `bare-mcp.md`, `plugin-skills-hooks.md` |
| Hook | No changes (already correct) |

## Verification

- Grep audit confirms zero remaining instances of "call start again", "start twice", "work→review before returning", or "own queue→work and work→review" across all plugin, skill, and doc directories
- Zone 1 sync verified between `workflow-orchestrator.md` and `workflow-analyst.md`

## Test plan

- [x] Verify grep audit: `grep -rn "advance.*start.*again\|start.*twice\|work→review.*before returning" claude-plugins/ .claude/skills/ current/docs/`
- [x] Review diff for consistent language across all 9 files
- [x] Functional: create a schema-free item, advance queue→work→terminal (lightweight lifecycle confirmed)
- [x] Functional: create a schema-covered item with review notes, advance queue→work→review (gated lifecycle confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)