### PR TITLE
fix: add short hex prefix resolution to manage_items update, delete, and per-item parentId

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/IdResolution.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/IdResolution.kt
@@ -1,0 +1,60 @@
+package io.github.jpicklyk.mcptask.current.application.tools
+
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import java.util.UUID
+
+/**
+ * Resolves a raw ID string to a [UUID], supporting both full UUIDs and short hex prefixes (4+ chars).
+ * Throws [ToolValidationException] on failure (invalid format, not found, ambiguous).
+ *
+ * This is a standalone utility for handler classes that don't extend [BaseToolDefinition] but still
+ * need short-ID resolution (e.g., [items.CreateItemHandler], [items.UpdateItemHandler], [items.DeleteItemHandler]).
+ *
+ * @param idStr The raw ID string (full UUID or hex prefix, minimum 4 chars)
+ * @param context The tool execution context providing repository access
+ * @param fieldLabel Human-readable label for error messages (e.g., "'id'", "'parentId'")
+ * @return The resolved [UUID]
+ * @throws ToolValidationException if the ID is invalid, not found, or ambiguous
+ */
+suspend fun resolveWorkItemIdString(
+    idStr: String,
+    context: ToolExecutionContext,
+    fieldLabel: String = "id"
+): UUID {
+    // Fast path: full UUID (36 chars)
+    if (idStr.length == 36) {
+        return try {
+            UUID.fromString(idStr)
+        } catch (_: IllegalArgumentException) {
+            throw ToolValidationException("$fieldLabel is not a valid UUID: $idStr")
+        }
+    }
+
+    // Prefix validation
+    if (!idStr.matches(BaseToolDefinition.HEX_PATTERN)) {
+        throw ToolValidationException(
+            "$fieldLabel must be a UUID or hex prefix (${BaseToolDefinition.MIN_PREFIX_LENGTH}+ chars), got: $idStr"
+        )
+    }
+    if (idStr.length < BaseToolDefinition.MIN_PREFIX_LENGTH) {
+        throw ToolValidationException(
+            "$fieldLabel prefix too short: minimum ${BaseToolDefinition.MIN_PREFIX_LENGTH} hex characters, got ${idStr.length}"
+        )
+    }
+
+    // Repository prefix resolution
+    return when (val result = context.workItemRepository().findByIdPrefix(idStr)) {
+        is Result.Success -> {
+            val matches = result.data
+            when {
+                matches.isEmpty() ->
+                    throw ToolValidationException("No WorkItem found matching $fieldLabel prefix: $idStr")
+                matches.size > 1 ->
+                    throw ToolValidationException("Ambiguous $fieldLabel prefix: $idStr matches ${matches.size} items")
+                else -> matches.first().id
+            }
+        }
+        is Result.Error ->
+            throw ToolValidationException("Failed to resolve $fieldLabel prefix: ${result.error.message}")
+    }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/CreateItemHandler.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/CreateItemHandler.kt
@@ -6,6 +6,7 @@ import io.github.jpicklyk.mcptask.current.application.tools.PropertiesHelper
 import io.github.jpicklyk.mcptask.current.application.tools.ResponseUtil
 import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
 import io.github.jpicklyk.mcptask.current.application.tools.ToolValidationException
+import io.github.jpicklyk.mcptask.current.application.tools.resolveWorkItemIdString
 import io.github.jpicklyk.mcptask.current.application.tools.toJsonString
 import io.github.jpicklyk.mcptask.current.domain.model.Priority
 import io.github.jpicklyk.mcptask.current.domain.model.Role
@@ -73,11 +74,7 @@ class CreateItemHandler(
                 val itemParentIdStr = extractItemString(itemObj, "parentId")
                 val parentId =
                     if (itemParentIdStr != null) {
-                        try {
-                            UUID.fromString(itemParentIdStr)
-                        } catch (_: IllegalArgumentException) {
-                            throw ToolValidationException("Item at index $index: 'parentId' is not a valid UUID")
-                        }
+                        resolveWorkItemIdString(itemParentIdStr, context, "Item at index $index: 'parentId'")
                     } else {
                         sharedParentId
                     }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/DeleteItemHandler.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/DeleteItemHandler.kt
@@ -2,9 +2,10 @@ package io.github.jpicklyk.mcptask.current.application.tools.items
 
 import io.github.jpicklyk.mcptask.current.application.tools.ResponseUtil
 import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
+import io.github.jpicklyk.mcptask.current.application.tools.ToolValidationException
+import io.github.jpicklyk.mcptask.current.application.tools.resolveWorkItemIdString
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import kotlinx.serialization.json.*
-import java.util.UUID
 
 /**
  * Handles the `delete` operation for [ManageItemsTool].
@@ -47,12 +48,12 @@ class DeleteItemHandler {
 
             val id =
                 try {
-                    UUID.fromString(idStr)
-                } catch (_: IllegalArgumentException) {
+                    resolveWorkItemIdString(idStr, context, "'id'")
+                } catch (e: ToolValidationException) {
                     failures.add(
                         buildJsonObject {
                             put("id", JsonPrimitive(idStr))
-                            put("error", JsonPrimitive("Invalid UUID format: $idStr"))
+                            put("error", JsonPrimitive(e.message ?: "Invalid ID: $idStr"))
                         }
                     )
                     continue

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt
@@ -49,13 +49,13 @@ Unified write operations for WorkItems (create, update, delete).
 - `tags` is always included (null if not set). `expectedNotes` is always included (empty array when no schema matches). `schemaMatch` indicates whether the item's tags matched a configured note schema.
 
 **update** - Partial update from `items` array.
-- Each item: `{ id (required), title?, description?, summary?, statusLabel?, priority?, complexity?, parentId?, metadata?, tags?, type?, properties? }`
+- Each item: `{ id (required, UUID or hex prefix 4+ chars), title?, description?, summary?, statusLabel?, priority?, complexity?, parentId? (UUID or hex prefix 4+ chars), metadata?, tags?, type?, properties? }`
 - Note: role changes are not allowed in update operations. Use advance_item with triggers (start, complete, block, hold, resume, cancel, reopen) instead.
 - Only provided fields are changed; omitted fields retain existing values
 - If parentId changes, depth is recomputed from new parent
 - Response: `{ items: [{id, modifiedAt}], updated: N, failed: N, failures: [{id, error}] }`
 
-**delete** - Delete by `ids` array.
+**delete** - Delete by `ids` array (UUIDs or hex prefixes 4+ chars).
 - Response: `{ ids: [...], deleted: N, failed: N, failures: [{id, error}] }`
 - Use `recursive: true` to recursively delete all descendant items before deleting the specified items.
   Without this flag, deleting an item with children will fail with a constraint error.
@@ -94,7 +94,7 @@ Unified write operations for WorkItems (create, update, delete).
                         "ids",
                         buildJsonObject {
                             put("type", JsonPrimitive("array"))
-                            put("description", JsonPrimitive("Array of item UUIDs for delete"))
+                            put("description", JsonPrimitive("Array of item UUIDs or hex prefixes (4+ chars) for delete"))
                         }
                     )
                     put(

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/UpdateItemHandler.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/UpdateItemHandler.kt
@@ -5,6 +5,7 @@ import io.github.jpicklyk.mcptask.current.application.tools.PropertiesHelper
 import io.github.jpicklyk.mcptask.current.application.tools.ResponseUtil
 import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
 import io.github.jpicklyk.mcptask.current.application.tools.ToolValidationException
+import io.github.jpicklyk.mcptask.current.application.tools.resolveWorkItemIdString
 import io.github.jpicklyk.mcptask.current.domain.model.Priority
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import kotlinx.serialization.json.*
@@ -51,12 +52,7 @@ class UpdateItemHandler(
                 itemId = extractItemString(itemObj, "id")
                     ?: throw ToolValidationException("Update item: 'id' is required")
 
-                val id =
-                    try {
-                        UUID.fromString(itemId)
-                    } catch (_: IllegalArgumentException) {
-                        throw ToolValidationException("Update item: 'id' is not a valid UUID: $itemId")
-                    }
+                val id = resolveWorkItemIdString(itemId, context, "Update item: 'id'")
 
                 // Fetch existing item
                 val existing =
@@ -112,12 +108,7 @@ class UpdateItemHandler(
                 val newParentId: UUID?
                 val newDepth: Int
                 if (parentIdStr != null) {
-                    newParentId =
-                        try {
-                            UUID.fromString(parentIdStr)
-                        } catch (_: IllegalArgumentException) {
-                            throw ToolValidationException("Item '$itemId': 'parentId' is not a valid UUID")
-                        }
+                    newParentId = resolveWorkItemIdString(parentIdStr, context, "Item '$itemId': 'parentId'")
 
                     newDepth =
                         hierarchyValidator.validateAndComputeDepth(

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsToolPrefixTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsToolPrefixTest.kt
@@ -40,18 +40,20 @@ class ManageItemsToolPrefixTest {
         title: String,
         parentId: String? = null
     ): String {
-        val itemObj = buildJsonObject {
-            put("title", JsonPrimitive(title))
-            parentId?.let { put("parentId", JsonPrimitive(it)) }
-        }
-        val result = tool.execute(
+        val itemObj =
             buildJsonObject {
-                put("operation", JsonPrimitive("create"))
-                put("items", JsonArray(listOf(itemObj)))
+                put("title", JsonPrimitive(title))
                 parentId?.let { put("parentId", JsonPrimitive(it)) }
-            },
-            context
-        ) as JsonObject
+            }
+        val result =
+            tool.execute(
+                buildJsonObject {
+                    put("operation", JsonPrimitive("create"))
+                    put("items", JsonArray(listOf(itemObj)))
+                    parentId?.let { put("parentId", JsonPrimitive(it)) }
+                },
+                context
+            ) as JsonObject
         return (result["data"] as JsonObject)["items"]!!
             .jsonArray[0]
             .jsonObject["id"]!!
@@ -63,469 +65,557 @@ class ManageItemsToolPrefixTest {
     // ──────────────────────────────────────────────
 
     @Test
-    fun `update by 4-char prefix resolves item`(): Unit = runBlocking {
-        val itemId = createItem("Update Prefix Test")
-        val prefix = itemId.substring(0, 4)
+    fun `update by 4-char prefix resolves item`(): Unit =
+        runBlocking {
+            val itemId = createItem("Update Prefix Test")
+            val prefix = itemId.substring(0, 4)
 
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("update"),
-                "items" to JsonArray(listOf(
-                    buildJsonObject {
-                        put("id", JsonPrimitive(prefix))
-                        put("summary", JsonPrimitive("Updated via 4-char prefix"))
-                    }
-                ))
-            ),
-            context
-        ) as JsonObject
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("update"),
+                        "items" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("id", JsonPrimitive(prefix))
+                                        put("summary", JsonPrimitive("Updated via 4-char prefix"))
+                                    }
+                                )
+                            )
+                    ),
+                    context
+                ) as JsonObject
 
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(1, data["updated"]!!.jsonPrimitive.int)
-        assertEquals(0, data["failed"]!!.jsonPrimitive.int)
-    }
-
-    @Test
-    fun `update by 8-char prefix resolves item`(): Unit = runBlocking {
-        val itemId = createItem("Update 8-char Test")
-        val prefix = itemId.substring(0, 8)
-
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("update"),
-                "items" to JsonArray(listOf(
-                    buildJsonObject {
-                        put("id", JsonPrimitive(prefix))
-                        put("summary", JsonPrimitive("Updated via 8-char prefix"))
-                    }
-                ))
-            ),
-            context
-        ) as JsonObject
-
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(1, data["updated"]!!.jsonPrimitive.int)
-    }
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(1, data["updated"]!!.jsonPrimitive.int)
+            assertEquals(0, data["failed"]!!.jsonPrimitive.int)
+        }
 
     @Test
-    fun `update by full UUID still works (regression)`(): Unit = runBlocking {
-        val itemId = createItem("Update Full UUID")
+    fun `update by 8-char prefix resolves item`(): Unit =
+        runBlocking {
+            val itemId = createItem("Update 8-char Test")
+            val prefix = itemId.substring(0, 8)
 
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("update"),
-                "items" to JsonArray(listOf(
-                    buildJsonObject {
-                        put("id", JsonPrimitive(itemId))
-                        put("summary", JsonPrimitive("Updated via full UUID"))
-                    }
-                ))
-            ),
-            context
-        ) as JsonObject
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("update"),
+                        "items" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("id", JsonPrimitive(prefix))
+                                        put("summary", JsonPrimitive("Updated via 8-char prefix"))
+                                    }
+                                )
+                            )
+                    ),
+                    context
+                ) as JsonObject
 
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(1, data["updated"]!!.jsonPrimitive.int)
-    }
-
-    @Test
-    fun `update with too-short prefix returns error`(): Unit = runBlocking {
-        createItem("Short Prefix Item")
-
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("update"),
-                "items" to JsonArray(listOf(
-                    buildJsonObject {
-                        put("id", JsonPrimitive("abc"))
-                        put("summary", JsonPrimitive("Should fail"))
-                    }
-                ))
-            ),
-            context
-        ) as JsonObject
-
-        assertTrue(result["success"]!!.jsonPrimitive.boolean) // envelope succeeds, item fails
-        val data = result["data"] as JsonObject
-        assertEquals(0, data["updated"]!!.jsonPrimitive.int)
-        assertEquals(1, data["failed"]!!.jsonPrimitive.int)
-        val failure = data["failures"]!!.jsonArray[0].jsonObject
-        assertTrue(failure["error"]!!.jsonPrimitive.content.contains("prefix too short"))
-    }
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(1, data["updated"]!!.jsonPrimitive.int)
+        }
 
     @Test
-    fun `update with non-hex prefix returns error`(): Unit = runBlocking {
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("update"),
-                "items" to JsonArray(listOf(
-                    buildJsonObject {
-                        put("id", JsonPrimitive("ghij1234"))
-                        put("summary", JsonPrimitive("Should fail"))
-                    }
-                ))
-            ),
-            context
-        ) as JsonObject
+    fun `update by full UUID still works (regression)`(): Unit =
+        runBlocking {
+            val itemId = createItem("Update Full UUID")
 
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(0, data["updated"]!!.jsonPrimitive.int)
-        assertEquals(1, data["failed"]!!.jsonPrimitive.int)
-        val failure = data["failures"]!!.jsonArray[0].jsonObject
-        assertTrue(failure["error"]!!.jsonPrimitive.content.contains("must be a UUID or hex prefix"))
-    }
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("update"),
+                        "items" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("id", JsonPrimitive(itemId))
+                                        put("summary", JsonPrimitive("Updated via full UUID"))
+                                    }
+                                )
+                            )
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(1, data["updated"]!!.jsonPrimitive.int)
+        }
 
     @Test
-    fun `update with non-matching prefix returns not-found error`(): Unit = runBlocking {
-        createItem("Some Item")
+    fun `update with too-short prefix returns error`(): Unit =
+        runBlocking {
+            createItem("Short Prefix Item")
 
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("update"),
-                "items" to JsonArray(listOf(
-                    buildJsonObject {
-                        put("id", JsonPrimitive("0000"))
-                        put("summary", JsonPrimitive("Should fail"))
-                    }
-                ))
-            ),
-            context
-        ) as JsonObject
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("update"),
+                        "items" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("id", JsonPrimitive("abc"))
+                                        put("summary", JsonPrimitive("Should fail"))
+                                    }
+                                )
+                            )
+                    ),
+                    context
+                ) as JsonObject
 
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(0, data["updated"]!!.jsonPrimitive.int)
-        assertEquals(1, data["failed"]!!.jsonPrimitive.int)
-        val failure = data["failures"]!!.jsonArray[0].jsonObject
-        assertTrue(failure["error"]!!.jsonPrimitive.content.contains("No WorkItem found"))
-    }
+            assertTrue(result["success"]!!.jsonPrimitive.boolean) // envelope succeeds, item fails
+            val data = result["data"] as JsonObject
+            assertEquals(0, data["updated"]!!.jsonPrimitive.int)
+            assertEquals(1, data["failed"]!!.jsonPrimitive.int)
+            val failure = data["failures"]!!.jsonArray[0].jsonObject
+            assertTrue(failure["error"]!!.jsonPrimitive.content.contains("prefix too short"))
+        }
+
+    @Test
+    fun `update with non-hex prefix returns error`(): Unit =
+        runBlocking {
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("update"),
+                        "items" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("id", JsonPrimitive("ghij1234"))
+                                        put("summary", JsonPrimitive("Should fail"))
+                                    }
+                                )
+                            )
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(0, data["updated"]!!.jsonPrimitive.int)
+            assertEquals(1, data["failed"]!!.jsonPrimitive.int)
+            val failure = data["failures"]!!.jsonArray[0].jsonObject
+            assertTrue(failure["error"]!!.jsonPrimitive.content.contains("must be a UUID or hex prefix"))
+        }
+
+    @Test
+    fun `update with non-matching prefix returns not-found error`(): Unit =
+        runBlocking {
+            createItem("Some Item")
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("update"),
+                        "items" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("id", JsonPrimitive("0000"))
+                                        put("summary", JsonPrimitive("Should fail"))
+                                    }
+                                )
+                            )
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(0, data["updated"]!!.jsonPrimitive.int)
+            assertEquals(1, data["failed"]!!.jsonPrimitive.int)
+            val failure = data["failures"]!!.jsonArray[0].jsonObject
+            assertTrue(failure["error"]!!.jsonPrimitive.content.contains("No WorkItem found"))
+        }
 
     // ──────────────────────────────────────────────
     // Update: items[].parentId prefix resolution
     // ──────────────────────────────────────────────
 
     @Test
-    fun `update parentId by short prefix moves item`(): Unit = runBlocking {
-        val parentId = createItem("New Parent")
-        val childId = createItem("Orphan Child")
-        val parentPrefix = parentId.substring(0, 8)
+    fun `update parentId by short prefix moves item`(): Unit =
+        runBlocking {
+            val parentId = createItem("New Parent")
+            val childId = createItem("Orphan Child")
+            val parentPrefix = parentId.substring(0, 8)
 
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("update"),
-                "items" to JsonArray(listOf(
-                    buildJsonObject {
-                        put("id", JsonPrimitive(childId))
-                        put("parentId", JsonPrimitive(parentPrefix))
-                    }
-                ))
-            ),
-            context
-        ) as JsonObject
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("update"),
+                        "items" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("id", JsonPrimitive(childId))
+                                        put("parentId", JsonPrimitive(parentPrefix))
+                                    }
+                                )
+                            )
+                    ),
+                    context
+                ) as JsonObject
 
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(1, data["updated"]!!.jsonPrimitive.int)
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(1, data["updated"]!!.jsonPrimitive.int)
 
-        // Verify the item was actually moved
-        val queryTool = QueryItemsTool()
-        val getResult = queryTool.execute(
-            params(
-                "operation" to JsonPrimitive("get"),
-                "id" to JsonPrimitive(childId)
-            ),
-            context
-        ) as JsonObject
-        val itemData = getResult["data"] as JsonObject
-        assertEquals(parentId, itemData["parentId"]!!.jsonPrimitive.content)
-        assertEquals(1, itemData["depth"]!!.jsonPrimitive.int)
-    }
+            // Verify the item was actually moved
+            val queryTool = QueryItemsTool()
+            val getResult =
+                queryTool.execute(
+                    params(
+                        "operation" to JsonPrimitive("get"),
+                        "id" to JsonPrimitive(childId)
+                    ),
+                    context
+                ) as JsonObject
+            val itemData = getResult["data"] as JsonObject
+            assertEquals(parentId, itemData["parentId"]!!.jsonPrimitive.content)
+            assertEquals(1, itemData["depth"]!!.jsonPrimitive.int)
+        }
 
     // ──────────────────────────────────────────────
     // Delete: ids[] prefix resolution
     // ──────────────────────────────────────────────
 
     @Test
-    fun `delete by 4-char prefix resolves and deletes item`(): Unit = runBlocking {
-        val itemId = createItem("Delete Prefix Test")
-        val prefix = itemId.substring(0, 4)
+    fun `delete by 4-char prefix resolves and deletes item`(): Unit =
+        runBlocking {
+            val itemId = createItem("Delete Prefix Test")
+            val prefix = itemId.substring(0, 4)
 
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("delete"),
-                "ids" to JsonArray(listOf(JsonPrimitive(prefix)))
-            ),
-            context
-        ) as JsonObject
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("delete"),
+                        "ids" to JsonArray(listOf(JsonPrimitive(prefix)))
+                    ),
+                    context
+                ) as JsonObject
 
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(1, data["deleted"]!!.jsonPrimitive.int)
-        assertEquals(0, data["failed"]!!.jsonPrimitive.int)
-    }
-
-    @Test
-    fun `delete by 8-char prefix resolves and deletes item`(): Unit = runBlocking {
-        val itemId = createItem("Delete 8-char Test")
-        val prefix = itemId.substring(0, 8)
-
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("delete"),
-                "ids" to JsonArray(listOf(JsonPrimitive(prefix)))
-            ),
-            context
-        ) as JsonObject
-
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(1, data["deleted"]!!.jsonPrimitive.int)
-    }
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(1, data["deleted"]!!.jsonPrimitive.int)
+            assertEquals(0, data["failed"]!!.jsonPrimitive.int)
+        }
 
     @Test
-    fun `delete by full UUID still works (regression)`(): Unit = runBlocking {
-        val itemId = createItem("Delete Full UUID")
+    fun `delete by 8-char prefix resolves and deletes item`(): Unit =
+        runBlocking {
+            val itemId = createItem("Delete 8-char Test")
+            val prefix = itemId.substring(0, 8)
 
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("delete"),
-                "ids" to JsonArray(listOf(JsonPrimitive(itemId)))
-            ),
-            context
-        ) as JsonObject
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("delete"),
+                        "ids" to JsonArray(listOf(JsonPrimitive(prefix)))
+                    ),
+                    context
+                ) as JsonObject
 
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(1, data["deleted"]!!.jsonPrimitive.int)
-    }
-
-    @Test
-    fun `delete with too-short prefix returns error`(): Unit = runBlocking {
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("delete"),
-                "ids" to JsonArray(listOf(JsonPrimitive("ab")))
-            ),
-            context
-        ) as JsonObject
-
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(0, data["deleted"]!!.jsonPrimitive.int)
-        assertEquals(1, data["failed"]!!.jsonPrimitive.int)
-        val failure = data["failures"]!!.jsonArray[0].jsonObject
-        assertTrue(failure["error"]!!.jsonPrimitive.content.contains("prefix too short"))
-    }
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(1, data["deleted"]!!.jsonPrimitive.int)
+        }
 
     @Test
-    fun `delete with non-hex prefix returns error`(): Unit = runBlocking {
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("delete"),
-                "ids" to JsonArray(listOf(JsonPrimitive("zzzz1234")))
-            ),
-            context
-        ) as JsonObject
+    fun `delete by full UUID still works (regression)`(): Unit =
+        runBlocking {
+            val itemId = createItem("Delete Full UUID")
 
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(0, data["deleted"]!!.jsonPrimitive.int)
-        assertEquals(1, data["failed"]!!.jsonPrimitive.int)
-        val failure = data["failures"]!!.jsonArray[0].jsonObject
-        assertTrue(failure["error"]!!.jsonPrimitive.content.contains("must be a UUID or hex prefix"))
-    }
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("delete"),
+                        "ids" to JsonArray(listOf(JsonPrimitive(itemId)))
+                    ),
+                    context
+                ) as JsonObject
 
-    @Test
-    fun `delete multiple items by short prefix`(): Unit = runBlocking {
-        val id1 = createItem("Delete Multi 1")
-        val id2 = createItem("Delete Multi 2")
-        val prefix1 = id1.substring(0, 8)
-        val prefix2 = id2.substring(0, 8)
-
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("delete"),
-                "ids" to JsonArray(listOf(JsonPrimitive(prefix1), JsonPrimitive(prefix2)))
-            ),
-            context
-        ) as JsonObject
-
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(2, data["deleted"]!!.jsonPrimitive.int)
-        assertEquals(0, data["failed"]!!.jsonPrimitive.int)
-    }
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(1, data["deleted"]!!.jsonPrimitive.int)
+        }
 
     @Test
-    fun `delete recursive by short prefix`(): Unit = runBlocking {
-        val parentId = createItem("Parent for Recursive")
-        val createChildResult = tool.execute(
-            buildJsonObject {
-                put("operation", JsonPrimitive("create"))
-                put("parentId", JsonPrimitive(parentId))
-                put("items", JsonArray(listOf(
-                    buildJsonObject { put("title", JsonPrimitive("Child 1")) },
-                    buildJsonObject { put("title", JsonPrimitive("Child 2")) }
-                )))
-            },
-            context
-        ) as JsonObject
-        assertTrue(createChildResult["success"]!!.jsonPrimitive.boolean)
+    fun `delete with too-short prefix returns error`(): Unit =
+        runBlocking {
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("delete"),
+                        "ids" to JsonArray(listOf(JsonPrimitive("ab")))
+                    ),
+                    context
+                ) as JsonObject
 
-        val prefix = parentId.substring(0, 8)
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("delete"),
-                "ids" to JsonArray(listOf(JsonPrimitive(prefix))),
-                "recursive" to JsonPrimitive(true)
-            ),
-            context
-        ) as JsonObject
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(0, data["deleted"]!!.jsonPrimitive.int)
+            assertEquals(1, data["failed"]!!.jsonPrimitive.int)
+            val failure = data["failures"]!!.jsonArray[0].jsonObject
+            assertTrue(failure["error"]!!.jsonPrimitive.content.contains("prefix too short"))
+        }
 
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        // 1 parent + 2 children = 3 total deleted
-        assertEquals(3, data["deleted"]!!.jsonPrimitive.int)
-    }
+    @Test
+    fun `delete with non-hex prefix returns error`(): Unit =
+        runBlocking {
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("delete"),
+                        "ids" to JsonArray(listOf(JsonPrimitive("zzzz1234")))
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(0, data["deleted"]!!.jsonPrimitive.int)
+            assertEquals(1, data["failed"]!!.jsonPrimitive.int)
+            val failure = data["failures"]!!.jsonArray[0].jsonObject
+            assertTrue(failure["error"]!!.jsonPrimitive.content.contains("must be a UUID or hex prefix"))
+        }
+
+    @Test
+    fun `delete multiple items by short prefix`(): Unit =
+        runBlocking {
+            val id1 = createItem("Delete Multi 1")
+            val id2 = createItem("Delete Multi 2")
+            val prefix1 = id1.substring(0, 8)
+            val prefix2 = id2.substring(0, 8)
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("delete"),
+                        "ids" to JsonArray(listOf(JsonPrimitive(prefix1), JsonPrimitive(prefix2)))
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(2, data["deleted"]!!.jsonPrimitive.int)
+            assertEquals(0, data["failed"]!!.jsonPrimitive.int)
+        }
+
+    @Test
+    fun `delete recursive by short prefix`(): Unit =
+        runBlocking {
+            val parentId = createItem("Parent for Recursive")
+            val createChildResult =
+                tool.execute(
+                    buildJsonObject {
+                        put("operation", JsonPrimitive("create"))
+                        put("parentId", JsonPrimitive(parentId))
+                        put(
+                            "items",
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject { put("title", JsonPrimitive("Child 1")) },
+                                    buildJsonObject { put("title", JsonPrimitive("Child 2")) }
+                                )
+                            )
+                        )
+                    },
+                    context
+                ) as JsonObject
+            assertTrue(createChildResult["success"]!!.jsonPrimitive.boolean)
+
+            val prefix = parentId.substring(0, 8)
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("delete"),
+                        "ids" to JsonArray(listOf(JsonPrimitive(prefix))),
+                        "recursive" to JsonPrimitive(true)
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            // 1 parent + 2 children = 3 total deleted
+            assertEquals(3, data["deleted"]!!.jsonPrimitive.int)
+        }
 
     // ──────────────────────────────────────────────
     // Create: per-item parentId prefix resolution
     // ──────────────────────────────────────────────
 
     @Test
-    fun `create with per-item parentId short prefix`(): Unit = runBlocking {
-        val parentId = createItem("Parent Item")
-        val parentPrefix = parentId.substring(0, 8)
+    fun `create with per-item parentId short prefix`(): Unit =
+        runBlocking {
+            val parentId = createItem("Parent Item")
+            val parentPrefix = parentId.substring(0, 8)
 
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("create"),
-                "items" to JsonArray(listOf(
-                    buildJsonObject {
-                        put("title", JsonPrimitive("Child via prefix"))
-                        put("parentId", JsonPrimitive(parentPrefix))
-                    }
-                ))
-            ),
-            context
-        ) as JsonObject
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("create"),
+                        "items" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("title", JsonPrimitive("Child via prefix"))
+                                        put("parentId", JsonPrimitive(parentPrefix))
+                                    }
+                                )
+                            )
+                    ),
+                    context
+                ) as JsonObject
 
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(1, data["created"]!!.jsonPrimitive.int)
-        assertEquals(0, data["failed"]!!.jsonPrimitive.int)
-        val created = data["items"]!!.jsonArray[0].jsonObject
-        assertEquals(1, created["depth"]!!.jsonPrimitive.int)
-    }
-
-    @Test
-    fun `create with per-item parentId 4-char prefix`(): Unit = runBlocking {
-        val parentId = createItem("Parent Short")
-        val prefix = parentId.substring(0, 4)
-
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("create"),
-                "items" to JsonArray(listOf(
-                    buildJsonObject {
-                        put("title", JsonPrimitive("Child via 4-char prefix"))
-                        put("parentId", JsonPrimitive(prefix))
-                    }
-                ))
-            ),
-            context
-        ) as JsonObject
-
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(1, data["created"]!!.jsonPrimitive.int)
-    }
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(1, data["created"]!!.jsonPrimitive.int)
+            assertEquals(0, data["failed"]!!.jsonPrimitive.int)
+            val created = data["items"]!!.jsonArray[0].jsonObject
+            assertEquals(1, created["depth"]!!.jsonPrimitive.int)
+        }
 
     @Test
-    fun `create with per-item parentId full UUID (regression)`(): Unit = runBlocking {
-        val parentId = createItem("Parent Full UUID")
+    fun `create with per-item parentId 4-char prefix`(): Unit =
+        runBlocking {
+            val parentId = createItem("Parent Short")
+            val prefix = parentId.substring(0, 4)
 
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("create"),
-                "items" to JsonArray(listOf(
-                    buildJsonObject {
-                        put("title", JsonPrimitive("Child via full UUID"))
-                        put("parentId", JsonPrimitive(parentId))
-                    }
-                ))
-            ),
-            context
-        ) as JsonObject
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("create"),
+                        "items" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("title", JsonPrimitive("Child via 4-char prefix"))
+                                        put("parentId", JsonPrimitive(prefix))
+                                    }
+                                )
+                            )
+                    ),
+                    context
+                ) as JsonObject
 
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(1, data["created"]!!.jsonPrimitive.int)
-    }
-
-    @Test
-    fun `create with invalid per-item parentId prefix returns error`(): Unit = runBlocking {
-        val result = tool.execute(
-            params(
-                "operation" to JsonPrimitive("create"),
-                "items" to JsonArray(listOf(
-                    buildJsonObject {
-                        put("title", JsonPrimitive("Bad parent"))
-                        put("parentId", JsonPrimitive("xyz"))
-                    }
-                ))
-            ),
-            context
-        ) as JsonObject
-
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(0, data["created"]!!.jsonPrimitive.int)
-        assertEquals(1, data["failed"]!!.jsonPrimitive.int)
-    }
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(1, data["created"]!!.jsonPrimitive.int)
+        }
 
     @Test
-    fun `create per-item parentId overrides shared parentId with short prefix`(): Unit = runBlocking {
-        val sharedParent = createItem("Shared Parent")
-        val itemParent = createItem("Item Parent")
-        val itemParentPrefix = itemParent.substring(0, 8)
+    fun `create with per-item parentId full UUID (regression)`(): Unit =
+        runBlocking {
+            val parentId = createItem("Parent Full UUID")
 
-        val result = tool.execute(
-            buildJsonObject {
-                put("operation", JsonPrimitive("create"))
-                put("parentId", JsonPrimitive(sharedParent))
-                put("items", JsonArray(listOf(
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("create"),
+                        "items" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("title", JsonPrimitive("Child via full UUID"))
+                                        put("parentId", JsonPrimitive(parentId))
+                                    }
+                                )
+                            )
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(1, data["created"]!!.jsonPrimitive.int)
+        }
+
+    @Test
+    fun `create with invalid per-item parentId prefix returns error`(): Unit =
+        runBlocking {
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("create"),
+                        "items" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("title", JsonPrimitive("Bad parent"))
+                                        put("parentId", JsonPrimitive("xyz"))
+                                    }
+                                )
+                            )
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(0, data["created"]!!.jsonPrimitive.int)
+            assertEquals(1, data["failed"]!!.jsonPrimitive.int)
+        }
+
+    @Test
+    fun `create per-item parentId overrides shared parentId with short prefix`(): Unit =
+        runBlocking {
+            val sharedParent = createItem("Shared Parent")
+            val itemParent = createItem("Item Parent")
+            val itemParentPrefix = itemParent.substring(0, 8)
+
+            val result =
+                tool.execute(
                     buildJsonObject {
-                        put("title", JsonPrimitive("Uses shared parent"))
+                        put("operation", JsonPrimitive("create"))
+                        put("parentId", JsonPrimitive(sharedParent))
+                        put(
+                            "items",
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("title", JsonPrimitive("Uses shared parent"))
+                                    },
+                                    buildJsonObject {
+                                        put("title", JsonPrimitive("Uses item-level parent"))
+                                        put("parentId", JsonPrimitive(itemParentPrefix))
+                                    }
+                                )
+                            )
+                        )
                     },
-                    buildJsonObject {
-                        put("title", JsonPrimitive("Uses item-level parent"))
-                        put("parentId", JsonPrimitive(itemParentPrefix))
-                    }
-                )))
-            },
-            context
-        ) as JsonObject
+                    context
+                ) as JsonObject
 
-        assertTrue(result["success"]!!.jsonPrimitive.boolean)
-        val data = result["data"] as JsonObject
-        assertEquals(2, data["created"]!!.jsonPrimitive.int)
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(2, data["created"]!!.jsonPrimitive.int)
 
-        // Verify the second item used the per-item parent
-        val secondItemId = data["items"]!!.jsonArray[1].jsonObject["id"]!!.jsonPrimitive.content
-        val queryTool = QueryItemsTool()
-        val getResult = queryTool.execute(
-            params(
-                "operation" to JsonPrimitive("get"),
-                "id" to JsonPrimitive(secondItemId)
-            ),
-            context
-        ) as JsonObject
-        val itemData = getResult["data"] as JsonObject
-        assertEquals(itemParent, itemData["parentId"]!!.jsonPrimitive.content)
-    }
+            // Verify the second item used the per-item parent
+            val secondItemId =
+                data["items"]!!
+                    .jsonArray[1]
+                    .jsonObject["id"]!!
+                    .jsonPrimitive.content
+            val queryTool = QueryItemsTool()
+            val getResult =
+                queryTool.execute(
+                    params(
+                        "operation" to JsonPrimitive("get"),
+                        "id" to JsonPrimitive(secondItemId)
+                    ),
+                    context
+                ) as JsonObject
+            val itemData = getResult["data"] as JsonObject
+            assertEquals(itemParent, itemData["parentId"]!!.jsonPrimitive.content)
+        }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsToolPrefixTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsToolPrefixTest.kt
@@ -1,0 +1,531 @@
+package io.github.jpicklyk.mcptask.current.application.tools.items
+
+import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.*
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.*
+
+/**
+ * Tests short hex prefix resolution for manage_items operations (create, update, delete).
+ *
+ * Covers the four parameters that were missing short-ID support:
+ * - update: items[].id and items[].parentId
+ * - delete: ids[]
+ * - create: per-item items[].parentId
+ */
+class ManageItemsToolPrefixTest {
+    private lateinit var context: ToolExecutionContext
+    private lateinit var tool: ManageItemsTool
+
+    @BeforeEach
+    fun setUp() {
+        val dbName = "test_${System.nanoTime()}"
+        val database = Database.connect("jdbc:h2:mem:$dbName;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+        val databaseManager = DatabaseManager(database)
+        DirectDatabaseSchemaManager().updateSchema()
+        val repositoryProvider = DefaultRepositoryProvider(databaseManager)
+        context = ToolExecutionContext(repositoryProvider)
+        tool = ManageItemsTool()
+    }
+
+    private fun params(vararg pairs: Pair<String, JsonElement>) = JsonObject(mapOf(*pairs))
+
+    private suspend fun createItem(
+        title: String,
+        parentId: String? = null
+    ): String {
+        val itemObj = buildJsonObject {
+            put("title", JsonPrimitive(title))
+            parentId?.let { put("parentId", JsonPrimitive(it)) }
+        }
+        val result = tool.execute(
+            buildJsonObject {
+                put("operation", JsonPrimitive("create"))
+                put("items", JsonArray(listOf(itemObj)))
+                parentId?.let { put("parentId", JsonPrimitive(it)) }
+            },
+            context
+        ) as JsonObject
+        return (result["data"] as JsonObject)["items"]!!
+            .jsonArray[0]
+            .jsonObject["id"]!!
+            .jsonPrimitive.content
+    }
+
+    // ──────────────────────────────────────────────
+    // Update: items[].id prefix resolution
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `update by 4-char prefix resolves item`(): Unit = runBlocking {
+        val itemId = createItem("Update Prefix Test")
+        val prefix = itemId.substring(0, 4)
+
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("update"),
+                "items" to JsonArray(listOf(
+                    buildJsonObject {
+                        put("id", JsonPrimitive(prefix))
+                        put("summary", JsonPrimitive("Updated via 4-char prefix"))
+                    }
+                ))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(1, data["updated"]!!.jsonPrimitive.int)
+        assertEquals(0, data["failed"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `update by 8-char prefix resolves item`(): Unit = runBlocking {
+        val itemId = createItem("Update 8-char Test")
+        val prefix = itemId.substring(0, 8)
+
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("update"),
+                "items" to JsonArray(listOf(
+                    buildJsonObject {
+                        put("id", JsonPrimitive(prefix))
+                        put("summary", JsonPrimitive("Updated via 8-char prefix"))
+                    }
+                ))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(1, data["updated"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `update by full UUID still works (regression)`(): Unit = runBlocking {
+        val itemId = createItem("Update Full UUID")
+
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("update"),
+                "items" to JsonArray(listOf(
+                    buildJsonObject {
+                        put("id", JsonPrimitive(itemId))
+                        put("summary", JsonPrimitive("Updated via full UUID"))
+                    }
+                ))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(1, data["updated"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `update with too-short prefix returns error`(): Unit = runBlocking {
+        createItem("Short Prefix Item")
+
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("update"),
+                "items" to JsonArray(listOf(
+                    buildJsonObject {
+                        put("id", JsonPrimitive("abc"))
+                        put("summary", JsonPrimitive("Should fail"))
+                    }
+                ))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean) // envelope succeeds, item fails
+        val data = result["data"] as JsonObject
+        assertEquals(0, data["updated"]!!.jsonPrimitive.int)
+        assertEquals(1, data["failed"]!!.jsonPrimitive.int)
+        val failure = data["failures"]!!.jsonArray[0].jsonObject
+        assertTrue(failure["error"]!!.jsonPrimitive.content.contains("prefix too short"))
+    }
+
+    @Test
+    fun `update with non-hex prefix returns error`(): Unit = runBlocking {
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("update"),
+                "items" to JsonArray(listOf(
+                    buildJsonObject {
+                        put("id", JsonPrimitive("ghij1234"))
+                        put("summary", JsonPrimitive("Should fail"))
+                    }
+                ))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(0, data["updated"]!!.jsonPrimitive.int)
+        assertEquals(1, data["failed"]!!.jsonPrimitive.int)
+        val failure = data["failures"]!!.jsonArray[0].jsonObject
+        assertTrue(failure["error"]!!.jsonPrimitive.content.contains("must be a UUID or hex prefix"))
+    }
+
+    @Test
+    fun `update with non-matching prefix returns not-found error`(): Unit = runBlocking {
+        createItem("Some Item")
+
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("update"),
+                "items" to JsonArray(listOf(
+                    buildJsonObject {
+                        put("id", JsonPrimitive("0000"))
+                        put("summary", JsonPrimitive("Should fail"))
+                    }
+                ))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(0, data["updated"]!!.jsonPrimitive.int)
+        assertEquals(1, data["failed"]!!.jsonPrimitive.int)
+        val failure = data["failures"]!!.jsonArray[0].jsonObject
+        assertTrue(failure["error"]!!.jsonPrimitive.content.contains("No WorkItem found"))
+    }
+
+    // ──────────────────────────────────────────────
+    // Update: items[].parentId prefix resolution
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `update parentId by short prefix moves item`(): Unit = runBlocking {
+        val parentId = createItem("New Parent")
+        val childId = createItem("Orphan Child")
+        val parentPrefix = parentId.substring(0, 8)
+
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("update"),
+                "items" to JsonArray(listOf(
+                    buildJsonObject {
+                        put("id", JsonPrimitive(childId))
+                        put("parentId", JsonPrimitive(parentPrefix))
+                    }
+                ))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(1, data["updated"]!!.jsonPrimitive.int)
+
+        // Verify the item was actually moved
+        val queryTool = QueryItemsTool()
+        val getResult = queryTool.execute(
+            params(
+                "operation" to JsonPrimitive("get"),
+                "id" to JsonPrimitive(childId)
+            ),
+            context
+        ) as JsonObject
+        val itemData = getResult["data"] as JsonObject
+        assertEquals(parentId, itemData["parentId"]!!.jsonPrimitive.content)
+        assertEquals(1, itemData["depth"]!!.jsonPrimitive.int)
+    }
+
+    // ──────────────────────────────────────────────
+    // Delete: ids[] prefix resolution
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `delete by 4-char prefix resolves and deletes item`(): Unit = runBlocking {
+        val itemId = createItem("Delete Prefix Test")
+        val prefix = itemId.substring(0, 4)
+
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("delete"),
+                "ids" to JsonArray(listOf(JsonPrimitive(prefix)))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(1, data["deleted"]!!.jsonPrimitive.int)
+        assertEquals(0, data["failed"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `delete by 8-char prefix resolves and deletes item`(): Unit = runBlocking {
+        val itemId = createItem("Delete 8-char Test")
+        val prefix = itemId.substring(0, 8)
+
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("delete"),
+                "ids" to JsonArray(listOf(JsonPrimitive(prefix)))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(1, data["deleted"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `delete by full UUID still works (regression)`(): Unit = runBlocking {
+        val itemId = createItem("Delete Full UUID")
+
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("delete"),
+                "ids" to JsonArray(listOf(JsonPrimitive(itemId)))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(1, data["deleted"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `delete with too-short prefix returns error`(): Unit = runBlocking {
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("delete"),
+                "ids" to JsonArray(listOf(JsonPrimitive("ab")))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(0, data["deleted"]!!.jsonPrimitive.int)
+        assertEquals(1, data["failed"]!!.jsonPrimitive.int)
+        val failure = data["failures"]!!.jsonArray[0].jsonObject
+        assertTrue(failure["error"]!!.jsonPrimitive.content.contains("prefix too short"))
+    }
+
+    @Test
+    fun `delete with non-hex prefix returns error`(): Unit = runBlocking {
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("delete"),
+                "ids" to JsonArray(listOf(JsonPrimitive("zzzz1234")))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(0, data["deleted"]!!.jsonPrimitive.int)
+        assertEquals(1, data["failed"]!!.jsonPrimitive.int)
+        val failure = data["failures"]!!.jsonArray[0].jsonObject
+        assertTrue(failure["error"]!!.jsonPrimitive.content.contains("must be a UUID or hex prefix"))
+    }
+
+    @Test
+    fun `delete multiple items by short prefix`(): Unit = runBlocking {
+        val id1 = createItem("Delete Multi 1")
+        val id2 = createItem("Delete Multi 2")
+        val prefix1 = id1.substring(0, 8)
+        val prefix2 = id2.substring(0, 8)
+
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("delete"),
+                "ids" to JsonArray(listOf(JsonPrimitive(prefix1), JsonPrimitive(prefix2)))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(2, data["deleted"]!!.jsonPrimitive.int)
+        assertEquals(0, data["failed"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `delete recursive by short prefix`(): Unit = runBlocking {
+        val parentId = createItem("Parent for Recursive")
+        val createChildResult = tool.execute(
+            buildJsonObject {
+                put("operation", JsonPrimitive("create"))
+                put("parentId", JsonPrimitive(parentId))
+                put("items", JsonArray(listOf(
+                    buildJsonObject { put("title", JsonPrimitive("Child 1")) },
+                    buildJsonObject { put("title", JsonPrimitive("Child 2")) }
+                )))
+            },
+            context
+        ) as JsonObject
+        assertTrue(createChildResult["success"]!!.jsonPrimitive.boolean)
+
+        val prefix = parentId.substring(0, 8)
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("delete"),
+                "ids" to JsonArray(listOf(JsonPrimitive(prefix))),
+                "recursive" to JsonPrimitive(true)
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        // 1 parent + 2 children = 3 total deleted
+        assertEquals(3, data["deleted"]!!.jsonPrimitive.int)
+    }
+
+    // ──────────────────────────────────────────────
+    // Create: per-item parentId prefix resolution
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `create with per-item parentId short prefix`(): Unit = runBlocking {
+        val parentId = createItem("Parent Item")
+        val parentPrefix = parentId.substring(0, 8)
+
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("create"),
+                "items" to JsonArray(listOf(
+                    buildJsonObject {
+                        put("title", JsonPrimitive("Child via prefix"))
+                        put("parentId", JsonPrimitive(parentPrefix))
+                    }
+                ))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(1, data["created"]!!.jsonPrimitive.int)
+        assertEquals(0, data["failed"]!!.jsonPrimitive.int)
+        val created = data["items"]!!.jsonArray[0].jsonObject
+        assertEquals(1, created["depth"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `create with per-item parentId 4-char prefix`(): Unit = runBlocking {
+        val parentId = createItem("Parent Short")
+        val prefix = parentId.substring(0, 4)
+
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("create"),
+                "items" to JsonArray(listOf(
+                    buildJsonObject {
+                        put("title", JsonPrimitive("Child via 4-char prefix"))
+                        put("parentId", JsonPrimitive(prefix))
+                    }
+                ))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(1, data["created"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `create with per-item parentId full UUID (regression)`(): Unit = runBlocking {
+        val parentId = createItem("Parent Full UUID")
+
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("create"),
+                "items" to JsonArray(listOf(
+                    buildJsonObject {
+                        put("title", JsonPrimitive("Child via full UUID"))
+                        put("parentId", JsonPrimitive(parentId))
+                    }
+                ))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(1, data["created"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `create with invalid per-item parentId prefix returns error`(): Unit = runBlocking {
+        val result = tool.execute(
+            params(
+                "operation" to JsonPrimitive("create"),
+                "items" to JsonArray(listOf(
+                    buildJsonObject {
+                        put("title", JsonPrimitive("Bad parent"))
+                        put("parentId", JsonPrimitive("xyz"))
+                    }
+                ))
+            ),
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(0, data["created"]!!.jsonPrimitive.int)
+        assertEquals(1, data["failed"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `create per-item parentId overrides shared parentId with short prefix`(): Unit = runBlocking {
+        val sharedParent = createItem("Shared Parent")
+        val itemParent = createItem("Item Parent")
+        val itemParentPrefix = itemParent.substring(0, 8)
+
+        val result = tool.execute(
+            buildJsonObject {
+                put("operation", JsonPrimitive("create"))
+                put("parentId", JsonPrimitive(sharedParent))
+                put("items", JsonArray(listOf(
+                    buildJsonObject {
+                        put("title", JsonPrimitive("Uses shared parent"))
+                    },
+                    buildJsonObject {
+                        put("title", JsonPrimitive("Uses item-level parent"))
+                        put("parentId", JsonPrimitive(itemParentPrefix))
+                    }
+                )))
+            },
+            context
+        ) as JsonObject
+
+        assertTrue(result["success"]!!.jsonPrimitive.boolean)
+        val data = result["data"] as JsonObject
+        assertEquals(2, data["created"]!!.jsonPrimitive.int)
+
+        // Verify the second item used the per-item parent
+        val secondItemId = data["items"]!!.jsonArray[1].jsonObject["id"]!!.jsonPrimitive.content
+        val queryTool = QueryItemsTool()
+        val getResult = queryTool.execute(
+            params(
+                "operation" to JsonPrimitive("get"),
+                "id" to JsonPrimitive(secondItemId)
+            ),
+            context
+        ) as JsonObject
+        val itemData = getResult["data"] as JsonObject
+        assertEquals(itemParent, itemData["parentId"]!!.jsonPrimitive.content)
+    }
+}


### PR DESCRIPTION
## Summary

- Closes gap from #98 where 4 `manage_items` parameters still used bare `UUID.fromString()` instead of short hex prefix resolution
- **Fixed:** `UpdateItemHandler` items[].id and items[].parentId, `DeleteItemHandler` ids[], `CreateItemHandler` per-item items[].parentId
- Adds `resolveWorkItemIdString()` utility for handler classes that don't extend `BaseToolDefinition`
- 19 new tests in `ManageItemsToolPrefixTest` covering success, regression, and error cases

## Test plan

- [x] All 19 new prefix tests pass (update by 4/8-char prefix, delete by prefix, create with per-item parentId prefix, recursive delete by prefix, error cases)
- [x] Full test suite passes with zero regressions
- [x] Manually validated via MCP tool calls before writing code (see conversation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)