### PR TITLE
feat(workflow): add role parameter and claim filtering to get_next_item (#117)

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
@@ -7,14 +7,21 @@ import io.modelcontextprotocol.kotlin.sdk.types.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.*
 
+/** Non-terminal roles that `get_next_item` may query. */
+private val VALID_ROLES = setOf("queue", "work", "review", "blocked")
+
 /**
  * Read-only MCP tool that recommends the next WorkItem(s) to work on.
  *
  * Selection logic:
- * 1. Find all items in QUEUE role (not yet started)
- * 2. Filter out blocked items (unsatisfied BLOCKS / IS_BLOCKED_BY dependencies)
- * 3. Sort by priority (HIGH > MEDIUM > LOW), then complexity ascending (quick wins first)
- * 4. Return top `limit` recommendations
+ * 1. Find all items in the requested role (default: QUEUE)
+ * 2. Filter out items with active (non-expired) claims unless includeClaimed=true
+ * 3. Filter out blocked items (unsatisfied BLOCKS / IS_BLOCKED_BY dependencies)
+ * 4. Sort by priority (HIGH > MEDIUM > LOW), then complexity ascending (quick wins first)
+ * 5. Return top `limit` recommendations
+ *
+ * Tiered claim disclosure: the response never exposes `claimedBy` or `claimedAt`.
+ * When `includeClaimed=true`, only a boolean `isClaimed` field is added to each item.
  */
 class GetNextItemTool : BaseToolDefinition() {
     override val name = "get_next_item"
@@ -23,15 +30,20 @@ class GetNextItemTool : BaseToolDefinition() {
         """
 Recommends next work item(s) based on role, dependencies, priority, and complexity.
 
-Finds QUEUE items, filters out those blocked by unsatisfied dependencies,
+Finds items in the requested role (default: queue), filters out those blocked by
+unsatisfied dependencies and those with active claims (unless includeClaimed=true),
 and ranks by priority (high first) then complexity (low first = quick wins).
 
 Parameters:
+- role (optional string, default "queue"): Role to query — "queue", "work", "review", or "blocked"
 - parentId (optional UUID): Scope to items under this parent
 - limit (optional int, default 1, max 20): Number of recommendations
 - includeDetails (optional boolean, default false): Include summary, tags, parentId
 - includeAncestors (optional boolean, default false): when true, each recommended item includes an
   `ancestors` array ordered root-first (direct parent last). Root items (depth=0) get `"ancestors": []`.
+- includeClaimed (optional boolean, default false): When false (default), items with an active
+  (non-expired) claim are filtered out. When true, claimed items are included but only a boolean
+  `isClaimed` field is exposed — the claiming agent's identity is never disclosed.
         """.trimIndent()
 
     override val category = ToolCategory.WORKFLOW
@@ -48,6 +60,18 @@ Parameters:
         ToolSchema(
             properties =
                 buildJsonObject {
+                    put(
+                        "role",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "Role to query (default: \"queue\"). Valid values: \"queue\", \"work\", \"review\", \"blocked\""
+                                )
+                            )
+                        }
+                    )
                     put(
                         "parentId",
                         buildJsonObject {
@@ -84,12 +108,32 @@ Parameters:
                             )
                         }
                     )
+                    put(
+                        "includeClaimed",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("boolean"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "When true, include items with active claims (shows isClaimed boolean only — identity never disclosed). Default: false."
+                                )
+                            )
+                        }
+                    )
                 },
             required = emptyList()
         )
 
     override fun validateParams(params: JsonElement) {
-        // All parameters are optional — just validate types if present
+        // Validate role parameter
+        val roleStr = optionalString(params, "role")
+        if (roleStr != null && roleStr.lowercase() !in VALID_ROLES) {
+            throw ToolValidationException(
+                "invalid_role: role must be one of ${VALID_ROLES.joinToString(", ")} — got: $roleStr"
+            )
+        }
+
+        // All other parameters are optional — just validate types if present
         validateIdOrPrefix(params, "parentId", required = false)
         val limit = optionalInt(params, "limit")
         if (limit != null && (limit < 1 || limit > 20)) {
@@ -101,22 +145,32 @@ Parameters:
         params: JsonElement,
         context: ToolExecutionContext
     ): JsonElement {
+        // Parse parameters
+        val roleStr = optionalString(params, "role") ?: "queue"
+        val targetRole =
+            Role.fromString(roleStr)
+                ?: return errorResponse("invalid_role: unrecognized role '$roleStr'", ErrorCodes.VALIDATION_ERROR)
+
         val (parentId, parentIdError) = resolveItemId(params, "parentId", context, required = false)
         if (parentIdError != null) return parentIdError
+
         val limit = optionalInt(params, "limit") ?: 1
         val includeDetails = optionalBoolean(params, "includeDetails", defaultValue = false)
         val includeAncestors = optionalBoolean(params, "includeAncestors", false)
+        val includeClaimed = optionalBoolean(params, "includeClaimed", false)
 
         val workItemRepo = context.workItemRepository()
         val dependencyRepo = context.dependencyRepository()
 
-        // Step 1: Find all QUEUE items (candidates)
+        // Step 1: Find items in the requested role, applying claim filter at the DB level
+        val excludeActiveClaims = !includeClaimed
         val candidatesResult =
-            if (parentId != null) {
-                workItemRepo.findByFilters(parentId = parentId, role = Role.QUEUE, limit = 200)
-            } else {
-                workItemRepo.findByRole(Role.QUEUE, limit = 200)
-            }
+            workItemRepo.findForNextItem(
+                role = targetRole,
+                parentId = parentId,
+                excludeActiveClaims = excludeActiveClaims,
+                limit = 200
+            )
 
         val candidates =
             when (candidatesResult) {
@@ -127,7 +181,7 @@ Parameters:
                 )
             }
 
-        // Step 2: Filter out blocked items
+        // Step 2: Filter out blocked items (dependency-blocked, not role-BLOCKED)
         val unblockedItems =
             candidates.filter { item ->
                 !isBlocked(item, workItemRepo, dependencyRepo)
@@ -173,6 +227,14 @@ Parameters:
                                     put("summary", JsonPrimitive(item.summary))
                                     item.tags?.let { put("tags", JsonPrimitive(it)) }
                                     item.parentId?.let { put("parentId", JsonPrimitive(it.toString())) }
+                                }
+                                // Tiered claim disclosure: expose only boolean isClaimed, never claimedBy/claimedAt.
+                                // An item is "actively claimed" when claimedBy is set and claimExpiresAt is in the future.
+                                if (includeClaimed) {
+                                    val activelyClaimedNow =
+                                        item.claimedBy != null &&
+                                            item.claimExpiresAt?.isAfter(java.time.Instant.now()) == true
+                                    put("isClaimed", JsonPrimitive(activelyClaimedNow))
                                 }
                                 if (includeAncestors) {
                                     put("ancestors", buildAncestorsArray(ancestorChains[item.id] ?: emptyList()))

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
@@ -215,4 +215,25 @@ interface WorkItemRepository {
      * Items with no parent (depth=0 root items) map to an empty list.
      */
     suspend fun findAncestorChains(itemIds: Set<UUID>): Result<Map<UUID, List<WorkItem>>>
+
+    /**
+     * Find work items for the "get next" recommendation query, supporting optional claim filtering.
+     *
+     * Returns items in the specified [role] that are not in TERMINAL. When [excludeActiveClaims]
+     * is true, items with a live (non-expired) claim are omitted from the result — i.e., only items
+     * where `claimed_by IS NULL OR claim_expires_at <= datetime('now')` are returned.
+     *
+     * The claim filter is applied at the DB level to avoid loading and discarding claimed rows.
+     *
+     * @param role            The role to query (e.g. QUEUE, WORK, REVIEW, BLOCKED).
+     * @param parentId        Optional parent UUID to scope results to direct children only.
+     * @param excludeActiveClaims When true, omit items with a live (non-expired) claim.
+     * @param limit           Maximum number of rows to return.
+     */
+    suspend fun findForNextItem(
+        role: Role,
+        parentId: UUID? = null,
+        excludeActiveClaims: Boolean = true,
+        limit: Int = 200
+    ): Result<List<WorkItem>>
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -18,6 +18,7 @@ import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.greaterEq
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.inList
+import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.isNull
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.lessEq
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.like
 import org.jetbrains.exposed.v1.core.VarCharColumnType
@@ -537,6 +538,43 @@ class SQLiteWorkItemRepository(
         } catch (e: Exception) {
             logger.error("Failed to release WorkItem $itemId for agent $agentId: ${e.message}", e)
             ReleaseResult.NotFound(itemId)
+        }
+
+    override suspend fun findForNextItem(
+        role: Role,
+        parentId: UUID?,
+        excludeActiveClaims: Boolean,
+        limit: Int
+    ): Result<List<WorkItem>> =
+        databaseManager.suspendedTransaction("Failed to find next items by role") {
+            val conditions = mutableListOf<Op<Boolean>>()
+
+            // Role filter
+            conditions.add(WorkItemsTable.role eq role.name.lowercase())
+
+            // Optional parent scope
+            parentId?.let { conditions.add(WorkItemsTable.parentId eq it) }
+
+            // Claim filter: exclude items with an active (non-expired) claim.
+            // An item is "actively claimed" when claimed_by IS NOT NULL AND claim_expires_at > now.
+            // The complement (items to include) is: claimed_by IS NULL OR claim_expires_at <= now.
+            if (excludeActiveClaims) {
+                val notClaimed = WorkItemsTable.claimedBy.isNull()
+                val claimExpired = WorkItemsTable.claimExpiresAt lessEq Instant.now()
+                // Re-express as: NOT (claimedBy IS NOT NULL AND claimExpiresAt > now)
+                //               = claimedBy IS NULL  OR  claimExpiresAt <= now
+                conditions.add(notClaimed or claimExpired)
+            }
+
+            val combined = conditions.reduce { acc, op -> acc and op }
+            val items =
+                WorkItemsTable
+                    .selectAll()
+                    .where { combined }
+                    .limit(limit)
+                    .mapNotNull { toWorkItemOrNull(it) }
+
+            Result.Success(items)
         }
 
     override suspend fun findAncestorChains(itemIds: Set<UUID>): Result<Map<UUID, List<WorkItem>>> {

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolTest.kt
@@ -720,4 +720,313 @@ class GetNextItemToolTest {
                 "Item should be blocked when IS_BLOCKED_BY dep is unsatisfied even if BLOCKS dep is satisfied"
             )
         }
+
+    // ──────────────────────────────────────────────
+    // role parameter tests
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `default role is queue — WORK items not returned without role param`(): Unit =
+        runBlocking {
+            createItem("Queue Item", role = Role.QUEUE)
+            createItem("Work Item", role = Role.WORK)
+
+            val result = tool.execute(params("limit" to JsonPrimitive(10)), context)
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            assertEquals(1, recs.size)
+            assertEquals("queue", recs[0].jsonObject["role"]!!.jsonPrimitive.content)
+        }
+
+    @Test
+    fun `role=queue returns QUEUE items`(): Unit =
+        runBlocking {
+            val item = createItem("Queue Only", role = Role.QUEUE)
+            createItem("Work Item", role = Role.WORK)
+
+            val result = tool.execute(params("role" to JsonPrimitive("queue"), "limit" to JsonPrimitive(10)), context)
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val recIds = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }
+            assertTrue(recIds.contains(item.id.toString()))
+        }
+
+    @Test
+    fun `role=work returns WORK items only`(): Unit =
+        runBlocking {
+            createItem("Queue Item", role = Role.QUEUE)
+            val workItem = createItem("Work Item", role = Role.WORK)
+
+            val result = tool.execute(params("role" to JsonPrimitive("work"), "limit" to JsonPrimitive(10)), context)
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            assertEquals(1, recs.size)
+            assertEquals(workItem.id.toString(), recs[0].jsonObject["itemId"]!!.jsonPrimitive.content)
+            assertEquals("work", recs[0].jsonObject["role"]!!.jsonPrimitive.content)
+        }
+
+    @Test
+    fun `role=review returns REVIEW items only`(): Unit =
+        runBlocking {
+            createItem("Queue Item", role = Role.QUEUE)
+            val reviewItem = createItem("Review Item", role = Role.REVIEW)
+
+            val result = tool.execute(params("role" to JsonPrimitive("review"), "limit" to JsonPrimitive(10)), context)
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            assertEquals(1, recs.size)
+            assertEquals(reviewItem.id.toString(), recs[0].jsonObject["itemId"]!!.jsonPrimitive.content)
+            assertEquals("review", recs[0].jsonObject["role"]!!.jsonPrimitive.content)
+        }
+
+    @Test
+    fun `role=blocked returns BLOCKED items only`(): Unit =
+        runBlocking {
+            createItem("Queue Item", role = Role.QUEUE)
+            val blockedItem = createItem("Blocked Item", role = Role.BLOCKED)
+
+            val result = tool.execute(params("role" to JsonPrimitive("blocked"), "limit" to JsonPrimitive(10)), context)
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            assertEquals(1, recs.size)
+            assertEquals(blockedItem.id.toString(), recs[0].jsonObject["itemId"]!!.jsonPrimitive.content)
+            assertEquals("blocked", recs[0].jsonObject["role"]!!.jsonPrimitive.content)
+        }
+
+    @Test
+    fun `invalid role value fails validation`() {
+        assertFailsWith<io.github.jpicklyk.mcptask.current.application.tools.ToolValidationException> {
+            tool.validateParams(params("role" to JsonPrimitive("terminal")))
+        }
+    }
+
+    @Test
+    fun `invalid role arbitrary string fails validation`() {
+        assertFailsWith<io.github.jpicklyk.mcptask.current.application.tools.ToolValidationException> {
+            tool.validateParams(params("role" to JsonPrimitive("done")))
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // includeClaimed / claim filtering tests
+    // ──────────────────────────────────────────────
+
+    /**
+     * Create a work item with an active claim (non-expired) directly via the repository.
+     * claimExpiresAt is set 1 hour in the future so it is definitely active.
+     */
+    private suspend fun createClaimedItem(
+        title: String,
+        role: Role = Role.QUEUE
+    ): WorkItem {
+        val item =
+            WorkItem(
+                title = title,
+                role = role,
+                claimedBy = "test-agent",
+                claimedAt =
+                    java.time.Instant
+                        .now()
+                        .minusSeconds(60),
+                claimExpiresAt =
+                    java.time.Instant
+                        .now()
+                        .plusSeconds(3600),
+                originalClaimedAt =
+                    java.time.Instant
+                        .now()
+                        .minusSeconds(60)
+            )
+        val result = context.workItemRepository().create(item)
+        return (result as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+    }
+
+    /**
+     * Create a work item with an expired claim (claimExpiresAt in the past).
+     */
+    private suspend fun createExpiredClaimItem(
+        title: String,
+        role: Role = Role.QUEUE
+    ): WorkItem {
+        val item =
+            WorkItem(
+                title = title,
+                role = role,
+                claimedBy = "test-agent",
+                claimedAt =
+                    java.time.Instant
+                        .now()
+                        .minusSeconds(7200),
+                claimExpiresAt =
+                    java.time.Instant
+                        .now()
+                        .minusSeconds(3600),
+                originalClaimedAt =
+                    java.time.Instant
+                        .now()
+                        .minusSeconds(7200)
+            )
+        val result = context.workItemRepository().create(item)
+        return (result as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+    }
+
+    @Test
+    fun `actively claimed items are filtered out by default`(): Unit =
+        runBlocking {
+            val unclaimed = createItem("Unclaimed Item", role = Role.QUEUE)
+            createClaimedItem("Claimed Item", role = Role.QUEUE)
+
+            val result = tool.execute(params("limit" to JsonPrimitive(10)), context)
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val recIds = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }
+            assertTrue(recIds.contains(unclaimed.id.toString()), "Unclaimed item should be recommended")
+            assertTrue(recIds.none { id -> id != unclaimed.id.toString() }, "Claimed item should be filtered")
+        }
+
+    @Test
+    fun `expired claimed items are treated as unclaimed and returned`(): Unit =
+        runBlocking {
+            val expiredClaim = createExpiredClaimItem("Expired Claim Item", role = Role.QUEUE)
+
+            val result = tool.execute(params("limit" to JsonPrimitive(10)), context)
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val recIds = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }
+            assertTrue(recIds.contains(expiredClaim.id.toString()), "Item with expired claim should be recommended")
+        }
+
+    @Test
+    fun `includeClaimed=true returns claimed items alongside unclaimed`(): Unit =
+        runBlocking {
+            val unclaimed = createItem("Unclaimed Item", role = Role.QUEUE)
+            val claimed = createClaimedItem("Claimed Item", role = Role.QUEUE)
+
+            val result =
+                tool.execute(
+                    params(
+                        "includeClaimed" to JsonPrimitive(true),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val recIds = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }
+            assertTrue(recIds.contains(unclaimed.id.toString()), "Unclaimed item should be included")
+            assertTrue(recIds.contains(claimed.id.toString()), "Claimed item should be included when includeClaimed=true")
+        }
+
+    @Test
+    fun `includeClaimed=true exposes isClaimed boolean for claimed items`(): Unit =
+        runBlocking {
+            val claimed = createClaimedItem("Claimed Item", role = Role.QUEUE)
+
+            val result =
+                tool.execute(
+                    params(
+                        "includeClaimed" to JsonPrimitive(true),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val claimedRec = recs.find { it.jsonObject["itemId"]!!.jsonPrimitive.content == claimed.id.toString() }
+            assertNotNull(claimedRec, "Claimed item should be in recommendations")
+
+            val isClaimed = claimedRec.jsonObject["isClaimed"]
+            assertNotNull(isClaimed, "isClaimed field should be present when includeClaimed=true")
+            assertTrue(isClaimed.jsonPrimitive.boolean, "isClaimed should be true for actively claimed item")
+        }
+
+    @Test
+    fun `includeClaimed=true shows isClaimed=false for unclaimed items`(): Unit =
+        runBlocking {
+            val unclaimed = createItem("Unclaimed Item", role = Role.QUEUE)
+
+            val result =
+                tool.execute(
+                    params(
+                        "includeClaimed" to JsonPrimitive(true),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val unclaimedRec = recs.find { it.jsonObject["itemId"]!!.jsonPrimitive.content == unclaimed.id.toString() }
+            assertNotNull(unclaimedRec)
+            val isClaimed = unclaimedRec.jsonObject["isClaimed"]
+            assertNotNull(isClaimed, "isClaimed field should be present when includeClaimed=true")
+            assertFalse(isClaimed.jsonPrimitive.boolean, "isClaimed should be false for unclaimed item")
+        }
+
+    @Test
+    fun `claimedBy is never disclosed in response even when includeClaimed=true`(): Unit =
+        runBlocking {
+            createClaimedItem("Claimed Item", role = Role.QUEUE)
+
+            val result =
+                tool.execute(
+                    params(
+                        "includeClaimed" to JsonPrimitive(true),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            assertEquals(1, recs.size)
+            val rec = recs[0].jsonObject
+            assertNull(rec["claimedBy"], "claimedBy must never be disclosed")
+            assertNull(rec["claimedAt"], "claimedAt must never be disclosed")
+            assertNull(rec["claimExpiresAt"], "claimExpiresAt must never be disclosed")
+            assertNull(rec["originalClaimedAt"], "originalClaimedAt must never be disclosed")
+        }
+
+    @Test
+    fun `isClaimed field is absent when includeClaimed=false (default)`(): Unit =
+        runBlocking {
+            createItem("Queue Item", role = Role.QUEUE)
+
+            val result = tool.execute(params("limit" to JsonPrimitive(10)), context)
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            assertEquals(1, recs.size)
+            assertNull(recs[0].jsonObject["isClaimed"], "isClaimed should not be present when includeClaimed=false")
+        }
+
+    @Test
+    fun `role=work with includeClaimed=false filters out actively claimed WORK items`(): Unit =
+        runBlocking {
+            val unclaimedWork = createItem("Unclaimed Work", role = Role.WORK)
+            createClaimedItem("Claimed Work", role = Role.WORK)
+
+            val result =
+                tool.execute(
+                    params(
+                        "role" to JsonPrimitive("work"),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            assertEquals(1, recs.size)
+            assertEquals(unclaimedWork.id.toString(), recs[0].jsonObject["itemId"]!!.jsonPrimitive.content)
+        }
 }


### PR DESCRIPTION
## Summary

Extends `GetNextItemTool` so review-group and triage-group agents can discover work in their phase, and ensures the recommendation surface respects the claim mechanism's tiered disclosure rules.

- New optional `role` parameter (default `"queue"` — backward compatible). Accepts `queue`, `work`, `review`, `blocked`. Invalid value returns a structured validation error
- New optional `includeClaimed` parameter (default `false`). When false, items with active (non-expired) claims are filtered out at the repository SQL layer — never loaded
- When `includeClaimed=true`, response items expose only an `isClaimed: Boolean` field. **No claimedBy, claimedAt, claimExpiresAt, or originalClaimedAt is ever surfaced** — the agent never sees the competing agent's identity, preventing claim sniping and jealousy patterns
- New repository method `findForNextItem(role, parentId, excludeActiveClaims)` adds claim filtering as `claimed_by IS NULL OR claim_expires_at <= now` via Exposed DSL conditions

## DB-side time trade-off (acknowledged)

The Exposed DSL emits `claim_expires_at <= ?` with `Instant.now()` bound as a JDBC parameter — verified by reading `JavaInstantColumnType.notNullValueToDB` in Exposed 1.0.0-beta-2 sources. Not literal `datetime('now')`. The claim WRITE path (item 4's canonical SQL) correctly uses `datetime('now')` for source-of-truth time. This filter READ path is the place to revisit if the project migrates off single-writer SQLite. Acceptable for current architecture.

Tracked in MCP work item ` + "`fed4ad1c`" + `.

## Test Results

1449 tests pass, 0 failures (was 1431 pre-change). 15 new tests in `GetNextItemToolTest` (45 total) covering: default `role="queue"` back-compat, role=work/review/blocked, invalid role rejection, claim filter default, `includeClaimed=true` with `isClaimed` boolean only, expired-claim-as-unclaimed, no `claimedBy` leakage path.

## Review

Verdict: **pass with observations**. Tiered disclosure verified — no claim-identity leakage in any response path. Repository filter is at SQL layer, not Kotlin post-fetch. Hand-off pattern for item 7 (`buildFilteredQuery` extensible via `conditions.add(...)`) is documented in implementation notes. Minor observation: case-insensitive role input is supported but not explicitly tested.

## MCP Items

- Parent feature: ` + "`0628e760`" + `
- This PR: ` + "`fed4ad1c-a9ee-4662-860f-443625cc3085`" + `