### PR TITLE
feat(auth): add degradedModePolicy config flag (#117)

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ActorParsing.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ActorParsing.kt
@@ -2,10 +2,31 @@ package io.github.jpicklyk.mcptask.current.application.tools
 
 import io.github.jpicklyk.mcptask.current.domain.model.ActorClaim
 import io.github.jpicklyk.mcptask.current.domain.model.ActorKind
+import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
 import io.github.jpicklyk.mcptask.current.domain.model.VerificationResult
+import io.github.jpicklyk.mcptask.current.domain.model.VerificationStatus
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
+import org.slf4j.LoggerFactory
+
+/**
+ * Outcome of applying the [DegradedModePolicy] to a (claim, verification) pair.
+ *
+ * - [Trusted] — a trusted actor id was resolved; downstream logic may proceed.
+ * - [Rejected] — the policy rejects the operation; the tool should return an error.
+ */
+sealed class PolicyResolution {
+    /** The trusted actor id to use in place of (or equal to) the self-reported id. */
+    data class Trusted(
+        val trustedId: String
+    ) : PolicyResolution()
+
+    /** The policy requires rejection; [reason] is a human-readable explanation. */
+    data class Rejected(
+        val reason: String
+    ) : PolicyResolution()
+}
 
 /**
  * Result of parsing an optional actor claim from a JSON object.
@@ -74,5 +95,93 @@ interface ActorAware {
             )
         val verification = context.actorVerifier().verify(claim)
         return ActorParseResult.Success(claim, verification)
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(ActorAware::class.java)
+
+        /**
+         * Applies the [DegradedModePolicy] to determine the trusted actor identity.
+         *
+         * This is the central resolution point that `claim_item` (item 4) and
+         * `AdvanceItemTool` ownership checks (item 5) must call when verifying that
+         * the actor performing an operation matches the claim holder.
+         *
+         * **Policy behaviour:**
+         * - [DegradedModePolicy.ACCEPT_CACHED]: When the verification status is
+         *   [VerificationStatus.VERIFIED] (including stale-cache verification where
+         *   `metadata["verifiedFromCache"] == "true"`), the verified `actor.id` from the
+         *   JWT (`claim.id` — already validated against `sub` by [JwksActorVerifier]) is
+         *   returned. For all other non-VERIFIED statuses (UNAVAILABLE without cache,
+         *   ABSENT, UNCHECKED, REJECTED), the self-reported `claim.id` is returned as-is,
+         *   preserving the pre-v3.3 implicit fallback.
+         * - [DegradedModePolicy.ACCEPT_SELF_REPORTED]: Always returns the self-reported
+         *   `claim.id`. Logs a deprecation-style warning when a JWKS verifier is active so
+         *   operators notice they've opted out of the identity guarantee.
+         * - [DegradedModePolicy.REJECT]: Returns [PolicyResolution.Rejected] for any status
+         *   other than [VerificationStatus.VERIFIED]. The caller must surface this as an
+         *   operation error.
+         *
+         * @param claim The parsed actor claim from the request.
+         * @param verification The result from [ActorVerifier.verify].
+         * @param policy The configured [DegradedModePolicy].
+         * @return [PolicyResolution.Trusted] with the identity to use, or
+         *         [PolicyResolution.Rejected] if the operation must be blocked.
+         */
+        fun resolveTrustedActorId(
+            claim: ActorClaim,
+            verification: VerificationResult,
+            policy: DegradedModePolicy
+        ): PolicyResolution {
+            val isVerified = verification.status == VerificationStatus.VERIFIED
+
+            return when (policy) {
+                DegradedModePolicy.ACCEPT_CACHED -> {
+                    // VERIFIED (live or stale-cache) → trust the JWT-validated actor.id
+                    if (isVerified) {
+                        PolicyResolution.Trusted(claim.id)
+                    } else {
+                        // Non-VERIFIED: fall back to self-reported id (preserves pre-v3.3 behavior)
+                        PolicyResolution.Trusted(claim.id)
+                    }
+                }
+
+                DegradedModePolicy.ACCEPT_SELF_REPORTED -> {
+                    // Always trust self-reported id — operator has explicitly opted out of JWKS guarantees.
+                    // Log a warning when verification was actually attempted but not VERIFIED.
+                    if (!isVerified && verification.verifier != null && verification.verifier != "noop") {
+                        logger.warn(
+                            "degradedModePolicy=accept-self-reported: using self-reported actor.id='{}' " +
+                                "despite verification status '{}' from verifier '{}'. " +
+                                "This negates JWKS identity guarantees.",
+                            claim.id,
+                            verification.status,
+                            verification.verifier
+                        )
+                    }
+                    PolicyResolution.Trusted(claim.id)
+                }
+
+                DegradedModePolicy.REJECT -> {
+                    if (isVerified) {
+                        PolicyResolution.Trusted(claim.id)
+                    } else {
+                        val reason =
+                            "degradedModePolicy=reject: actor verification status is " +
+                                "'${verification.status.toJsonString()}'" +
+                                (verification.reason?.let { " ($it)" } ?: "") +
+                                "; operation rejected. Configure JWKS verification or change " +
+                                "degraded_mode_policy to accept-cached or accept-self-reported."
+                        logger.info(
+                            "degradedModePolicy=reject blocking actor.id='{}': status={}, reason={}",
+                            claim.id,
+                            verification.status,
+                            verification.reason
+                        )
+                        PolicyResolution.Rejected(reason)
+                    }
+                }
+            }
+        }
     }
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
@@ -9,6 +9,7 @@ import io.github.jpicklyk.mcptask.current.application.service.NoOpStatusLabelSer
 import io.github.jpicklyk.mcptask.current.application.service.NoteSchemaService
 import io.github.jpicklyk.mcptask.current.application.service.StatusLabelService
 import io.github.jpicklyk.mcptask.current.application.service.WorkTreeExecutor
