### PR TITLE
feat(verification): align VerificationStatus enum and add JWKS metadata/stale-cache

### DIFF
--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1056,9 +1056,28 @@ Every persisted actor claim includes a verification record:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| status | string | `unverified` (Stage 1), `verified`, or `failed` |
-| verifier | string | Which verifier produced the result (e.g., `noop`) |
-| reason | string | Failure detail or notes (null for unverified/verified) |
+| status | string | One of the five values below |
+| verifier | string | Which verifier produced the result (e.g., `noop`, `jwks`) |
+| reason | string | Failure detail or exception message; null when absent or verified |
+| metadata | object | Optional key/value bag — omitted when empty (see below) |
+
+**VerificationStatus values:**
+
+| Value | Meaning |
+|-------|---------|
+| `absent` | No proof was provided; the caller decides how to treat proof-less actors |
+| `unchecked` | Proof was present but no verifier is configured to evaluate it |
+| `verified` | Proof was cryptographically validated and all claims passed |
+| `rejected` | Proof was present but validation failed (bad signature, expired, wrong claims, policy violation) |
+| `unavailable` | Verification could not complete due to a transient error (network failure, unreachable JWKS endpoint) |
+
+**Metadata fields:**
+
+| Key | Present when | Description |
+|-----|-------------|-------------|
+| `failureKind` | `rejected` or `unavailable` | Category of failure: `crypto` (signature/key), `claims` (exp/iss/aud/sub), `policy` (algorithm allowlist), `network` (JWKS fetch error), `internal` (unexpected exception) |
+| `verifiedFromCache` | `verified` + stale JWKS cache | `"true"` when the verification used a key set served from stale cache |
+| `cacheAgeSeconds` | `verified` + stale JWKS cache | Age of the cached key set in seconds at verification time |
 
 ### Chain Propagation Convention
 
@@ -1127,8 +1146,8 @@ auditing:
 
 | Verifier type | Behavior |
 |---|---|
-| `noop` (or absent) | All actor claims are accepted as `unverified`. No cryptographic check is performed. |
-| `jwks` | JWT tokens in `actor.proof` are validated against the configured JWKS key set. Valid token → `status: verified`. Invalid, expired, or wrong-claims token → `status: failed` with a descriptive `reason`. Missing proof → `status: unverified` (not failed). |
+| `noop` (or absent) | All actor claims are accepted as `unchecked`. No cryptographic check is performed. |
+| `jwks` | JWT tokens in `actor.proof` are validated against the configured JWKS key set. Valid token → `status: verified`. Invalid, expired, or wrong-claims token → `status: rejected` with a descriptive `reason` and `metadata.failureKind`. Missing proof → `status: absent`. Network/fetch errors → `status: unavailable`. |
 
 ### JWKS Key Sources
 
@@ -1143,6 +1162,7 @@ auditing:
 | `audience` | Expected `aud` claim in the JWT. |
 | `algorithms` | List of accepted signing algorithms (e.g., `["EdDSA", "RS256"]`). |
 | `cache_ttl_seconds` | How long to cache fetched JWKS keys (default: 300). |
+| `stale_on_error` | When true (default), a stale cached key set is used if a JWKS refresh fails. The result is `verified` with `metadata.verifiedFromCache="true"` and `metadata.cacheAgeSeconds` set. When false, fetch failures always return `unavailable`. |
 | `require_sub_match` | When true, the JWT `sub` claim must match `actor.id`. |
 
 ### Docker — JWKS Path Mount

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1039,7 +1039,7 @@ dependency edges). Terminal items are never included.
 
 ### Overview
 
-Actor attribution tracks *who* made changes to work items. Every `advance_item` transition and `manage_notes` upsert can include an optional `actor` claim. Stage 1 ships with a no-op verifier — all claims are persisted as `unverified`.
+Actor attribution tracks *who* made changes to work items. Every `advance_item` transition and `manage_notes` upsert can include an optional `actor` claim. Stage 1 ships with a no-op verifier — all claims are persisted as `unchecked`.
 
 ### Actor Claim Shape
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ActorVerifier.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ActorVerifier.kt
@@ -12,10 +12,10 @@ interface ActorVerifier {
 }
 
 /**
- * No-op verifier that marks all claims as unverified without performing any checks.
+ * No-op verifier that marks all claims as unchecked without performing any inspection.
  * Used as the default implementation until real verification is configured.
  */
 object NoOpActorVerifier : ActorVerifier {
     override suspend fun verify(actor: ActorClaim): VerificationResult =
-        VerificationResult(status = VerificationStatus.UNVERIFIED, verifier = "noop")
+        VerificationResult(status = VerificationStatus.UNCHECKED, verifier = "noop")
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/EntityJsonSerializers.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/EntityJsonSerializers.kt
@@ -133,8 +133,11 @@ fun VerificationResult.toJson(): JsonObject =
         verifier?.let { put("verifier", JsonPrimitive(it)) }
         reason?.let { put("reason", JsonPrimitive(it)) }
         if (metadata.isNotEmpty()) {
-            put("metadata", buildJsonObject {
-                metadata.forEach { (k, v) -> put(k, JsonPrimitive(v)) }
-            })
+            put(
+                "metadata",
+                buildJsonObject {
+                    metadata.forEach { (k, v) -> put(k, JsonPrimitive(v)) }
+                }
+            )
         }
     }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/EntityJsonSerializers.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/EntityJsonSerializers.kt
@@ -132,4 +132,9 @@ fun VerificationResult.toJson(): JsonObject =
         put("status", JsonPrimitive(status.toJsonString()))
         verifier?.let { put("verifier", JsonPrimitive(it)) }
         reason?.let { put("reason", JsonPrimitive(it)) }
+        if (metadata.isNotEmpty()) {
+            put("metadata", buildJsonObject {
+                metadata.forEach { (k, v) -> put(k, JsonPrimitive(v)) }
+            })
+        }
     }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/AuditingConfig.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/AuditingConfig.kt
