### PR TITLE
chore(skills): align skill descriptions with authoring best practices

### DIFF
--- a/.claude/skills/feature-implementation/SKILL.md
+++ b/.claude/skills/feature-implementation/SKILL.md
@@ -1,5 +1,6 @@
 ---
-description: Guide the full lifecycle of a feature-implementation tagged MCP item (the feature container) — from queue through review
+name: feature-implementation
+description: "Guide the full lifecycle of a feature-implementation tagged MCP item (the feature container) — from queue through review. Creates or resumes the feature container, fills gate-enforced notes at each phase (requirements, design, implementation-notes, test-results), dispatches implementation subagents, and advances through queue, work, and review to terminal. Use when the user says: implement a feature, start a new feature, feature workflow, resume feature work, guide feature lifecycle, or references a feature-implementation item UUID."
 ---
 
 # Feature Implementation Workflow

--- a/.claude/skills/feature-implementation/SKILL.md
+++ b/.claude/skills/feature-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feature-implementation
-description: "Guide the full lifecycle of a feature-implementation tagged MCP item (the feature container) — from queue through review. Creates or resumes the feature container, fills gate-enforced notes at each phase (requirements, design, implementation-notes, test-results), dispatches implementation subagents, and advances through queue, work, and review to terminal. Use when the user says: implement a feature, start a new feature, feature workflow, resume feature work, guide feature lifecycle, or references a feature-implementation item UUID."
+description: "Guides the full lifecycle of a feature-implementation tagged MCP item (the feature container) — from queue through review. Creates or resumes the feature container, fills gate-enforced notes at each phase (requirements, design, implementation-notes, test-results), dispatches implementation subagents, and advances through queue, work, and review to terminal. Use when the user says: implement a feature, start a new feature, feature workflow, resume feature work, guide feature lifecycle, or references a feature-implementation item UUID."
 ---
 
 # Feature Implementation Workflow

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -398,97 +398,17 @@ and report all failures together at the end.
 
 ## Worktree Isolation
 
-Use `isolation: "worktree"` on the Agent tool to give each agent an isolated copy
-of the repository. This prevents file conflicts, cross-cutting changes, test
-baseline contamination, and — critically — ensures changes are committed to a
-real branch that survives the agent's lifecycle.
+For full setup, dispatch patterns, lifecycle, parallel validation, and test baseline
+management, see [WORKTREE.md](WORKTREE.md).
 
-**When to use worktrees:**
+**Quick reference — when to use worktrees:**
 - Parallel dispatch of multiple implementation agents (prevents file conflicts)
-- Any implementation dispatch where you need the changes on an isolated branch
-- When you want the implementation agent to commit independently
+- Any dispatch where changes need to land on an isolated branch
 
-**When NOT to use worktrees:**
-- Tasks that depend on each other's file changes (use sequential dispatch instead)
-- Pure MCP operations with no file modifications (e.g., materialization subagents)
+**When NOT to use:**
+- Tasks with dependency edges between them (dispatch sequentially instead)
+- Pure MCP operations with no file modifications
 - Orchestrator implementing directly (already on a working branch)
