### PR TITLE
feat: add MCP registry metadata and Smithery config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,13 +4,13 @@
     "name": "Jeff Picklyk"
   },
   "metadata": {
-    "description": "MCP Task Orchestrator - Hierarchical task management with AI workflows",
-    "version": "2.0.0"
+    "description": "Server-enforced workflow discipline for AI agents — persistent work items, dependency graphs, note-gated transitions, and actor attribution",
+    "version": "3.1.0"
   },
   "plugins": [
     {
       "name": "task-orchestrator",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "description": "Skills, hooks, and workflows for MCP Task Orchestrator. Schema-aware context, note-driven workflow, and session hooks.",
       "author": {
         "name": "Jeff Picklyk",
@@ -19,9 +19,9 @@
       "homepage": "https://github.com/jpicklyk/task-orchestrator",
       "repository": "https://github.com/jpicklyk/task-orchestrator",
       "license": "MIT",
-      "keywords": ["task-management", "project-management", "workflow", "mcp", "ai-orchestration"],
+      "keywords": ["task-management", "project-management", "workflow", "mcp", "ai-orchestration", "claude-code", "ai-agents", "workflow-enforcement", "model-context-protocol", "quality-gates"],
       "category": "productivity",
-      "tags": ["tasks", "features", "projects", "dependencies", "workflows"],
+      "tags": ["tasks", "features", "projects", "dependencies", "workflows", "mcp-server", "ai-coding"],
       "source": "./claude-plugins/task-orchestrator",
       "strict": true
     }

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ LABEL org.opencontainers.image.title="MCP Task Orchestrator" \
       org.opencontainers.image.url="https://github.com/jpicklyk/task-orchestrator" \
       org.opencontainers.image.source="https://github.com/jpicklyk/task-orchestrator" \
       org.opencontainers.image.vendor="jpicklyk" \
-      org.opencontainers.image.licenses="MIT"
+      org.opencontainers.image.licenses="MIT" \
+      io.modelcontextprotocol.server.name="io.github.jpicklyk/task-orchestrator"
 
 WORKDIR /app
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.jpicklyk/task-orchestrator",
+  "title": "MCP Task Orchestrator",
+  "description": "Server-enforced workflow discipline for AI agents. Persistent hierarchical work items with dependency graphs, note-gated phase transitions, composable schema traits, and actor attribution. 13 MCP tools that give any MCP-compatible client a structured work breakdown with quality gates enforced at the server level — not in prompts.",
+  "repository": {
+    "url": "https://github.com/jpicklyk/task-orchestrator.git",
+    "source": "github"
+  },
+  "version": "3.1.0",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/jpicklyk/task-orchestrator:latest",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "DATABASE_PATH",
+          "description": "SQLite database file path (default: data/current-tasks.db)",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "USE_FLYWAY",
+          "description": "Enable Flyway database migrations (default: true)",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "AGENT_CONFIG_DIR",
+          "description": "Directory containing .taskorchestrator/config.yaml for workflow schemas (default: working dir)",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "MCP_TRANSPORT",
+          "description": "Transport mode: stdio (default) or http",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "MCP_HTTP_PORT",
+          "description": "HTTP port when using http transport (default: 3001)",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "LOG_LEVEL",
+          "description": "Logging level: DEBUG, INFO, WARN, ERROR (default: INFO)",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,18 @@
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties:
+      dataVolume:
+        type: string
+        description: "Docker volume name for SQLite data storage"
+        default: "mcp-task-data"
+  commandFunction: |-
+    (config) => ({
+      command: "docker",
+      args: [
+        "run", "--rm", "-i",
+        "-v", `${config.dataVolume || "mcp-task-data"}:/app/data`,
+        "ghcr.io/jpicklyk/task-orchestrator:latest"
+      ]
+    })


### PR DESCRIPTION
## Summary

- Add `io.modelcontextprotocol.server.name` label to Dockerfile for official MCP registry ownership verification
- Create `server.json` manifest for `mcp-publisher` CLI (official registry submission)
- Create `smithery.yaml` for Smithery.ai listing (Docker STDIO config with configSchema)
- Clean up `marketplace.json`: sync version to 3.1.0, expand keywords, align description

## Test plan

- [ ] Docker build succeeds with new label: `docker build -t task-orchestrator:dev .`
- [ ] `server.json` validates against MCP registry schema
- [ ] `smithery.yaml` configSchema produces valid Docker run command
- [ ] Verify `marketplace.json` version matches `version.properties`

## Post-merge steps (manual)

After merging, these submissions require user action:
1. **Official Registry**: `mcp-publisher login github && mcp-publisher publish`
2. **Glama.ai**: Submit repo URL at glama.ai/mcp/servers → "Add Server"
3. **Smithery.ai**: Submit repo URL at smithery.ai/new
4. **mcp.so**: Comment on github.com/chatmcp/mcp-directory/issues/1
5. **PulseMCP**: Auto-syncs from official registry within ~1 week

🤖 Generated with [Claude Code](https://claude.com/claude-code)