### PR TITLE
chore(implement-skill): require ktlintCheck alongside test suite

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -127,6 +127,19 @@ the missing notes and retry.
 
 ## Step 4 — Work Phase: Implementation
 
+**Verification commands.** Throughout this step, "run tests" means running BOTH
+the test suite AND the project linter:
+
+```bash
+./gradlew :current:test
+./gradlew :current:ktlintCheck
+```
+
+CI enforces both — a green test run with failing lint will still block the PR.
+If `ktlintCheck` fails, run `./gradlew :current:ktlintFormat` to auto-fix
+formatting violations, then verify with `ktlintCheck` again and re-run tests.
+Include both commands in every implementation-agent and review-agent prompt.
+
 This step is **tier-conditional**:
 
 **Direct tier:** Implement directly. Edit the files, run the test suite. No subagent
@@ -251,7 +264,7 @@ The review agent:
 1. Reads the review-quality skill
 2. Uses `get_context(itemId=...)` to load the item's notes and review-phase requirements
 3. Reads the changed files (from the worktree path if isolated, or the working branch)
-4. Runs the test suite (from the worktree if isolated)
+4. Runs the test suite AND the linter (both commands from Step 4's "Verification commands") — from the worktree if isolated. A PR with failing lint will not merge.
 5. Evaluates plan alignment, test quality, and simplification
 6. Fills the review-phase notes per `guidancePointer` with a verdict
 
@@ -469,7 +482,7 @@ When dispatching parallel worktree agents, check if any task modifies shared
 code (domain models, enums, database schema, test infrastructure). If so:
 
 1. Dispatch the shared-code task **first** (not in parallel)
-2. After it returns, run `./gradlew :current:test` on main to establish a clean baseline
+2. After it returns, run `./gradlew :current:test` AND `./gradlew :current:ktlintCheck` on main to establish a clean baseline
 3. **Then** dispatch the remaining independent tasks in parallel
 
 **Symptom of contamination:** Multiple agents report "N pre-existing test


### PR DESCRIPTION
## Summary

- CI runs `:current:test` **and** `:current:ktlintCheck`. The `/implement` skill's verification instructions only named the test suite, so implementation and review agents skipped lint — PR #122 passed local tests but failed CI on style violations and required a follow-up push.
- Adds a "Verification commands" callout at the top of Step 4 defining the test+lint pair and the `ktlintFormat` auto-fix path. Referenced from downstream sections instead of duplicating.
- Updates the review-agent checklist item to explicitly run both commands; updates the parallel-worktree test-baseline step to establish a clean lint baseline too.

## Test plan

- [x] Docs-only change — no tests
- [x] `ktlintCheck` still passes on this branch (no touched Kotlin)
- [ ] Verify the guidance takes effect on the next `/implement` run (qualitative — will observe on next feature)

## Motivation

See PR #122 — post-merge we saw a CI failure that would have been caught locally if the skill had prescribed lint alongside tests. This closes that gap for future runs.