### PR TITLE
fix: patch dependency CVEs and update to current stable versions

### DIFF
--- a/.claude/skills/prepare-release.md
+++ b/.claude/skills/prepare-release.md
@@ -74,7 +74,7 @@ Examine the changed files from Step 3 and classify:
 | Includes `claude-plugins/` or `.claude-plugin/` paths | **both** |
 
 Files that are neutral (`.github/`, `README.md`, `CHANGELOG.md`, `version.properties`,
-`.claude/`, `.gitignore`, `docs/`) do not influence the classification — they follow
+`server.json`, `smithery.yaml`, `.claude/`, `.gitignore`, `docs/`) do not influence the classification — they follow
 whichever type the substantive changes belong to. If only neutral files changed, ask the
 user which release type to use.
 
@@ -216,11 +216,15 @@ VERSION_MINOR=Y
 VERSION_PATCH=Z
 ```
 
+**All releases** — also edit `server.json` and `.claude-plugin/marketplace.json`:
+- Update `version` in `server.json` to match the new server version
+- Update `metadata.version` in `.claude-plugin/marketplace.json` to match the new server version
+
 **Both releases** — also edit `claude-plugins/task-orchestrator/.claude-plugin/plugin.json`
 and `.claude-plugin/marketplace.json`:
 - Update the `version` field in `plugin.json`
 - Update the `plugins[name="task-orchestrator"].version` field in `marketplace.json`
-- Both must carry the same version string
+- Both must carry the same plugin version string
 
 **Also update** the version table in `claude-plugins/CLAUDE.md` to reflect the new plugin version.
 
@@ -249,12 +253,13 @@ Stage only the files that changed:
 
 **Server release:**
 ```bash
-git add version.properties CHANGELOG.md
+git add version.properties server.json .claude-plugin/marketplace.json CHANGELOG.md
 ```
 
 **Both:**
 ```bash
 git add version.properties \
+        server.json \
         claude-plugins/task-orchestrator/.claude-plugin/plugin.json \
         .claude-plugin/marketplace.json \
         claude-plugins/CLAUDE.md \

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,31 +1,31 @@
 [versions]
 # Kotlin and Coroutines
 kotlin = "2.2.0"
-kotlinCoroutines = "1.8.0"
-kotlinSerialization = "1.8.0"
+kotlinCoroutines = "1.10.2"
+kotlinSerialization = "1.9.0"
 
 # MCP SDK
-mcpSdk = "0.9.0"
+mcpSdk = "0.11.1"
 
 # Ktor (version-aligned with MCP SDK's transitive dependency)
-ktor = "3.2.3"
+ktor = "3.4.2"
 
 # Database
-sqlite = "3.45.1.0"
-exposed = "1.0.0-beta-2"
-flyway = "10.22.0"
+sqlite = "3.49.1.0"
+exposed = "1.0.0-beta-4"
+flyway = "11.8.2"
 
 # Logging
 slf4j = "2.0.17"
 
-logback = "1.5.28"
+logback = "1.5.32"
 
 # Testing
-mockk = "1.14.2"
-junit = "5.10.2"
+mockk = "1.14.3"
+junit = "5.12.2"
 
 # YAML
-snakeyaml = "2.5"
+snakeyaml = "2.6"
 
 # Linting
 ktlint = "12.1.2"


### PR DESCRIPTION
## Summary

- **sqlite-jdbc** 3.45.1.0 → 3.49.1.0 — CVE-2025-6965 (CVSS 9.8 CRITICAL, memory corruption in bundled SQLite)
- **flyway-core** 10.22.0 → 11.8.2 — CVE-2024-7254 (CVSS 7.5 HIGH, protobuf DoS via transitive dep)
- **exposed** 1.0.0-beta-2 → 1.0.0-beta-4 — latest pre-release (no stable 1.x exists yet)
- **mcp kotlin-sdk** 0.9.0 → 0.11.1
- **ktor** 3.2.3 → 3.4.2
- **kotlinx-coroutines** 1.8.0 → 1.10.2
- **kotlinx-serialization** 1.8.0 → 1.9.0
- **logback** 1.5.28 → 1.5.32
- **snakeyaml** 2.5 → 2.6
- **mockk** 1.14.2 → 1.14.3, **junit** 5.10.2 → 5.12.2

Also updates `/prepare-release` skill to include `server.json` and `marketplace.json` `metadata.version` in the release bump workflow (previously missing, caused version drift).

### Known deprecation warnings (non-blocking)

Exposed ORM's `newSuspendedTransaction` is deprecated in beta-4 in favor of R2DBC `suspendTransaction()`. This is an API direction signal, not a removal — the function still works. Migration tracked separately.

### Not changed

- **Kotlin** stays at 2.2.0 (Ktor 3.4.2 pulls kotlin-stdlib 2.3.10 transitively — no conflict)
- **slf4j** stays at 2.0.17 (already current)
- **ktlint** stays at 12.1.2 (14.x is a major jump, separate effort)
- **Corretto base image** — already uses untagged `amazoncorretto:25-al2023-headless`; next `docker build --pull` will pick up quarterly patches. No Dockerfile change needed.

## Test plan

- [x] `./gradlew :current:test` — all tests pass
- [x] `./gradlew :current:ktlintCheck` — clean
- [x] Dependency tree resolves without conflicts
- [ ] Docker build succeeds with updated deps
- [ ] Smoke test: MCP server starts and responds to `get_context()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)