-
-### Dispatch pattern
-
-```
-Agent(
-  prompt="...",
-  model="sonnet",
-  isolation="worktree",
-  subagent_type="general-purpose"
-)
-```
-
-**Scoping rules:** The `subagent-start` hook automatically injects commit, scope,
-and cd-discipline rules into every subagent. You do NOT need to include these in
-delegation prompts. Focus prompts on task-specific context:
-- Item UUID and what to implement
-- Which files to modify (explicit list when possible)
-- Test expectations
-- Return format
-
-Cross-cutting changes (version bumps, shared config) are handled by the
-orchestrator after all agents return.
-
-### Worktree lifecycle
-
-Review happens in the worktree. After review passes, push the worktree branch
-to origin and create a GitHub PR.
-
-```
-1. Orchestrator dispatches agent with isolation: "worktree"
-2. Agent works in isolated worktree, commits to worktree branch
-3. Agent returns → result includes worktree path and branch name
-4. Orchestrator captures worktree metadata (path, branch, changed files)
-5. Orchestrator spot-checks diffs: git -C <worktree-path> diff main --stat
-6. Orchestrator runs /simplify in the worktree (or dispatches agent to do so)
-7. Review agent dispatched INTO the worktree (reads files and runs tests there)
-8. After review passes: push worktree branch to origin and create PR
-9. After PR merges: git checkout main && git pull origin main
-10. Worktrees with no changes are automatically cleaned up
-```
-
-### Capturing worktree metadata
-
-When an agent returns from worktree isolation, the Agent tool result includes:
-- **Worktree path** — the directory where the isolated copy lives
-- **Branch name** — the git branch the agent committed to
-
-Record these alongside the MCP item ID. You need them for:
-- Running `git -C <path> diff main --name-only` to get the changed files list
-- Pointing the review agent at the correct directory
-- Squash-merging the branch into local `main` after review
-
-### Parallel worktree validation
-
-When multiple agents return from parallel worktrees:
-
-1. Capture each agent's worktree path and branch from the return metadata
-2. Spot-check at least 2 diffs for insertion errors, scope violations, or
-   unintended modifications
-3. Run each worktree's test suite independently (or delegate to review agents)
-4. After review passes, push each worktree branch and create a PR
-5. Run the full test suite before pushing to catch integration issues
-6. Clean up local branches after PRs merge
-
-### Test baseline management
-
-When dispatching parallel worktree agents, check if any task modifies shared
-code (domain models, enums, database schema, test infrastructure). If so:
-
-1. Dispatch the shared-code task **first** (not in parallel)
-2. After it returns, run `./gradlew :current:test` AND `./gradlew :current:ktlintCheck` on main to establish a clean baseline
-3. **Then** dispatch the remaining independent tasks in parallel
-
-**Symptom of contamination:** Multiple agents report "N pre-existing test
-failures unrelated to our changes" on the same tests. That's contamination
-from a parallel task, not pre-existing failures. Always verify agent test
-reports with a direct test run after all agents complete.
 
 ---
 

--- a/.claude/skills/implement/WORKTREE.md
+++ b/.claude/skills/implement/WORKTREE.md
@@ -1,0 +1,93 @@
+# Worktree Isolation
+
+Use `isolation: "worktree"` on the Agent tool to give each agent an isolated copy
+of the repository. This prevents file conflicts, cross-cutting changes, test
+baseline contamination, and — critically — ensures changes are committed to a
+real branch that survives the agent's lifecycle.
+
+**When to use worktrees:**
+- Parallel dispatch of multiple implementation agents (prevents file conflicts)
+- Any implementation dispatch where you need the changes on an isolated branch
+- When you want the implementation agent to commit independently
+
+**When NOT to use worktrees:**
+- Tasks that depend on each other's file changes (use sequential dispatch instead)
+- Pure MCP operations with no file modifications (e.g., materialization subagents)
+- Orchestrator implementing directly (already on a working branch)
+
+## Dispatch pattern
+
+```
+Agent(
+  prompt="...",
+  model="sonnet",
+  isolation="worktree",
+  subagent_type="general-purpose"
+)
+```
+
+**Scoping rules:** The `subagent-start` hook automatically injects commit, scope,
+and cd-discipline rules into every subagent. You do NOT need to include these in
+delegation prompts. Focus prompts on task-specific context:
+- Item UUID and what to implement
+- Which files to modify (explicit list when possible)
+- Test expectations
+- Return format
+
+Cross-cutting changes (version bumps, shared config) are handled by the
+orchestrator after all agents return.
+
+## Worktree lifecycle
+
+Review happens in the worktree. After review passes, push the worktree branch
+to origin and create a GitHub PR.
+
+```
+1. Orchestrator dispatches agent with isolation: "worktree"
+2. Agent works in isolated worktree, commits to worktree branch
+3. Agent returns → result includes worktree path and branch name
+4. Orchestrator captures worktree metadata (path, branch, changed files)
+5. Orchestrator spot-checks diffs: git -C <worktree-path> diff main --stat
+6. Orchestrator runs /simplify in the worktree (or dispatches agent to do so)
+7. Review agent dispatched INTO the worktree (reads files and runs tests there)
+8. After review passes: push worktree branch to origin and create PR
+9. After PR merges: git checkout main && git pull origin main
+10. Worktrees with no changes are automatically cleaned up
+```
+
+## Capturing worktree metadata
+
+When an agent returns from worktree isolation, the Agent tool result includes:
+- **Worktree path** — the directory where the isolated copy lives
+- **Branch name** — the git branch the agent committed to
+
+Record these alongside the MCP item ID. You need them for:
+- Running `git -C <path> diff main --name-only` to get the changed files list
+- Pointing the review agent at the correct directory
+- Pushing the branch to origin after review
+
+## Parallel worktree validation
+
+When multiple agents return from parallel worktrees:
+
+1. Capture each agent's worktree path and branch from the return metadata
+2. Spot-check at least 2 diffs for insertion errors, scope violations, or
+   unintended modifications
+3. Run each worktree's test suite independently (or delegate to review agents)
+4. After review passes, push each worktree branch and create a PR
+5. Run the full test suite before pushing to catch integration issues
+6. Clean up local branches after PRs merge
+
+## Test baseline management
+
+When dispatching parallel worktree agents, check if any task modifies shared
+code (domain models, enums, database schema, test infrastructure). If so:
+
+1. Dispatch the shared-code task **first** (not in parallel)
+2. After it returns, run `./gradlew :current:test` AND `./gradlew :current:ktlintCheck` on main to establish a clean baseline
+3. **Then** dispatch the remaining independent tasks in parallel
+
+**Symptom of contamination:** Multiple agents report "N pre-existing test
+failures unrelated to our changes" on the same tests. That's contamination
+from a parallel task, not pre-existing failures. Always verify agent test
+reports with a direct test run after all agents complete.

