### PR TITLE
feat(infra): promote busy_timeout to DATABASE_BUSY_TIMEOUT_MS env var (#117)

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseConfig.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseConfig.kt
@@ -49,4 +49,36 @@ object DatabaseConfig {
      */
     val showSql: Boolean
         get() = System.getenv("DATABASE_SHOW_SQL")?.toBoolean() ?: false
+
+    /**
+     * SQLite busy_timeout in milliseconds — how long SQLite waits for a write lock before
+     * returning SQLITE_BUSY. Increase this in high-contention fleet deployments.
+     *
+     * Recommended range: 5000–30000 ms.
+     * Default: 5000 ms (5 seconds) — appropriate for single-process use and small fleets.
+     * Beyond 30 000 ms you are medicating a capacity problem rather than solving it;
+     * right-size the fleet or reduce concurrency instead.
+     *
+     * Override with the DATABASE_BUSY_TIMEOUT_MS environment variable.
+     * - If the variable is set but not parseable as a Long, the default (5000) is used.
+     * - If the parsed value is below 100 ms, 100 ms is used (sanity floor).
+     */
+    val busyTimeoutMs: Long
+        get() = resolveBusyTimeoutMs(System.getenv("DATABASE_BUSY_TIMEOUT_MS"))
+
+    /**
+     * Pure validation function — resolves a raw env-var string to a validated timeout value.
+     * Exposed as `internal` for unit testing without env-var manipulation.
+     *
+     * @param rawValue the raw string from the environment variable, or null if unset
+     * @return validated timeout in milliseconds
+     */
+    internal fun resolveBusyTimeoutMs(rawValue: String?): Long {
+        rawValue ?: return DEFAULT_BUSY_TIMEOUT_MS
+        val parsed = rawValue.toLongOrNull() ?: return DEFAULT_BUSY_TIMEOUT_MS
+        return if (parsed < MIN_BUSY_TIMEOUT_MS) MIN_BUSY_TIMEOUT_MS else parsed
+    }
+
+    internal const val DEFAULT_BUSY_TIMEOUT_MS = 5000L
+    internal const val MIN_BUSY_TIMEOUT_MS = 100L
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseManager.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseManager.kt
@@ -58,6 +58,9 @@ class DatabaseManager(
                     }
                 }
 
+            // Resolve busy_timeout with validation and warnings
+            val busyTimeoutMs = resolveBusyTimeout()
+
             // Create a database connection
             database =
                 Database.connect(
@@ -76,7 +79,8 @@ class DatabaseManager(
                             // Returns the active journal mode as a result row — must close statement.
                             stmt.execute("PRAGMA journal_mode=WAL")
                             // Avoid indefinite blocking when another process holds a write lock.
-                            stmt.execute("PRAGMA busy_timeout = 5000")
+                            // Configurable via DATABASE_BUSY_TIMEOUT_MS env var (default 5000 ms).
+                            stmt.execute("PRAGMA busy_timeout = $busyTimeoutMs")
                         }
                     }
                 )
@@ -171,6 +175,39 @@ class DatabaseManager(
         } catch (e: Exception) {
             logger.warn("Could not run parent-cycle integrity check: ${e.message}")
         }
