### PR TITLE
feat(domain): add claim fields to WorkItem and V5 migration (#117)

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/WorkItem.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/WorkItem.kt
@@ -24,7 +24,21 @@ data class WorkItem(
     val createdAt: Instant = Instant.now(),
     val modifiedAt: Instant = Instant.now(),
     val roleChangedAt: Instant = Instant.now(),
-    val version: Long = 1
+    val version: Long = 1,
+    /** Opaque agent identifier that currently holds this item. Null when unclaimed. */
+    val claimedBy: String? = null,
+    /** When the current claim was placed (refreshes on re-claim). Stored as UTC in SQLite. */
+    val claimedAt: Instant? = null,
+    /**
+     * TTL-based expiry for this claim. Computed DB-side via `datetime('now', '+N seconds')` to
+     * keep time semantics consistent. Agents inspecting rows directly should treat this as UTC.
+     */
+    val claimExpiresAt: Instant? = null,
+    /**
+     * Timestamp of the first claim by the current agent — preserved across re-claims by the same
+     * agent; reset when a different agent takes over the item.
+     */
+    val originalClaimedAt: Instant? = null,
 ) {
     init {
         validate()

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/WorkItemsTable.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/WorkItemsTable.kt
@@ -23,6 +23,10 @@ object WorkItemsTable : UUIDTable("work_items") {
     val modifiedAt = timestamp("modified_at")
     val roleChangedAt = timestamp("role_changed_at")
     val version = long("version").default(1)
+    val claimedBy = text("claimed_by").nullable()
+    val claimedAt = timestamp("claimed_at").nullable()
+    val claimExpiresAt = timestamp("claim_expires_at").nullable()
+    val originalClaimedAt = timestamp("original_claimed_at").nullable()
 
     init {
         foreignKey(parentId to WorkItemsTable.id)
@@ -31,5 +35,6 @@ object WorkItemsTable : UUIDTable("work_items") {
         index(isUnique = false, depth)
         index(isUnique = false, priority)
         index(isUnique = false, columns = arrayOf(role, roleChangedAt))
+        index(isUnique = false, claimedBy)
     }
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -80,6 +80,10 @@ class SQLiteWorkItemRepository(
             it[modifiedAt] = item.modifiedAt
             it[roleChangedAt] = item.roleChangedAt
             it[version] = item.version
+            it[claimedBy] = item.claimedBy
+            it[claimedAt] = item.claimedAt
+            it[claimExpiresAt] = item.claimExpiresAt
+            it[originalClaimedAt] = item.originalClaimedAt
         }
         return Result.Success(item)
     }
@@ -114,6 +118,10 @@ class SQLiteWorkItemRepository(
                     it[modifiedAt] = item.modifiedAt
                     it[roleChangedAt] = item.roleChangedAt
                     it[version] = item.version + 1
+                    it[claimedBy] = item.claimedBy
+                    it[claimedAt] = item.claimedAt
+                    it[claimExpiresAt] = item.claimExpiresAt
+                    it[originalClaimedAt] = item.originalClaimedAt
                 }
             if (updatedCount > 0) {
                 Result.Success(item.copy(version = item.version + 1))
@@ -539,7 +547,11 @@ class SQLiteWorkItemRepository(
             createdAt = row[WorkItemsTable.createdAt],
             modifiedAt = row[WorkItemsTable.modifiedAt],
             roleChangedAt = row[WorkItemsTable.roleChangedAt],
-            version = row[WorkItemsTable.version]
+            version = row[WorkItemsTable.version],
+            claimedBy = row[WorkItemsTable.claimedBy],
+            claimedAt = row[WorkItemsTable.claimedAt],
+            claimExpiresAt = row[WorkItemsTable.claimExpiresAt],
+            originalClaimedAt = row[WorkItemsTable.originalClaimedAt],
         )
 
     /**

--- a/current/src/main/resources/db/migration/V5__Add_Claim_Fields.sql
+++ b/current/src/main/resources/db/migration/V5__Add_Claim_Fields.sql
@@ -1,0 +1,20 @@
+-- V5: Add atomic-claim fields to work_items
+-- These four columns support the agent-claim mechanism (issue #117).
+-- Time values are stored as ISO-8601 text (SQLite TEXT affinity) to match Flyway/JDBC conventions,
+-- consistent with the existing timestamp columns in this table.
+
+ALTER TABLE work_items ADD COLUMN claimed_by TEXT DEFAULT NULL;
+ALTER TABLE work_items ADD COLUMN claimed_at TEXT DEFAULT NULL;
+ALTER TABLE work_items ADD COLUMN claim_expires_at TEXT DEFAULT NULL;
+ALTER TABLE work_items ADD COLUMN original_claimed_at TEXT DEFAULT NULL;
+
+-- Supports fast lookup of "all items held by agent X"
+CREATE INDEX idx_work_items_claimed_by ON work_items(claimed_by);
+
+-- Partial index: only rows that are actively claimed; used by expiry-scan queries.
+-- SQLite has supported partial indexes since v3.8.0 (2013); confirmed on v3.49.1 bundled via
+-- org.xerial:sqlite-jdbc:3.49.1.0.  The query planner uses this index only when the WHERE clause
+-- logically implies claimed_by IS NOT NULL, so always include a claimed_by predicate in
+-- expiry-scan queries.
+CREATE INDEX idx_work_items_claim_expires ON work_items(claim_expires_at)
+  WHERE claimed_by IS NOT NULL;

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemClaimFieldsTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemClaimFieldsTest.kt
@@ -1,0 +1,206 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database.repository
+
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
+import io.github.jpicklyk.mcptask.current.test.BaseRepositoryTest
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Tests that the four claim fields (claimedBy, claimedAt, claimExpiresAt, originalClaimedAt)
+ * round-trip correctly through create and update operations, and default to null on new items.
+ */
+class SQLiteWorkItemClaimFieldsTest : BaseRepositoryTest() {
+    private lateinit var repository: WorkItemRepository
+
+    @BeforeEach
+    fun setUp() {
+        repository = repositoryProvider.workItemRepository()
+    }
+
+    @Test
+    fun `new WorkItem defaults all claim fields to null`() {
+        val item = WorkItem(title = "Unclaimed item")
+        assertNull(item.claimedBy)
+        assertNull(item.claimedAt)
+        assertNull(item.claimExpiresAt)
+        assertNull(item.originalClaimedAt)
+    }
+
+    @Test
+    fun `create persists null claim fields and getById returns nulls`() =
+        runBlocking {
+            val item = WorkItem(title = "Unclaimed persisted item")
+            repository.create(item)
+
+            val result = repository.getById(item.id)
+            assertIs<Result.Success<WorkItem>>(result)
+            val retrieved = result.data
+            assertNull(retrieved.claimedBy)
+            assertNull(retrieved.claimedAt)
+            assertNull(retrieved.claimExpiresAt)
+            assertNull(retrieved.originalClaimedAt)
+        }
+
+    @Test
+    fun `create persists all claim fields and getById retrieves them`() =
+        runBlocking {
+            val now = Instant.now().truncatedTo(java.time.temporal.ChronoUnit.MILLIS)
+            val expiresAt = now.plusSeconds(900)
+            val item =
+                WorkItem(
+                    title = "Claimed item",
+                    claimedBy = "agent-abc-123",
+                    claimedAt = now,
+                    claimExpiresAt = expiresAt,
+                    originalClaimedAt = now,
+                )
+            repository.create(item)
+
+            val result = repository.getById(item.id)
+            assertIs<Result.Success<WorkItem>>(result)
+            val retrieved = result.data
+            assertEquals("agent-abc-123", retrieved.claimedBy)
+            assertNotNull(retrieved.claimedAt)
+            assertNotNull(retrieved.claimExpiresAt)
+            assertNotNull(retrieved.originalClaimedAt)
+            // Timestamps should round-trip without loss beyond millisecond precision
+            assertEquals(now.toEpochMilli(), retrieved.claimedAt!!.toEpochMilli())
+            assertEquals(expiresAt.toEpochMilli(), retrieved.claimExpiresAt!!.toEpochMilli())
+            assertEquals(now.toEpochMilli(), retrieved.originalClaimedAt!!.toEpochMilli())
+        }
+
+    @Test
+    fun `update can set claim fields on a previously unclaimed item`() =
+        runBlocking {
+            val item = WorkItem(title = "Will be claimed")
+            repository.create(item)
+
+            val now = Instant.now().truncatedTo(java.time.temporal.ChronoUnit.MILLIS)
+            val claimed =
+                item.copy(
+                    claimedBy = "agent-xyz",
+                    claimedAt = now,
+                    claimExpiresAt = now.plusSeconds(600),
+                    originalClaimedAt = now,
+                )
+            val updateResult = repository.update(claimed)
+            assertIs<Result.Success<WorkItem>>(updateResult)
+
+            val result = repository.getById(item.id)
+            assertIs<Result.Success<WorkItem>>(result)
+            val retrieved = result.data
+            assertEquals("agent-xyz", retrieved.claimedBy)
+            assertNotNull(retrieved.claimedAt)
+            assertNotNull(retrieved.claimExpiresAt)
+            assertNotNull(retrieved.originalClaimedAt)
+        }
+
+    @Test
+    fun `update can clear claim fields (release a claim)`() =
+        runBlocking {
+            val now = Instant.now().truncatedTo(java.time.temporal.ChronoUnit.MILLIS)
+            val item =
+                WorkItem(
+                    title = "Release test item",
+                    claimedBy = "agent-release",
+                    claimedAt = now,
+                    claimExpiresAt = now.plusSeconds(900),
+                    originalClaimedAt = now,
+                )
+            repository.create(item)
+
+            // Release by setting all claim fields to null
+            val released =
+                item.copy(
+                    claimedBy = null,
+                    claimedAt = null,
+                    claimExpiresAt = null,
+                    originalClaimedAt = null,
+                )
+            val updateResult = repository.update(released)
+            assertIs<Result.Success<WorkItem>>(updateResult)
+
+            val result = repository.getById(item.id)
+            assertIs<Result.Success<WorkItem>>(result)
+            val retrieved = result.data
+            assertNull(retrieved.claimedBy)
+            assertNull(retrieved.claimedAt)
+            assertNull(retrieved.claimExpiresAt)
+            assertNull(retrieved.originalClaimedAt)
+        }
+
+    @Test
+    fun `update preserves originalClaimedAt across TTL refresh (re-claim)`() =
+        runBlocking {
+            val firstClaimTime = Instant.now().truncatedTo(java.time.temporal.ChronoUnit.MILLIS)
+            val item =
+                WorkItem(
+                    title = "Re-claim test item",
+                    claimedBy = "agent-reclaim",
+                    claimedAt = firstClaimTime,
+                    claimExpiresAt = firstClaimTime.plusSeconds(900),
+                    originalClaimedAt = firstClaimTime,
+                )
+            repository.create(item)
+
+            // Simulate re-claim (extend TTL): claimedAt and claimExpiresAt refresh, originalClaimedAt stays
+            val refreshTime = firstClaimTime.plusSeconds(450)
+            val reClaimed =
+                item.copy(
+                    claimedAt = refreshTime,
+                    claimExpiresAt = refreshTime.plusSeconds(900),
+                    originalClaimedAt = firstClaimTime, // preserved
+                )
+            val updateResult = repository.update(reClaimed)
+            assertIs<Result.Success<WorkItem>>(updateResult)
+
+            val result = repository.getById(item.id)
+            assertIs<Result.Success<WorkItem>>(result)
+            val retrieved = result.data
+            assertEquals("agent-reclaim", retrieved.claimedBy)
+            assertEquals(refreshTime.toEpochMilli(), retrieved.claimedAt!!.toEpochMilli())
+            // originalClaimedAt preserved from first claim
+            assertEquals(firstClaimTime.toEpochMilli(), retrieved.originalClaimedAt!!.toEpochMilli())
+        }
+
+    @Test
+    fun `update resets originalClaimedAt when different agent takes over`() =
+        runBlocking {
+            val firstClaimTime = Instant.now().truncatedTo(java.time.temporal.ChronoUnit.MILLIS)
+            val item =
+                WorkItem(
+                    title = "Agent takeover test",
+                    claimedBy = "agent-first",
+                    claimedAt = firstClaimTime,
+                    claimExpiresAt = firstClaimTime.plusSeconds(900),
+                    originalClaimedAt = firstClaimTime,
+                )
+            repository.create(item)
+
+            // Different agent takes over: all claim fields reset to new agent's times
+            val newClaimTime = firstClaimTime.plusSeconds(1000)
+            val takenOver =
+                item.copy(
+                    claimedBy = "agent-second",
+                    claimedAt = newClaimTime,
+                    claimExpiresAt = newClaimTime.plusSeconds(900),
+                    originalClaimedAt = newClaimTime, // reset for new agent
+                )
+            val updateResult = repository.update(takenOver)
+            assertIs<Result.Success<WorkItem>>(updateResult)
+
+            val result = repository.getById(item.id)
+            assertIs<Result.Success<WorkItem>>(result)
+            val retrieved = result.data
+            assertEquals("agent-second", retrieved.claimedBy)
+            assertEquals(newClaimTime.toEpochMilli(), retrieved.originalClaimedAt!!.toEpochMilli())
+        }
+}


### PR DESCRIPTION
## Summary

- Add four nullable claim fields to `WorkItem` (`claimedBy`, `claimedAt`, `claimExpiresAt`, `originalClaimedAt`) — all default `null`, UTC docstring on `claimExpiresAt`
- V5 Flyway migration adds the four columns plus two indexes including a partial index on `claim_expires_at WHERE claimed_by IS NOT NULL` (SQLite 3.49.1 supports partial indexes — verified)
- Repository `toWorkItem` / `insertRow` / `update` round-trip the new fields; no claim logic — that lands in item 4

This is the foundation item for the atomic claim mechanism (issue #117). Tracked in MCP work item ` + "`1646e1c8`" + ` under feature ` + "`0628e760`" + `.

## Test Results

1285 tests passed, 0 failed. 7 new round-trip tests covering null defaults, persistence, update-set, update-clear, and original-claimed-at preservation.

## Review

Verdict: **pass**. Plan alignment verified line-by-line; test quality substantive; scope discipline clean. One non-blocking observation captured in MCP review notes.

## MCP Items

- Parent feature: ` + "`0628e760-0f2f-4677-a207-a68cf9625836`" + `
- This PR: ` + "`1646e1c8-d14f-4e8a-91f9-82f402f94c77`" + `