--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -1,5 +1,6 @@
 ---
-description: End-to-end release automation — reads commits since last tag, infers semver bump, drafts changelog, creates release PR, merges it, waits for CI green, tags, and monitors the Docker build to completion.
+name: prepare-release
+description: "End-to-end release automation — reads commits since last tag, infers semver bump, drafts changelog, creates release PR, merges it, waits for CI green, tags, and monitors the Docker build to completion. Use when the user says: prepare release, cut a release, bump version, create release PR, ship a new version, tag a release, deploy new version, or when all feature PRs are merged and it is time to release."
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/review-quality/SKILL.md
+++ b/.claude/skills/review-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-quality
-description: Review quality framework for the work-to-review transition gate. Guides verification of plan alignment, test quality, and code simplification before marking implementation complete. Referenced by schema guidance fields during review-phase note filling. Read this skill when filling review-checklist notes or when asked to review completed implementation work.
+description: Review quality framework for the work-to-review transition gate. Guides verification of plan alignment, test quality, and code simplification before marking implementation complete. Referenced by schema guidance fields during review-phase note filling. Use when filling review-checklist notes or when asked to review completed implementation work.
 user-invocable: false
 ---
 

--- a/.claude/skills/session-retrospective/SKILL.md
+++ b/.claude/skills/session-retrospective/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-retrospective
-description: "Analyze the current implementation run — evaluate schema effectiveness, delegation alignment, note quality, plan-to-execution fit. Captures cross-session trends and proposes improvements when patterns repeat. Use after implementation runs, or when user says 'retrospective', 'session review', 'what did we learn', 'analyze this run', 'how did that go', 'evaluate our process', 'wrap up', 'end of session review'. Also use when the output style's retrospective nudge fires after complete_tree."
+description: "Analyzes the current implementation run — evaluates schema effectiveness, delegation alignment, note quality, and plan-to-execution fit. Captures cross-session trends and proposes improvements when patterns repeat. Use after implementation runs, or when user says 'retrospective', 'session review', 'what did we learn', 'analyze this run', 'how did that go', 'evaluate our process', 'wrap up', 'end of session review'. Also use when the output style's retrospective nudge fires after complete_tree."
 argument-hint: "[optional: root item UUID] [--dry-run to preview without creating items]"
 ---
 

--- a/.claude/skills/spec-quality/SKILL.md
+++ b/.claude/skills/spec-quality/SKILL.md
@@ -88,6 +88,19 @@ them, or confirm they still pass with the new behavior.
 
 ---
 
+## Completion Checklist
+
+Validate spec completeness before advancing past queue phase:
+
+- [ ] At least 2 real alternatives evaluated (not strawmen)
+- [ ] At least 1 non-goal named (scope boundary explicit)
+- [ ] Downstream consumers of changed interfaces traced
+- [ ] 1-2 concrete risk flags identified
+- [ ] Test scenarios named for happy paths, failure paths, and edge cases
+- [ ] Shared interface breakage assessed (if applicable)
+
+---
+
 ## Using This Framework
 
 This framework sets a floor. The disciplines above are the minimum required analysis.