@@ -39,6 +39,8 @@ sealed class VerifierConfig {
      * @param cacheTtlSeconds How long (in seconds) to cache the fetched JWKS (default 300).
      * @param requireSubMatch When true, the JWT `sub` claim must match the actor id supplied by
      *   the caller (default true).
+     * @param staleOnError When true (default), a stale cached key set is served if the JWKS
+     *   endpoint is unreachable during a refresh. When false, the fetch exception propagates.
      */
     data class Jwks(
         val oidcDiscovery: String? = null,
@@ -48,6 +50,7 @@ sealed class VerifierConfig {
         val audience: String? = null,
         val algorithms: List<String> = emptyList(),
         val cacheTtlSeconds: Long = 300,
-        val requireSubMatch: Boolean = true
+        val requireSubMatch: Boolean = true,
+        val staleOnError: Boolean = true
     ) : VerifierConfig()
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/VerificationResult.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/VerificationResult.kt
@@ -2,26 +2,55 @@ package io.github.jpicklyk.mcptask.current.domain.model
 
 /**
  * Result of verifying an actor claim.
+ *
+ * Values:
+ * - [ABSENT] — no proof was supplied by the caller (previously "unverified" in storage).
+ * - [UNCHECKED] — a noop/bypass verifier was active; the claim was accepted without inspection.
+ * - [VERIFIED] — proof was cryptographically valid and all claims passed.
+ * - [REJECTED] — proof was present but failed validation (signature, claims, policy).
+ * - [UNAVAILABLE] — verification could not be completed due to a transient infrastructure error
+ *   (e.g., JWKS endpoint unreachable).
+ *
+ * Legacy string values stored in the database are mapped on read:
+ * - `"unverified"` → [ABSENT]
+ * - `"failed"` → [REJECTED]
  */
 enum class VerificationStatus {
-    UNVERIFIED,
+    ABSENT,
+    UNCHECKED,
     VERIFIED,
-    FAILED;
+    REJECTED,
+    UNAVAILABLE;
 
     fun toJsonString(): String = name.lowercase()
 
     companion object {
-        fun fromString(value: String): VerificationStatus =
-            entries.find { it.name.equals(value, ignoreCase = true) }
-                ?: throw IllegalArgumentException("Unknown VerificationStatus: $value")
+        fun fromString(value: String): VerificationStatus {
+            // Back-compat mapping for legacy stored values.
+            return when (value.lowercase()) {
+                "unverified" -> ABSENT
+                "failed" -> REJECTED
+                else -> entries.find { it.name.equals(value, ignoreCase = true) }
+                    ?: throw IllegalArgumentException("Unknown VerificationStatus: $value")
+            }
+        }
     }
 }
 
 /**
  * Outcome of running an [ActorVerifier] against an [ActorClaim].
+ *
+ * @param status Coarse verification outcome.
+ * @param verifier Name of the verifier that produced this result (e.g. "jwks", "noop").
+ * @param reason Human-readable explanation for non-[VerificationStatus.VERIFIED] outcomes.
+ * @param metadata Structured signal bag for downstream consumers. Common keys:
+ *   - `failureKind`: one of `crypto`, `claims`, `policy`, `network`, `internal`
+ *   - `verifiedFromCache`: `"true"` when the VERIFIED result was produced using a stale JWKS cache
+ *   - `cacheAgeSeconds`: seconds since the stale cache entry was fetched
  */
 data class VerificationResult(
     val status: VerificationStatus,
     val verifier: String? = null,
-    val reason: String? = null
+    val reason: String? = null,
+    val metadata: Map<String, String> = emptyMap()
 )

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/VerificationResult.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/VerificationResult.kt
@@ -30,8 +30,9 @@ enum class VerificationStatus {
             return when (value.lowercase()) {
                 "unverified" -> ABSENT
                 "failed" -> REJECTED
-                else -> entries.find { it.name.equals(value, ignoreCase = true) }
-                    ?: throw IllegalArgumentException("Unknown VerificationStatus: $value")
+                else ->
+                    entries.find { it.name.equals(value, ignoreCase = true) }
+                        ?: throw IllegalArgumentException("Unknown VerificationStatus: $value")
             }
         }
     }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifier.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifier.kt
@@ -12,8 +12,9 @@ import com.nimbusds.jwt.SignedJWT
 import io.github.jpicklyk.mcptask.current.application.service.ActorVerifier
 import io.github.jpicklyk.mcptask.current.domain.model.ActorClaim
 import io.github.jpicklyk.mcptask.current.domain.model.VerificationResult
-import io.github.jpicklyk.mcptask.current.domain.model.VerificationStatus.FAILED
-import io.github.jpicklyk.mcptask.current.domain.model.VerificationStatus.UNVERIFIED
+import io.github.jpicklyk.mcptask.current.domain.model.VerificationStatus.ABSENT
+import io.github.jpicklyk.mcptask.current.domain.model.VerificationStatus.REJECTED
+import io.github.jpicklyk.mcptask.current.domain.model.VerificationStatus.UNAVAILABLE
 import io.github.jpicklyk.mcptask.current.domain.model.VerificationStatus.VERIFIED
 import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
 import org.slf4j.LoggerFactory
@@ -30,8 +31,12 @@ import java.util.Date
  * 4. Verify the JWT signature.
  * 5. Validate standard claims: `exp`, `iss`, `aud`, and optionally `sub` vs. [ActorClaim.id].
  *
- * A missing or blank [ActorClaim.proof] returns [UNVERIFIED] (not [FAILED]) — the caller may
- * choose to treat unverified actors differently from actors whose proof failed validation.
+ * A missing or blank [ActorClaim.proof] returns [ABSENT] — the caller may choose to treat
+ * absent-proof actors differently from actors whose proof failed validation.
+ *
+ * Failure metadata is populated in [VerificationResult.metadata]:
+ * - `failureKind`: one of `crypto`, `claims`, `policy`, `network`, `internal`
+ * - On [VERIFIED] with stale JWKS cache: `verifiedFromCache="true"`, `cacheAgeSeconds="N"`
  */
 class JwksActorVerifier(
     private val config: VerifierConfig.Jwks,
@@ -45,7 +50,7 @@ class JwksActorVerifier(
             verifyInternal(actor)
         } catch (e: Exception) {
             logger.warn("Unexpected exception during actor verification for '{}': {}", actor.id, e.message)
-            VerificationResult(status = FAILED, verifier = VERIFIER_NAME, reason = e.message)
+            rejected(e.message ?: "unexpected error", "internal")
         }
 
     /**
@@ -60,10 +65,10 @@ class JwksActorVerifier(
     // -------------------------------------------------------------------------
 
     private suspend fun verifyInternal(actor: ActorClaim): VerificationResult {
-        // Step 1 — missing proof is not a failure; the caller decides how to handle unverified actors.
+        // Step 1 — missing proof is not a failure; the caller decides how to handle absent actors.
         val proof = actor.proof
         if (proof.isNullOrBlank()) {
-            return VerificationResult(status = UNVERIFIED, verifier = VERIFIER_NAME, reason = "no proof provided")
+            return VerificationResult(status = ABSENT, verifier = VERIFIER_NAME, reason = "no proof provided")
         }
 
         // Step 2 — parse JWT.
@@ -71,17 +76,13 @@ class JwksActorVerifier(
             try {
                 SignedJWT.parse(proof)
             } catch (e: Exception) {
-                return VerificationResult(status = FAILED, verifier = VERIFIER_NAME, reason = "failed to parse JWT: ${e.message}")
+                return rejected("failed to parse JWT: ${e.message}", "crypto")
             }
 
         // Step 3 — algorithm allowlist check.
         val alg = signedJWT.header.algorithm
         if (config.algorithms.isNotEmpty() && alg.name !in config.algorithms) {
-            return VerificationResult(
-                status = FAILED,
-                verifier = VERIFIER_NAME,
-                reason = "algorithm not allowed: ${alg.name}"
-            )
+            return rejected("algorithm not allowed: ${alg.name}", "policy")
         }
 
         // Step 4 — fetch JWKS.
@@ -89,11 +90,7 @@ class JwksActorVerifier(
             try {
                 keySetProvider.getKeySet()
             } catch (e: Exception) {
-                return VerificationResult(
-                    status = FAILED,
-                    verifier = VERIFIER_NAME,
-                    reason = "failed to fetch JWKS: ${e.message}"
-                )
+                return unavailable("failed to fetch JWKS: ${e.message}")
             }
 
         // Step 5 — select the key matching the JWT's kid.
@@ -101,11 +98,7 @@ class JwksActorVerifier(
         val matcher = JWKMatcher.Builder().keyID(kid).build()
         val matchingKeys = JWKSelector(matcher).select(jwkSet)
         if (matchingKeys.isEmpty()) {
-            return VerificationResult(
-                status = FAILED,
-                verifier = VERIFIER_NAME,
-                reason = "no matching key for kid: $kid"
-            )
+            return rejected("no matching key for kid: $kid", "crypto")
         }
 
         // Step 6 — build a JWS verifier from the first matching key and verify the signature.
@@ -116,22 +109,14 @@ class JwksActorVerifier(
                     is RSAKey -> RSASSAVerifier(jwk.toRSAPublicKey())
                     is ECKey -> ECDSAVerifier(jwk.toECPublicKey())
                     is OctetKeyPair -> Ed25519Verifier(jwk)
-                    else -> return VerificationResult(
-                        status = FAILED,
-                        verifier = VERIFIER_NAME,
-                        reason = "unsupported key type: ${jwk.keyType}"
-                    )
+                    else -> return rejected("unsupported key type: ${jwk.keyType}", "crypto")
                 }
             } catch (e: Exception) {
-                return VerificationResult(
-                    status = FAILED,
-                    verifier = VERIFIER_NAME,
-                    reason = "failed to build JWS verifier: ${e.message}"
-                )
+                return rejected("failed to build JWS verifier: ${e.message}", "crypto")
             }
 
         if (!signedJWT.verify(jwsVerifier)) {
-            return VerificationResult(status = FAILED, verifier = VERIFIER_NAME, reason = "signature verification failed")
+            return rejected("signature verification failed", "crypto")
         }
 
         // Step 7 — validate standard claims.
@@ -142,7 +127,7 @@ class JwksActorVerifier(
         if (expiry != null) {
             val skewAdjusted = Date.from(clock.instant().minusSeconds(CLOCK_SKEW_SECONDS))
             if (expiry.before(skewAdjusted)) {
-                return VerificationResult(status = FAILED, verifier = VERIFIER_NAME, reason = "token expired")
+                return rejected("token expired", "claims")
             }
         }
 
@@ -151,29 +136,21 @@ class JwksActorVerifier(
         if (notBefore != null) {
             val skewAdjusted = Date.from(clock.instant().plusSeconds(CLOCK_SKEW_SECONDS))
             if (notBefore.after(skewAdjusted)) {
-                return VerificationResult(status = FAILED, verifier = VERIFIER_NAME, reason = "token not yet valid")
+                return rejected("token not yet valid", "claims")
             }
         }
 
         // iss — explicit config overrides OIDC-discovered issuer
         val effectiveIssuer = config.issuer ?: keySetProvider.getResolvedIssuer()
         if (effectiveIssuer != null && claims.issuer != effectiveIssuer) {
-            return VerificationResult(
-                status = FAILED,
-                verifier = VERIFIER_NAME,
-                reason = "issuer mismatch: expected=$effectiveIssuer, got=${claims.issuer}"
-            )
+            return rejected("issuer mismatch: expected=$effectiveIssuer, got=${claims.issuer}", "claims")
         }
 
         // aud
         if (config.audience != null) {
             val aud = claims.audience
             if (aud == null || !aud.contains(config.audience)) {
-                return VerificationResult(
-                    status = FAILED,
-                    verifier = VERIFIER_NAME,
-                    reason = "audience mismatch: expected=${config.audience}, got=$aud"
-                )
+                return rejected("audience mismatch: expected=${config.audience}, got=$aud", "claims")
             }
         }
 
@@ -181,16 +158,42 @@ class JwksActorVerifier(
         if (config.requireSubMatch) {
             val sub = claims.subject
             if (sub != actor.id) {
-                return VerificationResult(
-                    status = FAILED,
-                    verifier = VERIFIER_NAME,
-                    reason = "sub mismatch: expected=${actor.id}, got=$sub"
-                )
+                return rejected("sub mismatch: expected=${actor.id}, got=$sub", "claims")
             }
         }
 
-        return VerificationResult(status = VERIFIED, verifier = VERIFIER_NAME)
+        // Success — inspect cache state for stale-cache metadata.
+        val cacheState = keySetProvider.getCacheState()
+        val successMetadata: Map<String, String> =
+            if (cacheState.fromStaleCache) {
+                buildMap {
+                    put("verifiedFromCache", "true")
+                    cacheState.ageSeconds?.let { put("cacheAgeSeconds", it.toString()) }
+                }
+            } else {
+                emptyMap()
+            }
+
+        return VerificationResult(
+            status = VERIFIED,
+            verifier = VERIFIER_NAME,
+            metadata = successMetadata
+        )
     }
+
+    private fun rejected(reason: String, failureKind: String) = VerificationResult(
+        status = REJECTED,
+        verifier = VERIFIER_NAME,
+        reason = reason,
+        metadata = mapOf("failureKind" to failureKind)
+    )
+
+    private fun unavailable(reason: String) = VerificationResult(
+        status = UNAVAILABLE,
+        verifier = VERIFIER_NAME,
+        reason = reason,
+        metadata = mapOf("failureKind" to "network")
+    )
 
     companion object {
         private const val VERIFIER_NAME = "jwks"

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifier.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifier.kt
@@ -181,19 +181,23 @@ class JwksActorVerifier(
         )
     }
 
-    private fun rejected(reason: String, failureKind: String) = VerificationResult(
+    private fun rejected(
+        reason: String,
+        failureKind: String
+    ) = VerificationResult(
         status = REJECTED,
         verifier = VERIFIER_NAME,
         reason = reason,
         metadata = mapOf("failureKind" to failureKind)
     )
 
-    private fun unavailable(reason: String) = VerificationResult(
-        status = UNAVAILABLE,
-        verifier = VERIFIER_NAME,
-        reason = reason,
-        metadata = mapOf("failureKind" to "network")
-    )
+    private fun unavailable(reason: String) =
+        VerificationResult(
+            status = UNAVAILABLE,
+            verifier = VERIFIER_NAME,
+            reason = reason,
+            metadata = mapOf("failureKind" to "network")
+        )
 
     companion object {
         private const val VERIFIER_NAME = "jwks"

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksKeySetProvider.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksKeySetProvider.kt
@@ -17,6 +17,19 @@ import java.time.Clock
 import java.time.Instant
 
 /**
+ * Snapshot of the cache state at the time the last key set was served.
+ *
+ * @param fromStaleCache True if the last [JwksKeySetProvider.getKeySet] call returned a
+ *   key set from an expired cache entry (i.e., the refresh failed and stale fallback was used).
+ * @param ageSeconds Age in seconds of the cached entry at the time it was served, or null if
+ *   the key set was freshly fetched or no fetch has occurred yet.
+ */
+data class CacheState(
+    val fromStaleCache: Boolean,
+    val ageSeconds: Long?
+)
+
+/**
  * Provides a [JWKSet] for JWT signature verification.
  *
  * Implementations are responsible for loading keys from a configured source (remote URI,
@@ -35,6 +48,12 @@ interface JwksKeySetProvider {
      * verifier level — this method only returns what was discovered.
      */
     fun getResolvedIssuer(): String?
+
+    /**
+     * Returns the [CacheState] reflecting whether the most recent [getKeySet] call was served
+     * from a stale cache entry and, if so, how old that entry was.
+     */
+    fun getCacheState(): CacheState
 
     /**
      * Releases any underlying resources (e.g., HTTP client connections).
@@ -73,33 +92,65 @@ class DefaultJwksKeySetProvider(
     @Volatile
     private var resolvedIssuer: String? = null
 
+    /** Cache state reflecting the most recent [getKeySet] outcome. */
+    @Volatile
+    private var lastCacheState: CacheState = FRESH_CACHE
+
     /** Thread-safe lazy HTTP client — created only when a remote fetch is needed. */
     private val httpClientDelegate = lazy { HttpClient(CIO) }
     private val httpClient: HttpClient by httpClientDelegate
 
     override suspend fun getKeySet(): JWKSet {
+        val now = clock.instant()
+
         // Fast path: return cached value if still valid.
         cached?.let { (set, fetchedAt) ->
-            if (clock.instant().isBefore(fetchedAt.plusSeconds(config.cacheTtlSeconds))) {
+            if (now.isBefore(fetchedAt.plusSeconds(config.cacheTtlSeconds))) {
+                lastCacheState = FRESH_CACHE
                 return set
             }
         }
 
         return refreshLock.withLock {
+            val nowInLock = clock.instant()
+
             // Double-check after acquiring the lock.
             cached?.let { (set, fetchedAt) ->
-                if (clock.instant().isBefore(fetchedAt.plusSeconds(config.cacheTtlSeconds))) {
+                if (nowInLock.isBefore(fetchedAt.plusSeconds(config.cacheTtlSeconds))) {
+                    lastCacheState = FRESH_CACHE
                     return@withLock set
                 }
             }
 
-            val fresh = fetchKeySet()
-            cached = Pair(fresh, clock.instant())
-            fresh
+            // Capture the previous cache entry before attempting refresh.
+            val previousCached = cached
+
+            try {
+                val fresh = fetchKeySet()
+                cached = Pair(fresh, nowInLock)
+                lastCacheState = FRESH_CACHE
+                fresh
+            } catch (e: Exception) {
+                if (config.staleOnError && previousCached != null) {
+                    val (staleSet, fetchedAt) = previousCached
+                    val ageSeconds = nowInLock.epochSecond - fetchedAt.epochSecond
+                    logger.warn(
+                        "JWKS refresh failed ({}); serving stale cache entry (age={}s). staleOnError=true",
+                        e.message,
+                        ageSeconds
+                    )
+                    lastCacheState = CacheState(fromStaleCache = true, ageSeconds = ageSeconds)
+                    staleSet
+                } else {
+                    throw e
+                }
+            }
         }
     }
 
     override fun getResolvedIssuer(): String? = resolvedIssuer
+
+    override fun getCacheState(): CacheState = lastCacheState
 
     override fun close() {
         if (httpClientDelegate.isInitialized()) {
@@ -178,4 +229,8 @@ class DefaultJwksKeySetProvider(
     }
 
     private suspend fun httpGet(url: String): String = httpClient.get(url).bodyAsText()
+
+    companion object {
+        private val FRESH_CACHE = CacheState(fromStaleCache = false, ageSeconds = null)
+    }
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlAuditingConfigService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlAuditingConfigService.kt
@@ -143,6 +143,8 @@ class YamlAuditingConfigService(
 
                 val requireSubMatch = (verifierMap["require_sub_match"] as? Boolean) ?: true
 
+                val staleOnError = (verifierMap["stale_on_error"] as? Boolean) ?: true
+
                 VerifierConfig.Jwks(
                     oidcDiscovery = oidcDiscovery,
                     jwksUri = jwksUri,
@@ -151,7 +153,8 @@ class YamlAuditingConfigService(
                     audience = audience,
                     algorithms = algorithms,
                     cacheTtlSeconds = cacheTtlSeconds,
-                    requireSubMatch = requireSubMatch
+                    requireSubMatch = requireSubMatch,
+                    staleOnError = staleOnError
                 )
             }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/ActorVerifierTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/ActorVerifierTest.kt
@@ -10,11 +10,11 @@ import kotlin.test.assertNull
 
 class ActorVerifierTest {
     @Test
-    fun `NoOpActorVerifier returns UNVERIFIED`() =
+    fun `NoOpActorVerifier returns UNCHECKED`() =
         runTest {
             val claim = ActorClaim(id = "agent-1", kind = ActorKind.SUBAGENT)
             val result = NoOpActorVerifier.verify(claim)
-            assertEquals(VerificationStatus.UNVERIFIED, result.status)
+            assertEquals(VerificationStatus.UNCHECKED, result.status)
             assertEquals("noop", result.verifier)
             assertNull(result.reason)
         }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandlerTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandlerTest.kt
@@ -668,7 +668,7 @@ class RoleTransitionHandlerTest {
             runBlocking {
                 val item = testItem(role = Role.QUEUE)
                 val actorClaim = ActorClaim(id = "orchestrator-1", kind = ActorKind.ORCHESTRATOR, parent = null)
-                val verification = VerificationResult(status = VerificationStatus.UNVERIFIED, verifier = "noop")
+                val verification = VerificationResult(status = VerificationStatus.UNCHECKED, verifier = "noop")
 
                 val transitionSlot = slot<RoleTransition>()
                 coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
@@ -693,7 +693,7 @@ class RoleTransitionHandlerTest {
                 assertEquals("orchestrator-1", captured.actorClaim!!.id)
                 assertEquals(ActorKind.ORCHESTRATOR, captured.actorClaim!!.kind)
                 assertNotNull(captured.verification)
-                assertEquals(VerificationStatus.UNVERIFIED, captured.verification!!.status)
+                assertEquals(VerificationStatus.UNCHECKED, captured.verification!!.status)
                 assertEquals("noop", captured.verification!!.verifier)
             }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/QueryNotesToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/QueryNotesToolTest.kt
@@ -358,10 +358,10 @@ class QueryNotesToolTest {
             assertEquals("orch-1", actor["parent"]!!.jsonPrimitive.content)
             assertFalse(actor.containsKey("proof"), "proof should be absent when not provided")
 
-            // Verification should be present (NoOpActorVerifier marks as unverified)
+            // Verification should be present (NoOpActorVerifier marks as unchecked)
             assertTrue(data.containsKey("verification"), "verification field should be present")
             val verification = data["verification"]!!.jsonObject
-            assertEquals("unverified", verification["status"]!!.jsonPrimitive.content)
+            assertEquals("unchecked", verification["status"]!!.jsonPrimitive.content)
             assertEquals("noop", verification["verifier"]!!.jsonPrimitive.content)
         }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
@@ -2142,9 +2142,9 @@ class AdvanceItemToolTest {
             assertEquals("session-abc", actor["parent"]!!.jsonPrimitive.content)
             assertFalse(actor.containsKey("proof"), "proof should be absent when not provided")
 
-            // Verification should be present (NoOpActorVerifier returns UNVERIFIED)
+            // Verification should be present (NoOpActorVerifier returns UNCHECKED)
             val verification = r["verification"]!!.jsonObject
-            assertEquals("unverified", verification["status"]!!.jsonPrimitive.content)
+            assertEquals("unchecked", verification["status"]!!.jsonPrimitive.content)
             assertEquals("noop", verification["verifier"]!!.jsonPrimitive.content)
         }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolTest.kt
@@ -1818,7 +1818,7 @@ class GetContextToolTest {
             val itemId = UUID.randomUUID()
 
             val actor = ActorClaim(id = "orch-1", kind = ActorKind.ORCHESTRATOR, parent = null)
-            val verification = VerificationResult(status = VerificationStatus.UNVERIFIED, verifier = "noop")
+            val verification = VerificationResult(status = VerificationStatus.UNCHECKED, verifier = "noop")
             val transition =
                 RoleTransition(
                     itemId = itemId,
@@ -1861,7 +1861,7 @@ class GetContextToolTest {
             // Verification should be present
             assertTrue(t.containsKey("verification"), "verification field should be present")
             val verObj = t["verification"]!!.jsonObject
-            assertEquals("unverified", verObj["status"]!!.jsonPrimitive.content)
+            assertEquals("unchecked", verObj["status"]!!.jsonPrimitive.content)
             assertEquals("noop", verObj["verifier"]!!.jsonPrimitive.content)
         }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ActorClaimTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ActorClaimTest.kt
@@ -196,10 +196,11 @@ class ActorClaimTest {
 
     @Test
     fun `VerificationResult metadata populated`() {
-        val result = VerificationResult(
-            status = VerificationStatus.REJECTED,
-            metadata = mapOf("failureKind" to "crypto")
-        )
+        val result =
+            VerificationResult(
+                status = VerificationStatus.REJECTED,
+                metadata = mapOf("failureKind" to "crypto")
+            )
         assertEquals("crypto", result.metadata["failureKind"])
     }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ActorClaimTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ActorClaimTest.kt
@@ -123,17 +123,30 @@ class ActorClaimTest {
     // --- VerificationStatus ---
 
     @Test
-    fun `VerificationStatus fromString round-trip all values`() {
-        assertEquals(VerificationStatus.UNVERIFIED, VerificationStatus.fromString("UNVERIFIED"))
+    fun `VerificationStatus fromString round-trip all new values`() {
+        assertEquals(VerificationStatus.ABSENT, VerificationStatus.fromString("ABSENT"))
+        assertEquals(VerificationStatus.UNCHECKED, VerificationStatus.fromString("UNCHECKED"))
         assertEquals(VerificationStatus.VERIFIED, VerificationStatus.fromString("VERIFIED"))
-        assertEquals(VerificationStatus.FAILED, VerificationStatus.fromString("FAILED"))
+        assertEquals(VerificationStatus.REJECTED, VerificationStatus.fromString("REJECTED"))
+        assertEquals(VerificationStatus.UNAVAILABLE, VerificationStatus.fromString("UNAVAILABLE"))
     }
 
     @Test
-    fun `VerificationStatus fromString case insensitive`() {
-        assertEquals(VerificationStatus.UNVERIFIED, VerificationStatus.fromString("unverified"))
+    fun `VerificationStatus fromString legacy back-compat mapping`() {
+        // Legacy stored values must map to conservative new values.
+        assertEquals(VerificationStatus.ABSENT, VerificationStatus.fromString("unverified"))
+        assertEquals(VerificationStatus.ABSENT, VerificationStatus.fromString("UNVERIFIED"))
+        assertEquals(VerificationStatus.REJECTED, VerificationStatus.fromString("failed"))
+        assertEquals(VerificationStatus.REJECTED, VerificationStatus.fromString("FAILED"))
+    }
+
+    @Test
+    fun `VerificationStatus fromString case insensitive for new values`() {
+        assertEquals(VerificationStatus.ABSENT, VerificationStatus.fromString("absent"))
+        assertEquals(VerificationStatus.UNCHECKED, VerificationStatus.fromString("unchecked"))
         assertEquals(VerificationStatus.VERIFIED, VerificationStatus.fromString("verified"))
-        assertEquals(VerificationStatus.FAILED, VerificationStatus.fromString("failed"))
+        assertEquals(VerificationStatus.REJECTED, VerificationStatus.fromString("rejected"))
+        assertEquals(VerificationStatus.UNAVAILABLE, VerificationStatus.fromString("unavailable"))
     }
 
     @Test
@@ -145,9 +158,11 @@ class ActorClaimTest {
 
     @Test
     fun `VerificationStatus toJsonString returns lowercase name`() {
-        assertEquals("unverified", VerificationStatus.UNVERIFIED.toJsonString())
+        assertEquals("absent", VerificationStatus.ABSENT.toJsonString())
+        assertEquals("unchecked", VerificationStatus.UNCHECKED.toJsonString())
         assertEquals("verified", VerificationStatus.VERIFIED.toJsonString())
-        assertEquals("failed", VerificationStatus.FAILED.toJsonString())
+        assertEquals("rejected", VerificationStatus.REJECTED.toJsonString())
+        assertEquals("unavailable", VerificationStatus.UNAVAILABLE.toJsonString())
     }
 
     // --- VerificationResult ---
@@ -167,9 +182,24 @@ class ActorClaimTest {
 
     @Test
     fun `VerificationResult valid creation with minimal fields`() {
-        val result = VerificationResult(status = VerificationStatus.UNVERIFIED)
-        assertEquals(VerificationStatus.UNVERIFIED, result.status)
+        val result = VerificationResult(status = VerificationStatus.ABSENT)
+        assertEquals(VerificationStatus.ABSENT, result.status)
         assertNull(result.verifier)
         assertNull(result.reason)
+    }
+
+    @Test
+    fun `VerificationResult metadata defaults to empty map`() {
+        val result = VerificationResult(status = VerificationStatus.VERIFIED)
+        assertEquals(emptyMap<String, String>(), result.metadata)
+    }
+
+    @Test
+    fun `VerificationResult metadata populated`() {
+        val result = VerificationResult(
+            status = VerificationStatus.REJECTED,
+            metadata = mapOf("failureKind" to "crypto")
+        )
+        assertEquals("crypto", result.metadata["failureKind"])
     }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/NoteTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/NoteTest.kt
@@ -132,7 +132,7 @@ class NoteTest {
             )
         val verification =
             VerificationResult(
-                status = VerificationStatus.UNVERIFIED,
+                status = VerificationStatus.UNCHECKED,
                 verifier = "noop"
             )
         val note =
@@ -147,6 +147,6 @@ class NoteTest {
         assertEquals(verification, note.verification)
         assertEquals("agent-1", note.actorClaim!!.id)
         assertEquals(ActorKind.SUBAGENT, note.actorClaim!!.kind)
-        assertEquals(VerificationStatus.UNVERIFIED, note.verification!!.status)
+        assertEquals(VerificationStatus.UNCHECKED, note.verification!!.status)
     }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/RoleTransitionTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/RoleTransitionTest.kt
@@ -160,7 +160,7 @@ class RoleTransitionTest {
             )
         val verification =
             VerificationResult(
-                status = VerificationStatus.UNVERIFIED,
+                status = VerificationStatus.UNCHECKED,
                 verifier = "noop"
             )
         val transition =
@@ -176,6 +176,6 @@ class RoleTransitionTest {
         assertEquals(verification, transition.verification)
         assertEquals("agent-42", transition.actorClaim!!.id)
         assertEquals(ActorKind.SUBAGENT, transition.actorClaim!!.kind)
-        assertEquals(VerificationStatus.UNVERIFIED, transition.verification!!.status)
+        assertEquals(VerificationStatus.UNCHECKED, transition.verification!!.status)
     }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/VerificationResultTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/VerificationResultTest.kt
@@ -7,11 +7,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class VerificationResultTest {
-
     // -------------------------------------------------------------------------
     // fromString — new values round-trip
     // -------------------------------------------------------------------------
@@ -94,10 +92,11 @@ class VerificationResultTest {
 
     @Test
     fun `metadata can be populated`() {
-        val result = VerificationResult(
-            status = VerificationStatus.REJECTED,
-            metadata = mapOf("failureKind" to "crypto")
-        )
+        val result =
+            VerificationResult(
+                status = VerificationStatus.REJECTED,
+                metadata = mapOf("failureKind" to "crypto")
+            )
         assertEquals("crypto", result.metadata["failureKind"])
     }
 
@@ -107,10 +106,11 @@ class VerificationResultTest {
 
     @Test
     fun `toJson omits metadata field when empty`() {
-        val result = VerificationResult(
-            status = VerificationStatus.VERIFIED,
-            verifier = "jwks"
-        )
+        val result =
+            VerificationResult(
+                status = VerificationStatus.VERIFIED,
+                verifier = "jwks"
+            )
         val json = result.toJson()
         assertFalse(json.containsKey("metadata"), "metadata key should be absent when map is empty")
         assertEquals("verified", json["status"]?.jsonPrimitive?.content)
@@ -119,12 +119,13 @@ class VerificationResultTest {
 
     @Test
     fun `toJson includes metadata field when non-empty`() {
-        val result = VerificationResult(
-            status = VerificationStatus.REJECTED,
-            verifier = "jwks",
-            reason = "token expired",
-            metadata = mapOf("failureKind" to "claims")
-        )
+        val result =
+            VerificationResult(
+                status = VerificationStatus.REJECTED,
+                verifier = "jwks",
+                reason = "token expired",
+                metadata = mapOf("failureKind" to "claims")
+            )
         val json = result.toJson()
         assertTrue(json.containsKey("metadata"), "metadata key should be present")
         val meta = json["metadata"]?.jsonObject
@@ -133,14 +134,16 @@ class VerificationResultTest {
 
     @Test
     fun `toJson includes multiple metadata entries`() {
-        val result = VerificationResult(
-            status = VerificationStatus.VERIFIED,
-            verifier = "jwks",
-            metadata = mapOf(
-                "verifiedFromCache" to "true",
-                "cacheAgeSeconds" to "450"
+        val result =
+            VerificationResult(
+                status = VerificationStatus.VERIFIED,
+                verifier = "jwks",
+                metadata =
+                    mapOf(
+                        "verifiedFromCache" to "true",
+                        "cacheAgeSeconds" to "450"
+                    )
             )
-        )
         val json = result.toJson()
         val meta = json["metadata"]?.jsonObject
         assertEquals("true", meta?.get("verifiedFromCache")?.jsonPrimitive?.content)
@@ -149,10 +152,11 @@ class VerificationResultTest {
 
     @Test
     fun `toJson reason field only emitted when non-null`() {
-        val withReason = VerificationResult(
-            status = VerificationStatus.REJECTED,
-            reason = "some reason"
-        )
+        val withReason =
+            VerificationResult(
+                status = VerificationStatus.REJECTED,
+                reason = "some reason"
+            )
         val withoutReason = VerificationResult(status = VerificationStatus.VERIFIED)
         assertTrue(withReason.toJson().containsKey("reason"))
         assertFalse(withoutReason.toJson().containsKey("reason"))
@@ -163,8 +167,11 @@ class VerificationResultTest {
         VerificationStatus.entries.forEach { status ->
             val result = VerificationResult(status = status)
             val json = result.toJson()
-            assertEquals(status.toJsonString(), json["status"]?.jsonPrimitive?.content,
-                "status JSON value should match toJsonString() for $status")
+            assertEquals(
+                status.toJsonString(),
+                json["status"]?.jsonPrimitive?.content,
+                "status JSON value should match toJsonString() for $status"
+            )
         }
     }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/VerificationResultTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/VerificationResultTest.kt
@@ -1,0 +1,170 @@
+package io.github.jpicklyk.mcptask.current.domain.model
+
+import io.github.jpicklyk.mcptask.current.application.tools.toJson
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class VerificationResultTest {
+
+    // -------------------------------------------------------------------------
+    // fromString — new values round-trip
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `fromString round-trips ABSENT`() {
+        assertEquals(VerificationStatus.ABSENT, VerificationStatus.fromString("ABSENT"))
+        assertEquals(VerificationStatus.ABSENT, VerificationStatus.fromString("absent"))
+    }
+
+    @Test
+    fun `fromString round-trips UNCHECKED`() {
+        assertEquals(VerificationStatus.UNCHECKED, VerificationStatus.fromString("UNCHECKED"))
+        assertEquals(VerificationStatus.UNCHECKED, VerificationStatus.fromString("unchecked"))
+    }
+
+    @Test
+    fun `fromString round-trips VERIFIED`() {
+        assertEquals(VerificationStatus.VERIFIED, VerificationStatus.fromString("VERIFIED"))
+        assertEquals(VerificationStatus.VERIFIED, VerificationStatus.fromString("verified"))
+    }
+
+    @Test
+    fun `fromString round-trips REJECTED`() {
+        assertEquals(VerificationStatus.REJECTED, VerificationStatus.fromString("REJECTED"))
+        assertEquals(VerificationStatus.REJECTED, VerificationStatus.fromString("rejected"))
+    }
+
+    @Test
+    fun `fromString round-trips UNAVAILABLE`() {
+        assertEquals(VerificationStatus.UNAVAILABLE, VerificationStatus.fromString("UNAVAILABLE"))
+        assertEquals(VerificationStatus.UNAVAILABLE, VerificationStatus.fromString("unavailable"))
+    }
+
+    // -------------------------------------------------------------------------
+    // fromString — legacy back-compat mapping
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `fromString maps legacy unverified to ABSENT`() {
+        assertEquals(VerificationStatus.ABSENT, VerificationStatus.fromString("unverified"))
+        assertEquals(VerificationStatus.ABSENT, VerificationStatus.fromString("UNVERIFIED"))
+    }
+
+    @Test
+    fun `fromString maps legacy failed to REJECTED`() {
+        assertEquals(VerificationStatus.REJECTED, VerificationStatus.fromString("failed"))
+        assertEquals(VerificationStatus.REJECTED, VerificationStatus.fromString("FAILED"))
+    }
+
+    @Test
+    fun `fromString throws on unknown value`() {
+        assertFailsWith<IllegalArgumentException> {
+            VerificationStatus.fromString("TOTALLY_UNKNOWN")
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // toJsonString
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `toJsonString returns lowercase for all values`() {
+        assertEquals("absent", VerificationStatus.ABSENT.toJsonString())
+        assertEquals("unchecked", VerificationStatus.UNCHECKED.toJsonString())
+        assertEquals("verified", VerificationStatus.VERIFIED.toJsonString())
+        assertEquals("rejected", VerificationStatus.REJECTED.toJsonString())
+        assertEquals("unavailable", VerificationStatus.UNAVAILABLE.toJsonString())
+    }
+
+    // -------------------------------------------------------------------------
+    // VerificationResult data class
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `metadata defaults to empty map`() {
+        val result = VerificationResult(status = VerificationStatus.VERIFIED)
+        assertEquals(emptyMap<String, String>(), result.metadata)
+    }
+
+    @Test
+    fun `metadata can be populated`() {
+        val result = VerificationResult(
+            status = VerificationStatus.REJECTED,
+            metadata = mapOf("failureKind" to "crypto")
+        )
+        assertEquals("crypto", result.metadata["failureKind"])
+    }
+
+    // -------------------------------------------------------------------------
+    // toJson — metadata field only emitted when non-empty
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `toJson omits metadata field when empty`() {
+        val result = VerificationResult(
+            status = VerificationStatus.VERIFIED,
+            verifier = "jwks"
+        )
+        val json = result.toJson()
+        assertFalse(json.containsKey("metadata"), "metadata key should be absent when map is empty")
+        assertEquals("verified", json["status"]?.jsonPrimitive?.content)
+        assertEquals("jwks", json["verifier"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `toJson includes metadata field when non-empty`() {
+        val result = VerificationResult(
+            status = VerificationStatus.REJECTED,
+            verifier = "jwks",
+            reason = "token expired",
+            metadata = mapOf("failureKind" to "claims")
+        )
+        val json = result.toJson()
+        assertTrue(json.containsKey("metadata"), "metadata key should be present")
+        val meta = json["metadata"]?.jsonObject
+        assertEquals("claims", meta?.get("failureKind")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `toJson includes multiple metadata entries`() {
+        val result = VerificationResult(
+            status = VerificationStatus.VERIFIED,
+            verifier = "jwks",
+            metadata = mapOf(
+                "verifiedFromCache" to "true",
+                "cacheAgeSeconds" to "450"
+            )
+        )
+        val json = result.toJson()
+        val meta = json["metadata"]?.jsonObject
+        assertEquals("true", meta?.get("verifiedFromCache")?.jsonPrimitive?.content)
+        assertEquals("450", meta?.get("cacheAgeSeconds")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `toJson reason field only emitted when non-null`() {
+        val withReason = VerificationResult(
+            status = VerificationStatus.REJECTED,
+            reason = "some reason"
+        )
+        val withoutReason = VerificationResult(status = VerificationStatus.VERIFIED)
+        assertTrue(withReason.toJson().containsKey("reason"))
+        assertFalse(withoutReason.toJson().containsKey("reason"))
+    }
+
+    @Test
+    fun `toJson status uses lowercase toJsonString`() {
+        VerificationStatus.entries.forEach { status ->
+            val result = VerificationResult(status = status)
+            val json = result.toJson()
+            assertEquals(status.toJsonString(), json["status"]?.jsonPrimitive?.content,
+                "status JSON value should match toJsonString() for $status")
+        }
+    }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifierTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksActorVerifierTest.kt
@@ -129,29 +129,44 @@ class JwksActorVerifierTest {
         proof: String? = null
     ) = ActorClaim(id = id, kind = ActorKind.SUBAGENT, proof = proof)
 
+    /** Fresh (non-stale) cache state. */
+    private val freshCacheState = CacheState(fromStaleCache = false, ageSeconds = null)
+
     /** Mock provider that returns the RSA public key. */
-    private fun rsaMockProvider(resolvedIssuer: String? = null): JwksKeySetProvider {
+    private fun rsaMockProvider(
+        resolvedIssuer: String? = null,
+        cacheState: CacheState = freshCacheState
+    ): JwksKeySetProvider {
         val provider = mockk<JwksKeySetProvider>()
         coEvery { provider.getKeySet() } returns JWKSet(listOf(rsaKey.toPublicJWK()))
         every { provider.getResolvedIssuer() } returns resolvedIssuer
+        every { provider.getCacheState() } returns cacheState
         every { provider.close() } just Runs
         return provider
     }
 
     /** Mock provider that returns the EdDSA public key. */
-    private fun edMockProvider(resolvedIssuer: String? = null): JwksKeySetProvider {
+    private fun edMockProvider(
+        resolvedIssuer: String? = null,
+        cacheState: CacheState = freshCacheState
+    ): JwksKeySetProvider {
         val provider = mockk<JwksKeySetProvider>()
         coEvery { provider.getKeySet() } returns JWKSet(listOf(edKey.toPublicJWK()))
         every { provider.getResolvedIssuer() } returns resolvedIssuer
+        every { provider.getCacheState() } returns cacheState
         every { provider.close() } just Runs
         return provider
     }
 
     /** Mock provider that returns the EC public key. */
-    private fun ecMockProvider(resolvedIssuer: String? = null): JwksKeySetProvider {
+    private fun ecMockProvider(
+        resolvedIssuer: String? = null,
+        cacheState: CacheState = freshCacheState
+    ): JwksKeySetProvider {
         val provider = mockk<JwksKeySetProvider>()
         coEvery { provider.getKeySet() } returns JWKSet(listOf(ecKey.toPublicJWK()))
         every { provider.getResolvedIssuer() } returns resolvedIssuer
+        every { provider.getCacheState() } returns cacheState
         every { provider.close() } just Runs
         return provider
     }
@@ -179,31 +194,32 @@ class JwksActorVerifierTest {
     // Tests
     // =========================================================================
 
-    // 1. null proof → UNVERIFIED
+    // 1. null proof → ABSENT
     @Test
-    fun `null proof returns UNVERIFIED`() =
+    fun `null proof returns ABSENT`() =
         runTest {
             val result = verifier().verify(actor(proof = null))
-            assertEquals(VerificationStatus.UNVERIFIED, result.status)
+            assertEquals(VerificationStatus.ABSENT, result.status)
             assertEquals("jwks", result.verifier)
         }
 
-    // 2. blank proof → UNVERIFIED
+    // 2. blank proof → ABSENT
     @Test
-    fun `blank proof returns UNVERIFIED`() =
+    fun `blank proof returns ABSENT`() =
         runTest {
             val result = verifier().verify(actor(proof = ""))
-            assertEquals(VerificationStatus.UNVERIFIED, result.status)
+            assertEquals(VerificationStatus.ABSENT, result.status)
             assertEquals("jwks", result.verifier)
         }
 
-    // 3. invalid JWT string → FAILED
+    // 3. invalid JWT string → REJECTED with failureKind=crypto
     @Test
-    fun `invalid JWT string returns FAILED`() =
+    fun `invalid JWT string returns REJECTED`() =
         runTest {
             val result = verifier().verify(actor(proof = "not-a-jwt"))
-            assertEquals(VerificationStatus.FAILED, result.status)
+            assertEquals(VerificationStatus.REJECTED, result.status)
             assertNotNull(result.reason)
+            assertEquals("crypto", result.metadata["failureKind"])
         }
 
     // 4. valid RSA JWT → VERIFIED
@@ -225,49 +241,53 @@ class JwksActorVerifierTest {
             assertEquals("jwks", result.verifier)
         }
 
-    // 6. expired JWT → FAILED
+    // 6. expired JWT → REJECTED with failureKind=claims
     @Test
-    fun `expired JWT returns FAILED`() =
+    fun `expired JWT returns REJECTED`() =
         runTest {
             val expiredClaims = buildClaims(expiry = Instant.now().minusSeconds(600))
             val result = verifier().verify(actor(proof = signRsa(expiredClaims)))
-            assertEquals(VerificationStatus.FAILED, result.status)
+            assertEquals(VerificationStatus.REJECTED, result.status)
             assertTrue(result.reason?.contains("expired") == true, "reason should mention 'expired': ${result.reason}")
+            assertEquals("claims", result.metadata["failureKind"])
         }
 
-    // 7. wrong issuer → FAILED
+    // 7. wrong issuer → REJECTED with failureKind=claims
     @Test
-    fun `wrong issuer returns FAILED`() =
+    fun `wrong issuer returns REJECTED`() =
         runTest {
             val claims = buildClaims(issuer = "https://other-issuer.example")
             val result = verifier().verify(actor(proof = signRsa(claims)))
-            assertEquals(VerificationStatus.FAILED, result.status)
+            assertEquals(VerificationStatus.REJECTED, result.status)
             assertTrue(result.reason?.contains("issuer") == true, "reason should mention 'issuer': ${result.reason}")
+            assertEquals("claims", result.metadata["failureKind"])
         }
 
-    // 8. wrong audience → FAILED
+    // 8. wrong audience → REJECTED with failureKind=claims
     @Test
-    fun `wrong audience returns FAILED`() =
+    fun `wrong audience returns REJECTED`() =
         runTest {
             val claims = buildClaims(audience = "wrong-audience")
             val result = verifier().verify(actor(proof = signRsa(claims)))
-            assertEquals(VerificationStatus.FAILED, result.status)
+            assertEquals(VerificationStatus.REJECTED, result.status)
             assertTrue(result.reason?.contains("audience") == true, "reason should mention 'audience': ${result.reason}")
+            assertEquals("claims", result.metadata["failureKind"])
         }
 
-    // 9. algorithm not in allowlist → FAILED
+    // 9. algorithm not in allowlist → REJECTED with failureKind=policy
     @Test
-    fun `algorithm not in allowlist returns FAILED`() =
+    fun `algorithm not in allowlist returns REJECTED`() =
         runTest {
             val config = baseConfig(algorithms = listOf("EdDSA"))
             val result = verifier(config = config, provider = rsaMockProvider()).verify(actor(proof = signRsa()))
-            assertEquals(VerificationStatus.FAILED, result.status)
+            assertEquals(VerificationStatus.REJECTED, result.status)
             assertTrue(result.reason?.contains("algorithm not allowed") == true, "reason: ${result.reason}")
+            assertEquals("policy", result.metadata["failureKind"])
         }
 
-    // 10. sub mismatch + requireSubMatch=true → FAILED
+    // 10. sub mismatch + requireSubMatch=true → REJECTED with failureKind=claims
     @Test
-    fun `sub mismatch with strict match returns FAILED`() =
+    fun `sub mismatch with strict match returns REJECTED`() =
         runTest {
             val claims = buildClaims(subject = "other-agent")
             // actor.id = "agent-1" but JWT sub = "other-agent"
@@ -275,8 +295,9 @@ class JwksActorVerifierTest {
                 verifier(config = baseConfig(requireSubMatch = true)).verify(
                     actor(id = "agent-1", proof = signRsa(claims))
                 )
-            assertEquals(VerificationStatus.FAILED, result.status)
+            assertEquals(VerificationStatus.REJECTED, result.status)
             assertTrue(result.reason?.contains("sub mismatch") == true, "reason: ${result.reason}")
+            assertEquals("claims", result.metadata["failureKind"])
         }
 
     // 11. sub mismatch + requireSubMatch=false → VERIFIED
@@ -289,18 +310,20 @@ class JwksActorVerifierTest {
             assertEquals(VerificationStatus.VERIFIED, result.status)
         }
 
-    // 12. provider throws → FAILED (graceful)
+    // 12. provider throws → UNAVAILABLE with failureKind=network
     @Test
-    fun `provider exception returns FAILED`() =
+    fun `provider exception returns UNAVAILABLE`() =
         runTest {
             val brokenProvider = mockk<JwksKeySetProvider>()
             coEvery { brokenProvider.getKeySet() } throws RuntimeException("network unreachable")
             every { brokenProvider.getResolvedIssuer() } returns null
+            every { brokenProvider.getCacheState() } returns freshCacheState
             every { brokenProvider.close() } just Runs
 
             val result = verifier(provider = brokenProvider).verify(actor(proof = signRsa()))
-            assertEquals(VerificationStatus.FAILED, result.status)
+            assertEquals(VerificationStatus.UNAVAILABLE, result.status)
             assertNotNull(result.reason)
+            assertEquals("network", result.metadata["failureKind"])
         }
 
     // 13. OIDC-discovered issuer used when config.issuer is null
@@ -323,7 +346,7 @@ class JwksActorVerifierTest {
             val provider = rsaMockProvider(resolvedIssuer = "https://expected-issuer.example")
             // JWT issuer is "https://test-issuer.example" but discovered issuer is different
             val result = verifier(config = config, provider = provider).verify(actor(proof = signRsa()))
-            assertEquals(VerificationStatus.FAILED, result.status)
+            assertEquals(VerificationStatus.REJECTED, result.status)
             assertTrue(result.reason?.contains("issuer mismatch") == true, "reason: ${result.reason}")
         }
 
@@ -338,14 +361,15 @@ class JwksActorVerifierTest {
             assertEquals(VerificationStatus.VERIFIED, result.status)
         }
 
-    // 16. no matching kid → FAILED
+    // 16. no matching kid → REJECTED with failureKind=crypto
     @Test
-    fun `no matching kid returns FAILED`() =
+    fun `no matching kid returns REJECTED`() =
         runTest {
             // Provider only has the EdDSA key; JWT is signed with RSA (kid="rsa-test-key")
             val result = verifier(provider = edMockProvider()).verify(actor(proof = signRsa()))
-            assertEquals(VerificationStatus.FAILED, result.status)
+            assertEquals(VerificationStatus.REJECTED, result.status)
             assertTrue(result.reason?.contains("no matching key") == true, "reason: ${result.reason}")
+            assertEquals("crypto", result.metadata["failureKind"])
         }
 
     // =========================================================================
@@ -376,32 +400,35 @@ class JwksActorVerifierTest {
         runTest {
             val config = baseConfig(algorithms = listOf("RS256"))
             val result = verifier(config = config, provider = ecMockProvider()).verify(actor(proof = signEc()))
-            assertEquals(VerificationStatus.FAILED, result.status)
+            assertEquals(VerificationStatus.REJECTED, result.status)
             assertTrue(result.reason?.contains("algorithm not allowed") == true, "reason: ${result.reason}")
+            assertEquals("policy", result.metadata["failureKind"])
         }
 
-    // 20. EC JWT with wrong issuer → FAILED (claim validation works with EC keys)
+    // 20. EC JWT with wrong issuer → REJECTED (claim validation works with EC keys)
     @Test
-    fun `EC JWT with wrong issuer returns FAILED`() =
+    fun `EC JWT with wrong issuer returns REJECTED`() =
         runTest {
             val claims = buildClaims(issuer = "https://wrong-issuer.example")
             val result = verifier(provider = ecMockProvider()).verify(actor(proof = signEc(claims)))
-            assertEquals(VerificationStatus.FAILED, result.status)
+            assertEquals(VerificationStatus.REJECTED, result.status)
             assertTrue(result.reason?.contains("issuer") == true, "reason: ${result.reason}")
+            assertEquals("claims", result.metadata["failureKind"])
         }
 
     // =========================================================================
     // nbf (not-before) claim validation
     // =========================================================================
 
-    // 21. JWT with nbf far in the future → FAILED
+    // 21. JWT with nbf far in the future → REJECTED with failureKind=claims
     @Test
-    fun `JWT with future nbf returns FAILED`() =
+    fun `JWT with future nbf returns REJECTED`() =
         runTest {
             val claims = buildClaims(notBefore = Instant.now().plusSeconds(600))
             val result = verifier().verify(actor(proof = signRsa(claims)))
-            assertEquals(VerificationStatus.FAILED, result.status)
+            assertEquals(VerificationStatus.REJECTED, result.status)
             assertTrue(result.reason?.contains("not yet valid") == true, "reason: ${result.reason}")
+            assertEquals("claims", result.metadata["failureKind"])
         }
 
     // 22. JWT with nbf in the past → VERIFIED
@@ -420,5 +447,50 @@ class JwksActorVerifierTest {
             // Default buildClaims() has no notBefore
             val result = verifier().verify(actor(proof = signRsa()))
             assertEquals(VerificationStatus.VERIFIED, result.status)
+        }
+
+    // =========================================================================
+    // Stale cache metadata
+    // =========================================================================
+
+    // 24. Successful verification using stale cache → VERIFIED with verifiedFromCache metadata
+    @Test
+    fun `verified with stale cache includes verifiedFromCache metadata`() =
+        runTest {
+            val staleState = CacheState(fromStaleCache = true, ageSeconds = 450L)
+            val provider = rsaMockProvider(cacheState = staleState)
+            val result = verifier(provider = provider).verify(actor(proof = signRsa()))
+            assertEquals(VerificationStatus.VERIFIED, result.status)
+            assertEquals("true", result.metadata["verifiedFromCache"])
+            assertEquals("450", result.metadata["cacheAgeSeconds"])
+        }
+
+    // 25. Successful verification with fresh cache → no cache metadata
+    @Test
+    fun `verified with fresh cache has no stale metadata`() =
+        runTest {
+            val provider = rsaMockProvider(cacheState = freshCacheState)
+            val result = verifier(provider = provider).verify(actor(proof = signRsa()))
+            assertEquals(VerificationStatus.VERIFIED, result.status)
+            assertTrue(result.metadata.isEmpty(), "Expected empty metadata for fresh cache: ${result.metadata}")
+        }
+
+    // 26. Unexpected exception in success path → REJECTED with failureKind=internal
+    @Test
+    fun `verify returns REJECTED with failureKind=internal on unexpected exception`() =
+        runTest {
+            // getCacheState() is called after all inner try/catch blocks in the success path.
+            // Throwing here bypasses every inner catch and reaches the outer catch in verify(),
+            // which maps any unexpected exception to REJECTED + failureKind="internal".
+            val throwingProvider = mockk<JwksKeySetProvider>()
+            coEvery { throwingProvider.getKeySet() } returns JWKSet(listOf(rsaKey.toPublicJWK()))
+            every { throwingProvider.getResolvedIssuer() } returns null
+            every { throwingProvider.getCacheState() } throws RuntimeException("simulated internal failure")
+            every { throwingProvider.close() } just Runs
+
+            val result = verifier(provider = throwingProvider).verify(actor(proof = signRsa()))
+            assertEquals(VerificationStatus.REJECTED, result.status)
+            assertEquals("internal", result.metadata["failureKind"])
+            assertNotNull(result.reason)
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksKeySetProviderTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksKeySetProviderTest.kt
@@ -295,7 +295,9 @@ class JwksKeySetProviderTest {
             val advancingClock =
                 object : Clock() {
                     override fun getZone() = java.time.ZoneOffset.UTC
+
                     override fun withZone(zone: java.time.ZoneId): Clock = this
+
                     override fun instant(): Instant = currentInstant
                 }
 
@@ -303,11 +305,12 @@ class JwksKeySetProviderTest {
             System.setProperty("user.dir", tempDir.toAbsolutePath().toString())
             try {
                 // TTL = 60s. staleOnError = true (default)
-                val config = VerifierConfig.Jwks(
-                    jwksPath = "test-jwks.json",
-                    cacheTtlSeconds = 60,
-                    staleOnError = true
-                )
+                val config =
+                    VerifierConfig.Jwks(
+                        jwksPath = "test-jwks.json",
+                        cacheTtlSeconds = 60,
+                        staleOnError = true
+                    )
                 val provider = DefaultJwksKeySetProvider(config, clock = advancingClock)
                 try {
                     // First successful fetch
@@ -344,10 +347,11 @@ class JwksKeySetProviderTest {
             System.setProperty("user.dir", tempDir.toAbsolutePath().toString())
             try {
                 // File doesn't exist; no prior cache entry
-                val config = VerifierConfig.Jwks(
-                    jwksPath = "does-not-exist.json",
-                    staleOnError = true
-                )
+                val config =
+                    VerifierConfig.Jwks(
+                        jwksPath = "does-not-exist.json",
+                        staleOnError = true
+                    )
                 val provider = DefaultJwksKeySetProvider(config)
                 try {
                     assertThrows<Exception> {
@@ -372,18 +376,21 @@ class JwksKeySetProviderTest {
             val advancingClock =
                 object : Clock() {
                     override fun getZone() = java.time.ZoneOffset.UTC
+
                     override fun withZone(zone: java.time.ZoneId): Clock = this
+
                     override fun instant(): Instant = currentInstant
                 }
 
             val prevUserDir = System.getProperty("user.dir")
             System.setProperty("user.dir", tempDir.toAbsolutePath().toString())
             try {
-                val config = VerifierConfig.Jwks(
-                    jwksPath = "test-jwks.json",
-                    cacheTtlSeconds = 60,
-                    staleOnError = false
-                )
+                val config =
+                    VerifierConfig.Jwks(
+                        jwksPath = "test-jwks.json",
+                        cacheTtlSeconds = 60,
+                        staleOnError = false
+                    )
                 val provider = DefaultJwksKeySetProvider(config, clock = advancingClock)
                 try {
                     // First successful fetch

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksKeySetProviderTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/JwksKeySetProviderTest.kt
@@ -10,6 +10,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
@@ -271,6 +272,155 @@ class JwksKeySetProviderTest {
                 try {
                     provider.getKeySet() // trigger fetch
                     assertNull(provider.getResolvedIssuer())
+                } finally {
+                    provider.close()
+                }
+            } finally {
+                System.setProperty("user.dir", prevUserDir)
+            }
+        }
+
+    // -------------------------------------------------------------------------
+    // Stale cache fallback
+    // -------------------------------------------------------------------------
+
+    // 9. staleOnError=true: when refresh fails and cache exists, returns stale set
+    @Test
+    fun `stale fallback returns cached set when refresh fails and staleOnError is true`() =
+        runTest {
+            writeJwksFile()
+            val baseInstant = Instant.parse("2024-01-01T00:00:00Z")
+
+            var currentInstant = baseInstant
+            val advancingClock =
+                object : Clock() {
+                    override fun getZone() = java.time.ZoneOffset.UTC
+                    override fun withZone(zone: java.time.ZoneId): Clock = this
+                    override fun instant(): Instant = currentInstant
+                }
+
+            val prevUserDir = System.getProperty("user.dir")
+            System.setProperty("user.dir", tempDir.toAbsolutePath().toString())
+            try {
+                // TTL = 60s. staleOnError = true (default)
+                val config = VerifierConfig.Jwks(
+                    jwksPath = "test-jwks.json",
+                    cacheTtlSeconds = 60,
+                    staleOnError = true
+                )
+                val provider = DefaultJwksKeySetProvider(config, clock = advancingClock)
+                try {
+                    // First successful fetch
+                    val first = provider.getKeySet()
+                    assertNotNull(first)
+
+                    // Advance past TTL and delete the file to simulate endpoint unavailability
+                    currentInstant = baseInstant.plusSeconds(120)
+                    tempDir.resolve("test-jwks.json").toFile().delete()
+
+                    // Should return the stale set rather than throwing
+                    val stale = provider.getKeySet()
+                    assertNotNull(stale)
+                    assertEquals(first.keys.size, stale.keys.size)
+
+                    // getCacheState should report stale
+                    val state = provider.getCacheState()
+                    assertTrue(state.fromStaleCache, "Expected fromStaleCache=true")
+                    assertNotNull(state.ageSeconds)
+                    assertTrue(state.ageSeconds!! >= 120L, "Expected ageSeconds >= 120, got ${state.ageSeconds}")
+                } finally {
+                    provider.close()
+                }
+            } finally {
+                System.setProperty("user.dir", prevUserDir)
+            }
+        }
+
+    // 10. staleOnError=true: no prior cache → exception propagates
+    @Test
+    fun `stale fallback throws when no prior cache and staleOnError is true`() =
+        runTest {
+            val prevUserDir = System.getProperty("user.dir")
+            System.setProperty("user.dir", tempDir.toAbsolutePath().toString())
+            try {
+                // File doesn't exist; no prior cache entry
+                val config = VerifierConfig.Jwks(
+                    jwksPath = "does-not-exist.json",
+                    staleOnError = true
+                )
+                val provider = DefaultJwksKeySetProvider(config)
+                try {
+                    assertThrows<Exception> {
+                        provider.getKeySet()
+                    }
+                } finally {
+                    provider.close()
+                }
+            } finally {
+                System.setProperty("user.dir", prevUserDir)
+            }
+        }
+
+    // 11. staleOnError=false: refresh failure propagates even when cache exists
+    @Test
+    fun `staleOnError false propagates exception despite existing cache`() =
+        runTest {
+            writeJwksFile()
+            val baseInstant = Instant.parse("2024-01-01T00:00:00Z")
+
+            var currentInstant = baseInstant
+            val advancingClock =
+                object : Clock() {
+                    override fun getZone() = java.time.ZoneOffset.UTC
+                    override fun withZone(zone: java.time.ZoneId): Clock = this
+                    override fun instant(): Instant = currentInstant
+                }
+
+            val prevUserDir = System.getProperty("user.dir")
+            System.setProperty("user.dir", tempDir.toAbsolutePath().toString())
+            try {
+                val config = VerifierConfig.Jwks(
+                    jwksPath = "test-jwks.json",
+                    cacheTtlSeconds = 60,
+                    staleOnError = false
+                )
+                val provider = DefaultJwksKeySetProvider(config, clock = advancingClock)
+                try {
+                    // First successful fetch
+                    provider.getKeySet()
+
+                    // Advance past TTL and delete the file
+                    currentInstant = baseInstant.plusSeconds(120)
+                    tempDir.resolve("test-jwks.json").toFile().delete()
+
+                    // Should throw because staleOnError=false
+                    assertThrows<Exception> {
+                        provider.getKeySet()
+                    }
+                } finally {
+                    provider.close()
+                }
+            } finally {
+                System.setProperty("user.dir", prevUserDir)
+            }
+        }
+
+    // 12. getCacheState returns non-stale after fresh fetch
+    @Test
+    fun `getCacheState returns non-stale after successful fetch`() =
+        runTest {
+            writeJwksFile()
+
+            val prevUserDir = System.getProperty("user.dir")
+            System.setProperty("user.dir", tempDir.toAbsolutePath().toString())
+            try {
+                val config = VerifierConfig.Jwks(jwksPath = "test-jwks.json")
+                val provider = DefaultJwksKeySetProvider(config)
+                try {
+                    provider.getKeySet()
+                    val state = provider.getCacheState()
+                    assertTrue(!state.fromStaleCache, "Expected fromStaleCache=false after fresh fetch")
+                    assertNull(state.ageSeconds)
                 } finally {
                     provider.close()
                 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlAuditingConfigServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlAuditingConfigServiceTest.kt
@@ -312,6 +312,59 @@ class YamlAuditingConfigServiceTest {
     }
 
     @Test
+    fun `stale_on_error defaults to true when absent`() {
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  verifier:
+                    type: jwks
+                    jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
+                """.trimIndent()
+            )
+        val service = YamlAuditingConfigService(configFile)
+
+        val verifier = service.getConfig().verifier as VerifierConfig.Jwks
+        assertTrue(verifier.staleOnError)
+    }
+
+    @Test
+    fun `stale_on_error false is respected`() {
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  verifier:
+                    type: jwks
+                    jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
+                    stale_on_error: false
+                """.trimIndent()
+            )
+        val service = YamlAuditingConfigService(configFile)
+
+        val verifier = service.getConfig().verifier as VerifierConfig.Jwks
+        assertFalse(verifier.staleOnError)
+    }
+
+    @Test
+    fun `stale_on_error true is respected`() {
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  verifier:
+                    type: jwks
+                    jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
+                    stale_on_error: true
+                """.trimIndent()
+            )
+        val service = YamlAuditingConfigService(configFile)
+
+        val verifier = service.getConfig().verifier as VerifierConfig.Jwks
+        assertTrue(verifier.staleOnError)
+    }
+
+    @Test
     fun `auditing enabled flag false is respected`() {
         val configFile =
             createConfigFile(

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteNoteRepositoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteNoteRepositoryTest.kt
@@ -266,7 +266,7 @@ class SQLiteNoteRepositoryTest {
             val actor = ActorClaim(id = "agent-1", kind = ActorKind.SUBAGENT, parent = "orch-1")
             val verification =
                 VerificationResult(
-                    status = VerificationStatus.UNVERIFIED,
+                    status = VerificationStatus.UNCHECKED,
                     verifier = "noop"
                 )
             val note =
@@ -290,7 +290,7 @@ class SQLiteNoteRepositoryTest {
             assertEquals("orch-1", found.actorClaim!!.parent)
             assertNull(found.actorClaim!!.proof)
             assertNotNull(found.verification)
-            assertEquals(VerificationStatus.UNVERIFIED, found.verification!!.status)
+            assertEquals(VerificationStatus.UNCHECKED, found.verification!!.status)
             assertEquals("noop", found.verification!!.verifier)
         }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteRoleTransitionRepositoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteRoleTransitionRepositoryTest.kt
@@ -342,7 +342,7 @@ class SQLiteRoleTransitionRepositoryTest {
                 )
             val verification =
                 VerificationResult(
-                    status = VerificationStatus.UNVERIFIED,
+                    status = VerificationStatus.UNCHECKED,
                     verifier = "noop",
                     reason = null
                 )
@@ -367,7 +367,7 @@ class SQLiteRoleTransitionRepositoryTest {
             assertEquals("orchestrator-1", found.actorClaim!!.parent)
             assertEquals("proof-token", found.actorClaim!!.proof)
             assertNotNull(found.verification)
-            assertEquals(VerificationStatus.UNVERIFIED, found.verification!!.status)
+            assertEquals(VerificationStatus.UNCHECKED, found.verification!!.status)
             assertEquals("noop", found.verification!!.verifier)
             assertNull(found.verification!!.reason)
         }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/test/TestFixtures.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/test/TestFixtures.kt
@@ -93,7 +93,7 @@ fun makeActorClaim(
 ): ActorClaim = ActorClaim(id = id, kind = kind, parent = parent, proof = proof)
 
 fun makeVerificationResult(
-    status: VerificationStatus = VerificationStatus.UNVERIFIED,
+    status: VerificationStatus = VerificationStatus.UNCHECKED,
     verifier: String? = "noop",
     reason: String? = null
 ): VerificationResult = VerificationResult(status = status, verifier = verifier, reason = reason)


### PR DESCRIPTION
## Summary

- Replaces the 3-value `VerificationStatus` enum (`UNVERIFIED`, `VERIFIED`, `FAILED`) with a 5-value enum aligned to industry patterns: `ABSENT`, `UNCHECKED`, `VERIFIED`, `REJECTED`, `UNAVAILABLE`.
- Adds an optional `metadata: Map<String, String>` field to `VerificationResult` for machine-readable detail. `JwksActorVerifier` populates `failureKind` (`crypto | claims | policy | network | internal`) on non-success outcomes, and `verifiedFromCache` + `cacheAgeSeconds` when the JWKS was served from stale cache.
- `DefaultJwksKeySetProvider` gains stale-on-error fallback — if the JWKS endpoint is temporarily unreachable and a cached key set exists, the provider serves the stale entry instead of throwing. Controlled by `staleOnError: Boolean = true` on `VerifierConfig.Jwks`, parsed from the `stale_on_error` YAML key.
- Backward compatibility for stored `verification_status` strings is handled via a shim in `VerificationStatus.fromString` (legacy `"unverified"` → `ABSENT`, legacy `"failed"` → `REJECTED`). No Flyway migration required.

Resolves #120 and #121.

## Test Results

- **1279 tests pass / 0 fail** (full `:current:test` suite)
- **25+ new test cases added:**
  - `VerificationResultTest.kt` — new file; covers `fromString` back-compat mapping and metadata JSON serialization (empty + non-empty)
  - `JwksActorVerifierTest.kt` — per-`failureKind` coverage (`crypto`, `claims`, `policy`, `network`, `internal`) plus stale-cache metadata on success path
  - `JwksKeySetProviderTest.kt` — stale fallback with cache, stale fallback without cache (propagates), `staleOnError=false` behavior
  - `YamlAuditingConfigServiceTest.kt` — `stale_on_error` parse tests (true, false, default)

## Review

Separate review agent verdict: **PASS with observations** (all 8 acceptance criteria satisfied; helper dedup from `/simplify` pass covered by existing tests through callers; no scope creep). Two gaps identified in first-pass review were closed before merge:

1. Added `failureKind=internal` outer-catch test (injection via mock `getCacheState()` throw).
2. Updated `current/docs/api-reference.md` — 5-value enum, `metadata` field, `stale_on_error` config documented.

## Non-goals (intentionally out of scope)

- Persisting `metadata` / `reason` to the database (would require schema migration)
- Persistent (Redis/file) JWKS cache
- Flyway migration for stored status strings (the `fromString` shim is sufficient and lossless)
- Any claim-mechanism changes from #117

## Files

22 files changed, +598 / -97. Main source: 7 files (`VerificationResult.kt`, `AuditingConfig.kt`, `JwksActorVerifier.kt`, `JwksKeySetProvider.kt`, `YamlAuditingConfigService.kt`, `ActorVerifier.kt`, `EntityJsonSerializers.kt`). Docs: `current/docs/api-reference.md`. Tests: 14 updated + 1 new.

## MCP Items

- Feature: `4c0293ea-a80d-4889-bfdc-0b96098ca139` — "feat: VerificationStatus enum alignment and JWKS metadata/stale-cache (#120 + #121)"