### PR TITLE
fix: update server.json for MCP registry publication

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,12 +2,12 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.jpicklyk/task-orchestrator",
   "title": "MCP Task Orchestrator",
-  "description": "Server-enforced workflow discipline for AI agents. Persistent hierarchical work items with dependency graphs, note-gated phase transitions, composable schema traits, and actor attribution. 13 MCP tools that give any MCP-compatible client a structured work breakdown with quality gates enforced at the server level — not in prompts.",
+  "description": "Server-enforced workflow discipline for AI agents: work items, dependency graphs, quality gates",
   "repository": {
     "url": "https://github.com/jpicklyk/task-orchestrator.git",
     "source": "github"
   },
-  "version": "3.1.0",
+  "version": "3.2.0",
   "packages": [
     {
       "registryType": "oci",


### PR DESCRIPTION
## Summary
- Bump `server.json` version from 3.1.0 to 3.2.0 (missed in the v3.2.0 release)
- Trim description to 95 characters to meet the MCP registry's 100-character limit

## Test plan
- [x] Successfully published to registry.modelcontextprotocol.io with these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)