### PR TITLE
feat: config-driven auditing enforcement and actor attribution docs

### DIFF
--- a/claude-plugins/task-orchestrator/hooks/enforce-actor-attribution.mjs
+++ b/claude-plugins/task-orchestrator/hooks/enforce-actor-attribution.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// PreToolUse hook — enforces actor attribution on MCP write operations when
+// auditing is enabled in .taskorchestrator/config.yaml.
+//
+// Config format:
+//   auditing:
+//     enabled: true
+//
+// When enabled, blocks advance_item and manage_notes(upsert) calls that are
+// missing an actor object on any transition/note element.
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+let input = '';
+try {
+  input = readFileSync(0, 'utf-8');
+} catch {
+  process.exit(0);
+}
+
+let hookInput;
+try {
+  hookInput = JSON.parse(input);
+} catch {
+  process.exit(0);
+}
+
+const toolName = hookInput.tool_name || '';
+const toolInput = hookInput.tool_input || {};
+
+// Early exit: only enforce on advance_item or manage_notes upsert
+const isAdvance = toolName.includes('advance_item');
+const isNoteUpsert = toolName.includes('manage_notes') && toolInput.operation === 'upsert';
+if (!isAdvance && !isNoteUpsert) process.exit(0);
+
+// Locate and read config.yaml — check AGENT_CONFIG_DIR, then walk up from cwd.
+// Handles worktrees where cwd is nested under .claude/worktrees/<name>/.
+function readConfigContent() {
+  const candidates = [];
+  if (process.env.AGENT_CONFIG_DIR) {
+    candidates.push(resolve(process.env.AGENT_CONFIG_DIR, '.taskorchestrator', 'config.yaml'));
+  }
+  let dir = process.cwd();
+  const root = resolve(dir, '/');
+  while (dir !== root) {
+    candidates.push(resolve(dir, '.taskorchestrator', 'config.yaml'));
+    dir = resolve(dir, '..');
+  }
+  for (const candidate of candidates) {
+    try {
+      return readFileSync(candidate, 'utf-8');
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+// Returns true only when auditing.enabled is explicitly set to true.
+// Handles both block YAML and inline forms, strips trailing comments.
+function isAuditingEnabled(configContent) {
+  if (!configContent) return false;
+
+  let inAuditingSection = false;
+
+  for (const line of configContent.split('\n')) {
+    const trimmed = line.trim();
+
+    // Detect top-level "auditing:" — check for inline form first
+    if (/^auditing\s*:/.test(trimmed)) {
+      // Handle inline: `auditing: { enabled: true }`
+      const inlineMatch = trimmed.match(/^auditing\s*:\s*\{(.+)\}/);
+      if (inlineMatch) {
+        const inner = inlineMatch[1];
+        const enabledMatch = inner.match(/enabled\s*:\s*(\S+)/);
+        return enabledMatch ? enabledMatch[1].replace(/#.*$/, '').trim().toLowerCase() === 'true' : false;
+      }
+      inAuditingSection = true;
+      continue;
+    }
+
+    // Any other top-level key (non-indented, non-empty) ends the auditing section
+    if (inAuditingSection && /^\S/.test(line)) {
+      inAuditingSection = false;
+    }
+
+    if (inAuditingSection) {
+      const match = trimmed.match(/^enabled\s*:\s*(.+)/);
+      if (match) {
+        return match[1].replace(/#.*$/, '').trim().toLowerCase() === 'true';
+      }
+    }
+  }
+
+  return false;
+}
+
+const configContent = readConfigContent();
+if (!isAuditingEnabled(configContent)) {
+  process.exit(0);
+}
+
+let missing = false;
+
+if (isAdvance) {
+  const transitions = toolInput.transitions || [];
+  missing = transitions.some(t => !t.actor);
+} else if (isNoteUpsert) {
+  const notes = toolInput.notes || [];
+  missing = notes.some(n => !n.actor);
+}
+
+if (!missing) {
+  process.exit(0);
+}
+
+process.stdout.write(JSON.stringify({
+  decision: 'block',
+  reason: 'Auditing is enabled \u2014 actor attribution required. Include an "actor" object ' +
+    'with "id" (string) and "kind" (orchestrator|subagent|user|external) on every ' +
+    'transition/note element. For subagents, include "parent" with the dispatching agent\'s id.'
+}));

--- a/claude-plugins/task-orchestrator/hooks/hooks-config.json
+++ b/claude-plugins/task-orchestrator/hooks/hooks-config.json
@@ -32,6 +32,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "mcp__mcp-task-orchestrator__advance_item|mcp__mcp-task-orchestrator__manage_notes",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/enforce-actor-attribution.mjs",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
@@ -77,6 +77,14 @@ If the config has a `traits:` section, show a separate traits summary table:
 | needs-migration-review | migration-assessment (queue, req) | migration-review |
 ```
 
+If the config has an `auditing:` section, display the auditing status:
+
+```
+◆ Auditing: enabled
+```
+
+Or `◆ Auditing: disabled` (or omit if the section is absent).
+
 ### EDIT — Modify an Existing Schema
 
 Read current config, display the target schema, ask what to change (add note, remove note, toggle required, change description/guidance/skill, change lifecycle mode, add/remove default_traits, rename key), apply changes, write back.

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
@@ -186,6 +186,46 @@ Items with `type: feature-task` use the `work_item_schemas` entry. Items with ta
 
 ---
 
+## Auditing
+
+The `auditing` section is a top-level key alongside `work_item_schemas` and `traits`. It controls whether actor attribution is enforced on write operations.
+
+```yaml
+auditing:
+  enabled: true
+
+work_item_schemas:
+  # ...
+```
+
+Default: `false` when absent — auditing is opt-in.
+
+### Fields
+
+| Field | Required | Type | Notes |
+|-------|----------|------|-------|
+| `enabled` | yes | boolean | `true` = block write calls missing actor claims. `false` = no enforcement |
+
+### Behavior
+
+When `auditing.enabled` is `true`, the plugin's PreToolUse hook blocks `advance_item` and `manage_notes(upsert)` calls that are missing an `actor` object on any element. The agent must retry with actor attribution included.
+
+When `false` or absent, actor claims are optional — calls pass through with no enforcement. Actor claims can still be provided voluntarily.
+
+### Stage 2 Expansion
+
+A future release will add `verifier` configuration under `auditing` for server-side claim validation (e.g., JWT). The `enabled` field will continue to control client-side enforcement independently:
+
+```yaml
+auditing:
+  enabled: true
+  verifier:
+    type: jwt
+    jwks_uri: "https://..."
+```
+
+---
+
 ## Key Stability Warning
 
 Changing a `key` after notes have been written orphans existing notes under the old key. There is no automatic migration — orphaned notes become ad-hoc notes on their items.

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/validate-workflow.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/validate-workflow.md
@@ -15,6 +15,7 @@ Parse the file. If YAML is invalid, report the parse error with line number (if 
 - At least one of `work_item_schemas` or `note_schemas` must exist at the top level
 - Each must be a mapping (not a list or scalar)
 - `traits` is an optional top-level key — if present, must be a mapping
+- `auditing` is an optional top-level key — if present, must be a mapping containing `enabled` (boolean)
 - No other top-level keys expected (warn if found)
 
 ### 3. Schema Entry Structure
@@ -66,6 +67,7 @@ For each note in each schema (and trait):
   work_item_schemas: 3 schemas
   note_schemas: 1 schema (legacy)
   traits: 2 traits
+  auditing: enabled
 
   Errors (must fix):
     ✗ bug-fix.fix-summary: missing "required" field
@@ -84,5 +86,5 @@ If no issues are found:
 ```
 ◆ Config Validation — .taskorchestrator/config.yaml
 
-  ✓ Valid — 3 schemas, 2 traits, 14 notes, no issues found
+  ✓ Valid — 3 schemas, 2 traits, 14 notes, auditing enabled, no issues found
 ```

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1072,66 +1072,30 @@ This is a documentation convention, not enforced by the server. Stage 1 trusts s
 
 ### Enforcing Actor Attribution
 
-Actor claims are **optional by default** — users who don't need auditing pay no extra token cost. To require actor claims on all write operations, configure a Claude Code `PreToolUse` hook.
+Actor claims are **optional by default** — users who don't need auditing pay no extra token cost. To require actor claims on all write operations, enable auditing in `.taskorchestrator/config.yaml`:
 
-#### Hook Configuration
-
-Add to your `.claude/settings.json` or `.claude/settings.local.json`:
-
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "type": "command",
-        "command": "node .claude/hooks/enforce-actor-attribution.js",
-        "matcher": "mcp__mcp-task-orchestrator__advance_item|mcp__mcp-task-orchestrator__manage_notes"
-      }
-    ]
-  }
-}
+```yaml
+auditing:
+  enabled: true
 ```
 
-#### Reference Hook Script
+When enabled, the plugin's `PreToolUse` hook blocks any `advance_item` or `manage_notes(upsert)` call where one or more elements are missing an `actor` object. The call never reaches the server — the agent must retry with actor claims included.
 
-Create `.claude/hooks/enforce-actor-attribution.js`:
+When `enabled` is `false` or the `auditing` section is absent, calls pass through with no enforcement. Actor claims can still be provided voluntarily.
 
-```javascript
-#!/usr/bin/env node
+> **Note:** Config changes require an MCP reconnect (`/mcp`) or session restart to take effect.
 
-// Enforce actor attribution on MCP Task Orchestrator write operations.
-// Soft enforcement: injects additionalContext reminding Claude to include actor.
-// For hard enforcement: change to output { "decision": "block", "reason": "..." }
+#### Subagent Behavior
 
-const fs = require('fs');
-const input = JSON.parse(fs.readFileSync('/dev/stdin', 'utf8'));
-const toolName = input.tool_name || '';
-const toolInput = input.tool_input || {};
+Actor claims are self-reported by convention — the server does not inject them automatically. This means:
 
-let missing = false;
+- **Uninstructed subagents** make calls with no actor data, producing anonymous transitions and notes
+- **Instructed subagents** include actor claims only when the delegation prompt tells them to
+- The enforcement hook applies to all callers in the session, including subagents, providing a safety net regardless of prompt quality
 
-if (toolName.includes('advance_item')) {
-  const transitions = toolInput.transitions || [];
-  missing = transitions.some(t => !t.actor);
-} else if (toolName.includes('manage_notes') && toolInput.operation === 'upsert') {
-  const notes = toolInput.notes || [];
-  missing = notes.some(n => !n.actor);
-}
+For reliable attribution, combine auditing enforcement with explicit delegation instructions:
 
-if (missing) {
-  const output = {
-    hookSpecificOutput: {
-      hookEventName: 'PreToolUse',
-      additionalContext: 'Actor attribution is required. Include an "actor" object with "id" and "kind" fields on each transition/note element. Example: { "id": "my-agent", "kind": "subagent", "parent": "orchestrator-id" }'
-    }
-  };
-  console.log(JSON.stringify(output));
-} else {
-  process.exit(0);
-}
 ```
-
-#### Soft vs Hard Enforcement
-
-- **Soft** (default above): Injects `additionalContext` — Claude sees the reminder and retries with actor claims included. The tool call is NOT blocked.
-- **Hard**: Replace `hookSpecificOutput` with `{ "decision": "block", "reason": "Actor attribution required" }` — the tool call is rejected outright and Claude must reformulate.
+Include an "actor" object on every advance_item and manage_notes call:
+{ "id": "your-agent-name", "kind": "subagent", "parent": "orchestrator-id" }
+```

--- a/current/docs/quick-start.md
+++ b/current/docs/quick-start.md
@@ -122,6 +122,8 @@ Hooks run automatically — no invocation required:
 - **Plan mode** — after plan approval, prompts Claude to create MCP items so persistent tracking stays in sync with the conversation
 - **Subagent start** — passes task context into spawned subagents so they start with full awareness of the current item
 
+**Optional:** Enable auditing to require agents to identify themselves on every write operation — add an `auditing` section with `enabled: true` to `.taskorchestrator/config.yaml`. See [Enforcing Actor Attribution](./api-reference.md#enforcing-actor-attribution) in the API reference.
+
 ### Output style
 
 The plugin includes a **Workflow Analyst** output style. When active, Claude Code acts as a project management orchestrator — it plans, delegates implementation to subagents, and tracks progress in the WorkItem graph without writing code directly. Useful for complex multi-step features. Select it from the output style menu (`/output-style`) after installing the plugin.

--- a/current/docs/workflow-guide.md
+++ b/current/docs/workflow-guide.md
@@ -668,6 +668,36 @@ When completing a blocking item, the response includes `unblockedItems`:
 
 Items in `unblockedItems` are now eligible to be started.
 
+### Actor Attribution
+
+`advance_item` transitions and `manage_notes` upserts accept an optional `actor` claim that records *who* performed the action. This enables post-mortem analysis of multi-agent workflows.
+
+```json
+advance_item(transitions=[{
+  "itemId": "abc-123",
+  "trigger": "start",
+  "actor": { "id": "impl-agent", "kind": "subagent", "parent": "orchestrator-1" }
+}])
+```
+
+The response echoes the actor claim and includes a verification record:
+
+```json
+{
+  "actor": { "id": "impl-agent", "kind": "subagent", "parent": "orchestrator-1" },
+  "verification": { "status": "unverified", "verifier": "noop" }
+}
+```
+
+Key behaviors:
+- **Optional by default** — omitting `actor` produces no error and no attribution data
+- **Cascade transitions** always have null actor (system-generated, not attributable)
+- **Note re-upsert** replaces the actor (last-writer-wins semantics)
+- **`get_context` session resume** includes actor/verification on recent transitions
+- **`query_notes`** includes actor/verification on notes that have them
+
+Actor claims are self-reported — the server trusts them as-is in Stage 1. To require actor claims on all write operations, enable auditing in `.taskorchestrator/config.yaml` (set `auditing.enabled: true`). See [Enforcing Actor Attribution](./api-reference.md#enforcing-actor-attribution) in the API reference.
+
 ---
 
 ## 8. Efficient Queries

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesTool.kt
@@ -29,10 +29,11 @@ Unified write operations for Notes (upsert, delete).
 **Operations:**
 
 **upsert** - Upsert notes from `notes` array.
-- Each note: `{ itemId (required), key (required), role (required: "queue"|"work"|"review"), body? }`
+- Each note: `{ itemId (required), key (required), role (required: "queue"|"work"|"review"), body?, actor? }`
+- `actor` (optional): `{ id (required string), kind (required: orchestrator|subagent|user|external), parent? (optional string), proof? (optional string) }` — records who wrote the note. Re-upsert replaces the actor (last-writer-wins).
 - (itemId, key) is unique — existing notes with same pair are updated
 - Validates that itemId references an existing WorkItem
-- Response: `{ notes: [{id, itemId, key, role}], upserted: N, failed: N, failures: [{index, error}], itemContext: { "<itemId>": { guidancePointer: "...|null", noteProgress: { filled: N, remaining: N, total: N }|null } } }`
+- Response: `{ notes: [{id, itemId, key, role, actor?, verification?}], upserted: N, failed: N, failures: [{index, error}], itemContext: { "<itemId>": { guidancePointer: "...|null", noteProgress: { filled: N, remaining: N, total: N }|null } } }`
 
 **delete** - Delete notes.
 - By `ids` array: delete each note by UUID

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/QueryNotesTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/QueryNotesTool.kt
@@ -24,13 +24,13 @@ Read-only query operations for Notes (get, list).
 
 **get** - Get a single Note by ID.
 - Required: `id` (UUID)
-- Response: full Note JSON
+- Response: full Note JSON (includes `actor` and `verification` when present)
 
 **list** - List notes for a WorkItem.
 - Required: `itemId` (UUID)
 - Optional: `role` — filter by role: "queue", "work", "review"
 - Optional: `includeBody` (boolean, default true) — set false to omit body for token efficiency
-- Response: `{ notes: [...], total: N }`
+- Response: `{ notes: [...], total: N }` — each note includes `actor` and `verification` fields when attribution was provided at write time
         """.trimIndent()
 
     override val category = ToolCategory.NOTE_MANAGEMENT

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -41,8 +41,9 @@ class AdvanceItemTool :
 Trigger-based role transitions for WorkItems with validation, cascade detection, and unblock reporting.
 
 **Parameters:**
-- `transitions` (required array): Each element: `{ itemId (required UUID or short hex prefix, min 4 chars), trigger (required string), summary? (optional string) }`
+- `transitions` (required array): Each element: `{ itemId (required UUID or short hex prefix, min 4 chars), trigger (required string), summary? (optional string), actor? (optional object) }`
 - Valid triggers: start, complete, block, hold, resume, cancel, reopen
+- `actor` (optional): `{ id (required string), kind (required: orchestrator|subagent|user|external), parent? (optional string), proof? (optional string) }` — records who performed the transition. Cascade transitions always have null actor.
 
 **Trigger effects:**
 - start: QUEUE->WORK, WORK->REVIEW (or TERMINAL if no review phase in schema), REVIEW->TERMINAL
@@ -66,6 +67,8 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
       "newRole": "work",
       "trigger": "start",
       "applied": true,
+      "actor": { "id": "agent-1", "kind": "subagent", "parent": "orch-1" },
+      "verification": { "status": "unverified", "verifier": "noop" },
       "cascadeEvents": [
         { "itemId": "uuid", "title": "Parent Item Title", "previousRole": "work", "targetRole": "terminal", "applied": true }
       ],

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
@@ -39,8 +39,8 @@ gate status (canAdvance + missing required notes for current phase), and `notePr
 (`{filled, remaining, total}` counts of required notes for the current role; null for terminal or schema-free items).
 
 **Session resume** — `since` (ISO 8601 timestamp):
-Returns active items (role=work or review), recent role transitions since the timestamp,
-and stalled items (active items with missing required notes).
+Returns active items (role=work or review), recent role transitions since the timestamp
+(including actor/verification when present), and stalled items (active items with missing required notes).
 
 **Health check** — no parameters:
 Returns all active items (work/review), blocked items, and stalled items.


### PR DESCRIPTION
## Summary

- Moves actor attribution enforcement into the plugin with a config-driven toggle (`auditing.enabled` in `.taskorchestrator/config.yaml`)
- Documents actor/verification fields across all affected MCP tool descriptions
- Completes Stage 1 of actor attribution

### Plugin hook
- New `enforce-actor-attribution.mjs` — reads config at runtime via `findConfigPath()` pattern (AGENT_CONFIG_DIR + cwd walk-up)
- Handles inline YAML (`auditing: { enabled: true }`) and trailing comments (`enabled: true  # comment`)
- Early exits for non-upsert `manage_notes` operations (no config read wasted)
- Registered in `hooks-config.json` for `advance_item` and `manage_notes`

### Documentation
- `api-reference.md` — replaced manual hook installation with config toggle
- `workflow-guide.md` — new Actor Attribution section covering usage, response shape, key behaviors
- `quick-start.md` — auditing cross-reference under hooks
- `config-format.md` — documents `auditing` section with Stage 2 `verifier` expansion path
- `manage-schemas` skill — VIEW shows auditing status, VALIDATE checks config validity

### MCP tool descriptions
- `AdvanceItemTool` — documents `actor?` parameter and actor/verification in response example
- `ManageNotesTool` — documents `actor?` on upsert notes and actor/verification in response
- `QueryNotesTool` — notes include actor/verification when present
- `GetContextTool` — session resume includes actor/verification on transitions

## Test plan

- [x] Hook tested with 12 scenarios: enabled/disabled/absent config, inline YAML, trailing comments, advance_item, manage_notes upsert/delete, mixed batches, unrelated tools
- [x] Build passes (Kotlin compile + ktlint + all tests)
- [x] E2E actor attribution tested against live MCP server (PR #105 session)

Relates to #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)