### PR TITLE
feat: JWKS-based ActorVerifier implementation (Stage 2) (#107)

### DIFF
--- a/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
@@ -77,13 +77,19 @@ If the config has a `traits:` section, show a separate traits summary table:
 | needs-migration-review | migration-assessment (queue, req) | migration-review |
 ```
 
-If the config has an `auditing:` section, display the auditing status:
+If the config has an `auditing:` section, display the auditing status including verifier type when present:
 
 ```
-◆ Auditing: enabled
+◆ Auditing: enabled, verifier: noop
 ```
 
-Or `◆ Auditing: disabled` (or omit if the section is absent).
+Or with a JWKS verifier and its source:
+
+```
+◆ Auditing: enabled, verifier: jwks (uri: https://provider.example/.well-known/jwks.json)
+```
+
+Or `◆ Auditing: disabled` (or omit if the section is absent). When `verifier` is absent, default to `verifier: noop`.
 
 ### EDIT — Modify an Existing Schema
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
@@ -227,17 +227,64 @@ When `auditing.enabled` is `true`, the plugin's PreToolUse hook blocks `advance_
 
 When `false` or absent, actor claims are optional — calls pass through with no enforcement. Actor claims can still be provided voluntarily.
 
-### Stage 2 Expansion
+### Verifier
 
-A future release will add `verifier` configuration under `auditing` for server-side claim validation (e.g., JWT). The `enabled` field will continue to control client-side enforcement independently:
+The optional `verifier` sub-key enables server-side JWT validation of actor claims. It operates independently of `enabled` — a call can pass client-side enforcement (actor present) but still fail server-side verification (bad or expired JWT).
+
+**Fields:**
+
+| Field | Required | Type | Default | Notes |
+|-------|----------|------|---------|-------|
+| `type` | yes | string | `"noop"` | `"noop"` or `"jwks"` |
+| `oidc_discovery` | no | string | — | OIDC discovery URL; auto-populates `jwks_uri` and `issuer` |
+| `jwks_uri` | no | string | — | Direct JWKS endpoint URL (overrides OIDC-discovered value) |
+| `jwks_path` | no | string | — | Local JWKS file path (relative to `AGENT_CONFIG_DIR`) |
+| `issuer` | no | string | — | Expected `iss` claim (overrides OIDC-discovered value) |
+| `audience` | no | string | — | Expected `aud` claim |
+| `algorithms` | no | list | `[]` | Allowed signing algorithms; empty = accept any |
+| `cache_ttl_seconds` | no | number | `300` | JWKS cache TTL in seconds |
+| `require_sub_match` | no | boolean | `true` | JWT `sub` must match `actor.id` |
+
+When `type: jwks`, at least one of `oidc_discovery`, `jwks_uri`, or `jwks_path` is required. Explicit `jwks_uri` and `issuer` values override OIDC-discovered values when both are present.
+
+**Example — OIDC discovery (simplest):**
 
 ```yaml
 auditing:
   enabled: true
   verifier:
-    type: jwt
-    jwks_uri: "https://..."
+    type: jwks
+    oidc_discovery: "https://agentlair.dev/.well-known/openid-configuration"
 ```
+
+**Example — File-based (air-gapped):**
+
+```yaml
+auditing:
+  enabled: true
+  verifier:
+    type: jwks
+    jwks_path: ".agentlair/jwks.json"
+```
+
+**Example — Full config (all options):**
+
+```yaml
+auditing:
+  enabled: true
+  verifier:
+    type: jwks
+    oidc_discovery: "https://agentlair.dev/.well-known/openid-configuration"
+    jwks_uri: "https://provider.example/.well-known/jwks.json"
+    jwks_path: ".agentlair/jwks.json"
+    issuer: "https://provider.example"
+    audience: "task-orchestrator"
+    algorithms: ["EdDSA", "RS256"]
+    cache_ttl_seconds: 300
+    require_sub_match: true
+```
+
+> **Note:** `enabled` (client-side enforcement) and `verifier` (server-side validation) are independent concerns. A call can pass enforcement (actor present) but have verification fail (bad JWT).
 
 ---
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/validate-workflow.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/validate-workflow.md
@@ -16,6 +16,12 @@ Parse the file. If YAML is invalid, report the parse error with line number (if 
 - Each must be a mapping (not a list or scalar)
 - `traits` is an optional top-level key — if present, must be a mapping
 - `auditing` is an optional top-level key — if present, must be a mapping containing `enabled` (boolean)
+- `auditing.verifier` (if present) must be a mapping
+- `verifier.type` must be one of: `noop`, `jwks` (warn on unknown type)
+- When `type: jwks`: at least one of `oidc_discovery`, `jwks_uri`, `jwks_path` must be set (error if none)
+- `algorithms` (if present) must be a list of strings
+- `cache_ttl_seconds` (if present) must be a positive number
+- `require_sub_match` (if present) must be a boolean
 - No other top-level keys expected (warn if found)
 
 ### 3. Schema Entry Structure
@@ -67,7 +73,7 @@ For each note in each schema (and trait):
   work_item_schemas: 3 schemas
   note_schemas: 1 schema (legacy)
   traits: 2 traits
-  auditing: enabled
+  auditing: enabled, verifier: jwks
 
   Errors (must fix):
     ✗ bug-fix.fix-summary: missing "required" field

--- a/current/build.gradle.kts
+++ b/current/build.gradle.kts
@@ -86,6 +86,11 @@ dependencies {
     implementation(platform(libs.ktor.bom))
     // CIO engine — not provided transitively by the MCP SDK, must be declared explicitly
     implementation(libs.ktor.server.cio)
+    // Ktor HTTP client — used by JwksKeySetProvider for JWKS URI and OIDC discovery fetching
+    implementation(libs.ktor.client.cio)
+
+    // JWT / JWKS — used by JwksActorVerifier for JWT validation against JWKS key sets
+    implementation(libs.nimbus.jose.jwt)
 
     // Testing
     testImplementation(libs.kotlin.test)
@@ -100,6 +105,12 @@ dependencies {
 
     // H2 in-memory database for testing
     testImplementation("com.h2database:h2:2.2.224")
+
+    // Bouncy Castle — provides OctetKeyPair raw key generation in tests
+    testImplementation(libs.bouncycastle.provider)
+
+    // Google Tink — required by nimbus-jose-jwt Ed25519Signer/Verifier in tests
+    testImplementation(libs.google.tink)
 }
 
 tasks.test {

--- a/current/build.gradle.kts
+++ b/current/build.gradle.kts
@@ -110,8 +110,6 @@ dependencies {
 
     // Bouncy Castle — provides OctetKeyPair raw key generation in tests
     testImplementation(libs.bouncycastle.provider)
-
-    // Bounced to implementation — Tink is already a production dep for EdDSA verification
 }
 
 tasks.test {

--- a/current/build.gradle.kts
+++ b/current/build.gradle.kts
@@ -91,6 +91,8 @@ dependencies {
 
     // JWT / JWKS — used by JwksActorVerifier for JWT validation against JWKS key sets
     implementation(libs.nimbus.jose.jwt)
+    // Google Tink — required at runtime by nimbus Ed25519Verifier for EdDSA/Ed25519 JWT verification
+    implementation(libs.google.tink)
 
     // Testing
     testImplementation(libs.kotlin.test)
@@ -109,8 +111,7 @@ dependencies {
     // Bouncy Castle — provides OctetKeyPair raw key generation in tests
     testImplementation(libs.bouncycastle.provider)
 
-    // Google Tink — required by nimbus-jose-jwt Ed25519Signer/Verifier in tests
-    testImplementation(libs.google.tink)
+    // Bounced to implementation — Tink is already a production dep for EdDSA verification
 }
 
 tasks.test {

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1099,3 +1099,74 @@ For reliable attribution, combine auditing enforcement with explicit delegation 
 Include an "actor" object on every advance_item and manage_notes call:
 { "id": "your-agent-name", "kind": "subagent", "parent": "orchestrator-id" }
 ```
+
+---
+
+## Auditing & Actor Verification
+
+### Verifier Configuration
+
+The `auditing` section in `.taskorchestrator/config.yaml` controls actor attribution enforcement and verification. The `enabled` flag and the `verifier` block are independent — enforcement checks actor presence, while the verifier checks proof validity.
+
+```yaml
+auditing:
+  enabled: true          # Enforce actor claims on write operations
+  verifier:
+    type: jwks           # "noop" (default) | "jwks"
+    oidc_discovery: "https://provider.example/.well-known/openid-configuration"
+    jwks_uri: "https://provider.example/.well-known/jwks.json"
+    jwks_path: ".agentlair/jwks.json"
+    issuer: "https://provider.example"
+    audience: "task-orchestrator"
+    algorithms: ["EdDSA", "RS256"]
+    cache_ttl_seconds: 300
+    require_sub_match: true
+```
+
+### Verification Behavior
+
+| Verifier type | Behavior |
+|---|---|
+| `noop` (or absent) | All actor claims are accepted as `unverified`. No cryptographic check is performed. |
+| `jwks` | JWT tokens in `actor.proof` are validated against the configured JWKS key set. Valid token → `status: verified`. Invalid, expired, or wrong-claims token → `status: failed` with a descriptive `reason`. Missing proof → `status: unverified` (not failed). |
+
+### JWKS Key Sources
+
+`oidc_discovery`, `jwks_uri`, and `jwks_path` can be used alone or combined. URI-sourced keys and file-sourced keys are merged into a single key set. When both `oidc_discovery` and explicit `jwks_uri`/`issuer` are set, the explicit values override the OIDC-discovered values.
+
+| Field | Description |
+|---|---|
+| `oidc_discovery` | URL to an OpenID Connect discovery document. The server fetches `jwks_uri` and `issuer` from the document. |
+| `jwks_uri` | Direct URL to a JWKS endpoint. Overrides the URI discovered via `oidc_discovery`. |
+| `jwks_path` | Path to a local JWKS JSON file, relative to `AGENT_CONFIG_DIR`. Useful for local dev and air-gapped environments. |
+| `issuer` | Expected `iss` claim in the JWT. Overrides the issuer discovered via `oidc_discovery`. |
+| `audience` | Expected `aud` claim in the JWT. |
+| `algorithms` | List of accepted signing algorithms (e.g., `["EdDSA", "RS256"]`). |
+| `cache_ttl_seconds` | How long to cache fetched JWKS keys (default: 300). |
+| `require_sub_match` | When true, the JWT `sub` claim must match `actor.id`. |
+
+### Docker — JWKS Path Mount
+
+When using `jwks_path`, the `.agentlair/` directory must be mounted into the container alongside `.taskorchestrator/`:
+
+```bash
+docker run --rm -i \
+  -v mcp-task-data:/app/data \
+  -v "$(pwd)"/.taskorchestrator:/project/.taskorchestrator:ro \
+  -v "$(pwd)"/.agentlair:/project/.agentlair:ro \
+  -e AGENT_CONFIG_DIR=/project \
+  task-orchestrator:dev
+```
+
+The `.agentlair/` mount is only needed when using `jwks_path`. When using `jwks_uri` or `oidc_discovery`, the container must be able to reach the endpoint over the network.
+
+**Network access from Docker containers:**
+
+| Scenario | Works? | Notes |
+|----------|--------|-------|
+| Public HTTPS endpoint | Yes | Standard outbound from container |
+| `localhost` on host | No | Container localhost is itself, not the host |
+| `host.docker.internal` | Docker Desktop only | On Linux: add `--add-host=host.docker.internal:host-gateway` |
+| Docker network service | Yes | Use the container name as hostname |
+
+`jwks_path` (local file) avoids all networking concerns — recommended for local dev and air-gapped environments.

--- a/current/docs/quick-start.md
+++ b/current/docs/quick-start.md
@@ -320,6 +320,12 @@ After adding or editing this file, reconnect the MCP server:
 > }
 > ```
 > Only the `.taskorchestrator/` folder is exposed — the server has no access to the rest of your project.
+>
+> **Using JWKS path verification?** Also mount `.agentlair/` so the container can read your local JWKS file:
+> ```json
+> "-v", "${workspaceFolder}/.agentlair:/project/.agentlair:ro",
+> ```
+> Add this line alongside the `.taskorchestrator` mount. The `.agentlair/` mount is only needed when `verifier.jwks_path` is configured. See [Auditing & Actor Verification](./api-reference.md#auditing--actor-verification) in the API reference for details including Docker network access options.
 
 ---
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/AuditingConfig.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/AuditingConfig.kt
@@ -1,0 +1,53 @@
+package io.github.jpicklyk.mcptask.current.domain.model
+
+/**
+ * Top-level auditing configuration parsed from `.taskorchestrator/config.yaml`
+ * under the `auditing:` key.
+ *
+ * @param enabled Whether auditing is active (default true).
+ * @param verifier The actor-claim verifier strategy to use.
+ */
+data class AuditingConfig(
+    val enabled: Boolean = true,
+    val verifier: VerifierConfig = VerifierConfig.Noop
+)
+
+/**
+ * Discriminated union describing how actor claims on MCP transitions are verified.
+ *
+ * - [Noop] — no verification; all claims are accepted as-is.
+ * - [Jwks] — validate JWT bearer tokens against a JWKS source.
+ */
+sealed class VerifierConfig {
+    /** No-op verifier: every actor claim passes without inspection. */
+    data object Noop : VerifierConfig()
+
+    /**
+     * JWKS-backed verifier.
+     *
+     * Exactly one of [oidcDiscovery], [jwksUri], or [jwksPath] must be provided;
+     * the service that constructs the verifier enforces this constraint.
+     *
+     * @param oidcDiscovery HTTPS URL of an OIDC Discovery document (`/.well-known/openid-configuration`).
+     *   The JWKS URI is fetched from the `jwks_uri` field of the discovery document.
+     * @param jwksUri Direct HTTPS URL of a JWKS endpoint.
+     * @param jwksPath File-system path to a local JWKS JSON file (resolution done by the provider).
+     * @param issuer Expected `iss` claim value; null means "any issuer accepted".
+     * @param audience Expected `aud` claim value; null means "any audience accepted".
+     * @param algorithms Allowed signing algorithms (e.g. `["RS256", "ES256"]`).
+     *   An empty list means "accept any algorithm supported by the JWKS".
+     * @param cacheTtlSeconds How long (in seconds) to cache the fetched JWKS (default 300).
+     * @param requireSubMatch When true, the JWT `sub` claim must match the actor id supplied by
+     *   the caller (default true).
+     */
+    data class Jwks(
+        val oidcDiscovery: String? = null,
+        val jwksUri: String? = null,
+        val jwksPath: String? = null,
+        val issuer: String? = null,
+        val audience: String? = null,
+        val algorithms: List<String> = emptyList(),
+        val cacheTtlSeconds: Long = 300,
+        val requireSubMatch: Boolean = true
+    ) : VerifierConfig()
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifier.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifier.kt
@@ -1,0 +1,192 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.config
+
+import com.nimbusds.jose.crypto.ECDSAVerifier
+import com.nimbusds.jose.crypto.Ed25519Verifier
+import com.nimbusds.jose.crypto.RSASSAVerifier
+import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jose.jwk.JWKMatcher
+import com.nimbusds.jose.jwk.JWKSelector
+import com.nimbusds.jose.jwk.OctetKeyPair
+import com.nimbusds.jose.jwk.RSAKey
+import com.nimbusds.jwt.SignedJWT
+import io.github.jpicklyk.mcptask.current.application.service.ActorVerifier
+import io.github.jpicklyk.mcptask.current.domain.model.ActorClaim
+import io.github.jpicklyk.mcptask.current.domain.model.VerificationResult
+import io.github.jpicklyk.mcptask.current.domain.model.VerificationStatus.FAILED
+import io.github.jpicklyk.mcptask.current.domain.model.VerificationStatus.UNVERIFIED
+import io.github.jpicklyk.mcptask.current.domain.model.VerificationStatus.VERIFIED
+import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
+import org.slf4j.LoggerFactory
+import java.time.Clock
+import java.util.Date
+
+/**
+ * [ActorVerifier] implementation that validates JWT bearer tokens against a JWKS key set.
+ *
+ * Verification steps:
+ * 1. Parse the JWT from [ActorClaim.proof].
+ * 2. Check that the signing algorithm is in the configured allowlist (if non-empty).
+ * 3. Fetch the public key matching the JWT's `kid` header from the [JwksKeySetProvider].
+ * 4. Verify the JWT signature.
+ * 5. Validate standard claims: `exp`, `iss`, `aud`, and optionally `sub` vs. [ActorClaim.id].
+ *
+ * A missing or blank [ActorClaim.proof] returns [UNVERIFIED] (not [FAILED]) — the caller may
+ * choose to treat unverified actors differently from actors whose proof failed validation.
+ */
+class JwksActorVerifier(
+    private val config: VerifierConfig.Jwks,
+    private val keySetProvider: JwksKeySetProvider = DefaultJwksKeySetProvider(config),
+    private val clock: Clock = Clock.systemUTC()
+) : ActorVerifier {
+    private val logger = LoggerFactory.getLogger(JwksActorVerifier::class.java)
+
+    override suspend fun verify(actor: ActorClaim): VerificationResult =
+        try {
+            verifyInternal(actor)
+        } catch (e: Exception) {
+            logger.warn("Unexpected exception during actor verification for '{}': {}", actor.id, e.message)
+            VerificationResult(status = FAILED, verifier = VERIFIER_NAME, reason = e.message)
+        }
+
+    /**
+     * Releases underlying [JwksKeySetProvider] resources (e.g., HTTP client).
+     */
+    fun close() {
+        keySetProvider.close()
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal implementation
+    // -------------------------------------------------------------------------
+
+    private suspend fun verifyInternal(actor: ActorClaim): VerificationResult {
+        // Step 1 — missing proof is not a failure; the caller decides how to handle unverified actors.
+        val proof = actor.proof
+        if (proof.isNullOrBlank()) {
+            return VerificationResult(status = UNVERIFIED, verifier = VERIFIER_NAME, reason = "no proof provided")
+        }
+
+        // Step 2 — parse JWT.
+        val signedJWT =
+            try {
+                SignedJWT.parse(proof)
+            } catch (e: Exception) {
+                return VerificationResult(status = FAILED, verifier = VERIFIER_NAME, reason = "failed to parse JWT: ${e.message}")
+            }
+
+        // Step 3 — algorithm allowlist check.
+        val alg = signedJWT.header.algorithm
+        if (config.algorithms.isNotEmpty() && alg.name !in config.algorithms) {
+            return VerificationResult(
+                status = FAILED,
+                verifier = VERIFIER_NAME,
+                reason = "algorithm not allowed: ${alg.name}"
+            )
+        }
+
+        // Step 4 — fetch JWKS.
+        val jwkSet =
+            try {
+                keySetProvider.getKeySet()
+            } catch (e: Exception) {
+                return VerificationResult(
+                    status = FAILED,
+                    verifier = VERIFIER_NAME,
+                    reason = "failed to fetch JWKS: ${e.message}"
+                )
+            }
+
+        // Step 5 — select the key matching the JWT's kid.
+        val kid = signedJWT.header.keyID
+        val matcher = JWKMatcher.Builder().keyID(kid).build()
+        val matchingKeys = JWKSelector(matcher).select(jwkSet)
+        if (matchingKeys.isEmpty()) {
+            return VerificationResult(
+                status = FAILED,
+                verifier = VERIFIER_NAME,
+                reason = "no matching key for kid: $kid"
+            )
+        }
+
+        // Step 6 — build a JWS verifier from the first matching key and verify the signature.
+        val jwk = matchingKeys.first()
+        val jwsVerifier =
+            try {
+                when (jwk) {
+                    is RSAKey -> RSASSAVerifier(jwk.toRSAPublicKey())
+                    is ECKey -> ECDSAVerifier(jwk.toECPublicKey())
+                    is OctetKeyPair -> Ed25519Verifier(jwk)
+                    else -> return VerificationResult(
+                        status = FAILED,
+                        verifier = VERIFIER_NAME,
+                        reason = "unsupported key type: ${jwk.keyType}"
+                    )
+                }
+            } catch (e: Exception) {
+                return VerificationResult(
+                    status = FAILED,
+                    verifier = VERIFIER_NAME,
+                    reason = "failed to build JWS verifier: ${e.message}"
+                )
+            }
+
+        if (!signedJWT.verify(jwsVerifier)) {
+            return VerificationResult(status = FAILED, verifier = VERIFIER_NAME, reason = "signature verification failed")
+        }
+
+        // Step 7 — validate standard claims.
+        val claims = signedJWT.jwtClaimsSet
+
+        // exp — allow 60 s of clock skew.
+        val expiry = claims.expirationTime
+        if (expiry != null) {
+            val skewAdjusted = Date.from(clock.instant().minusSeconds(CLOCK_SKEW_SECONDS))
+            if (expiry.before(skewAdjusted)) {
+                return VerificationResult(status = FAILED, verifier = VERIFIER_NAME, reason = "token expired")
+            }
+        }
+
+        // iss
+        if (config.issuer != null) {
+            val effectiveIssuer = config.issuer
+            if (claims.issuer != effectiveIssuer) {
+                return VerificationResult(
+                    status = FAILED,
+                    verifier = VERIFIER_NAME,
+                    reason = "issuer mismatch: expected=$effectiveIssuer, got=${claims.issuer}"
+                )
+            }
+        }
+
+        // aud
+        if (config.audience != null) {
+            val aud = claims.audience
+            if (aud == null || !aud.contains(config.audience)) {
+                return VerificationResult(
+                    status = FAILED,
+                    verifier = VERIFIER_NAME,
+                    reason = "audience mismatch: expected=${config.audience}, got=$aud"
+                )
+            }
+        }
+
+        // sub vs actor.id
+        if (config.requireSubMatch) {
+            val sub = claims.subject
+            if (sub != actor.id) {
+                return VerificationResult(
+                    status = FAILED,
+                    verifier = VERIFIER_NAME,
+                    reason = "sub mismatch: expected=${actor.id}, got=$sub"
+                )
+            }
+        }
+
+        return VerificationResult(status = VERIFIED, verifier = VERIFIER_NAME)
+    }
+
+    companion object {
+        private const val VERIFIER_NAME = "jwks"
+        private const val CLOCK_SKEW_SECONDS = 60L
+    }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifier.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifier.kt
@@ -146,16 +146,14 @@ class JwksActorVerifier(
             }
         }
 
-        // iss
-        if (config.issuer != null) {
-            val effectiveIssuer = config.issuer
-            if (claims.issuer != effectiveIssuer) {
-                return VerificationResult(
-                    status = FAILED,
-                    verifier = VERIFIER_NAME,
-                    reason = "issuer mismatch: expected=$effectiveIssuer, got=${claims.issuer}"
-                )
-            }
+        // iss — explicit config overrides OIDC-discovered issuer
+        val effectiveIssuer = config.issuer ?: keySetProvider.getResolvedIssuer()
+        if (effectiveIssuer != null && claims.issuer != effectiveIssuer) {
+            return VerificationResult(
+                status = FAILED,
+                verifier = VERIFIER_NAME,
+                reason = "issuer mismatch: expected=$effectiveIssuer, got=${claims.issuer}"
+            )
         }
 
         // aud

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifier.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifier.kt
@@ -137,12 +137,21 @@ class JwksActorVerifier(
         // Step 7 — validate standard claims.
         val claims = signedJWT.jwtClaimsSet
 
-        // exp — allow 60 s of clock skew.
+        // exp — allow 60 s of clock skew. A missing exp claim is accepted (no expiry check).
         val expiry = claims.expirationTime
         if (expiry != null) {
             val skewAdjusted = Date.from(clock.instant().minusSeconds(CLOCK_SKEW_SECONDS))
             if (expiry.before(skewAdjusted)) {
                 return VerificationResult(status = FAILED, verifier = VERIFIER_NAME, reason = "token expired")
+            }
+        }
+
+        // nbf — reject tokens not yet valid (allow 60 s of clock skew).
+        val notBefore = claims.notBeforeTime
+        if (notBefore != null) {
+            val skewAdjusted = Date.from(clock.instant().plusSeconds(CLOCK_SKEW_SECONDS))
+            if (notBefore.after(skewAdjusted)) {
+                return VerificationResult(status = FAILED, verifier = VERIFIER_NAME, reason = "token not yet valid")
             }
         }
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksKeySetProvider.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksKeySetProvider.kt
@@ -1,0 +1,173 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.config
+
+import com.nimbusds.jose.jwk.JWKSet
+import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.slf4j.LoggerFactory
+import java.nio.file.Paths
+import java.time.Clock
+import java.time.Instant
+
+/**
+ * Provides a [JWKSet] for JWT signature verification.
+ *
+ * Implementations are responsible for loading keys from a configured source (remote URI,
+ * OIDC discovery document, or local file) and caching the result according to the
+ * configured TTL.
+ */
+interface JwksKeySetProvider {
+    /**
+     * Returns the current [JWKSet]. Implementations may cache and refresh transparently.
+     */
+    suspend fun getKeySet(): JWKSet
+
+    /**
+     * Releases any underlying resources (e.g., HTTP client connections).
+     */
+    fun close()
+}
+
+/**
+ * Default [JwksKeySetProvider] backed by [VerifierConfig.Jwks].
+ *
+ * Key-loading strategy (all sources are merged if multiple are configured):
+ * 1. **OIDC discovery** — fetches `oidcDiscovery` URL, extracts `jwks_uri` (and optionally
+ *    `issuer`) from the response JSON, then fetches the JWKS from that URI.
+ * 2. **Direct URI** — fetches `jwksUri` directly and parses the response as a JWKS.
+ * 3. **Local file** — reads `jwksPath` from the filesystem (resolved relative to
+ *    `AGENT_CONFIG_DIR` or `user.dir`) and parses it as a JWKS.
+ *
+ * Results are cached for [VerifierConfig.Jwks.cacheTtlSeconds] seconds.
+ */
+class DefaultJwksKeySetProvider(
+    private val config: VerifierConfig.Jwks,
+    private val clock: Clock = Clock.systemUTC()
+) : JwksKeySetProvider {
+    private val logger = LoggerFactory.getLogger(DefaultJwksKeySetProvider::class.java)
+
+    @Volatile
+    private var cached: Pair<JWKSet, Instant>? = null
+
+    private val refreshLock = Mutex()
+
+    /** URI discovered via OIDC, cached after first successful discovery call. */
+    @Volatile
+    private var resolvedJwksUri: String? = null
+
+    /** Issuer discovered via OIDC (only populated when discovery is used). */
+    @Volatile
+    private var resolvedIssuer: String? = null
+
+    /** Lazy HTTP client — created only when a remote fetch is needed. */
+    private var httpClient: HttpClient? = null
+
+    override suspend fun getKeySet(): JWKSet {
+        // Fast path: return cached value if still valid.
+        cached?.let { (set, fetchedAt) ->
+            if (clock.instant().isBefore(fetchedAt.plusSeconds(config.cacheTtlSeconds))) {
+                return set
+            }
+        }
+
+        return refreshLock.withLock {
+            // Double-check after acquiring the lock.
+            cached?.let { (set, fetchedAt) ->
+                if (clock.instant().isBefore(fetchedAt.plusSeconds(config.cacheTtlSeconds))) {
+                    return@withLock set
+                }
+            }
+
+            val fresh = fetchKeySet()
+            cached = Pair(fresh, clock.instant())
+            fresh
+        }
+    }
+
+    override fun close() {
+        httpClient?.close()
+        httpClient = null
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    private suspend fun fetchKeySet(): JWKSet {
+        // Step 1: Resolve OIDC discovery if configured and not yet resolved.
+        if (config.oidcDiscovery != null && resolvedJwksUri == null) {
+            try {
+                runOidcDiscovery(config.oidcDiscovery)
+            } catch (e: Exception) {
+                logger.warn("OIDC discovery failed for '{}': {}", config.oidcDiscovery, e.message)
+            }
+        }
+
+        // Explicit config values override discovered values.
+        val effectiveJwksUri = config.jwksUri ?: resolvedJwksUri
+
+        val uriKeys: JWKSet? =
+            effectiveJwksUri?.let { uri ->
+                try {
+                    val body = httpGet(uri)
+                    JWKSet.parse(body)
+                } catch (e: Exception) {
+                    logger.warn("Failed to fetch JWKS from URI '{}': {}", uri, e.message)
+                    throw e
+                }
+            }
+
+        val pathKeys: JWKSet? =
+            config.jwksPath?.let { relPath ->
+                try {
+                    val basePath =
+                        Paths.get(
+                            System.getenv("AGENT_CONFIG_DIR") ?: System.getProperty("user.dir")
+                        )
+                    val resolved = basePath.resolve(relPath)
+                    val content = resolved.toFile().readText()
+                    JWKSet.parse(content)
+                } catch (e: Exception) {
+                    logger.warn("Failed to load JWKS from path '{}': {}", relPath, e.message)
+                    throw e
+                }
+            }
+
+        return when {
+            uriKeys != null && pathKeys != null ->
+                JWKSet(uriKeys.keys + pathKeys.keys)
+            uriKeys != null -> uriKeys
+            pathKeys != null -> pathKeys
+            else -> throw IllegalStateException(
+                "No JWKS source produced a key set — check oidcDiscovery, jwksUri, and jwksPath configuration"
+            )
+        }
+    }
+
+    private suspend fun runOidcDiscovery(discoveryUrl: String) {
+        val body = httpGet(discoveryUrl)
+        val json = Json.parseToJsonElement(body).jsonObject
+        val discovered = json["jwks_uri"]?.jsonPrimitive?.content
+        val issuer = json["issuer"]?.jsonPrimitive?.content
+        if (discovered != null) {
+            resolvedJwksUri = discovered
+            logger.debug("OIDC discovery resolved jwks_uri={}", discovered)
+        }
+        if (issuer != null) {
+            resolvedIssuer = issuer
+            logger.debug("OIDC discovery resolved issuer={}", issuer)
+        }
+    }
+
+    private suspend fun httpGet(url: String): String {
+        val client = httpClient ?: HttpClient(CIO).also { httpClient = it }
+        return client.get(url).bodyAsText()
+    }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksKeySetProvider.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksKeySetProvider.kt
@@ -30,6 +30,13 @@ interface JwksKeySetProvider {
     suspend fun getKeySet(): JWKSet
 
     /**
+     * Returns the issuer resolved via OIDC discovery, or null if discovery was not configured
+     * or has not yet run. Explicit [VerifierConfig.Jwks.issuer] overrides this value at the
+     * verifier level — this method only returns what was discovered.
+     */
+    fun getResolvedIssuer(): String?
+
+    /**
      * Releases any underlying resources (e.g., HTTP client connections).
      */
     fun close()
@@ -90,6 +97,8 @@ class DefaultJwksKeySetProvider(
             fresh
         }
     }
+
+    override fun getResolvedIssuer(): String? = resolvedIssuer
 
     override fun close() {
         httpClient?.close()

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksKeySetProvider.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksKeySetProvider.kt
@@ -73,8 +73,9 @@ class DefaultJwksKeySetProvider(
     @Volatile
     private var resolvedIssuer: String? = null
 
-    /** Lazy HTTP client — created only when a remote fetch is needed. */
-    private var httpClient: HttpClient? = null
+    /** Thread-safe lazy HTTP client — created only when a remote fetch is needed. */
+    private val httpClientDelegate = lazy { HttpClient(CIO) }
+    private val httpClient: HttpClient by httpClientDelegate
 
     override suspend fun getKeySet(): JWKSet {
         // Fast path: return cached value if still valid.
@@ -101,8 +102,9 @@ class DefaultJwksKeySetProvider(
     override fun getResolvedIssuer(): String? = resolvedIssuer
 
     override fun close() {
-        httpClient?.close()
-        httpClient = null
+        if (httpClientDelegate.isInitialized()) {
+            httpClient.close()
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -175,8 +177,5 @@ class DefaultJwksKeySetProvider(
         }
     }
 
-    private suspend fun httpGet(url: String): String {
-        val client = httpClient ?: HttpClient(CIO).also { httpClient = it }
-        return client.get(url).bodyAsText()
-    }
+    private suspend fun httpGet(url: String): String = httpClient.get(url).bodyAsText()
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlAuditingConfigService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlAuditingConfigService.kt
@@ -68,23 +68,26 @@ class YamlAuditingConfigService(
         return try {
             val yaml = Yaml()
             FileReader(configPath.toFile()).use { reader ->
-                val root = yaml.load<Map<String, Any>>(reader)
-                    ?: return@use LoadResult(AuditingConfig(), warnings)
+                val root =
+                    yaml.load<Map<String, Any>>(reader)
+                        ?: return@use LoadResult(AuditingConfig(), warnings)
 
-                val auditingSection = root["auditing"] as? Map<String, Any>
-                    ?: run {
-                        logger.debug("No 'auditing' section in config; using defaults")
-                        return@use LoadResult(AuditingConfig(), warnings)
-                    }
+                val auditingSection =
+                    root["auditing"] as? Map<String, Any>
+                        ?: run {
+                            logger.debug("No 'auditing' section in config; using defaults")
+                            return@use LoadResult(AuditingConfig(), warnings)
+                        }
 
                 val enabled = (auditingSection["enabled"] as? Boolean) ?: true
 
                 val verifierSection = auditingSection["verifier"] as? Map<String, Any>
-                val verifier = if (verifierSection != null) {
-                    parseVerifier(verifierSection, warnings)
-                } else {
-                    VerifierConfig.Noop
-                }
+                val verifier =
+                    if (verifierSection != null) {
+                        parseVerifier(verifierSection, warnings)
+                    } else {
+                        VerifierConfig.Noop
+                    }
 
                 LoadResult(AuditingConfig(enabled = enabled, verifier = verifier), warnings)
             }
@@ -112,8 +115,9 @@ class YamlAuditingConfigService(
                 val jwksPath = verifierMap["jwks_path"] as? String
 
                 if (oidcDiscovery == null && jwksUri == null && jwksPath == null) {
-                    val msg = "auditing.verifier type 'jwks' requires one of: " +
-                        "oidc_discovery, jwks_uri, or jwks_path; falling back to Noop"
+                    val msg =
+                        "auditing.verifier type 'jwks' requires one of: " +
+                            "oidc_discovery, jwks_uri, or jwks_path; falling back to Noop"
                     warnings.add(msg)
                     logger.warn(msg)
                     return VerifierConfig.Noop
@@ -123,17 +127,19 @@ class YamlAuditingConfigService(
                 val audience = verifierMap["audience"] as? String
 
                 val rawAlgorithms = verifierMap["algorithms"]
-                val algorithms: List<String> = when (rawAlgorithms) {
-                    is List<*> -> rawAlgorithms.filterIsInstance<String>()
-                    else -> emptyList()
-                }
+                val algorithms: List<String> =
+                    when (rawAlgorithms) {
+                        is List<*> -> rawAlgorithms.filterIsInstance<String>()
+                        else -> emptyList()
+                    }
 
-                val cacheTtlSeconds = when (val raw = verifierMap["cache_ttl_seconds"]) {
-                    is Int -> raw.toLong()
-                    is Long -> raw
-                    is Number -> raw.toLong()
-                    else -> 300L
-                }
+                val cacheTtlSeconds =
+                    when (val raw = verifierMap["cache_ttl_seconds"]) {
+                        is Int -> raw.toLong()
+                        is Long -> raw
+                        is Number -> raw.toLong()
+                        else -> 300L
+                    }
 
                 val requireSubMatch = (verifierMap["require_sub_match"] as? Boolean) ?: true
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlAuditingConfigService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlAuditingConfigService.kt
@@ -1,0 +1,160 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.config
+
+import io.github.jpicklyk.mcptask.current.domain.model.AuditingConfig
+import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
+import org.slf4j.LoggerFactory
+import org.yaml.snakeyaml.Yaml
+import java.io.FileReader
+import java.nio.file.Path
+
+/**
+ * YAML-backed loader for the `auditing:` section of `.taskorchestrator/config.yaml`.
+ *
+ * The config path is resolved using the same `AGENT_CONFIG_DIR` environment-variable
+ * pattern as [YamlNoteSchemaService].
+ *
+ * Expected YAML structure:
+ * ```yaml
+ * auditing:
+ *   enabled: true
+ *   verifier:
+ *     type: jwks          # "jwks" or "noop" (default: noop)
+ *     oidc_discovery: "https://accounts.example.com/.well-known/openid-configuration"
+ *     jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
+ *     jwks_path: "/etc/keys/jwks.json"
+ *     issuer: "https://accounts.example.com"
+ *     audience: "mcp-task-orchestrator"
+ *     algorithms:
+ *       - RS256
+ *       - ES256
+ *     cache_ttl_seconds: 300
+ *     require_sub_match: true
+ * ```
+ *
+ * For the `jwks` type, exactly one of `oidc_discovery`, `jwks_uri`, or `jwks_path` should be
+ * provided. If none is present, a warning is added and the verifier falls back to [VerifierConfig.Noop].
+ *
+ * If the config file is missing, the `auditing:` section is absent, or any exception occurs
+ * during parsing, [AuditingConfig] defaults are returned (`enabled=true`, [VerifierConfig.Noop]).
+ */
+class YamlAuditingConfigService(
+    private val configPath: Path = YamlNoteSchemaService.resolveDefaultConfigPath()
+) {
+    private val logger = LoggerFactory.getLogger(YamlAuditingConfigService::class.java)
+
+    private data class LoadResult(
+        val config: AuditingConfig,
+        val warnings: List<String>
+    )
+
+    /** Lazily loaded result containing the parsed config and any parse warnings. */
+    private val loadResult: LoadResult by lazy { loadConfig() }
+
+    /** Returns the parsed [AuditingConfig]; defaults are returned on any error. */
+    fun getConfig(): AuditingConfig = loadResult.config
+
+    /** Returns warnings collected during config parsing (empty list if none). */
+    fun getWarnings(): List<String> = loadResult.warnings
+
+    @Suppress("UNCHECKED_CAST")
+    private fun loadConfig(): LoadResult {
+        val warnings = mutableListOf<String>()
+
+        if (!configPath.toFile().exists()) {
+            logger.debug("No config file found at {}; using default auditing config", configPath)
+            return LoadResult(AuditingConfig(), warnings)
+        }
+
+        return try {
+            val yaml = Yaml()
+            FileReader(configPath.toFile()).use { reader ->
+                val root = yaml.load<Map<String, Any>>(reader)
+                    ?: return@use LoadResult(AuditingConfig(), warnings)
+
+                val auditingSection = root["auditing"] as? Map<String, Any>
+                    ?: run {
+                        logger.debug("No 'auditing' section in config; using defaults")
+                        return@use LoadResult(AuditingConfig(), warnings)
+                    }
+
+                val enabled = (auditingSection["enabled"] as? Boolean) ?: true
+
+                val verifierSection = auditingSection["verifier"] as? Map<String, Any>
+                val verifier = if (verifierSection != null) {
+                    parseVerifier(verifierSection, warnings)
+                } else {
+                    VerifierConfig.Noop
+                }
+
+                LoadResult(AuditingConfig(enabled = enabled, verifier = verifier), warnings)
+            }
+        } catch (e: Exception) {
+            val msg = "Failed to load auditing config from '$configPath': ${e.message}"
+            warnings.add(msg)
+            logger.warn(msg)
+            LoadResult(AuditingConfig(), warnings)
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun parseVerifier(
+        verifierMap: Map<String, Any>,
+        warnings: MutableList<String>
+    ): VerifierConfig {
+        val type = (verifierMap["type"] as? String)?.lowercase()
+
+        return when (type) {
+            null, "noop" -> VerifierConfig.Noop
+
+            "jwks" -> {
+                val oidcDiscovery = verifierMap["oidc_discovery"] as? String
+                val jwksUri = verifierMap["jwks_uri"] as? String
+                val jwksPath = verifierMap["jwks_path"] as? String
+
+                if (oidcDiscovery == null && jwksUri == null && jwksPath == null) {
+                    val msg = "auditing.verifier type 'jwks' requires one of: " +
+                        "oidc_discovery, jwks_uri, or jwks_path; falling back to Noop"
+                    warnings.add(msg)
+                    logger.warn(msg)
+                    return VerifierConfig.Noop
+                }
+
+                val issuer = verifierMap["issuer"] as? String
+                val audience = verifierMap["audience"] as? String
+
+                val rawAlgorithms = verifierMap["algorithms"]
+                val algorithms: List<String> = when (rawAlgorithms) {
+                    is List<*> -> rawAlgorithms.filterIsInstance<String>()
+                    else -> emptyList()
+                }
+
+                val cacheTtlSeconds = when (val raw = verifierMap["cache_ttl_seconds"]) {
+                    is Int -> raw.toLong()
+                    is Long -> raw
+                    is Number -> raw.toLong()
+                    else -> 300L
+                }
+
+                val requireSubMatch = (verifierMap["require_sub_match"] as? Boolean) ?: true
+
+                VerifierConfig.Jwks(
+                    oidcDiscovery = oidcDiscovery,
+                    jwksUri = jwksUri,
+                    jwksPath = jwksPath,
+                    issuer = issuer,
+                    audience = audience,
+                    algorithms = algorithms,
+                    cacheTtlSeconds = cacheTtlSeconds,
+                    requireSubMatch = requireSubMatch
+                )
+            }
+
+            else -> {
+                val msg = "Unknown auditing.verifier type '$type'; falling back to Noop"
+                warnings.add(msg)
+                logger.warn(msg)
+                VerifierConfig.Noop
+            }
+        }
+    }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
@@ -14,6 +14,12 @@ import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetBlockedI
 import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetContextTool
 import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetNextItemTool
 import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetNextStatusTool
+import io.github.jpicklyk.mcptask.current.application.service.ActorVerifier
+import io.github.jpicklyk.mcptask.current.application.service.NoOpActorVerifier
+import io.github.jpicklyk.mcptask.current.domain.model.AuditingConfig
+import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
+import io.github.jpicklyk.mcptask.current.infrastructure.config.JwksActorVerifier
+import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlAuditingConfigService
 import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlNoteSchemaService
 import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlStatusLabelService
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseConfig
@@ -81,7 +87,8 @@ class CurrentMcpServer(
             val noteSchemaService = YamlNoteSchemaService()
             val statusLabelService = YamlStatusLabelService()
             val mcpLoggingService = DefaultMcpLoggingService()
-            val toolContext = ToolExecutionContext(repositoryProvider, noteSchemaService, statusLabelService, mcpLoggingService)
+            val actorVerifier = createActorVerifier()
+            val toolContext = ToolExecutionContext(repositoryProvider, noteSchemaService, statusLabelService, mcpLoggingService, actorVerifier)
             logger.info("Repository provider and tool context initialized")
 
             // Build tool list
@@ -143,6 +150,31 @@ class CurrentMcpServer(
      */
     suspend fun close() {
         mcpSdkServer?.close()
+    }
+
+    /**
+     * Creates the appropriate [ActorVerifier] based on the auditing configuration.
+     */
+    private fun createActorVerifier(): ActorVerifier {
+        val configService = YamlAuditingConfigService()
+        configService.getWarnings().forEach { logger.warn("Auditing config: {}", it) }
+        val config = configService.getConfig()
+        val verifier = when (val vc = config.verifier) {
+            is VerifierConfig.Noop -> {
+                logger.info("Actor verifier: noop (all claims unverified)")
+                NoOpActorVerifier
+            }
+            is VerifierConfig.Jwks -> {
+                logger.info("Actor verifier: jwks (uri={}, path={}, discovery={})",
+                    vc.jwksUri ?: "none", vc.jwksPath ?: "none", vc.oidcDiscovery ?: "none")
+                JwksActorVerifier(vc).also { jwksVerifier ->
+                    shutdownCoordinator?.addCleanupAction("Close JWKS ActorVerifier") {
+                        jwksVerifier.close()
+                    }
+                }
+            }
+        }
+        return verifier
     }
 
     private fun registerCommonCleanup(server: Server) {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
@@ -1,5 +1,7 @@
 package io.github.jpicklyk.mcptask.current.interfaces.mcp
 
+import io.github.jpicklyk.mcptask.current.application.service.ActorVerifier
+import io.github.jpicklyk.mcptask.current.application.service.NoOpActorVerifier
 import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
 import io.github.jpicklyk.mcptask.current.application.tools.compound.CompleteTreeTool
 import io.github.jpicklyk.mcptask.current.application.tools.compound.CreateWorkTreeTool
@@ -14,9 +16,6 @@ import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetBlockedI
 import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetContextTool
 import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetNextItemTool
 import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetNextStatusTool
-import io.github.jpicklyk.mcptask.current.application.service.ActorVerifier
-import io.github.jpicklyk.mcptask.current.application.service.NoOpActorVerifier
-import io.github.jpicklyk.mcptask.current.domain.model.AuditingConfig
 import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
 import io.github.jpicklyk.mcptask.current.infrastructure.config.JwksActorVerifier
 import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlAuditingConfigService
@@ -88,7 +87,14 @@ class CurrentMcpServer(
             val statusLabelService = YamlStatusLabelService()
             val mcpLoggingService = DefaultMcpLoggingService()
             val actorVerifier = createActorVerifier()
-            val toolContext = ToolExecutionContext(repositoryProvider, noteSchemaService, statusLabelService, mcpLoggingService, actorVerifier)
+            val toolContext =
+                ToolExecutionContext(
+                    repositoryProvider,
+                    noteSchemaService,
+                    statusLabelService,
+                    mcpLoggingService,
+                    actorVerifier
+                )
             logger.info("Repository provider and tool context initialized")
 
             // Build tool list
@@ -159,21 +165,26 @@ class CurrentMcpServer(
         val configService = YamlAuditingConfigService()
         configService.getWarnings().forEach { logger.warn("Auditing config: {}", it) }
         val config = configService.getConfig()
-        val verifier = when (val vc = config.verifier) {
-            is VerifierConfig.Noop -> {
-                logger.info("Actor verifier: noop (all claims unverified)")
-                NoOpActorVerifier
-            }
-            is VerifierConfig.Jwks -> {
-                logger.info("Actor verifier: jwks (uri={}, path={}, discovery={})",
-                    vc.jwksUri ?: "none", vc.jwksPath ?: "none", vc.oidcDiscovery ?: "none")
-                JwksActorVerifier(vc).also { jwksVerifier ->
-                    shutdownCoordinator?.addCleanupAction("Close JWKS ActorVerifier") {
-                        jwksVerifier.close()
+        val verifier =
+            when (val vc = config.verifier) {
+                is VerifierConfig.Noop -> {
+                    logger.info("Actor verifier: noop (all claims unverified)")
+                    NoOpActorVerifier
+                }
+                is VerifierConfig.Jwks -> {
+                    logger.info(
+                        "Actor verifier: jwks (uri={}, path={}, discovery={})",
+                        vc.jwksUri ?: "none",
+                        vc.jwksPath ?: "none",
+                        vc.oidcDiscovery ?: "none"
+                    )
+                    JwksActorVerifier(vc).also { jwksVerifier ->
+                        shutdownCoordinator?.addCleanupAction("Close JWKS ActorVerifier") {
+                            jwksVerifier.close()
+                        }
                     }
                 }
             }
-        }
         return verifier
     }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifierTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifierTest.kt
@@ -2,11 +2,13 @@ package io.github.jpicklyk.mcptask.current.infrastructure.config
 
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.ECDSASigner
 import com.nimbusds.jose.crypto.Ed25519Signer
 import com.nimbusds.jose.crypto.RSASSASigner
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jose.jwk.OctetKeyPair
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
 import com.nimbusds.jose.util.Base64URL
 import com.nimbusds.jwt.JWTClaimsSet
@@ -48,6 +50,9 @@ class JwksActorVerifierTest {
         // RSA key — uses standard JCA (no Tink needed).
         val rsaKey = RSAKeyGenerator(2048).keyID("rsa-test-key").generate()
 
+        // EC P-256 key — uses standard JCA.
+        val ecKey = ECKeyGenerator(Curve.P_256).keyID("ec-test-key").generate()
+
         // Ed25519 key — constructed via Bouncy Castle raw API to avoid Tink dependency.
         val edKey: OctetKeyPair =
             run {
@@ -72,15 +77,21 @@ class JwksActorVerifierTest {
         subject: String = "agent-1",
         issuer: String = "https://test-issuer.example",
         audience: String = "task-orchestrator",
-        expiry: Instant = Instant.now().plusSeconds(300)
-    ): JWTClaimsSet =
-        JWTClaimsSet
-            .Builder()
-            .subject(subject)
-            .issuer(issuer)
-            .audience(audience)
-            .expirationTime(Date.from(expiry))
-            .build()
+        expiry: Instant = Instant.now().plusSeconds(300),
+        notBefore: Instant? = null
+    ): JWTClaimsSet {
+        val builder =
+            JWTClaimsSet
+                .Builder()
+                .subject(subject)
+                .issuer(issuer)
+                .audience(audience)
+                .expirationTime(Date.from(expiry))
+        if (notBefore != null) {
+            builder.notBeforeTime(Date.from(notBefore))
+        }
+        return builder.build()
+    }
 
     private fun signRsa(claims: JWTClaimsSet = buildClaims()): String {
         val jwt =
@@ -99,6 +110,16 @@ class JwksActorVerifierTest {
                 claims
             )
         jwt.sign(Ed25519Signer(edKey))
+        return jwt.serialize()
+    }
+
+    private fun signEc(claims: JWTClaimsSet = buildClaims()): String {
+        val jwt =
+            SignedJWT(
+                JWSHeader.Builder(JWSAlgorithm.ES256).keyID("ec-test-key").build(),
+                claims
+            )
+        jwt.sign(ECDSASigner(ecKey))
         return jwt.serialize()
     }
 
@@ -121,6 +142,15 @@ class JwksActorVerifierTest {
     private fun edMockProvider(resolvedIssuer: String? = null): JwksKeySetProvider {
         val provider = mockk<JwksKeySetProvider>()
         coEvery { provider.getKeySet() } returns JWKSet(listOf(edKey.toPublicJWK()))
+        every { provider.getResolvedIssuer() } returns resolvedIssuer
+        every { provider.close() } just Runs
+        return provider
+    }
+
+    /** Mock provider that returns the EC public key. */
+    private fun ecMockProvider(resolvedIssuer: String? = null): JwksKeySetProvider {
+        val provider = mockk<JwksKeySetProvider>()
+        coEvery { provider.getKeySet() } returns JWKSet(listOf(ecKey.toPublicJWK()))
         every { provider.getResolvedIssuer() } returns resolvedIssuer
         every { provider.close() } just Runs
         return provider
@@ -316,5 +346,79 @@ class JwksActorVerifierTest {
             val result = verifier(provider = edMockProvider()).verify(actor(proof = signRsa()))
             assertEquals(VerificationStatus.FAILED, result.status)
             assertTrue(result.reason?.contains("no matching key") == true, "reason: ${result.reason}")
+        }
+
+    // =========================================================================
+    // EC key type verification
+    // =========================================================================
+
+    // 17. valid EC (P-256 / ES256) JWT → VERIFIED
+    @Test
+    fun `valid EC P-256 JWT returns VERIFIED`() =
+        runTest {
+            val result = verifier(provider = ecMockProvider()).verify(actor(proof = signEc()))
+            assertEquals(VerificationStatus.VERIFIED, result.status)
+            assertEquals("jwks", result.verifier)
+        }
+
+    // 18. EC JWT with algorithm allowlist including ES256 → VERIFIED
+    @Test
+    fun `EC JWT passes algorithm allowlist containing ES256`() =
+        runTest {
+            val config = baseConfig(algorithms = listOf("ES256", "RS256"))
+            val result = verifier(config = config, provider = ecMockProvider()).verify(actor(proof = signEc()))
+            assertEquals(VerificationStatus.VERIFIED, result.status)
+        }
+
+    // 19. EC JWT rejected when algorithm allowlist excludes ES256
+    @Test
+    fun `EC JWT rejected when algorithm allowlist excludes ES256`() =
+        runTest {
+            val config = baseConfig(algorithms = listOf("RS256"))
+            val result = verifier(config = config, provider = ecMockProvider()).verify(actor(proof = signEc()))
+            assertEquals(VerificationStatus.FAILED, result.status)
+            assertTrue(result.reason?.contains("algorithm not allowed") == true, "reason: ${result.reason}")
+        }
+
+    // 20. EC JWT with wrong issuer → FAILED (claim validation works with EC keys)
+    @Test
+    fun `EC JWT with wrong issuer returns FAILED`() =
+        runTest {
+            val claims = buildClaims(issuer = "https://wrong-issuer.example")
+            val result = verifier(provider = ecMockProvider()).verify(actor(proof = signEc(claims)))
+            assertEquals(VerificationStatus.FAILED, result.status)
+            assertTrue(result.reason?.contains("issuer") == true, "reason: ${result.reason}")
+        }
+
+    // =========================================================================
+    // nbf (not-before) claim validation
+    // =========================================================================
+
+    // 21. JWT with nbf far in the future → FAILED
+    @Test
+    fun `JWT with future nbf returns FAILED`() =
+        runTest {
+            val claims = buildClaims(notBefore = Instant.now().plusSeconds(600))
+            val result = verifier().verify(actor(proof = signRsa(claims)))
+            assertEquals(VerificationStatus.FAILED, result.status)
+            assertTrue(result.reason?.contains("not yet valid") == true, "reason: ${result.reason}")
+        }
+
+    // 22. JWT with nbf in the past → VERIFIED
+    @Test
+    fun `JWT with past nbf returns VERIFIED`() =
+        runTest {
+            val claims = buildClaims(notBefore = Instant.now().minusSeconds(60))
+            val result = verifier().verify(actor(proof = signRsa(claims)))
+            assertEquals(VerificationStatus.VERIFIED, result.status)
+        }
+
+    // 23. JWT without nbf → VERIFIED (nbf is optional)
+    @Test
+    fun `JWT without nbf returns VERIFIED`() =
+        runTest {
+            // Default buildClaims() has no notBefore
+            val result = verifier().verify(actor(proof = signRsa()))
+            assertEquals(VerificationStatus.VERIFIED, result.status)
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifierTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifierTest.kt
@@ -109,17 +109,19 @@ class JwksActorVerifierTest {
     ) = ActorClaim(id = id, kind = ActorKind.SUBAGENT, proof = proof)
 
     /** Mock provider that returns the RSA public key. */
-    private fun rsaMockProvider(): JwksKeySetProvider {
+    private fun rsaMockProvider(resolvedIssuer: String? = null): JwksKeySetProvider {
         val provider = mockk<JwksKeySetProvider>()
         coEvery { provider.getKeySet() } returns JWKSet(listOf(rsaKey.toPublicJWK()))
+        every { provider.getResolvedIssuer() } returns resolvedIssuer
         every { provider.close() } just Runs
         return provider
     }
 
     /** Mock provider that returns the EdDSA public key. */
-    private fun edMockProvider(): JwksKeySetProvider {
+    private fun edMockProvider(resolvedIssuer: String? = null): JwksKeySetProvider {
         val provider = mockk<JwksKeySetProvider>()
         coEvery { provider.getKeySet() } returns JWKSet(listOf(edKey.toPublicJWK()))
+        every { provider.getResolvedIssuer() } returns resolvedIssuer
         every { provider.close() } just Runs
         return provider
     }
@@ -263,6 +265,7 @@ class JwksActorVerifierTest {
         runTest {
             val brokenProvider = mockk<JwksKeySetProvider>()
             coEvery { brokenProvider.getKeySet() } throws RuntimeException("network unreachable")
+            every { brokenProvider.getResolvedIssuer() } returns null
             every { brokenProvider.close() } just Runs
 
             val result = verifier(provider = brokenProvider).verify(actor(proof = signRsa()))
@@ -270,7 +273,42 @@ class JwksActorVerifierTest {
             assertNotNull(result.reason)
         }
 
-    // 13. no matching kid → FAILED
+    // 13. OIDC-discovered issuer used when config.issuer is null
+    @Test
+    fun `OIDC-discovered issuer is used when config issuer is null`() =
+        runTest {
+            // Config has no explicit issuer, but provider discovered one via OIDC
+            val config = baseConfig(issuer = null)
+            val provider = rsaMockProvider(resolvedIssuer = "https://test-issuer.example")
+            // JWT issuer matches discovered issuer → VERIFIED
+            val result = verifier(config = config, provider = provider).verify(actor(proof = signRsa()))
+            assertEquals(VerificationStatus.VERIFIED, result.status)
+        }
+
+    // 14. OIDC-discovered issuer rejects mismatched JWT
+    @Test
+    fun `OIDC-discovered issuer rejects mismatched JWT issuer`() =
+        runTest {
+            val config = baseConfig(issuer = null)
+            val provider = rsaMockProvider(resolvedIssuer = "https://expected-issuer.example")
+            // JWT issuer is "https://test-issuer.example" but discovered issuer is different
+            val result = verifier(config = config, provider = provider).verify(actor(proof = signRsa()))
+            assertEquals(VerificationStatus.FAILED, result.status)
+            assertTrue(result.reason?.contains("issuer mismatch") == true, "reason: ${result.reason}")
+        }
+
+    // 15. explicit config.issuer overrides OIDC-discovered issuer
+    @Test
+    fun `explicit config issuer overrides OIDC-discovered issuer`() =
+        runTest {
+            // Config has explicit issuer matching JWT; discovered issuer is different
+            val config = baseConfig(issuer = "https://test-issuer.example")
+            val provider = rsaMockProvider(resolvedIssuer = "https://other-issuer.example")
+            val result = verifier(config = config, provider = provider).verify(actor(proof = signRsa()))
+            assertEquals(VerificationStatus.VERIFIED, result.status)
+        }
+
+    // 16. no matching kid → FAILED
     @Test
     fun `no matching kid returns FAILED`() =
         runTest {

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifierTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifierTest.kt
@@ -1,0 +1,282 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.config
+
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.Ed25519Signer
+import com.nimbusds.jose.crypto.RSASSASigner
+import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.OctetKeyPair
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
+import com.nimbusds.jose.util.Base64URL
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import io.github.jpicklyk.mcptask.current.domain.model.ActorClaim
+import io.github.jpicklyk.mcptask.current.domain.model.ActorKind
+import io.github.jpicklyk.mcptask.current.domain.model.VerificationStatus
+import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
+import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.security.SecureRandom
+import java.security.Security
+import java.time.Clock
+import java.time.Instant
+import java.util.Date
+
+class JwksActorVerifierTest {
+    companion object {
+        init {
+            // Register BouncyCastle before any crypto operations.
+            if (Security.getProvider("BC") == null) {
+                Security.addProvider(BouncyCastleProvider())
+            }
+        }
+
+        // RSA key — uses standard JCA (no Tink needed).
+        val rsaKey = RSAKeyGenerator(2048).keyID("rsa-test-key").generate()
+
+        // Ed25519 key — constructed via Bouncy Castle raw API to avoid Tink dependency.
+        val edKey: OctetKeyPair =
+            run {
+                val gen = Ed25519KeyPairGenerator()
+                gen.init(Ed25519KeyGenerationParameters(SecureRandom()))
+                val pair = gen.generateKeyPair()
+                val priv = pair.private as Ed25519PrivateKeyParameters
+                val pub = pair.public as Ed25519PublicKeyParameters
+                OctetKeyPair
+                    .Builder(Curve.Ed25519, Base64URL.encode(pub.encoded))
+                    .d(Base64URL.encode(priv.encoded))
+                    .keyID("ed-test-key")
+                    .build()
+            }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private fun buildClaims(
+        subject: String = "agent-1",
+        issuer: String = "https://test-issuer.example",
+        audience: String = "task-orchestrator",
+        expiry: Instant = Instant.now().plusSeconds(300)
+    ): JWTClaimsSet =
+        JWTClaimsSet
+            .Builder()
+            .subject(subject)
+            .issuer(issuer)
+            .audience(audience)
+            .expirationTime(Date.from(expiry))
+            .build()
+
+    private fun signRsa(claims: JWTClaimsSet = buildClaims()): String {
+        val jwt =
+            SignedJWT(
+                JWSHeader.Builder(JWSAlgorithm.RS256).keyID("rsa-test-key").build(),
+                claims
+            )
+        jwt.sign(RSASSASigner(rsaKey))
+        return jwt.serialize()
+    }
+
+    private fun signEd(claims: JWTClaimsSet = buildClaims()): String {
+        val jwt =
+            SignedJWT(
+                JWSHeader.Builder(JWSAlgorithm.Ed25519).keyID("ed-test-key").build(),
+                claims
+            )
+        jwt.sign(Ed25519Signer(edKey))
+        return jwt.serialize()
+    }
+
+    /** Actor whose id matches the JWT sub claim. */
+    private fun actor(
+        id: String = "agent-1",
+        proof: String? = null
+    ) = ActorClaim(id = id, kind = ActorKind.SUBAGENT, proof = proof)
+
+    /** Mock provider that returns the RSA public key. */
+    private fun rsaMockProvider(): JwksKeySetProvider {
+        val provider = mockk<JwksKeySetProvider>()
+        coEvery { provider.getKeySet() } returns JWKSet(listOf(rsaKey.toPublicJWK()))
+        every { provider.close() } just Runs
+        return provider
+    }
+
+    /** Mock provider that returns the EdDSA public key. */
+    private fun edMockProvider(): JwksKeySetProvider {
+        val provider = mockk<JwksKeySetProvider>()
+        coEvery { provider.getKeySet() } returns JWKSet(listOf(edKey.toPublicJWK()))
+        every { provider.close() } just Runs
+        return provider
+    }
+
+    private fun baseConfig(
+        issuer: String? = "https://test-issuer.example",
+        audience: String? = "task-orchestrator",
+        algorithms: List<String> = emptyList(),
+        requireSubMatch: Boolean = true
+    ) = VerifierConfig.Jwks(
+        jwksPath = "/unused-in-unit-tests",
+        issuer = issuer,
+        audience = audience,
+        algorithms = algorithms,
+        requireSubMatch = requireSubMatch
+    )
+
+    private fun verifier(
+        config: VerifierConfig.Jwks = baseConfig(),
+        provider: JwksKeySetProvider = rsaMockProvider(),
+        clock: Clock = Clock.systemUTC()
+    ) = JwksActorVerifier(config = config, keySetProvider = provider, clock = clock)
+
+    // =========================================================================
+    // Tests
+    // =========================================================================
+
+    // 1. null proof → UNVERIFIED
+    @Test
+    fun `null proof returns UNVERIFIED`() =
+        runTest {
+            val result = verifier().verify(actor(proof = null))
+            assertEquals(VerificationStatus.UNVERIFIED, result.status)
+            assertEquals("jwks", result.verifier)
+        }
+
+    // 2. blank proof → UNVERIFIED
+    @Test
+    fun `blank proof returns UNVERIFIED`() =
+        runTest {
+            val result = verifier().verify(actor(proof = ""))
+            assertEquals(VerificationStatus.UNVERIFIED, result.status)
+            assertEquals("jwks", result.verifier)
+        }
+
+    // 3. invalid JWT string → FAILED
+    @Test
+    fun `invalid JWT string returns FAILED`() =
+        runTest {
+            val result = verifier().verify(actor(proof = "not-a-jwt"))
+            assertEquals(VerificationStatus.FAILED, result.status)
+            assertNotNull(result.reason)
+        }
+
+    // 4. valid RSA JWT → VERIFIED
+    @Test
+    fun `valid RSA JWT returns VERIFIED`() =
+        runTest {
+            val result = verifier(provider = rsaMockProvider()).verify(actor(proof = signRsa()))
+            assertEquals(VerificationStatus.VERIFIED, result.status)
+            assertEquals("jwks", result.verifier)
+        }
+
+    // 5. valid EdDSA JWT → VERIFIED
+    @Test
+    fun `valid EdDSA JWT returns VERIFIED`() =
+        runTest {
+            val config = baseConfig(algorithms = emptyList())
+            val result = verifier(config = config, provider = edMockProvider()).verify(actor(proof = signEd()))
+            assertEquals(VerificationStatus.VERIFIED, result.status)
+            assertEquals("jwks", result.verifier)
+        }
+
+    // 6. expired JWT → FAILED
+    @Test
+    fun `expired JWT returns FAILED`() =
+        runTest {
+            val expiredClaims = buildClaims(expiry = Instant.now().minusSeconds(600))
+            val result = verifier().verify(actor(proof = signRsa(expiredClaims)))
+            assertEquals(VerificationStatus.FAILED, result.status)
+            assertTrue(result.reason?.contains("expired") == true, "reason should mention 'expired': ${result.reason}")
+        }
+
+    // 7. wrong issuer → FAILED
+    @Test
+    fun `wrong issuer returns FAILED`() =
+        runTest {
+            val claims = buildClaims(issuer = "https://other-issuer.example")
+            val result = verifier().verify(actor(proof = signRsa(claims)))
+            assertEquals(VerificationStatus.FAILED, result.status)
+            assertTrue(result.reason?.contains("issuer") == true, "reason should mention 'issuer': ${result.reason}")
+        }
+
+    // 8. wrong audience → FAILED
+    @Test
+    fun `wrong audience returns FAILED`() =
+        runTest {
+            val claims = buildClaims(audience = "wrong-audience")
+            val result = verifier().verify(actor(proof = signRsa(claims)))
+            assertEquals(VerificationStatus.FAILED, result.status)
+            assertTrue(result.reason?.contains("audience") == true, "reason should mention 'audience': ${result.reason}")
+        }
+
+    // 9. algorithm not in allowlist → FAILED
+    @Test
+    fun `algorithm not in allowlist returns FAILED`() =
+        runTest {
+            val config = baseConfig(algorithms = listOf("EdDSA"))
+            val result = verifier(config = config, provider = rsaMockProvider()).verify(actor(proof = signRsa()))
+            assertEquals(VerificationStatus.FAILED, result.status)
+            assertTrue(result.reason?.contains("algorithm not allowed") == true, "reason: ${result.reason}")
+        }
+
+    // 10. sub mismatch + requireSubMatch=true → FAILED
+    @Test
+    fun `sub mismatch with strict match returns FAILED`() =
+        runTest {
+            val claims = buildClaims(subject = "other-agent")
+            // actor.id = "agent-1" but JWT sub = "other-agent"
+            val result =
+                verifier(config = baseConfig(requireSubMatch = true)).verify(
+                    actor(id = "agent-1", proof = signRsa(claims))
+                )
+            assertEquals(VerificationStatus.FAILED, result.status)
+            assertTrue(result.reason?.contains("sub mismatch") == true, "reason: ${result.reason}")
+        }
+
+    // 11. sub mismatch + requireSubMatch=false → VERIFIED
+    @Test
+    fun `sub mismatch with relaxed match returns VERIFIED`() =
+        runTest {
+            val claims = buildClaims(subject = "other-agent")
+            val config = baseConfig(requireSubMatch = false)
+            val result = verifier(config = config).verify(actor(id = "agent-1", proof = signRsa(claims)))
+            assertEquals(VerificationStatus.VERIFIED, result.status)
+        }
+
+    // 12. provider throws → FAILED (graceful)
+    @Test
+    fun `provider exception returns FAILED`() =
+        runTest {
+            val brokenProvider = mockk<JwksKeySetProvider>()
+            coEvery { brokenProvider.getKeySet() } throws RuntimeException("network unreachable")
+            every { brokenProvider.close() } just Runs
+
+            val result = verifier(provider = brokenProvider).verify(actor(proof = signRsa()))
+            assertEquals(VerificationStatus.FAILED, result.status)
+            assertNotNull(result.reason)
+        }
+
+    // 13. no matching kid → FAILED
+    @Test
+    fun `no matching kid returns FAILED`() =
+        runTest {
+            // Provider only has the EdDSA key; JWT is signed with RSA (kid="rsa-test-key")
+            val result = verifier(provider = edMockProvider()).verify(actor(proof = signRsa()))
+            assertEquals(VerificationStatus.FAILED, result.status)
+            assertTrue(result.reason?.contains("no matching key") == true, "reason: ${result.reason}")
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksKeySetProviderTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksKeySetProviderTest.kt
@@ -1,0 +1,141 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.config
+
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
+import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
+import kotlinx.coroutines.test.runTest
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.security.Security
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class JwksKeySetProviderTest {
+    companion object {
+        init {
+            if (Security.getProvider("BC") == null) {
+                Security.addProvider(BouncyCastleProvider())
+            }
+        }
+    }
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private val rsaKey = RSAKeyGenerator(2048).keyID("file-rsa-key").generate()
+
+    /** Write a JWKS JSON file containing the public RSA key and return its relative path. */
+    private fun writeJwksFile(name: String = "test-jwks.json"): Path {
+        val jwkSet = JWKSet(listOf(rsaKey.toPublicJWK()))
+        val file = tempDir.resolve(name).toFile()
+        file.writeText(jwkSet.toString())
+        return tempDir.resolve(name)
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    // 1. File-based loading parses a valid JWK set
+    @Test
+    fun `file-based loading parses JWK set`() =
+        runTest {
+            val jwksFile = writeJwksFile()
+            // Temporarily override user.dir to point at the temp directory so the relative path resolves.
+            val prevUserDir = System.getProperty("user.dir")
+            System.setProperty("user.dir", tempDir.toAbsolutePath().toString())
+            try {
+                val config = VerifierConfig.Jwks(jwksPath = "test-jwks.json")
+                val provider = DefaultJwksKeySetProvider(config)
+                try {
+                    val keySet = provider.getKeySet()
+                    assertNotNull(keySet)
+                    assertEquals(1, keySet.keys.size)
+                    assertEquals("file-rsa-key", keySet.keys.first().keyID)
+                } finally {
+                    provider.close()
+                }
+            } finally {
+                System.setProperty("user.dir", prevUserDir)
+            }
+        }
+
+    // 2. Cache returns same instance within TTL
+    @Test
+    fun `cache returns same set within TTL`() =
+        runTest {
+            val jwksFile = writeJwksFile()
+            val fixedNow = Instant.parse("2024-01-01T00:00:00Z")
+            // Fixed clock — time never advances, so cache never expires.
+            val fixedClock = Clock.fixed(fixedNow, ZoneOffset.UTC)
+
+            val prevUserDir = System.getProperty("user.dir")
+            System.setProperty("user.dir", tempDir.toAbsolutePath().toString())
+            try {
+                val config = VerifierConfig.Jwks(jwksPath = "test-jwks.json", cacheTtlSeconds = 300)
+                val provider = DefaultJwksKeySetProvider(config, clock = fixedClock)
+                try {
+                    val first = provider.getKeySet()
+                    val second = provider.getKeySet()
+                    // Same instance means the cache was used.
+                    assert(first === second) { "Expected cache hit to return the same JWKSet instance" }
+                } finally {
+                    provider.close()
+                }
+            } finally {
+                System.setProperty("user.dir", prevUserDir)
+            }
+        }
+
+    // 3. Cache expires after TTL and triggers a refetch
+    @Test
+    fun `cache expires after TTL`() =
+        runTest {
+            val jwksFile = writeJwksFile()
+            val baseInstant = Instant.parse("2024-01-01T00:00:00Z")
+
+            // Mutable instant that we advance between calls.
+            var currentInstant = baseInstant
+            val advancingClock =
+                object : Clock() {
+                    override fun getZone(): ZoneOffset = ZoneOffset.UTC
+
+                    override fun withZone(zone: java.time.ZoneId): Clock = this
+
+                    override fun instant(): Instant = currentInstant
+                }
+
+            val prevUserDir = System.getProperty("user.dir")
+            System.setProperty("user.dir", tempDir.toAbsolutePath().toString())
+            try {
+                val config = VerifierConfig.Jwks(jwksPath = "test-jwks.json", cacheTtlSeconds = 60)
+                val provider = DefaultJwksKeySetProvider(config, clock = advancingClock)
+                try {
+                    val first = provider.getKeySet()
+
+                    // Advance clock past TTL.
+                    currentInstant = baseInstant.plusSeconds(120)
+
+                    val second = provider.getKeySet()
+                    // After TTL expires, a new JWKSet is parsed — it should equal the first but be a fresh instance.
+                    assertNotNull(second)
+                    assertEquals(first.keys.size, second.keys.size)
+                    // The instances should NOT be the same object (cache was invalidated and refreshed).
+                    assert(first !== second) { "Expected a new JWKSet instance after cache expiry" }
+                } finally {
+                    provider.close()
+                }
+            } finally {
+                System.setProperty("user.dir", prevUserDir)
+            }
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksKeySetProviderTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksKeySetProviderTest.kt
@@ -3,11 +3,15 @@ package io.github.jpicklyk.mcptask.current.infrastructure.config
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
 import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.test.runTest
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import java.security.Security
@@ -131,6 +135,142 @@ class JwksKeySetProviderTest {
                     assertEquals(first.keys.size, second.keys.size)
                     // The instances should NOT be the same object (cache was invalidated and refreshed).
                     assert(first !== second) { "Expected a new JWKSet instance after cache expiry" }
+                } finally {
+                    provider.close()
+                }
+            } finally {
+                System.setProperty("user.dir", prevUserDir)
+            }
+        }
+
+    // -------------------------------------------------------------------------
+    // Concurrent access
+    // -------------------------------------------------------------------------
+
+    // 4. Concurrent coroutines all get a valid key set without exceptions
+    @Test
+    fun `concurrent access returns valid key set for all callers`() =
+        runTest {
+            writeJwksFile()
+            val fixedClock = Clock.fixed(Instant.parse("2024-01-01T00:00:00Z"), ZoneOffset.UTC)
+
+            val prevUserDir = System.getProperty("user.dir")
+            System.setProperty("user.dir", tempDir.toAbsolutePath().toString())
+            try {
+                val config = VerifierConfig.Jwks(jwksPath = "test-jwks.json", cacheTtlSeconds = 300)
+                val provider = DefaultJwksKeySetProvider(config, clock = fixedClock)
+                try {
+                    // Launch 20 concurrent fetches — all should succeed without exceptions.
+                    val results =
+                        (1..20)
+                            .map { async { provider.getKeySet() } }
+                            .awaitAll()
+
+                    assertEquals(20, results.size)
+                    results.forEach { keySet ->
+                        assertNotNull(keySet)
+                        assertEquals(1, keySet.keys.size)
+                        assertEquals("file-rsa-key", keySet.keys.first().keyID)
+                    }
+                    // All should be the same cached instance.
+                    val distinct = results.distinct()
+                    assertEquals(1, distinct.size, "All concurrent callers should get the same cached instance")
+                } finally {
+                    provider.close()
+                }
+            } finally {
+                System.setProperty("user.dir", prevUserDir)
+            }
+        }
+
+    // -------------------------------------------------------------------------
+    // OIDC discovery failure + fallback
+    // -------------------------------------------------------------------------
+
+    // 5. OIDC discovery fails but jwksPath succeeds — keys still loaded from file
+    @Test
+    fun `OIDC discovery failure falls back to file-based keys`() =
+        runTest {
+            writeJwksFile()
+
+            val prevUserDir = System.getProperty("user.dir")
+            System.setProperty("user.dir", tempDir.toAbsolutePath().toString())
+            try {
+                // oidcDiscovery points to unreachable host; jwksPath points to a valid file
+                val config =
+                    VerifierConfig.Jwks(
+                        oidcDiscovery = "http://192.0.2.1:1/nonexistent",
+                        jwksPath = "test-jwks.json"
+                    )
+                val provider = DefaultJwksKeySetProvider(config)
+                try {
+                    val keySet = provider.getKeySet()
+                    assertNotNull(keySet)
+                    assertEquals(1, keySet.keys.size)
+                    assertEquals("file-rsa-key", keySet.keys.first().keyID)
+                    // OIDC discovery failed, so resolved issuer should be null
+                    assertNull(provider.getResolvedIssuer())
+                } finally {
+                    provider.close()
+                }
+            } finally {
+                System.setProperty("user.dir", prevUserDir)
+            }
+        }
+
+    // 6. OIDC discovery fails and no other source — throws IllegalStateException
+    @Test
+    fun `OIDC discovery failure with no fallback source throws`() =
+        runTest {
+            val config =
+                VerifierConfig.Jwks(
+                    oidcDiscovery = "http://192.0.2.1:1/nonexistent"
+                )
+            val provider = DefaultJwksKeySetProvider(config)
+            try {
+                assertThrows<Exception> {
+                    provider.getKeySet()
+                }
+            } finally {
+                provider.close()
+            }
+        }
+
+    // 7. Missing file path throws and does not silently return empty key set
+    @Test
+    fun `missing jwksPath file throws`() =
+        runTest {
+            val prevUserDir = System.getProperty("user.dir")
+            System.setProperty("user.dir", tempDir.toAbsolutePath().toString())
+            try {
+                val config = VerifierConfig.Jwks(jwksPath = "does-not-exist.json")
+                val provider = DefaultJwksKeySetProvider(config)
+                try {
+                    assertThrows<Exception> {
+                        provider.getKeySet()
+                    }
+                } finally {
+                    provider.close()
+                }
+            } finally {
+                System.setProperty("user.dir", prevUserDir)
+            }
+        }
+
+    // 8. Resolved issuer is null when no OIDC discovery is configured
+    @Test
+    fun `resolved issuer is null without OIDC discovery`() =
+        runTest {
+            writeJwksFile()
+
+            val prevUserDir = System.getProperty("user.dir")
+            System.setProperty("user.dir", tempDir.toAbsolutePath().toString())
+            try {
+                val config = VerifierConfig.Jwks(jwksPath = "test-jwks.json")
+                val provider = DefaultJwksKeySetProvider(config)
+                try {
+                    provider.getKeySet() // trigger fetch
+                    assertNull(provider.getResolvedIssuer())
                 } finally {
                     provider.close()
                 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlAuditingConfigServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlAuditingConfigServiceTest.kt
@@ -9,7 +9,6 @@ import java.io.File
 import java.nio.file.Path
 
 class YamlAuditingConfigServiceTest {
-
     @TempDir
     lateinit var tempDir: Path
 
@@ -31,12 +30,13 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `config with auditing enabled but no verifier section returns Noop`() {
-        val configFile = createConfigFile(
-            """
-            auditing:
-              enabled: true
-            """.trimIndent()
-        )
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  enabled: true
+                """.trimIndent()
+            )
         val service = YamlAuditingConfigService(configFile)
 
         val config = service.getConfig()
@@ -47,15 +47,16 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `config with no auditing section returns defaults`() {
-        val configFile = createConfigFile(
-            """
-            note_schemas:
-              default:
-                - key: test
-                  role: queue
-                  required: false
-            """.trimIndent()
-        )
+        val configFile =
+            createConfigFile(
+                """
+                note_schemas:
+                  default:
+                    - key: test
+                      role: queue
+                      required: false
+                """.trimIndent()
+            )
         val service = YamlAuditingConfigService(configFile)
 
         val config = service.getConfig()
@@ -69,14 +70,15 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `verifier type noop returns Noop`() {
-        val configFile = createConfigFile(
-            """
-            auditing:
-              enabled: true
-              verifier:
-                type: noop
-            """.trimIndent()
-        )
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  enabled: true
+                  verifier:
+                    type: noop
+                """.trimIndent()
+            )
         val service = YamlAuditingConfigService(configFile)
 
         assertEquals(VerifierConfig.Noop, service.getConfig().verifier)
@@ -89,24 +91,25 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `verifier type jwks with all fields returns fully populated Jwks`() {
-        val configFile = createConfigFile(
-            """
-            auditing:
-              enabled: true
-              verifier:
-                type: jwks
-                oidc_discovery: "https://accounts.example.com/.well-known/openid-configuration"
-                jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
-                jwks_path: "/etc/keys/jwks.json"
-                issuer: "https://accounts.example.com"
-                audience: "mcp-task-orchestrator"
-                algorithms:
-                  - RS256
-                  - ES256
-                cache_ttl_seconds: 600
-                require_sub_match: false
-            """.trimIndent()
-        )
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  enabled: true
+                  verifier:
+                    type: jwks
+                    oidc_discovery: "https://accounts.example.com/.well-known/openid-configuration"
+                    jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
+                    jwks_path: "/etc/keys/jwks.json"
+                    issuer: "https://accounts.example.com"
+                    audience: "mcp-task-orchestrator"
+                    algorithms:
+                      - RS256
+                      - ES256
+                    cache_ttl_seconds: 600
+                    require_sub_match: false
+                """.trimIndent()
+            )
         val service = YamlAuditingConfigService(configFile)
 
         val verifier = service.getConfig().verifier
@@ -129,14 +132,15 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `verifier type jwks with only jwks_path is valid`() {
-        val configFile = createConfigFile(
-            """
-            auditing:
-              verifier:
-                type: jwks
-                jwks_path: "/etc/keys/jwks.json"
-            """.trimIndent()
-        )
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  verifier:
+                    type: jwks
+                    jwks_path: "/etc/keys/jwks.json"
+                """.trimIndent()
+            )
         val service = YamlAuditingConfigService(configFile)
 
         val verifier = service.getConfig().verifier
@@ -150,14 +154,15 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `verifier type jwks with only oidc_discovery is valid`() {
-        val configFile = createConfigFile(
-            """
-            auditing:
-              verifier:
-                type: jwks
-                oidc_discovery: "https://accounts.example.com/.well-known/openid-configuration"
-            """.trimIndent()
-        )
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  verifier:
+                    type: jwks
+                    oidc_discovery: "https://accounts.example.com/.well-known/openid-configuration"
+                """.trimIndent()
+            )
         val service = YamlAuditingConfigService(configFile)
 
         val verifier = service.getConfig().verifier
@@ -171,14 +176,15 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `verifier type jwks with only jwks_uri is valid`() {
-        val configFile = createConfigFile(
-            """
-            auditing:
-              verifier:
-                type: jwks
-                jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
-            """.trimIndent()
-        )
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  verifier:
+                    type: jwks
+                    jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
+                """.trimIndent()
+            )
         val service = YamlAuditingConfigService(configFile)
 
         val verifier = service.getConfig().verifier
@@ -196,14 +202,15 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `verifier type jwks with no source URI, path, or discovery produces warning and falls back to Noop`() {
-        val configFile = createConfigFile(
-            """
-            auditing:
-              verifier:
-                type: jwks
-                issuer: "https://accounts.example.com"
-            """.trimIndent()
-        )
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  verifier:
+                    type: jwks
+                    issuer: "https://accounts.example.com"
+                """.trimIndent()
+            )
         val service = YamlAuditingConfigService(configFile)
 
         assertEquals(VerifierConfig.Noop, service.getConfig().verifier)
@@ -213,13 +220,14 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `unknown verifier type produces warning and falls back to Noop`() {
-        val configFile = createConfigFile(
-            """
-            auditing:
-              verifier:
-                type: magic-unicorn
-            """.trimIndent()
-        )
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  verifier:
+                    type: magic-unicorn
+                """.trimIndent()
+            )
         val service = YamlAuditingConfigService(configFile)
 
         assertEquals(VerifierConfig.Noop, service.getConfig().verifier)
@@ -233,18 +241,19 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `algorithms parsed as list of strings`() {
-        val configFile = createConfigFile(
-            """
-            auditing:
-              verifier:
-                type: jwks
-                jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
-                algorithms:
-                  - RS256
-                  - ES384
-                  - PS256
-            """.trimIndent()
-        )
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  verifier:
+                    type: jwks
+                    jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
+                    algorithms:
+                      - RS256
+                      - ES384
+                      - PS256
+                """.trimIndent()
+            )
         val service = YamlAuditingConfigService(configFile)
 
         val verifier = service.getConfig().verifier as VerifierConfig.Jwks
@@ -253,14 +262,15 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `require_sub_match defaults to true when absent`() {
-        val configFile = createConfigFile(
-            """
-            auditing:
-              verifier:
-                type: jwks
-                jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
-            """.trimIndent()
-        )
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  verifier:
+                    type: jwks
+                    jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
+                """.trimIndent()
+            )
         val service = YamlAuditingConfigService(configFile)
 
         val verifier = service.getConfig().verifier as VerifierConfig.Jwks
@@ -269,14 +279,15 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `cache_ttl_seconds defaults to 300 when absent`() {
-        val configFile = createConfigFile(
-            """
-            auditing:
-              verifier:
-                type: jwks
-                jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
-            """.trimIndent()
-        )
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  verifier:
+                    type: jwks
+                    jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
+                """.trimIndent()
+            )
         val service = YamlAuditingConfigService(configFile)
 
         val verifier = service.getConfig().verifier as VerifierConfig.Jwks
@@ -285,14 +296,15 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `algorithms defaults to empty list when absent`() {
-        val configFile = createConfigFile(
-            """
-            auditing:
-              verifier:
-                type: jwks
-                jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
-            """.trimIndent()
-        )
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  verifier:
+                    type: jwks
+                    jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
+                """.trimIndent()
+            )
         val service = YamlAuditingConfigService(configFile)
 
         val verifier = service.getConfig().verifier as VerifierConfig.Jwks
@@ -301,14 +313,15 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `auditing enabled flag false is respected`() {
-        val configFile = createConfigFile(
-            """
-            auditing:
-              enabled: false
-              verifier:
-                type: noop
-            """.trimIndent()
-        )
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  enabled: false
+                  verifier:
+                    type: noop
+                """.trimIndent()
+            )
         val service = YamlAuditingConfigService(configFile)
 
         assertFalse(service.getConfig().enabled)
@@ -320,7 +333,8 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `malformed YAML falls back to defaults gracefully`() {
-        val configFile = createConfigFile("{{{{invalid yaml!!!")
+        val configFile =
+            createConfigFile("{{{{invalid yaml!!!")
         val service = YamlAuditingConfigService(configFile)
 
         val config = service.getConfig()

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlAuditingConfigServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlAuditingConfigServiceTest.kt
@@ -1,0 +1,342 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.config
+
+import io.github.jpicklyk.mcptask.current.domain.model.AuditingConfig
+import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+
+class YamlAuditingConfigServiceTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    // -------------------------------------------------------------------------
+    // Missing / empty config
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `missing config file returns AuditingConfig defaults`() {
+        val nonExistentPath = tempDir.resolve("does-not-exist/config.yaml")
+        val service = YamlAuditingConfigService(nonExistentPath)
+
+        val config = service.getConfig()
+        assertEquals(AuditingConfig(), config)
+        assertTrue(config.enabled)
+        assertEquals(VerifierConfig.Noop, config.verifier)
+        assertTrue(service.getWarnings().isEmpty())
+    }
+
+    @Test
+    fun `config with auditing enabled but no verifier section returns Noop`() {
+        val configFile = createConfigFile(
+            """
+            auditing:
+              enabled: true
+            """.trimIndent()
+        )
+        val service = YamlAuditingConfigService(configFile)
+
+        val config = service.getConfig()
+        assertTrue(config.enabled)
+        assertEquals(VerifierConfig.Noop, config.verifier)
+        assertTrue(service.getWarnings().isEmpty())
+    }
+
+    @Test
+    fun `config with no auditing section returns defaults`() {
+        val configFile = createConfigFile(
+            """
+            note_schemas:
+              default:
+                - key: test
+                  role: queue
+                  required: false
+            """.trimIndent()
+        )
+        val service = YamlAuditingConfigService(configFile)
+
+        val config = service.getConfig()
+        assertEquals(AuditingConfig(), config)
+        assertTrue(service.getWarnings().isEmpty())
+    }
+
+    // -------------------------------------------------------------------------
+    // Noop verifier
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `verifier type noop returns Noop`() {
+        val configFile = createConfigFile(
+            """
+            auditing:
+              enabled: true
+              verifier:
+                type: noop
+            """.trimIndent()
+        )
+        val service = YamlAuditingConfigService(configFile)
+
+        assertEquals(VerifierConfig.Noop, service.getConfig().verifier)
+        assertTrue(service.getWarnings().isEmpty())
+    }
+
+    // -------------------------------------------------------------------------
+    // JWKS verifier — fully populated
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `verifier type jwks with all fields returns fully populated Jwks`() {
+        val configFile = createConfigFile(
+            """
+            auditing:
+              enabled: true
+              verifier:
+                type: jwks
+                oidc_discovery: "https://accounts.example.com/.well-known/openid-configuration"
+                jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
+                jwks_path: "/etc/keys/jwks.json"
+                issuer: "https://accounts.example.com"
+                audience: "mcp-task-orchestrator"
+                algorithms:
+                  - RS256
+                  - ES256
+                cache_ttl_seconds: 600
+                require_sub_match: false
+            """.trimIndent()
+        )
+        val service = YamlAuditingConfigService(configFile)
+
+        val verifier = service.getConfig().verifier
+        assertInstanceOf(VerifierConfig.Jwks::class.java, verifier)
+        verifier as VerifierConfig.Jwks
+        assertEquals("https://accounts.example.com/.well-known/openid-configuration", verifier.oidcDiscovery)
+        assertEquals("https://accounts.example.com/.well-known/jwks.json", verifier.jwksUri)
+        assertEquals("/etc/keys/jwks.json", verifier.jwksPath)
+        assertEquals("https://accounts.example.com", verifier.issuer)
+        assertEquals("mcp-task-orchestrator", verifier.audience)
+        assertEquals(listOf("RS256", "ES256"), verifier.algorithms)
+        assertEquals(600L, verifier.cacheTtlSeconds)
+        assertFalse(verifier.requireSubMatch)
+        assertTrue(service.getWarnings().isEmpty())
+    }
+
+    // -------------------------------------------------------------------------
+    // JWKS verifier — minimal valid configs
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `verifier type jwks with only jwks_path is valid`() {
+        val configFile = createConfigFile(
+            """
+            auditing:
+              verifier:
+                type: jwks
+                jwks_path: "/etc/keys/jwks.json"
+            """.trimIndent()
+        )
+        val service = YamlAuditingConfigService(configFile)
+
+        val verifier = service.getConfig().verifier
+        assertInstanceOf(VerifierConfig.Jwks::class.java, verifier)
+        verifier as VerifierConfig.Jwks
+        assertEquals("/etc/keys/jwks.json", verifier.jwksPath)
+        assertNull(verifier.oidcDiscovery)
+        assertNull(verifier.jwksUri)
+        assertTrue(service.getWarnings().isEmpty())
+    }
+
+    @Test
+    fun `verifier type jwks with only oidc_discovery is valid`() {
+        val configFile = createConfigFile(
+            """
+            auditing:
+              verifier:
+                type: jwks
+                oidc_discovery: "https://accounts.example.com/.well-known/openid-configuration"
+            """.trimIndent()
+        )
+        val service = YamlAuditingConfigService(configFile)
+
+        val verifier = service.getConfig().verifier
+        assertInstanceOf(VerifierConfig.Jwks::class.java, verifier)
+        verifier as VerifierConfig.Jwks
+        assertEquals("https://accounts.example.com/.well-known/openid-configuration", verifier.oidcDiscovery)
+        assertNull(verifier.jwksUri)
+        assertNull(verifier.jwksPath)
+        assertTrue(service.getWarnings().isEmpty())
+    }
+
+    @Test
+    fun `verifier type jwks with only jwks_uri is valid`() {
+        val configFile = createConfigFile(
+            """
+            auditing:
+              verifier:
+                type: jwks
+                jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
+            """.trimIndent()
+        )
+        val service = YamlAuditingConfigService(configFile)
+
+        val verifier = service.getConfig().verifier
+        assertInstanceOf(VerifierConfig.Jwks::class.java, verifier)
+        verifier as VerifierConfig.Jwks
+        assertEquals("https://accounts.example.com/.well-known/jwks.json", verifier.jwksUri)
+        assertNull(verifier.oidcDiscovery)
+        assertNull(verifier.jwksPath)
+        assertTrue(service.getWarnings().isEmpty())
+    }
+
+    // -------------------------------------------------------------------------
+    // JWKS verifier — error / fallback cases
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `verifier type jwks with no source URI, path, or discovery produces warning and falls back to Noop`() {
+        val configFile = createConfigFile(
+            """
+            auditing:
+              verifier:
+                type: jwks
+                issuer: "https://accounts.example.com"
+            """.trimIndent()
+        )
+        val service = YamlAuditingConfigService(configFile)
+
+        assertEquals(VerifierConfig.Noop, service.getConfig().verifier)
+        assertTrue(service.getWarnings().isNotEmpty())
+        assertTrue(service.getWarnings().any { it.contains("jwks") && it.contains("oidc_discovery") })
+    }
+
+    @Test
+    fun `unknown verifier type produces warning and falls back to Noop`() {
+        val configFile = createConfigFile(
+            """
+            auditing:
+              verifier:
+                type: magic-unicorn
+            """.trimIndent()
+        )
+        val service = YamlAuditingConfigService(configFile)
+
+        assertEquals(VerifierConfig.Noop, service.getConfig().verifier)
+        assertTrue(service.getWarnings().isNotEmpty())
+        assertTrue(service.getWarnings().any { it.contains("magic-unicorn") })
+    }
+
+    // -------------------------------------------------------------------------
+    // Field-level defaults and parsing
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `algorithms parsed as list of strings`() {
+        val configFile = createConfigFile(
+            """
+            auditing:
+              verifier:
+                type: jwks
+                jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
+                algorithms:
+                  - RS256
+                  - ES384
+                  - PS256
+            """.trimIndent()
+        )
+        val service = YamlAuditingConfigService(configFile)
+
+        val verifier = service.getConfig().verifier as VerifierConfig.Jwks
+        assertEquals(listOf("RS256", "ES384", "PS256"), verifier.algorithms)
+    }
+
+    @Test
+    fun `require_sub_match defaults to true when absent`() {
+        val configFile = createConfigFile(
+            """
+            auditing:
+              verifier:
+                type: jwks
+                jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
+            """.trimIndent()
+        )
+        val service = YamlAuditingConfigService(configFile)
+
+        val verifier = service.getConfig().verifier as VerifierConfig.Jwks
+        assertTrue(verifier.requireSubMatch)
+    }
+
+    @Test
+    fun `cache_ttl_seconds defaults to 300 when absent`() {
+        val configFile = createConfigFile(
+            """
+            auditing:
+              verifier:
+                type: jwks
+                jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
+            """.trimIndent()
+        )
+        val service = YamlAuditingConfigService(configFile)
+
+        val verifier = service.getConfig().verifier as VerifierConfig.Jwks
+        assertEquals(300L, verifier.cacheTtlSeconds)
+    }
+
+    @Test
+    fun `algorithms defaults to empty list when absent`() {
+        val configFile = createConfigFile(
+            """
+            auditing:
+              verifier:
+                type: jwks
+                jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
+            """.trimIndent()
+        )
+        val service = YamlAuditingConfigService(configFile)
+
+        val verifier = service.getConfig().verifier as VerifierConfig.Jwks
+        assertEquals(emptyList<String>(), verifier.algorithms)
+    }
+
+    @Test
+    fun `auditing enabled flag false is respected`() {
+        val configFile = createConfigFile(
+            """
+            auditing:
+              enabled: false
+              verifier:
+                type: noop
+            """.trimIndent()
+        )
+        val service = YamlAuditingConfigService(configFile)
+
+        assertFalse(service.getConfig().enabled)
+    }
+
+    // -------------------------------------------------------------------------
+    // Malformed YAML
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `malformed YAML falls back to defaults gracefully`() {
+        val configFile = createConfigFile("{{{{invalid yaml!!!")
+        val service = YamlAuditingConfigService(configFile)
+
+        val config = service.getConfig()
+        assertEquals(AuditingConfig(), config)
+        assertTrue(service.getWarnings().isNotEmpty())
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    private fun createConfigFile(content: String): Path {
+        val configDir = File(tempDir.toFile(), ".taskorchestrator")
+        configDir.mkdirs()
+        val configFile = File(configDir, "config.yaml")
+        configFile.writeText(content)
+        return configFile.toPath()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,15 @@ junit = "5.12.2"
 # YAML
 snakeyaml = "2.6"
 
+# JWT / JWKS
+nimbusJoseJwt = "10.3"
+
+# Bouncy Castle (test-only — provides Ed25519/OKP crypto backend for nimbus-jose-jwt tests)
+bouncyCastle = "1.80"
+
+# Google Tink (test-only — required by nimbus-jose-jwt Ed25519Signer/Verifier)
+googleTink = "1.18.0"
+
 # Linting
 ktlint = "12.1.2"
 
@@ -44,6 +53,7 @@ mcp-sdk-testing = { module = "io.modelcontextprotocol:kotlin-sdk-testing", versi
 # Ktor
 ktor-bom        = { module = "io.ktor:ktor-bom",        version.ref = "ktor" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 
 # Database
 sqlite = { module = "org.xerial:sqlite-jdbc", version.ref = "sqlite" }
@@ -60,6 +70,15 @@ logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 
 # YAML
 snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
+
+# JWT / JWKS
+nimbus-jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbusJoseJwt" }
+
+# Bouncy Castle (test-only)
+bouncycastle-provider = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncyCastle" }
+
+# Google Tink (test-only — required by nimbus-jose-jwt Ed25519Signer/Verifier)
+google-tink = { module = "com.google.crypto.tink:tink", version.ref = "googleTink" }
 
 # Testing
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ nimbusJoseJwt = "10.3"
 # Bouncy Castle (test-only — provides Ed25519/OKP crypto backend for nimbus-jose-jwt tests)
 bouncyCastle = "1.80"
 
-# Google Tink (test-only — required by nimbus-jose-jwt Ed25519Signer/Verifier)
+# Google Tink (runtime — required by nimbus-jose-jwt Ed25519Verifier for EdDSA support)
 googleTink = "1.18.0"
 
 # Linting
@@ -77,7 +77,7 @@ nimbus-jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimb
 # Bouncy Castle (test-only)
 bouncycastle-provider = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncyCastle" }
 
-# Google Tink (test-only — required by nimbus-jose-jwt Ed25519Signer/Verifier)
+# Google Tink (runtime — required by nimbus-jose-jwt Ed25519Verifier for EdDSA support)
 google-tink = { module = "com.google.crypto.tink:tink", version.ref = "googleTink" }
 
 # Testing


### PR DESCRIPTION
## Summary

- Implement `JwksActorVerifier` — validates JWT bearer tokens against JWKS key sets, completing Stage 2 of actor attribution (#107)
- Support three JWKS sources: `jwks_uri` (network), `jwks_path` (local file), and `oidc_discovery` (auto-populates both `jwks_uri` and `issuer` from a single OIDC discovery URL)
- Add algorithm allowlist, configurable `sub` match, and OIDC-discovered issuer auto-use for `iss` claim validation

> **Note:** The JWKS verifier implementation will be in **beta review** with this release. The `auditing.verifier.type: jwks` configuration is functional and tested but should be considered pre-production until validated against live identity providers.

## What changed

**New production files:**
- `AuditingConfig.kt` — domain model (`VerifierConfig` sealed class with `Noop`/`Jwks` variants)
- `YamlAuditingConfigService.kt` — parses `auditing.verifier` section from `config.yaml`
- `JwksKeySetProvider.kt` — interface + `DefaultJwksKeySetProvider` (JWKS fetching, caching, OIDC discovery, key set merging)
- `JwksActorVerifier.kt` — `ActorVerifier` implementation (JWT parsing, signature verification, claim validation)
- `CurrentMcpServer.kt` — wiring: constructs the appropriate verifier from config and passes to `ToolExecutionContext`

**New dependencies:**
- `nimbus-jose-jwt:10.3` — JWT/JWKS parsing and verification (RSA, EC, EdDSA)
- `ktor-client-cio` — HTTP client for remote JWKS and OIDC discovery fetching
- `google-tink:1.18.0` — required at runtime by nimbus `Ed25519Verifier` for EdDSA support
- `bouncycastle:1.80` (test-only) — Ed25519 key generation in tests

**Documentation:**
- `config-format.md` — full verifier field reference replacing Stage 2 stub
- `validate-workflow.md` — expanded auditing validation checks
- `SKILL.md` — VIEW operation shows verifier type
- `api-reference.md` — auditing verifier config section + Docker network access table

**Tests:** 35 new tests (16 config parser + 16 verifier + 3 provider)

## Configuration

```yaml
auditing:
  enabled: true
  verifier:
    type: jwks
    oidc_discovery: "https://agentlair.dev/.well-known/openid-configuration"
    # Optional overrides:
    jwks_uri: "https://provider.example/.well-known/jwks.json"
    jwks_path: ".agentlair/jwks.json"
    issuer: "https://provider.example"
    audience: "task-orchestrator"
    algorithms: ["EdDSA", "RS256"]
    cache_ttl_seconds: 300
    require_sub_match: true
```

## Test plan

- [x] All 35 new tests pass (config parsing, JWT verification, key set caching)
- [x] All existing tests pass unchanged (noop verifier path untouched)
- [x] EdDSA (Ed25519) and RSA key types verified
- [x] OIDC-discovered issuer auto-use confirmed with dedicated tests
- [x] `./gradlew :current:test` — BUILD SUCCESSFUL
- [ ] Manual: build Docker image, verify with `type: noop` (existing behavior)
- [ ] Manual: verify with `type: jwks` + local JWKS file
- [ ] Manual: verify with live OIDC discovery endpoint

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)