--- a/.claude/skills/spec-quality/SKILL.md
+++ b/.claude/skills/spec-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-quality
-description: Specification quality framework for planning. Defines the minimum bar for what a plan must address — alternatives, non-goals, blast radius, risk flags, and test strategy. Referenced by schema guidance fields during queue-phase note filling. Read this skill whenever filling requirements or design notes for any MCP work item.
+description: Specification quality framework for planning. Defines the minimum bar for what a plan must address — alternatives, non-goals, blast radius, risk flags, and test strategy. Referenced by schema guidance fields during queue-phase note filling. Use when filling requirements or design notes for any MCP work item.
 user-invocable: false
 ---
 

--- a/claude-plugins/task-orchestrator/skills/batch-complete/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/batch-complete/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: batch-complete
-description: Complete or cancel multiple items at once — close out features, clean up old work, archive completed workstreams. Use when a user says "close out this feature", "complete everything under X", "cancel this workstream", "clean up old items", "bulk complete", "finish this feature", or "archive completed work".
+description: "Completes or cancels multiple items at once — closes out features, cleans up old work, and archives completed workstreams. Use when a user says: close out this feature, complete everything under X, cancel this workstream, clean up old items, bulk complete, finish this feature, or archive completed work."
 argument-hint: "[optional: root item UUID or title to complete]"
 ---
 

--- a/claude-plugins/task-orchestrator/skills/create-item/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/create-item/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-item
-description: Create an MCP work item from conversation context. Scans existing containers to anchor the item in the right place (Bugs, Features, Tech Debt, Observations, etc.), infers type and priority, creates single items or work trees, and pre-fills required notes. Use this whenever the conversation surfaces a bug, feature idea, tech debt item, or observation worth tracking persistently. Also use when user says "track this", "log this bug", "create a task for", or "add this to the backlog".
+description: "Creates an MCP work item from conversation context. Scans existing containers to anchor the item in the right place (Bugs, Features, Tech Debt, Observations, etc.), infers type and priority, creates single items or work trees, and pre-fills required notes. Use when the conversation surfaces a bug, feature idea, tech debt item, or observation worth tracking persistently. Also use when user says: track this, log this bug, create a task for, or add this to the backlog."
 argument-hint: "[optional: brief description of what to create]"
 ---
 

--- a/claude-plugins/task-orchestrator/skills/dependency-manager/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/dependency-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dependency-manager
-description: Visualize, create, and diagnose dependencies between MCP work items. Use when a user says "what blocks this", "add a dependency", "show dependency graph", "why can't this start", "link these items", "unblock this", "remove dependency", or "show blockers".
+description: "Visualizes, creates, and diagnoses dependencies between MCP work items. Use when a user says: what blocks this, add a dependency, show dependency graph, why can't this start, link these items, unblock this, remove dependency, or show blockers."
 argument-hint: "[optional: item UUID, title, or action like 'show blockers for X']"
 ---
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: manage-schemas
-description: "Create, view, edit, delete, and validate note schemas for the MCP Task Orchestrator in .taskorchestrator/config.yaml — the templates that define which notes agents must fill at each workflow phase. Use when user says \"create schema\", \"show schemas\", \"edit schema\", \"delete schema\", \"validate config\", \"what schemas exist\", \"add a note to schema\", \"remove note from schema\", or \"configure gates\"."
+description: "Creates, views, edits, deletes, and validates note schemas for the MCP Task Orchestrator in .taskorchestrator/config.yaml — the templates that define which notes agents must fill at each workflow phase. Use when user says: create schema, show schemas, edit schema, delete schema, validate config, what schemas exist, add a note to schema, remove note from schema, or configure gates."
 argument-hint: "[optional: action + schema name, e.g. 'view bug-fix', 'create research-spike', 'validate']"
 ---
 

--- a/claude-plugins/task-orchestrator/skills/pre-plan-workflow/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/pre-plan-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pre-plan-workflow
-description: Internal workflow for plan mode — checks MCP for existing work, note schemas, and gate requirements to set the definition floor before planning begins. Triggered automatically when entering plan mode for any non-trivial implementation task.
+description: "Gathers existing MCP work items, note schemas, and gate requirements to establish a definition floor before planning begins. Queries get_context() for active, blocked, and stalled items, reads .taskorchestrator/config.yaml for schema-defined note requirements per phase, and structures the plan so each task maps to one MCP work item with correct dependency ordering. Use when entering plan mode, starting implementation planning, creating a task breakdown, or beginning project setup for any non-trivial implementation task. Triggered automatically by the plan-mode hook."
 user-invocable: false
 ---
 