+import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
@@ -32,7 +33,8 @@ class ToolExecutionContext(
     private val noteSchemaService: NoteSchemaService = NoOpNoteSchemaService,
     private val statusLabelService: StatusLabelService = NoOpStatusLabelService,
     private val mcpLoggingService: McpLoggingService = NoOpMcpLoggingService,
-    private val actorVerifier: ActorVerifier = NoOpActorVerifier
+    private val actorVerifier: ActorVerifier = NoOpActorVerifier,
+    val degradedModePolicy: DegradedModePolicy = DegradedModePolicy.ACCEPT_CACHED
 ) {
     /** Access to WorkItem CRUD and query operations. */
     fun workItemRepository(): WorkItemRepository = repositoryProvider.workItemRepository()

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/AuditingConfig.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/AuditingConfig.kt
@@ -1,15 +1,79 @@
 package io.github.jpicklyk.mcptask.current.domain.model
 
 /**
+ * Determines how the system behaves when actor-claim verification cannot produce a
+ * [VerificationStatus.VERIFIED] result.
+ *
+ * Three-value enum aligned with the `auth.degradedModePolicy` config key described in the
+ * v1 implementation plan (issue #117, distributed-correctness contract item 4).
+ *
+ * Values:
+ * - [ACCEPT_CACHED] *(default)* — preserves the v3.3.0 stale-cache fallback.
+ *   When verification status is [VerificationStatus.UNAVAILABLE] **and** a stale cached key was
+ *   used (i.e., `metadata["verifiedFromCache"] == "true"`), the verified `actor.id` from the JWT
+ *   is trusted. For all other non-VERIFIED outcomes, the system falls back to the self-reported
+ *   `actor.id` supplied by the caller (same as prior implicit behavior).
+ * - [ACCEPT_SELF_REPORTED] — always trusts the caller-supplied `actor.id` regardless of
+ *   verification outcome. This is the v3.2 implicit behavior; explicitly labeled here so operators
+ *   understand they are opting out of JWKS identity guarantees.
+ * - [REJECT] — any operation that requires verified identity is rejected when the verification
+ *   status is not [VerificationStatus.VERIFIED]. Recommended for cross-org `did:web` deployments.
+ *
+ * **Downstream integration points (items 4 and 5):**
+ * - `claim_item` (item 4): when placing a claim, the trusted actor id is determined by
+ *   `DegradedModePolicy.resolveTrustedActorId(actorClaim, verificationResult)`.
+ * - `AdvanceItemTool` ownership checks (item 5): claim ownership is validated against the
+ *   same trusted actor id resolver to ensure consistent identity resolution.
+ */
+enum class DegradedModePolicy {
+    /** Trust verified `actor.id` from stale-cache fallback; otherwise fall back to self-reported. */
+    ACCEPT_CACHED,
+
+    /**
+     * Always trust the self-reported `actor.id` from the caller, regardless of verification.
+     * Documents the pre-v3.3 implicit behavior explicitly.
+     */
+    ACCEPT_SELF_REPORTED,
+
+    /** Reject any operation requiring identity when the actor is not fully verified. */
+    REJECT;
+
+    fun toConfigString(): String =
+        when (this) {
+            ACCEPT_CACHED -> "accept-cached"
+            ACCEPT_SELF_REPORTED -> "accept-self-reported"
+            REJECT -> "reject"
+        }
+
+    companion object {
+        /**
+         * Parse a config-file string to a [DegradedModePolicy].
+         * Accepts both hyphenated config-file form (`accept-cached`) and enum name form (`ACCEPT_CACHED`).
+         * Defaults to [ACCEPT_CACHED] if the value is unrecognized (with caller responsible for warning).
+         */
+        fun fromConfigString(value: String): DegradedModePolicy? =
+            when (value.lowercase().replace("_", "-")) {
+                "accept-cached" -> ACCEPT_CACHED
+                "accept-self-reported" -> ACCEPT_SELF_REPORTED
+                "reject" -> REJECT
+                else -> null
+            }
+    }
+}
+
+/**
  * Top-level auditing configuration parsed from `.taskorchestrator/config.yaml`
  * under the `auditing:` key.
  *
  * @param enabled Whether auditing is active (default true).
  * @param verifier The actor-claim verifier strategy to use.
+ * @param degradedModePolicy Controls what happens when actor verification is not fully successful.
+ *   See [DegradedModePolicy] for the three values and their security trade-offs.
  */
 data class AuditingConfig(
     val enabled: Boolean = true,
-    val verifier: VerifierConfig = VerifierConfig.Noop
+    val verifier: VerifierConfig = VerifierConfig.Noop,
+    val degradedModePolicy: DegradedModePolicy = DegradedModePolicy.ACCEPT_CACHED
 )
 
 /**

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlAuditingConfigService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlAuditingConfigService.kt
@@ -1,6 +1,7 @@
 package io.github.jpicklyk.mcptask.current.infrastructure.config
 
 import io.github.jpicklyk.mcptask.current.domain.model.AuditingConfig
+import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
 import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
 import org.slf4j.LoggerFactory
 import org.yaml.snakeyaml.Yaml
@@ -17,6 +18,7 @@ import java.nio.file.Path
  * ```yaml
  * auditing:
  *   enabled: true
+ *   degraded_mode_policy: accept-cached   # accept-cached (default) | accept-self-reported | reject
  *   verifier:
  *     type: jwks          # "jwks" or "noop" (default: noop)
  *     oidc_discovery: "https://accounts.example.com/.well-known/openid-configuration"
@@ -89,7 +91,16 @@ class YamlAuditingConfigService(
                         VerifierConfig.Noop
                     }
 
-                LoadResult(AuditingConfig(enabled = enabled, verifier = verifier), warnings)
+                val degradedModePolicy = parseDegradedModePolicy(auditingSection, warnings)
+
+                LoadResult(
+                    AuditingConfig(
+                        enabled = enabled,
+                        verifier = verifier,
+                        degradedModePolicy = degradedModePolicy
+                    ),
+                    warnings
+                )
             }
         } catch (e: Exception) {
             val msg = "Failed to load auditing config from '$configPath': ${e.message}"
@@ -97,6 +108,23 @@ class YamlAuditingConfigService(
             logger.warn(msg)
             LoadResult(AuditingConfig(), warnings)
         }
+    }
+
+    private fun parseDegradedModePolicy(
+        auditingSection: Map<String, Any>,
+        warnings: MutableList<String>
+    ): DegradedModePolicy {
+        val raw = auditingSection["degraded_mode_policy"] as? String ?: return DegradedModePolicy.ACCEPT_CACHED
+        val parsed = DegradedModePolicy.fromConfigString(raw)
+        if (parsed == null) {
+            val msg =
+                "Unknown auditing.degraded_mode_policy '$raw'; " +
+                    "valid values: accept-cached, accept-self-reported, reject. Defaulting to accept-cached."
+            warnings.add(msg)
+            logger.warn(msg)
+            return DegradedModePolicy.ACCEPT_CACHED
+        }
+        return parsed
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
@@ -16,6 +16,7 @@ import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetBlockedI
 import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetContextTool
 import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetNextItemTool
 import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetNextStatusTool
+import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
 import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
 import io.github.jpicklyk.mcptask.current.infrastructure.config.JwksActorVerifier
 import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlAuditingConfigService
@@ -86,14 +87,15 @@ class CurrentMcpServer(
             val noteSchemaService = YamlNoteSchemaService()
             val statusLabelService = YamlStatusLabelService()
             val mcpLoggingService = DefaultMcpLoggingService()
-            val actorVerifier = createActorVerifier()
+            val (actorVerifier, degradedModePolicy) = createActorVerifierAndPolicy()
             val toolContext =
                 ToolExecutionContext(
                     repositoryProvider,
                     noteSchemaService,
                     statusLabelService,
                     mcpLoggingService,
-                    actorVerifier
+                    actorVerifier,
+                    degradedModePolicy
                 )
             logger.info("Repository provider and tool context initialized")
 
@@ -159,12 +161,14 @@ class CurrentMcpServer(
     }
 
     /**
-     * Creates the appropriate [ActorVerifier] based on the auditing configuration.
+     * Creates the appropriate [ActorVerifier] and reads [DegradedModePolicy] from configuration.
+     * Returns a [Pair] of (verifier, policy) so both can be wired into [ToolExecutionContext].
      */
-    private fun createActorVerifier(): ActorVerifier {
+    private fun createActorVerifierAndPolicy(): Pair<ActorVerifier, DegradedModePolicy> {
         val configService = YamlAuditingConfigService()
         configService.getWarnings().forEach { logger.warn("Auditing config: {}", it) }
         val config = configService.getConfig()
+        logger.info("Degraded mode policy: {}", config.degradedModePolicy.toConfigString())
         val verifier =
             when (val vc = config.verifier) {
                 is VerifierConfig.Noop -> {
@@ -185,7 +189,7 @@ class CurrentMcpServer(
                     }
                 }
             }
-        return verifier
+        return Pair(verifier, config.degradedModePolicy)
     }
 
     private fun registerCommonCleanup(server: Server) {

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/DegradedModePolicyTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/DegradedModePolicyTest.kt
@@ -1,0 +1,260 @@
+package io.github.jpicklyk.mcptask.current.application.tools
+
+import io.github.jpicklyk.mcptask.current.domain.model.ActorClaim
+import io.github.jpicklyk.mcptask.current.domain.model.ActorKind
+import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
+import io.github.jpicklyk.mcptask.current.domain.model.VerificationResult
+import io.github.jpicklyk.mcptask.current.domain.model.VerificationStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [DegradedModePolicy] resolution via [ActorAware.resolveTrustedActorId].
+ *
+ * Covers the three-policy matrix against the five [VerificationStatus] values:
+ * - Policy: ACCEPT_CACHED, ACCEPT_SELF_REPORTED, REJECT
+ * - Statuses: VERIFIED, UNAVAILABLE (fresh), UNAVAILABLE (stale-cache), ABSENT, UNCHECKED, REJECTED
+ */
+class DegradedModePolicyTest {
+    private val actorId = "agent-test-1"
+    private val claim = ActorClaim(id = actorId, kind = ActorKind.SUBAGENT)
+
+    // -------------------------------------------------------------------------
+    // Default policy value
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `default DegradedModePolicy is ACCEPT_CACHED`() {
+        assertEquals(DegradedModePolicy.ACCEPT_CACHED, DegradedModePolicy.ACCEPT_CACHED)
+        // Verify the AuditingConfig default via the enum itself
+        val policy = DegradedModePolicy.ACCEPT_CACHED
+        assertEquals("accept-cached", policy.toConfigString())
+    }
+
+    // -------------------------------------------------------------------------
+    // DegradedModePolicy.fromConfigString — parsing
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `fromConfigString parses accept-cached`() {
+        assertEquals(DegradedModePolicy.ACCEPT_CACHED, DegradedModePolicy.fromConfigString("accept-cached"))
+    }
+
+    @Test
+    fun `fromConfigString parses accept-self-reported`() {
+        assertEquals(DegradedModePolicy.ACCEPT_SELF_REPORTED, DegradedModePolicy.fromConfigString("accept-self-reported"))
+    }
+
+    @Test
+    fun `fromConfigString parses reject`() {
+        assertEquals(DegradedModePolicy.REJECT, DegradedModePolicy.fromConfigString("reject"))
+    }
+
+    @Test
+    fun `fromConfigString accepts underscore variant of accept_cached`() {
+        assertEquals(DegradedModePolicy.ACCEPT_CACHED, DegradedModePolicy.fromConfigString("accept_cached"))
+    }
+
+    @Test
+    fun `fromConfigString accepts UPPERCASE enum names`() {
+        assertEquals(DegradedModePolicy.ACCEPT_CACHED, DegradedModePolicy.fromConfigString("ACCEPT-CACHED"))
+        assertEquals(DegradedModePolicy.ACCEPT_SELF_REPORTED, DegradedModePolicy.fromConfigString("ACCEPT-SELF-REPORTED"))
+        assertEquals(DegradedModePolicy.REJECT, DegradedModePolicy.fromConfigString("REJECT"))
+    }
+
+    @Test
+    fun `fromConfigString returns null for unknown value`() {
+        assertEquals(null, DegradedModePolicy.fromConfigString("magic-policy"))
+    }
+
+    // -------------------------------------------------------------------------
+    // ACCEPT_CACHED policy
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `ACCEPT_CACHED — VERIFIED returns trusted actor id`() {
+        val verification = VerificationResult(status = VerificationStatus.VERIFIED, verifier = "jwks")
+        val result = ActorAware.resolveTrustedActorId(claim, verification, DegradedModePolicy.ACCEPT_CACHED)
+        assertInstanceOf(PolicyResolution.Trusted::class.java, result)
+        assertEquals(actorId, (result as PolicyResolution.Trusted).trustedId)
+    }
+
+    @Test
+    fun `ACCEPT_CACHED — VERIFIED with stale-cache metadata returns trusted actor id`() {
+        val verification =
+            VerificationResult(
+                status = VerificationStatus.VERIFIED,
+                verifier = "jwks",
+                metadata = mapOf("verifiedFromCache" to "true", "cacheAgeSeconds" to "450")
+            )
+        val result = ActorAware.resolveTrustedActorId(claim, verification, DegradedModePolicy.ACCEPT_CACHED)
+        assertInstanceOf(PolicyResolution.Trusted::class.java, result)
+        assertEquals(actorId, (result as PolicyResolution.Trusted).trustedId)
+    }
+
+    @Test
+    fun `ACCEPT_CACHED — UNAVAILABLE falls back to self-reported actor id`() {
+        val verification =
+            VerificationResult(
+                status = VerificationStatus.UNAVAILABLE,
+                verifier = "jwks",
+                reason = "network error"
+            )
+        val result = ActorAware.resolveTrustedActorId(claim, verification, DegradedModePolicy.ACCEPT_CACHED)
+        assertInstanceOf(PolicyResolution.Trusted::class.java, result)
+        // Falls back to the self-reported claim.id (pre-v3.3 behavior preserved)
+        assertEquals(actorId, (result as PolicyResolution.Trusted).trustedId)
+    }
+
+    @Test
+    fun `ACCEPT_CACHED — ABSENT falls back to self-reported actor id`() {
+        val verification = VerificationResult(status = VerificationStatus.ABSENT, verifier = "jwks")
+        val result = ActorAware.resolveTrustedActorId(claim, verification, DegradedModePolicy.ACCEPT_CACHED)
+        assertInstanceOf(PolicyResolution.Trusted::class.java, result)
+        assertEquals(actorId, (result as PolicyResolution.Trusted).trustedId)
+    }
+
+    @Test
+    fun `ACCEPT_CACHED — UNCHECKED falls back to self-reported actor id`() {
+        val verification = VerificationResult(status = VerificationStatus.UNCHECKED, verifier = "noop")
+        val result = ActorAware.resolveTrustedActorId(claim, verification, DegradedModePolicy.ACCEPT_CACHED)
+        assertInstanceOf(PolicyResolution.Trusted::class.java, result)
+        assertEquals(actorId, (result as PolicyResolution.Trusted).trustedId)
+    }
+
+    @Test
+    fun `ACCEPT_CACHED — REJECTED falls back to self-reported actor id`() {
+        val verification =
+            VerificationResult(
+                status = VerificationStatus.REJECTED,
+                verifier = "jwks",
+                reason = "signature mismatch",
+                metadata = mapOf("failureKind" to "crypto")
+            )
+        val result = ActorAware.resolveTrustedActorId(claim, verification, DegradedModePolicy.ACCEPT_CACHED)
+        assertInstanceOf(PolicyResolution.Trusted::class.java, result)
+        assertEquals(actorId, (result as PolicyResolution.Trusted).trustedId)
+    }
+
+    // -------------------------------------------------------------------------
+    // ACCEPT_SELF_REPORTED policy
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `ACCEPT_SELF_REPORTED — VERIFIED returns self-reported actor id`() {
+        val verification = VerificationResult(status = VerificationStatus.VERIFIED, verifier = "jwks")
+        val result = ActorAware.resolveTrustedActorId(claim, verification, DegradedModePolicy.ACCEPT_SELF_REPORTED)
+        assertInstanceOf(PolicyResolution.Trusted::class.java, result)
+        assertEquals(actorId, (result as PolicyResolution.Trusted).trustedId)
+    }
+
+    @Test
+    fun `ACCEPT_SELF_REPORTED — UNAVAILABLE still returns self-reported actor id`() {
+        val verification = VerificationResult(status = VerificationStatus.UNAVAILABLE, verifier = "jwks")
+        val result = ActorAware.resolveTrustedActorId(claim, verification, DegradedModePolicy.ACCEPT_SELF_REPORTED)
+        assertInstanceOf(PolicyResolution.Trusted::class.java, result)
+        assertEquals(actorId, (result as PolicyResolution.Trusted).trustedId)
+    }
+
+    @Test
+    fun `ACCEPT_SELF_REPORTED — ABSENT returns self-reported actor id`() {
+        val verification = VerificationResult(status = VerificationStatus.ABSENT, verifier = "jwks")
+        val result = ActorAware.resolveTrustedActorId(claim, verification, DegradedModePolicy.ACCEPT_SELF_REPORTED)
+        assertInstanceOf(PolicyResolution.Trusted::class.java, result)
+        assertEquals(actorId, (result as PolicyResolution.Trusted).trustedId)
+    }
+
+    @Test
+    fun `ACCEPT_SELF_REPORTED — UNCHECKED noop verifier returns self-reported actor id without warning log`() {
+        // noop verifier → no warning expected (this is normal no-JWKS operation)
+        val verification = VerificationResult(status = VerificationStatus.UNCHECKED, verifier = "noop")
+        val result = ActorAware.resolveTrustedActorId(claim, verification, DegradedModePolicy.ACCEPT_SELF_REPORTED)
+        assertInstanceOf(PolicyResolution.Trusted::class.java, result)
+        assertEquals(actorId, (result as PolicyResolution.Trusted).trustedId)
+    }
+
+    @Test
+    fun `ACCEPT_SELF_REPORTED — REJECTED returns self-reported actor id`() {
+        val verification =
+            VerificationResult(
+                status = VerificationStatus.REJECTED,
+                verifier = "jwks",
+                reason = "expired token"
+            )
+        val result = ActorAware.resolveTrustedActorId(claim, verification, DegradedModePolicy.ACCEPT_SELF_REPORTED)
+        assertInstanceOf(PolicyResolution.Trusted::class.java, result)
+        assertEquals(actorId, (result as PolicyResolution.Trusted).trustedId)
+    }
+
+    // -------------------------------------------------------------------------
+    // REJECT policy
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `REJECT — VERIFIED returns trusted actor id`() {
+        val verification = VerificationResult(status = VerificationStatus.VERIFIED, verifier = "jwks")
+        val result = ActorAware.resolveTrustedActorId(claim, verification, DegradedModePolicy.REJECT)
+        assertInstanceOf(PolicyResolution.Trusted::class.java, result)
+        assertEquals(actorId, (result as PolicyResolution.Trusted).trustedId)
+    }
+
+    @Test
+    fun `REJECT — UNAVAILABLE returns Rejected`() {
+        val verification =
+            VerificationResult(
+                status = VerificationStatus.UNAVAILABLE,
+                verifier = "jwks",
+                reason = "JWKS endpoint down"
+            )
+        val result = ActorAware.resolveTrustedActorId(claim, verification, DegradedModePolicy.REJECT)
+        assertInstanceOf(PolicyResolution.Rejected::class.java, result)
+        val rejection = result as PolicyResolution.Rejected
+        assertNotNull(rejection.reason)
+        assert(rejection.reason.contains("unavailable")) {
+            "Expected reason to contain 'unavailable', got: ${rejection.reason}"
+        }
+    }
+
+    @Test
+    fun `REJECT — ABSENT returns Rejected`() {
+        val verification = VerificationResult(status = VerificationStatus.ABSENT, verifier = "jwks")
+        val result = ActorAware.resolveTrustedActorId(claim, verification, DegradedModePolicy.REJECT)
+        assertInstanceOf(PolicyResolution.Rejected::class.java, result)
+        assert((result as PolicyResolution.Rejected).reason.contains("absent")) {
+            "Expected reason to mention 'absent': ${result.reason}"
+        }
+    }
+
+    @Test
+    fun `REJECT — UNCHECKED returns Rejected`() {
+        val verification = VerificationResult(status = VerificationStatus.UNCHECKED, verifier = "noop")
+        val result = ActorAware.resolveTrustedActorId(claim, verification, DegradedModePolicy.REJECT)
+        assertInstanceOf(PolicyResolution.Rejected::class.java, result)
+        assert((result as PolicyResolution.Rejected).reason.contains("unchecked")) {
+            "Expected reason to mention 'unchecked': ${result.reason}"
+        }
+    }
+
+    @Test
+    fun `REJECT — REJECTED status returns Rejected with reason in message`() {
+        val verification =
+            VerificationResult(
+                status = VerificationStatus.REJECTED,
+                verifier = "jwks",
+                reason = "signature invalid",
+                metadata = mapOf("failureKind" to "crypto")
+            )
+        val result = ActorAware.resolveTrustedActorId(claim, verification, DegradedModePolicy.REJECT)
+        assertInstanceOf(PolicyResolution.Rejected::class.java, result)
+        val rejection = result as PolicyResolution.Rejected
+        assert(rejection.reason.contains("rejected")) {
+            "Expected reason to contain 'rejected': ${rejection.reason}"
+        }
+        // The verification reason should be included in the rejection message
+        assert(rejection.reason.contains("signature invalid")) {
+            "Expected original reason to be surfaced: ${rejection.reason}"
+        }
+    }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlAuditingConfigServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlAuditingConfigServiceTest.kt
@@ -1,6 +1,7 @@
 package io.github.jpicklyk.mcptask.current.infrastructure.config
 
 import io.github.jpicklyk.mcptask.current.domain.model.AuditingConfig
+import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
 import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -378,6 +379,111 @@ class YamlAuditingConfigServiceTest {
         val service = YamlAuditingConfigService(configFile)
 
         assertFalse(service.getConfig().enabled)
+    }
+
+    // -------------------------------------------------------------------------
+    // degraded_mode_policy parsing
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `degraded_mode_policy defaults to ACCEPT_CACHED when absent`() {
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  enabled: true
+                  verifier:
+                    type: noop
+                """.trimIndent()
+            )
+        val service = YamlAuditingConfigService(configFile)
+        assertEquals(DegradedModePolicy.ACCEPT_CACHED, service.getConfig().degradedModePolicy)
+        assertTrue(service.getWarnings().isEmpty())
+    }
+
+    @Test
+    fun `degraded_mode_policy accept-cached is parsed correctly`() {
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  enabled: true
+                  degraded_mode_policy: accept-cached
+                  verifier:
+                    type: noop
+                """.trimIndent()
+            )
+        val service = YamlAuditingConfigService(configFile)
+        assertEquals(DegradedModePolicy.ACCEPT_CACHED, service.getConfig().degradedModePolicy)
+        assertTrue(service.getWarnings().isEmpty())
+    }
+
+    @Test
+    fun `degraded_mode_policy accept-self-reported is parsed correctly`() {
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  enabled: true
+                  degraded_mode_policy: accept-self-reported
+                  verifier:
+                    type: noop
+                """.trimIndent()
+            )
+        val service = YamlAuditingConfigService(configFile)
+        assertEquals(DegradedModePolicy.ACCEPT_SELF_REPORTED, service.getConfig().degradedModePolicy)
+        assertTrue(service.getWarnings().isEmpty())
+    }
+
+    @Test
+    fun `degraded_mode_policy reject is parsed correctly`() {
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  enabled: true
+                  degraded_mode_policy: reject
+                  verifier:
+                    type: noop
+                """.trimIndent()
+            )
+        val service = YamlAuditingConfigService(configFile)
+        assertEquals(DegradedModePolicy.REJECT, service.getConfig().degradedModePolicy)
+        assertTrue(service.getWarnings().isEmpty())
+    }
+
+    @Test
+    fun `degraded_mode_policy unknown value produces warning and defaults to ACCEPT_CACHED`() {
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  enabled: true
+                  degraded_mode_policy: banana
+                  verifier:
+                    type: noop
+                """.trimIndent()
+            )
+        val service = YamlAuditingConfigService(configFile)
+        assertEquals(DegradedModePolicy.ACCEPT_CACHED, service.getConfig().degradedModePolicy)
+        assertTrue(service.getWarnings().isNotEmpty())
+        assertTrue(service.getWarnings().any { it.contains("banana") })
+    }
+
+    @Test
+    fun `AuditingConfig default has degraded_mode_policy ACCEPT_CACHED`() {
+        val configFile =
+            createConfigFile(
+                """
+                note_schemas:
+                  default:
+                    - key: test
+                      role: queue
+                      required: false
+                """.trimIndent()
+            )
+        val service = YamlAuditingConfigService(configFile)
+        assertEquals(DegradedModePolicy.ACCEPT_CACHED, service.getConfig().degradedModePolicy)
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- New `DegradedModePolicy` enum (ACCEPT_CACHED | ACCEPT_SELF_REPORTED | REJECT) on `AuditingConfig` with default `ACCEPT_CACHED`
- `ActorAware.resolveTrustedActorId(claim, verification, policy)` returns a `PolicyResolution` sealed type (Trusted / Rejected) — the integration point for items 4 and 5
- ACCEPT_CACHED preserves v3.3.0 stale-cache fallback behavior; ACCEPT_SELF_REPORTED warns on non-VERIFIED with real verifier; REJECT denies any non-VERIFIED operation
- YAML parsing with permissive case-insensitive matching; unknown values fall back to default with a logged warning
- Policy placed at `AuditingConfig` level (not inside `VerifierConfig.Jwks`) — single deployment-wide posture

Tracked in MCP work item ` + "`4816a26e`" + `.

## Test Results

1308 tests passed, 0 failed. 29 new tests covering all three policy values × all five `VerificationStatus` values, plus YAML parsing.

## Review

Verdict: **pass with observations**. Default safety confirmed. One non-blocking note for item 4: when JWT-extracted identity differs from `claim.id`, the ACCEPT_CACHED branch will need a small refinement.

## MCP Items

- Parent feature: ` + "`0628e760`" + `
- This PR: ` + "`4816a26e-d578-46f4-84e3-ca25a6fac970`" + `