### PR TITLE
feat(infra): add ToolError envelope and IdempotencyCache service (#117)

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/IdempotencyCache.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/IdempotencyCache.kt
@@ -20,8 +20,10 @@ import kotlin.concurrent.write
  *   removed to bound memory consumption.
  * - **TTL expiry** — entries older than [ttlSeconds] are treated as absent. Expired entries are
  *   cleaned lazily on [get]/[getOrCompute] and eagerly during [put] when the cache is full.
- * - **Thread-safe** — a [ReentrantReadWriteLock] guards all mutations. Concurrent reads do not
- *   block one another; writes are exclusive.
+ * - **Thread-safe** — a [ReentrantReadWriteLock] guards all accesses. Because the underlying
+ *   [java.util.LinkedHashMap] mutates on every read (to maintain LRU order), all operations
+ *   including [get] and [getOrCompute] take the write lock. [size] is the only truly
+ *   read-only operation.
  *
  * @param maxCapacity Maximum number of live (non-expired) entries to retain (default 1000).
  * @param ttlSeconds  Time-to-live per entry in seconds (default 600 = 10 minutes).
@@ -74,12 +76,17 @@ class IdempotencyCache(
     /**
      * Returns the cached value for `(actorId, requestId)` if it exists and has not expired.
      * Returns null otherwise (both "not found" and "expired" map to null).
+     *
+     * Uses a **write lock** because [store] is a `LinkedHashMap(accessOrder = true)` which
+     * mutates its internal linked-list on every [LinkedHashMap.get] call to track LRU order.
+     * Calling [LinkedHashMap.get] under a shared read lock from multiple threads concurrently
+     * would cause a data race and potential [java.util.ConcurrentModificationException].
      */
     fun get(
         actorId: String,
         requestId: UUID
     ): Any? =
-        lock.read {
+        lock.write {
             val key = CacheKey(actorId, requestId)
             val entry = store[key] ?: return null
             if (isExpired(entry)) null else entry.value
@@ -133,21 +140,32 @@ class IdempotencyCache(
         requestId: UUID,
         compute: () -> T
     ): T {
-        // Fast path: check under read lock
-        val cached =
-            lock.read {
-                val key = CacheKey(actorId, requestId)
-                val entry = store[key]
-                if (entry != null && !isExpired(entry)) entry else null
+        // Hold the write lock across the entire check-compute-store cycle to prevent
+        // TOCTOU: without this, concurrent threads on a cache miss would all pass the
+        // "not found" check and each call compute(), defeating the idempotency guarantee.
+        //
+        // The write lock is also required by the LRU LinkedHashMap — see get() comment.
+        //
+        // Note: compute() (the actual tool execution) runs while the write lock is held.
+        // This is intentional: for our use case the MCP tool already serialises through
+        // SQLite's own write lock, so holding the cache write lock for the duration adds
+        // no additional practical contention.
+        return lock.write {
+            val key = CacheKey(actorId, requestId)
+            val entry = store[key]
+            if (entry != null && !isExpired(entry)) {
+                entry.value as T
+            } else {
+                val result = compute()
+                val now = Instant.now()
+                evictExpired(now)
+                if (store.size >= maxCapacity) {
+                    store.remove(store.keys.first())
+                }
+                store[key] = CachedResponse(value = result, storedAt = now)
+                result
             }
-        if (cached != null) {
-            return cached.value as T
         }
-        // Slow path: compute outside all locks to avoid holding locks during potentially
-        // long-running work, then store the result.
-        val result = compute()
-        put(actorId, requestId, result)
-        return result
     }
 
     /**

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/IdempotencyCache.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/IdempotencyCache.kt
@@ -1,0 +1,186 @@
+package io.github.jpicklyk.mcptask.current.application.service
+
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+
+/**
+ * In-memory LRU cache keyed on `(actorId, requestId)` pairs.
+ *
+ * Used by mutating MCP tools to detect duplicate requests from the same actor: if a tool
+ * receives a request with the same `(actorId, requestId)` it already processed, it returns
+ * the cached result instead of re-executing the operation.
+ *
+ * Design decisions:
+ * - **Single-instance scope** — no restart persistence needed; a fresh JVM always starts with
+ *   an empty cache. Persistent HA semantics are deferred to a future v2 storage layer.
+ * - **LRU eviction** — once [maxCapacity] entries are stored, the least-recently-used entry is
+ *   removed to bound memory consumption.
+ * - **TTL expiry** — entries older than [ttlSeconds] are treated as absent. Expired entries are
+ *   cleaned lazily on [get]/[getOrCompute] and eagerly during [put] when the cache is full.
+ * - **Thread-safe** — a [ReentrantReadWriteLock] guards all mutations. Concurrent reads do not
+ *   block one another; writes are exclusive.
+ *
+ * @param maxCapacity Maximum number of live (non-expired) entries to retain (default 1000).
+ * @param ttlSeconds  Time-to-live per entry in seconds (default 600 = 10 minutes).
+ */
+class IdempotencyCache(
+    val maxCapacity: Int = 1000,
+    val ttlSeconds: Long = 600L
+) {
+    init {
+        require(maxCapacity > 0) { "maxCapacity must be positive, got $maxCapacity" }
+        require(ttlSeconds > 0) { "ttlSeconds must be positive, got $ttlSeconds" }
+    }
+
+    /**
+     * A single cached response entry.
+     *
+     * @property value    The cached result value (may be null — null is a valid cached result).
+     * @property storedAt The instant at which the entry was written.
+     */
+    data class CachedResponse(
+        val value: Any?,
+        val storedAt: Instant
+    )
+
+    /**
+     * Composite cache key combining the actor identifier and the request's idempotency UUID.
+     */
+    private data class CacheKey(
+        val actorId: String,
+        val requestId: UUID
+    )
+
+    /**
+     * Access-ordered LinkedHashMap used as the underlying LRU container.
+     * `accessOrder = true` moves the accessed entry to the tail on every [get]/[put],
+     * so the head is always the least-recently-used entry.
+     *
+     * Note: LinkedHashMap itself is not thread-safe; all accesses are guarded by [lock].
+     * The third constructor parameter is `accessOrder` — set to `true` for LRU ordering.
+     */
+    private val store: LinkedHashMap<CacheKey, CachedResponse> =
+        LinkedHashMap(16, 0.75f, true)
+
+    private val lock = ReentrantReadWriteLock()
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the cached value for `(actorId, requestId)` if it exists and has not expired.
+     * Returns null otherwise (both "not found" and "expired" map to null).
+     */
+    fun get(
+        actorId: String,
+        requestId: UUID
+    ): Any? =
+        lock.read {
+            val key = CacheKey(actorId, requestId)
+            val entry = store[key] ?: return null
+            if (isExpired(entry)) null else entry.value
+        }
+
+    /**
+     * Stores `value` for `(actorId, requestId)`.
+     *
+     * If the cache is at [maxCapacity] after expiry cleanup, the least-recently-used entry
+     * is evicted to make room.
+     */
+    fun put(
+        actorId: String,
+        requestId: UUID,
+        value: Any?
+    ): Unit =
+        lock.write {
+            val key = CacheKey(actorId, requestId)
+            val now = Instant.now()
+            // Remove expired entries first to avoid evicting live data unnecessarily
+            evictExpired(now)
+            // If still at capacity after expiry cleanup, remove the LRU entry
+            if (store.size >= maxCapacity) {
+                val lruKey = store.keys.first()
+                store.remove(lruKey)
+            }
+            store[key] = CachedResponse(value = value, storedAt = now)
+        }
+
+    /**
+     * Returns the cached result for `(actorId, requestId)` if present and non-expired,
+     * otherwise calls [compute], caches its result, and returns it.
+     *
+     * This is the primary entry point for idempotent tool implementations.
+     *
+     * ```kotlin
+     * val result = idempotencyCache.getOrCompute(actor.id, requestId) {
+     *     // perform the mutating operation here
+     *     doWork()
+     * }
+     * ```
+     *
+     * @param actorId   The actor's identifier (session ID, container hostname, JWT jti, etc.).
+     * @param requestId Client-supplied idempotency key for this request.
+     * @param compute   Lambda that produces the result when no cached entry exists.
+     * @return Cached or freshly computed result.
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun <T> getOrCompute(
+        actorId: String,
+        requestId: UUID,
+        compute: () -> T
+    ): T {
+        // Fast path: check under read lock
+        val cached =
+            lock.read {
+                val key = CacheKey(actorId, requestId)
+                val entry = store[key]
+                if (entry != null && !isExpired(entry)) entry else null
+            }
+        if (cached != null) {
+            return cached.value as T
+        }
+        // Slow path: compute outside all locks to avoid holding locks during potentially
+        // long-running work, then store the result.
+        val result = compute()
+        put(actorId, requestId, result)
+        return result
+    }
+
+    /**
+     * Returns the number of entries currently in the store (including potentially expired ones
+     * that have not yet been lazily evicted). Exposed primarily for testing and diagnostics.
+     */
+    fun size(): Int = lock.read { store.size }
+
+    /**
+     * Removes all entries from the cache. Exposed for testing.
+     */
+    fun clear(): Unit = lock.write { store.clear() }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    private fun isExpired(entry: CachedResponse): Boolean {
+        val expiresAt = entry.storedAt.plusSeconds(ttlSeconds)
+        return Instant.now().isAfter(expiresAt)
+    }
+
+    /**
+     * Removes all entries whose TTL has elapsed. Must be called within a write lock.
+     */
+    private fun evictExpired(now: Instant) {
+        val iter = store.entries.iterator()
+        while (iter.hasNext()) {
+            val entry = iter.next()
+            val expiresAt = entry.value.storedAt.plusSeconds(ttlSeconds)
+            if (now.isAfter(expiresAt)) {
+                iter.remove()
+            }
+        }
+    }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ToolError.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ToolError.kt
@@ -1,0 +1,110 @@
+package io.github.jpicklyk.mcptask.current.domain.model
+
+import java.util.UUID
+
+/**
+ * Classifies the retry semantics of a [ToolError].
+ *
+ * - [TRANSIENT] — the failure is temporary; the caller should retry with exponential backoff.
+ *   Typical causes: lock contention, JWKS unavailable, transient DB busy.
+ * - [PERMANENT] — the failure is definitive; retrying will produce the same result.
+ *   Typical causes: validation errors, authorization failures, not-found.
+ * - [SHEDDING] — the server is temporarily over capacity; the caller should retry after
+ *   an explicit delay indicated by [ToolError.retryAfterMs].
+ *   Typical causes: writer queue saturated, circuit-breaker open.
+ */
+enum class ErrorKind {
+    TRANSIENT,
+    PERMANENT,
+    SHEDDING;
+
+    fun toJsonString(): String = name.lowercase()
+
+    companion object {
+        fun fromString(value: String): ErrorKind =
+            entries.find { it.name.equals(value, ignoreCase = true) }
+                ?: throw IllegalArgumentException("Unknown ErrorKind: $value")
+    }
+}
+
+/**
+ * Structured error envelope returned by all MCP tools on failure.
+ *
+ * Provides enough information for an agent to decide:
+ * 1. **Whether to retry** — determined by [kind]
+ * 2. **When to retry** — [retryAfterMs] for [ErrorKind.SHEDDING] (null means "use own backoff")
+ * 3. **Which item to act on next** — [contendedItemId] distinguishes "retry *this* item" from
+ *    "pick a *different* item" without requiring string-parsing of [message].
+ *
+ * @property kind       Retry semantics classification.
+ * @property code       Structured error code (use constants from [ErrorCodes]).
+ * @property message    Human-readable description of the failure.
+ * @property retryAfterMs Milliseconds to wait before retrying (populated for [ErrorKind.SHEDDING];
+ *                        null means the caller should apply its own back-off).
+ * @property contendedItemId UUID of the work item involved in a contention error (populated for
+ *                           [ErrorKind.TRANSIENT] claim-race or version-conflict failures).
+ */
+data class ToolError(
+    val kind: ErrorKind,
+    val code: String,
+    val message: String,
+    val retryAfterMs: Long? = null,
+    val contendedItemId: UUID? = null
+) {
+    companion object {
+        /**
+         * Creates a [TRANSIENT][ErrorKind.TRANSIENT] error (lock contention, JWKS outage, etc.).
+         *
+         * @param code             Structured error code.
+         * @param message          Human-readable description.
+         * @param contendedItemId  UUID of the item involved in the contention (if applicable).
+         */
+        fun transient(
+            code: String,
+            message: String,
+            contendedItemId: UUID? = null
+        ): ToolError =
+            ToolError(
+                kind = ErrorKind.TRANSIENT,
+                code = code,
+                message = message,
+                contendedItemId = contendedItemId
+            )
+
+        /**
+         * Creates a [PERMANENT][ErrorKind.PERMANENT] error (validation, authorization, not-found).
+         *
+         * @param code    Structured error code.
+         * @param message Human-readable description.
+         */
+        fun permanent(
+            code: String,
+            message: String
+        ): ToolError =
+            ToolError(
+                kind = ErrorKind.PERMANENT,
+                code = code,
+                message = message
+            )
+
+        /**
+         * Creates a [SHEDDING][ErrorKind.SHEDDING] error (server over-capacity).
+         *
+         * @param code          Structured error code.
+         * @param message       Human-readable description.
+         * @param retryAfterMs  Milliseconds to wait before retrying. If null the caller uses
+         *                      its own backoff strategy.
+         */
+        fun shedding(
+            code: String,
+            message: String,
+            retryAfterMs: Long? = null
+        ): ToolError =
+            ToolError(
+                kind = ErrorKind.SHEDDING,
+                code = code,
+                message = message,
+                retryAfterMs = retryAfterMs
+            )
+    }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/IdempotencyCacheTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/IdempotencyCacheTest.kt
@@ -365,5 +365,7 @@ class IdempotencyCacheTest {
         // All threads must have received "shared-result"
         assertEquals(threadCount, resultsLock.size)
         assertTrue(resultsLock.all { it == "shared-result" }, "Not all threads received the same result")
+        // compute() must have been called exactly once — this is the idempotency guarantee
+        assertEquals(1, computeCount.get(), "compute() was called ${computeCount.get()} times but should be called exactly once")
     }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/IdempotencyCacheTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/IdempotencyCacheTest.kt
@@ -1,0 +1,369 @@
+package io.github.jpicklyk.mcptask.current.application.service
+
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class IdempotencyCacheTest {
+    // -------------------------------------------------------------------------
+    // Construction / defaults
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `default maxCapacity and ttlSeconds are positive`() {
+        val cache = IdempotencyCache()
+        assertTrue(cache.maxCapacity > 0)
+        assertTrue(cache.ttlSeconds > 0)
+    }
+
+    @Test
+    fun `default values are 1000 capacity and 600 seconds`() {
+        val cache = IdempotencyCache()
+        assertEquals(1000, cache.maxCapacity)
+        assertEquals(600L, cache.ttlSeconds)
+    }
+
+    @Test
+    fun `custom maxCapacity and ttlSeconds are stored`() {
+        val cache = IdempotencyCache(maxCapacity = 50, ttlSeconds = 30)
+        assertEquals(50, cache.maxCapacity)
+        assertEquals(30L, cache.ttlSeconds)
+    }
+
+    @Test
+    fun `zero maxCapacity throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            IdempotencyCache(maxCapacity = 0)
+        }
+    }
+
+    @Test
+    fun `negative maxCapacity throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            IdempotencyCache(maxCapacity = -1)
+        }
+    }
+
+    @Test
+    fun `zero ttlSeconds throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            IdempotencyCache(ttlSeconds = 0)
+        }
+    }
+
+    @Test
+    fun `negative ttlSeconds throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            IdempotencyCache(ttlSeconds = -5)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Basic get / put
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `get returns null for absent key`() {
+        val cache = IdempotencyCache()
+        assertNull(cache.get("actor-1", UUID.randomUUID()))
+    }
+
+    @Test
+    fun `put then get returns stored value`() {
+        val cache = IdempotencyCache()
+        val reqId = UUID.randomUUID()
+        cache.put("actor-1", reqId, "result-A")
+        assertEquals("result-A", cache.get("actor-1", reqId))
+    }
+
+    @Test
+    fun `put null value is distinguishable from absent key via getOrCompute`() {
+        val cache = IdempotencyCache()
+        val reqId = UUID.randomUUID()
+        val computeCount = AtomicInteger(0)
+
+        // First call — computes and caches null
+        val first =
+            cache.getOrCompute("actor-1", reqId) {
+                computeCount.incrementAndGet()
+                null
+            }
+        assertNull(first)
+        assertEquals(1, computeCount.get())
+
+        // Second call — should return cached null WITHOUT re-computing
+        val second =
+            cache.getOrCompute("actor-1", reqId) {
+                computeCount.incrementAndGet()
+                null
+            }
+        assertNull(second)
+        // compute should NOT have been called again
+        assertEquals(1, computeCount.get(), "compute was called a second time but should have used cache")
+    }
+
+    @Test
+    fun `different actorId same requestId are independent entries`() {
+        val cache = IdempotencyCache()
+        val reqId = UUID.randomUUID()
+        cache.put("actor-A", reqId, "value-A")
+        cache.put("actor-B", reqId, "value-B")
+        assertEquals("value-A", cache.get("actor-A", reqId))
+        assertEquals("value-B", cache.get("actor-B", reqId))
+    }
+
+    @Test
+    fun `same actorId different requestId are independent entries`() {
+        val cache = IdempotencyCache()
+        val reqA = UUID.randomUUID()
+        val reqB = UUID.randomUUID()
+        cache.put("actor-1", reqA, "value-A")
+        cache.put("actor-1", reqB, "value-B")
+        assertEquals("value-A", cache.get("actor-1", reqA))
+        assertEquals("value-B", cache.get("actor-1", reqB))
+    }
+
+    @Test
+    fun `put overwrites existing entry for same key`() {
+        val cache = IdempotencyCache()
+        val reqId = UUID.randomUUID()
+        cache.put("actor-1", reqId, "first")
+        cache.put("actor-1", reqId, "second")
+        assertEquals("second", cache.get("actor-1", reqId))
+    }
+
+    @Test
+    fun `size increments on new puts`() {
+        val cache = IdempotencyCache()
+        assertEquals(0, cache.size())
+        cache.put("actor-1", UUID.randomUUID(), "v1")
+        assertEquals(1, cache.size())
+        cache.put("actor-1", UUID.randomUUID(), "v2")
+        assertEquals(2, cache.size())
+    }
+
+    @Test
+    fun `clear empties the cache`() {
+        val cache = IdempotencyCache()
+        cache.put("actor-1", UUID.randomUUID(), "x")
+        cache.put("actor-2", UUID.randomUUID(), "y")
+        cache.clear()
+        assertEquals(0, cache.size())
+    }
+
+    // -------------------------------------------------------------------------
+    // getOrCompute
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `getOrCompute calls compute on cache miss`() {
+        val cache = IdempotencyCache()
+        val reqId = UUID.randomUUID()
+        val callCount = AtomicInteger(0)
+
+        val result =
+            cache.getOrCompute("actor-1", reqId) {
+                callCount.incrementAndGet()
+                "computed-value"
+            }
+
+        assertEquals("computed-value", result)
+        assertEquals(1, callCount.get())
+    }
+
+    @Test
+    fun `getOrCompute returns cached value on second call`() {
+        val cache = IdempotencyCache()
+        val reqId = UUID.randomUUID()
+        val callCount = AtomicInteger(0)
+
+        cache.getOrCompute("actor-1", reqId) {
+            callCount.incrementAndGet()
+            "value"
+        }
+        val second =
+            cache.getOrCompute("actor-1", reqId) {
+                callCount.incrementAndGet()
+                "other"
+            }
+
+        assertEquals("value", second)
+        assertEquals(1, callCount.get())
+    }
+
+    @Test
+    fun `getOrCompute returns typed result correctly`() {
+        val cache = IdempotencyCache()
+        val reqId = UUID.randomUUID()
+        val result: Int = cache.getOrCompute("actor-1", reqId) { 42 }
+        assertEquals(42, result)
+    }
+
+    // -------------------------------------------------------------------------
+    // TTL expiry
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `get returns null for expired entry`() {
+        // 1-second TTL; store entry, then wait for expiry
+        val cache = IdempotencyCache(ttlSeconds = 1)
+        val reqId = UUID.randomUUID()
+        cache.put("actor-1", reqId, "stale")
+        Thread.sleep(1100)
+        assertNull(cache.get("actor-1", reqId))
+    }
+
+    @Test
+    fun `getOrCompute re-computes after TTL expiry`() {
+        val cache = IdempotencyCache(ttlSeconds = 1)
+        val reqId = UUID.randomUUID()
+        val callCount = AtomicInteger(0)
+
+        cache.getOrCompute("actor-1", reqId) {
+            callCount.incrementAndGet()
+            "first"
+        }
+        Thread.sleep(1100)
+        val second =
+            cache.getOrCompute("actor-1", reqId) {
+                callCount.incrementAndGet()
+                "second"
+            }
+
+        assertEquals("second", second)
+        assertEquals(2, callCount.get())
+    }
+
+    // -------------------------------------------------------------------------
+    // LRU eviction at capacity
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `LRU entry is evicted when capacity is exceeded`() {
+        val cache = IdempotencyCache(maxCapacity = 3)
+
+        val req1 = UUID.randomUUID()
+        val req2 = UUID.randomUUID()
+        val req3 = UUID.randomUUID()
+        val req4 = UUID.randomUUID()
+
+        cache.put("actor", req1, "v1")
+        cache.put("actor", req2, "v2")
+        cache.put("actor", req3, "v3")
+        // Access req1 so req2 becomes the LRU
+        cache.get("actor", req1)
+        // Adding req4 should evict req2 (the LRU after req1 was touched)
+        cache.put("actor", req4, "v4")
+
+        assertNull(cache.get("actor", req2), "LRU entry req2 should have been evicted")
+        assertNotNull(cache.get("actor", req1), "req1 (accessed recently) should still be present")
+        assertNotNull(cache.get("actor", req3), "req3 should still be present")
+        assertNotNull(cache.get("actor", req4), "req4 (just added) should be present")
+    }
+
+    @Test
+    fun `cache size never exceeds maxCapacity`() {
+        val capacity = 5
+        val cache = IdempotencyCache(maxCapacity = capacity, ttlSeconds = 3600)
+
+        repeat(10) { i ->
+            cache.put("actor-$i", UUID.randomUUID(), "value-$i")
+        }
+
+        assertTrue(cache.size() <= capacity, "size ${cache.size()} exceeded maxCapacity $capacity")
+    }
+
+    // -------------------------------------------------------------------------
+    // CachedResponse data class
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `CachedResponse storedAt is set to approximately now`() {
+        val cache = IdempotencyCache()
+        val reqId = UUID.randomUUID()
+        val before = java.time.Instant.now()
+        cache.put("actor-1", reqId, "x")
+        val after = java.time.Instant.now()
+
+        // Verify via re-computation not being triggered (can't read storedAt directly from public API)
+        // We validate via TTL semantics: an entry stored 'now' should not expire immediately
+        val result = cache.get("actor-1", reqId)
+        assertEquals("x", result)
+        assertTrue(!before.isAfter(after))
+    }
+
+    // -------------------------------------------------------------------------
+    // Concurrent access safety
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `concurrent puts and gets do not throw`() {
+        val cache = IdempotencyCache(maxCapacity = 200)
+        val threadCount = 10
+        val opsPerThread = 20
+        val executor = Executors.newFixedThreadPool(threadCount)
+        val latch = CountDownLatch(threadCount)
+        val errors = AtomicInteger(0)
+
+        repeat(threadCount) { t ->
+            executor.submit {
+                try {
+                    repeat(opsPerThread) { i ->
+                        val reqId = UUID.randomUUID()
+                        cache.put("actor-$t", reqId, "value-$t-$i")
+                        cache.get("actor-$t", reqId)
+                        cache.getOrCompute("actor-$t", UUID.randomUUID()) { "computed-$t-$i" }
+                    }
+                } catch (e: Exception) {
+                    errors.incrementAndGet()
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        assertTrue(latch.await(60, TimeUnit.SECONDS), "Concurrent test timed out")
+        executor.shutdown()
+        assertEquals(0, errors.get(), "Concurrent access produced ${errors.get()} error(s)")
+    }
+
+    @Test
+    fun `getOrCompute is idempotent under concurrent requests for same key`() {
+        val cache = IdempotencyCache(maxCapacity = 100)
+        val reqId = UUID.randomUUID()
+        val computeCount = AtomicInteger(0)
+        val threadCount = 20
+        val latch = CountDownLatch(1)
+        val executor = Executors.newFixedThreadPool(threadCount)
+        val results = mutableListOf<String>()
+        val resultsLock = java.util.concurrent.ConcurrentLinkedQueue<String>()
+
+        repeat(threadCount) {
+            executor.submit {
+                latch.await()
+                val value =
+                    cache.getOrCompute("actor-shared", reqId) {
+                        computeCount.incrementAndGet()
+                        "shared-result"
+                    }
+                resultsLock.add(value)
+            }
+        }
+
+        latch.countDown()
+        executor.shutdown()
+        assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS))
+
+        // All threads must have received "shared-result"
+        assertEquals(threadCount, resultsLock.size)
+        assertTrue(resultsLock.all { it == "shared-result" }, "Not all threads received the same result")
+    }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ToolErrorTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ToolErrorTest.kt
@@ -1,0 +1,165 @@
+package io.github.jpicklyk.mcptask.current.domain.model
+
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class ToolErrorTest {
+    // -------------------------------------------------------------------------
+    // ErrorKind
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `ErrorKind has all three expected variants`() {
+        assertEquals(3, ErrorKind.entries.size)
+        assertNotNull(ErrorKind.TRANSIENT)
+        assertNotNull(ErrorKind.PERMANENT)
+        assertNotNull(ErrorKind.SHEDDING)
+    }
+
+    @Test
+    fun `ErrorKind fromString round-trip all values`() {
+        assertEquals(ErrorKind.TRANSIENT, ErrorKind.fromString("TRANSIENT"))
+        assertEquals(ErrorKind.PERMANENT, ErrorKind.fromString("PERMANENT"))
+        assertEquals(ErrorKind.SHEDDING, ErrorKind.fromString("SHEDDING"))
+    }
+
+    @Test
+    fun `ErrorKind fromString is case insensitive`() {
+        assertEquals(ErrorKind.TRANSIENT, ErrorKind.fromString("transient"))
+        assertEquals(ErrorKind.PERMANENT, ErrorKind.fromString("permanent"))
+        assertEquals(ErrorKind.SHEDDING, ErrorKind.fromString("shedding"))
+        assertEquals(ErrorKind.TRANSIENT, ErrorKind.fromString("Transient"))
+    }
+
+    @Test
+    fun `ErrorKind fromString invalid value throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            ErrorKind.fromString("UNKNOWN")
+        }
+    }
+
+    @Test
+    fun `ErrorKind toJsonString returns lowercase`() {
+        assertEquals("transient", ErrorKind.TRANSIENT.toJsonString())
+        assertEquals("permanent", ErrorKind.PERMANENT.toJsonString())
+        assertEquals("shedding", ErrorKind.SHEDDING.toJsonString())
+    }
+
+    // -------------------------------------------------------------------------
+    // ToolError construction
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `ToolError direct construction with all required fields`() {
+        val err =
+            ToolError(
+                kind = ErrorKind.PERMANENT,
+                code = "VALIDATION_ERROR",
+                message = "field 'x' is required"
+            )
+        assertEquals(ErrorKind.PERMANENT, err.kind)
+        assertEquals("VALIDATION_ERROR", err.code)
+        assertEquals("field 'x' is required", err.message)
+        assertNull(err.retryAfterMs)
+        assertNull(err.contendedItemId)
+    }
+
+    @Test
+    fun `ToolError retryAfterMs and contendedItemId default to null`() {
+        val err = ToolError(ErrorKind.TRANSIENT, "LOCK_CONTENTION", "item locked")
+        assertNull(err.retryAfterMs)
+        assertNull(err.contendedItemId)
+    }
+
+    @Test
+    fun `ToolError all fields populated`() {
+        val itemId = UUID.randomUUID()
+        val err =
+            ToolError(
+                kind = ErrorKind.TRANSIENT,
+                code = "LOCK_CONTENTION",
+                message = "item is locked by another agent",
+                retryAfterMs = 500L,
+                contendedItemId = itemId
+            )
+        assertEquals(ErrorKind.TRANSIENT, err.kind)
+        assertEquals("LOCK_CONTENTION", err.code)
+        assertEquals("item is locked by another agent", err.message)
+        assertEquals(500L, err.retryAfterMs)
+        assertEquals(itemId, err.contendedItemId)
+    }
+
+    @Test
+    fun `ToolError is a data class with value equality`() {
+        val id = UUID.randomUUID()
+        val a = ToolError(ErrorKind.TRANSIENT, "CODE", "msg", 100L, id)
+        val b = ToolError(ErrorKind.TRANSIENT, "CODE", "msg", 100L, id)
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    // -------------------------------------------------------------------------
+    // Factory helpers
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `ToolError transient factory without contendedItemId`() {
+        val err = ToolError.transient("LOCK_CONTENTION", "item locked")
+        assertEquals(ErrorKind.TRANSIENT, err.kind)
+        assertEquals("LOCK_CONTENTION", err.code)
+        assertEquals("item locked", err.message)
+        assertNull(err.retryAfterMs)
+        assertNull(err.contendedItemId)
+    }
+
+    @Test
+    fun `ToolError transient factory with contendedItemId`() {
+        val itemId = UUID.randomUUID()
+        val err = ToolError.transient("LOCK_CONTENTION", "item locked", contendedItemId = itemId)
+        assertEquals(ErrorKind.TRANSIENT, err.kind)
+        assertEquals(itemId, err.contendedItemId)
+        assertNull(err.retryAfterMs)
+    }
+
+    @Test
+    fun `ToolError permanent factory produces PERMANENT kind`() {
+        val err = ToolError.permanent("VALIDATION_ERROR", "missing required field")
+        assertEquals(ErrorKind.PERMANENT, err.kind)
+        assertEquals("VALIDATION_ERROR", err.code)
+        assertEquals("missing required field", err.message)
+        assertNull(err.retryAfterMs)
+        assertNull(err.contendedItemId)
+    }
+
+    @Test
+    fun `ToolError shedding factory without retryAfterMs`() {
+        val err = ToolError.shedding("CAPACITY_EXCEEDED", "writer queue saturated")
+        assertEquals(ErrorKind.SHEDDING, err.kind)
+        assertEquals("CAPACITY_EXCEEDED", err.code)
+        assertNull(err.retryAfterMs)
+        assertNull(err.contendedItemId)
+    }
+
+    @Test
+    fun `ToolError shedding factory with retryAfterMs`() {
+        val err = ToolError.shedding("CAPACITY_EXCEEDED", "writer queue saturated", retryAfterMs = 3000L)
+        assertEquals(ErrorKind.SHEDDING, err.kind)
+        assertEquals(3000L, err.retryAfterMs)
+    }
+
+    @Test
+    fun `ToolError shedding factory never sets contendedItemId`() {
+        val err = ToolError.shedding("CODE", "msg", retryAfterMs = 1000L)
+        assertNull(err.contendedItemId)
+    }
+
+    @Test
+    fun `ToolError transient factory never sets retryAfterMs`() {
+        val err = ToolError.transient("CODE", "msg")
+        assertNull(err.retryAfterMs)
+    }
+}


### PR DESCRIPTION
## Summary

- New `ToolError` data class (domain model) with `ErrorKind` enum (TRANSIENT | PERMANENT | SHEDDING), `code`, `message`, `retryAfterMs`, and `contendedItemId` fields. Three factory helpers: `transient()`, `permanent()`, `shedding()`.
- New `IdempotencyCache` service — in-memory LRU with capacity-bounded eviction and TTL expiry. Thread-safe via `ReentrantReadWriteLock`. Public API: `get()`, `put()`, `getOrCompute()`, `size()`, `clear()`.
- Includes the `contendedItemId` late refinement from piiiico's 2026-04-28 review — agents can distinguish "retry this item" vs "pick a different one" without parsing error strings.
- Purely additive — zero existing files modified. Item 8 will integrate `IdempotencyCache` into mutating tools.

Tracked in MCP work item ` + "`a951186b`" + `.

## Test Results

1320 tests passed, 0 failed. 37 new tests covering ToolError construction (all kinds, factory methods, null defaults) and IdempotencyCache (cache hit/miss, TTL expiry, LRU eviction, concurrent access — including a 20-thread idempotency test with `assertEquals(1, computeCount)`).

## Review

Initial review found **3 blocking concurrency bugs**, all fixed in follow-up commit ` + "`f56706b`" + ` and confirmed in re-review:

1. **LRU mutation under read lock** — `LinkedHashMap(accessOrder=true)` mutates internal state on every `get()`. Fix: switched `get()` and `getOrCompute()` fast-path to write lock.
2. **TOCTOU double-invocation in getOrCompute** — concurrent cache misses all called compute(). Fix: hold write lock across full check-compute-store cycle.
3. **Missing assertion in concurrent test** — test tracked `computeCount` but never asserted on it. Fix: added `assertEquals(1, computeCount.get())` after 20 concurrent invocations.

Re-review verdict: **all-pass, ready to merge**.

## MCP Items

- Parent feature: ` + "`0628e760`" + `
- This PR: ` + "`a951186b-b6fe-4050-a4cb-4d444cf2a7b5`" + `