@@ -44,8 +44,22 @@ Read `.taskorchestrator/config.yaml` in the project root (this is a file read, n
 
 If no config file exists, the project has no note schemas — items will be schema-free with no gate enforcement. Proceed with planning normally.
 
+**Minimal config example:**
+
+```yaml
+work_item_schemas:
+  feature-task:
+    notes:
+      - key: requirements
+        role: queue
+        required: true
+      - key: implementation-notes
+        role: work
+        required: true
+```
+
 **Use schemas to inform the plan:** When a schema applies, each planned task should:
-- Note which schema type will be applied at materialization (e.g., `type: "feature-implementation"`)
+- Note which schema type will be applied at materialization (e.g., `type: "feature-task"`)
 - Account for required notes — plan sections should naturally produce content that maps to required note keys
 - Respect dependency ordering — which tasks block others (these become `BLOCKS` edges)
 

--- a/claude-plugins/task-orchestrator/skills/schema-workflow/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/schema-workflow/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: schema-workflow
-description: >
-  Guide an MCP work item through its schema-defined lifecycle — filling required notes using
-  guidancePointer and advancing through gate-enforced phases. Internal skill triggered by hooks
-  and output styles during orchestration workflows. Use when an item has schema tags and needs
-  to progress through queue, work, review, or terminal phases with note gates.
+description: "Guides an MCP work item through its schema-defined lifecycle — filling required notes using guidancePointer and advancing through gate-enforced phases. Internal skill triggered by hooks and output styles during orchestration workflows. Use when an item has schema tags and needs to progress through queue, work, review, or terminal phases with note gates."
 user-invocable: false
 ---
 

--- a/claude-plugins/task-orchestrator/skills/status-progression/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/status-progression/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: status-progression
-description: Navigate role transitions for MCP work items using advance_item. Shows current role, gate status, required notes, and the correct trigger to use. Use when a user says "advance this item", "move to work", "start this task", "complete this item", "what's the next status", "why can't I advance", "unblock this", "cancel this item", or "check gate status".
+description: "Navigates role transitions for MCP work items using advance_item. Shows current role, gate status, required notes, and the correct trigger to use. Use when a user says: advance this item, move to work, start this task, complete this item, what's the next status, why can't I advance, unblock this, cancel this item, or check gate status."
 argument-hint: "[optional: item UUID or title to look up]"
 ---
 

--- a/claude-plugins/task-orchestrator/skills/work-summary/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/work-summary/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: work-summary
-description: Generate a hierarchical project dashboard showing all work items organized by container, with IDs, tags, status, and priority visible. Always use this skill for any request about project status, work summaries, or item overviews — never construct dashboards manually with raw MCP calls. Trigger on any of these phrases or intent: "project status", "what's active", "show me the dashboard", "work summary", "summary", "what should I work on", "project health", "what's blocked", "where did I leave off", "show items", "what's in the backlog", "overview", or any request to see or review the current state of work items. This includes session-start context gathering — if you need to understand current project state, use this skill.
+description: "Generates a hierarchical project dashboard showing all work items organized by container, with IDs, tags, status, and priority visible. Use when the user says: project status, what's active, show me the dashboard, work summary, what should I work on, project health, what's blocked, where did I leave off, show items, what's in the backlog, overview, or any request to see or review the current state of work items. Also use at session start when gathering current project context."
 argument-hint: "[optional: container UUID or title to scope the summary]"
 ---
 


### PR DESCRIPTION
## Summary

- Adds missing `name:` frontmatter to `feature-implementation` and `prepare-release` skills (required field per spec)
- Expands skill descriptions with concrete trigger phrases to improve skill routing accuracy
- Adds Completion Checklist to `spec-quality` and a YAML config example to `pre-plan-workflow`
- Fixes third-person verb conjugation across 9 skills (`Guide→Guides`, `Create→Creates`, `Navigate→Navigates`, etc.) per the [skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)
- Removes second-person instructions embedded in descriptions (`work-summary`, `spec-quality`, `review-quality`) — replaced with clean `Use when:` patterns
- Splits `implement/SKILL.md` Worktree Isolation section into `WORKTREE.md` to bring the file under the 500-line recommended limit (514 → 433 lines)

## Context

These changes were identified during a security review of PR #125 (rejected — coordinated bot campaign). The legitimate improvements proposed in that PR were cherry-picked and extended with a full audit against Anthropic's official skill authoring best practices.

No Kotlin source files were modified. `ktlintCheck` passes clean.