### PR TITLE
docs: add community health files, CI badge, and fix doc links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Report a problem with the MCP Task Orchestrator
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Describe the Bug
+
+A clear and concise description of what the bug is.
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+1. Call tool '...' with parameters '...'
+2. Observe response '...'
+3. Expected '...' but got '...'
+
+## Expected Behavior
+
+A clear description of what you expected to happen.
+
+## Environment
+
+- **MCP Client**: (e.g., Claude Code, Cursor, Windsurf, Claude Desktop)
+- **Task Orchestrator Version**: (e.g., v3.1.0 — check Docker image tag)
+- **Transport**: STDIO / HTTP
+- **OS**: (e.g., macOS 15, Windows 11, Ubuntu 24.04)
+- **Docker Version**: (run `docker --version`)
+
+## Relevant Config
+
+If applicable, share the relevant portion of your `.taskorchestrator/config.yaml` (redact any sensitive values).
+
+## Additional Context
+
+Add any other context about the problem here — logs, screenshots, or MCP tool responses.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature Request
+about: Suggest an idea for the MCP Task Orchestrator
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+
+A clear description of the problem or limitation you're experiencing.
+
+Example: "When working with large work trees, I need to ..."
+
+## Proposed Solution
+
+A clear description of what you'd like to happen.
+
+## Alternatives Considered
+
+Describe any alternative solutions or workarounds you've considered.
+
+## Use Case
+
+How would this feature fit into your workflow? Which MCP client(s) do you use?
+
+- **MCP Client**: (e.g., Claude Code, Cursor, Windsurf, Claude Desktop)
+- **Workflow**: (e.g., multi-agent orchestration, solo development, team coordination)
+
+## Additional Context
+
+Add any other context, mockups, or tool response examples that illustrate the feature.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+Brief description of what this PR does and why.
+
+## Changes
+
+- 
+
+## Testing
+
+- [ ] All existing tests pass (`./gradlew test`)
+- [ ] New tests added for new functionality
+- [ ] Manual verification completed
+
+## Checklist
+
+- [ ] Follows [contribution guidelines](../CONTRIBUTING.md)
+- [ ] Commit messages follow conventional commit format
+- [ ] Database migrations (if any) handle SQLite table recreation correctly
+- [ ] API reference updated (if tool behavior changed)
+- [ ] CHANGELOG.md updated

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,36 @@
+# Code of Conduct
+
+## Our Pledge
+
+We are committed to making participation in this project a welcoming experience for everyone, regardless of background or experience level.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive feedback
+- Focusing on what is best for the community
+
+Examples of behavior we do not accept:
+
+- Trolling, insulting or derogatory comments, and personal attacks
+- Public or private communication that others would reasonably consider unwelcome
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair action in response to any instances of unacceptable behavior.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — issues, pull requests, discussions, and any other communication channel associated with this project.
+
+## Reporting
+
+Instances of unacceptable behavior may be reported by opening an issue or contacting the maintainer directly. All reports will be reviewed and investigated.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,7 @@ Thank you for your interest in contributing to MCP Task Orchestrator! This guide
 
 ## Code of Conduct
 
-This project follows a simple code of conduct:
-- Be respectful and considerate of others
-- Focus on constructive feedback
-- Help create a welcoming environment for all contributors
+This project is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold it.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Prompt-based frameworks hope the LLM follows instructions. This one blocks the call if it doesn't.
 
 [![Version](https://img.shields.io/github/v/tag/jpicklyk/task-orchestrator?sort=semver)](https://github.com/jpicklyk/task-orchestrator/releases)
+[![CI](https://github.com/jpicklyk/task-orchestrator/actions/workflows/test.yml/badge.svg)](https://github.com/jpicklyk/task-orchestrator/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![MCP Compatible](https://img.shields.io/badge/MCP-Compatible-purple)](https://modelcontextprotocol.io)
 
@@ -303,10 +304,10 @@ Agent: advance_item(trigger="start", itemId="a3f2",
 
 | Resource | What's there |
 |----------|-------------|
-| **[Quick Start Guide](current/docs/quick-start.md)** | Full setup walkthrough with first work item |
-| **[API Reference](current/docs/api-reference.md)** | All 13 tools — parameters, response shapes, actor attribution |
-| **[Workflow Guide](current/docs/workflow-guide.md)** | Schemas, phase gates, dependencies, lifecycle modes |
-| **[Integration Guides](current/docs/integration-guides/index.md)** | 6 tiers from bare MCP to self-improving orchestration |
+| **[Quick Start Guide](https://github.com/jpicklyk/task-orchestrator/wiki/quick-start)** | Full setup walkthrough with first work item |
+| **[API Reference](https://github.com/jpicklyk/task-orchestrator/wiki/api-reference)** | All 13 tools — parameters, response shapes, actor attribution |
+| **[Workflow Guide](https://github.com/jpicklyk/task-orchestrator/wiki/workflow-guide)** | Schemas, phase gates, dependencies, lifecycle modes |
+| **[Integration Guides](https://github.com/jpicklyk/task-orchestrator/wiki/integration-guides)** | 6 tiers from bare MCP to self-improving orchestration |
 | **[Wiki](https://github.com/jpicklyk/task-orchestrator/wiki)** | Full documentation hub |
 | **[Changelog](CHANGELOG.md)** | Release history |
 | **[Contributing](CONTRIBUTING.md)** | Developer setup and contribution process |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 3.x     | Yes       |
+| 2.x     | No        |
+| 1.x     | No        |
+
+## Reporting a Security Issue
+
+If you discover a security issue in MCP Task Orchestrator, please report it responsibly.
+
+**Do not open a public GitHub issue for security concerns.**
+
+Instead, please email the maintainer directly or use [GitHub's private vulnerability reporting](https://github.com/jpicklyk/task-orchestrator/security/advisories/new) to submit a report.
+
+### What to include
+
+- Description of the issue
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if you have one)
+
+### What to expect
+
+- Acknowledgment within 48 hours
+- A plan for resolution within 7 days
+- Credit in the fix announcement (unless you prefer to remain anonymous)
+
+## Security Considerations
+
+MCP Task Orchestrator is designed to run locally or in a controlled environment:
+
+- **SQLite database**: Stored on a Docker volume (`mcp-task-data`). Ensure appropriate file permissions on the host mount.
+- **No authentication by default**: The MCP server trusts its transport layer. When using HTTP transport, ensure it is only accessible from trusted clients.
+- **Actor attribution**: When `auditing.enabled: true` in config, the server requires agent identity on all write operations. This provides accountability, not authentication — actor claims are self-reported by default. For verified attribution, configure JWKS validation.
+- **Config files**: `.taskorchestrator/config.yaml` is mounted read-only (`:ro`) in Docker. It contains workflow rules, not credentials.


### PR DESCRIPTION
## Summary

- Add GitHub community health files: CODE_OF_CONDUCT.md, SECURITY.md, issue templates (bug report, feature request), PR template
- Add CI status badge to README
- Fix documentation table links — replace broken `current/docs/` relative paths with wiki URLs
- Update CONTRIBUTING.md to reference standalone CODE_OF_CONDUCT.md

## Test plan

- [ ] Verify CI badge renders correctly on GitHub
- [ ] Verify documentation table links resolve to wiki pages
- [ ] Confirm issue templates appear in "New Issue" dropdown
- [ ] Confirm PR template auto-populates on new PR creation
- [ ] Check CODE_OF_CONDUCT.md and SECURITY.md appear in GitHub community profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)