+    }
+
+    /**
+     * Resolves the busy_timeout value from [DatabaseConfig.busyTimeoutMs] with logging.
+     *
+     * Validation rules (enforced in [DatabaseConfig]):
+     *   - Unset → default 5000 ms
+     *   - Unparseable → default 5000 ms (warns here)
+     *   - Below 100 ms → floor 100 ms (warns here)
+     */
+    private fun resolveBusyTimeout(): Long {
+        val rawEnv = System.getenv("DATABASE_BUSY_TIMEOUT_MS")
+        val resolved = DatabaseConfig.busyTimeoutMs
+        if (rawEnv != null) {
+            val parsed = rawEnv.toLongOrNull()
+            when {
+                parsed == null ->
+                    logger.warn(
+                        "DATABASE_BUSY_TIMEOUT_MS='$rawEnv' is not a valid Long; " +
+                            "using default 5000 ms"
+                    )
+                parsed < 100L ->
+                    logger.warn(
+                        "DATABASE_BUSY_TIMEOUT_MS=$parsed ms is below the 100 ms sanity floor; " +
+                            "using 100 ms"
+                    )
+                else ->
+                    logger.info("DATABASE_BUSY_TIMEOUT_MS set to $resolved ms")
+            }
+        } else {
+            logger.info("DATABASE_BUSY_TIMEOUT_MS not set; using default $resolved ms")
+        }
+        return resolved
     }
 
     /**

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseConfigTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseConfigTest.kt
@@ -1,0 +1,99 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/**
+ * Unit tests for [DatabaseConfig.resolveBusyTimeoutMs] — validates the env-var parsing
+ * and boundary logic without requiring actual environment variable manipulation.
+ */
+class DatabaseConfigTest {
+    // ------------------------------------------------------------------
+    // Default behaviour (unset env var)
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `returns default 5000 when env var is null`() {
+        val result = DatabaseConfig.resolveBusyTimeoutMs(null)
+        assertEquals(5000L, result)
+    }
+
+    // ------------------------------------------------------------------
+    // Valid values
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `returns parsed value when env var is a valid Long`() {
+        val result = DatabaseConfig.resolveBusyTimeoutMs("10000")
+        assertEquals(10000L, result)
+    }
+
+    @Test
+    fun `returns parsed value for recommended maximum 30000`() {
+        val result = DatabaseConfig.resolveBusyTimeoutMs("30000")
+        assertEquals(30000L, result)
+    }
+
+    @Test
+    fun `accepts values above the hard-ceiling documentation threshold`() {
+        // Hard ceiling (30 000 ms) is documentation-only; code must NOT reject values above it.
+        val result = DatabaseConfig.resolveBusyTimeoutMs("60000")
+        assertEquals(60000L, result)
+    }
+
+    @Test
+    fun `returns exactly 100 when env var is exactly the floor value`() {
+        val result = DatabaseConfig.resolveBusyTimeoutMs("100")
+        assertEquals(100L, result)
+    }
+
+    // ------------------------------------------------------------------
+    // Unparseable input → default
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `returns default when env var is not a valid Long`() {
+        val result = DatabaseConfig.resolveBusyTimeoutMs("not-a-number")
+        assertEquals(5000L, result)
+    }
+
+    @Test
+    fun `returns default when env var is an empty string`() {
+        val result = DatabaseConfig.resolveBusyTimeoutMs("")
+        assertEquals(5000L, result)
+    }
+
+    @Test
+    fun `returns default when env var is a decimal float string`() {
+        val result = DatabaseConfig.resolveBusyTimeoutMs("5000.5")
+        assertEquals(5000L, result)
+    }
+
+    // ------------------------------------------------------------------
+    // Below-floor input → 100 ms sanity floor
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `applies 100 ms floor when env var is below 100`() {
+        val result = DatabaseConfig.resolveBusyTimeoutMs("50")
+        assertEquals(100L, result)
+    }
+
+    @Test
+    fun `applies 100 ms floor for zero`() {
+        val result = DatabaseConfig.resolveBusyTimeoutMs("0")
+        assertEquals(100L, result)
+    }
+
+    @Test
+    fun `applies 100 ms floor for negative value`() {
+        val result = DatabaseConfig.resolveBusyTimeoutMs("-1")
+        assertEquals(100L, result)
+    }
+
+    @Test
+    fun `applies 100 ms floor for value of 99`() {
+        val result = DatabaseConfig.resolveBusyTimeoutMs("99")
+        assertEquals(100L, result)
+    }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseManagerBusyTimeoutTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseManagerBusyTimeoutTest.kt
@@ -1,0 +1,89 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database
+
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Integration tests verifying that [DatabaseManager] applies the busy_timeout PRAGMA correctly
+ * to SQLite connections.  Each test uses a unique in-memory SQLite database so they are fully
+ * isolated.
+ *
+ * Because env vars cannot be set programmatically on a standard JVM, the busy_timeout path
+ * exercised here always uses the default (5000 ms).  The validation logic is covered separately
+ * in [DatabaseConfigTest] which calls [DatabaseConfig.resolveBusyTimeoutMs] directly.
+ */
+class DatabaseManagerBusyTimeoutTest {
+    private val managers = mutableListOf<DatabaseManager>()
+
+    /** Create a fresh in-memory SQLite DatabaseManager and track it for cleanup. */
+    private fun buildManager(): DatabaseManager {
+        val dbName = "test_busy_${System.nanoTime()}"
+        val manager = DatabaseManager()
+        // Use SQLite in-memory URL with a named cache so the same connection is reused within
+        // the same JVM process (required for pragma verification to work on the same connection).
+        val initialized = manager.initialize("jdbc:sqlite:file:$dbName?mode=memory&cache=shared")
+        assertTrue(initialized, "DatabaseManager should initialize successfully")
+        managers += manager
+        return manager
+    }
+
+    @AfterEach
+    fun tearDown() {
+        managers.forEach { it.shutdown() }
+        managers.clear()
+    }
+
+    // ------------------------------------------------------------------
+    // Default busy_timeout — verifies PRAGMA is applied
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `busy_timeout pragma is applied on new connection`() {
+        val manager = buildManager()
+        val db = manager.getDatabase()
+
+        val pragmaValue =
+            transaction(db) {
+                var value = -1L
+                exec("PRAGMA busy_timeout") { rs ->
+                    if (rs.next()) value = rs.getLong(1)
+                }
+                value
+            }
+        // Default is 5000 ms.  SQLite may round or normalise the value, but it must be
+        // at least 5000 ms (and typically equals 5000).
+        assertTrue(pragmaValue >= 5000L, "Expected busy_timeout >= 5000 ms but got $pragmaValue")
+    }
+
+    @Test
+    fun `busy_timeout is a non-negative value after initialization`() {
+        val manager = buildManager()
+        val db = manager.getDatabase()
+
+        val pragmaValue =
+            transaction(db) {
+                var value = -1L
+                exec("PRAGMA busy_timeout") { rs ->
+                    if (rs.next()) value = rs.getLong(1)
+                }
+                value
+            }
+        assertTrue(pragmaValue >= 0L, "busy_timeout should be non-negative, got $pragmaValue")
+    }
+
+    // ------------------------------------------------------------------
+    // Verify DatabaseManager initializes successfully (no exception)
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `initialize returns true for a valid in-memory SQLite path`() {
+        val manager = DatabaseManager()
+        val dbName = "test_init_${System.nanoTime()}"
+        val result = manager.initialize("jdbc:sqlite:file:$dbName?mode=memory&cache=shared")
+        managers += manager
+        assertEquals(true, result)
+    }
+}


### PR DESCRIPTION
## Summary

- Promote SQLite `busy_timeout` from hardcoded `5000` in `DatabaseManager` to a configurable `DATABASE_BUSY_TIMEOUT_MS` env var
- Validation: unparseable value falls back to default `5000ms` with warn log; values below `100ms` floor to `100ms` with warn log
- Hard ceiling at `30000ms` is documentation guidance only — no code-level rejection (operators can override if a use case demands it)
- Recommended fleet-posture range documented: 5000-30000ms
- Pragma application verified end-to-end via integration test against a live SQLite connection

Tracked in MCP work item ` + "`da75caed`" + `.

## Test Results

1294 tests passed, 0 failed. 12 unit tests covering validation branches; 3 integration tests verifying the pragma is applied to a real connection.

## Review

Verdict: **pass**. Plan alignment verified. Pragma application confirmed by integration test reading back the pragma value.

## MCP Items

- Parent feature: ` + "`0628e760`" + `
- This PR: ` + "`da75caed-b0f1-4e42-b1cf-844ea5cad53e`" + `