### PR TITLE
release: v3.3.0 — plugin v3.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "task-orchestrator",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "description": "Skills, hooks, and workflows for MCP Task Orchestrator. Schema-aware context, note-driven workflow, and session hooks.",
       "author": {
         "name": "Jeff Picklyk",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2026-04-24 (Plugin v3.1.1)
+
+### Changed
+- Improved skill descriptions across 8 plugin skills to use third-person verb form and consistent "Use when:" trigger patterns, improving skill routing accuracy
+- Added trigger phrase expansions to `pre-plan-workflow`, `work-summary`, `create-item`, `batch-complete`, `dependency-manager`, `manage-schemas`, `schema-workflow`, and `status-progression`
+- Updated `pre-plan-workflow` with a minimal config YAML example for schema illustration
+- Bumped plugin version to 3.1.1 (skill description content fixes and routing improvements)
+
+---
+
 ## [3.3.0] - 2026-04-23
 
 ### Added

--- a/claude-plugins/CLAUDE.md
+++ b/claude-plugins/CLAUDE.md
@@ -10,7 +10,7 @@ removing and re-adding the marketplace in Claude Code. No version bump is needed
 
 | Plugin | Directory | Current Version |
 |--------|-----------|-----------------|
-| `task-orchestrator` | `claude-plugins/task-orchestrator/` | `3.1.0` |
+| `task-orchestrator` | `claude-plugins/task-orchestrator/` | `3.1.1` |
 
 > Updated automatically by `/prepare-release`. Do not bump manually.
 

--- a/claude-plugins/task-orchestrator/.claude-plugin/plugin.json
+++ b/claude-plugins/task-orchestrator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "task-orchestrator",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Claude Code integration for MCP Task Orchestrator — schema-aware context, note-driven workflow",
   "skills": "./skills",
   "hooks": "./hooks/hooks-config.json",


### PR DESCRIPTION
## Summary

- Improved skill descriptions across 8 plugin skills — third-person verb form and consistent "Use when:" trigger patterns
- Added trigger phrase expansions to `pre-plan-workflow`, `work-summary`, `create-item`, `batch-complete`, `dependency-manager`, `manage-schemas`, `schema-workflow`, and `status-progression`
- Updated `pre-plan-workflow` with a minimal config YAML example for schema illustration

## Version

**Release type:** plugin-only
3.1.0 → 3.1.1 (server v3.3.0 unchanged)

Prepared with /prepare-release