### PR TITLE
docs: remove broken Integration Guides wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,6 @@ Agent: advance_item(trigger="start", itemId="a3f2",
 | **[Quick Start Guide](https://github.com/jpicklyk/task-orchestrator/wiki/quick-start)** | Full setup walkthrough with first work item |
 | **[API Reference](https://github.com/jpicklyk/task-orchestrator/wiki/api-reference)** | All 13 tools — parameters, response shapes, actor attribution |
 | **[Workflow Guide](https://github.com/jpicklyk/task-orchestrator/wiki/workflow-guide)** | Schemas, phase gates, dependencies, lifecycle modes |
-| **[Integration Guides](https://github.com/jpicklyk/task-orchestrator/wiki/integration-guides)** | 6 tiers from bare MCP to self-improving orchestration |
 | **[Wiki](https://github.com/jpicklyk/task-orchestrator/wiki)** | Full documentation hub |
 | **[Changelog](CHANGELOG.md)** | Release history |
 | **[Contributing](CONTRIBUTING.md)** | Developer setup and contribution process |


### PR DESCRIPTION
## Summary
- Remove the `wiki/integration-guides` row from the README documentation table — the page does not exist in the wiki and silently redirects to Home.

## Context
Found during a documentation link audit. The README referenced a wiki page (`integration-guides`) that was never created. The wiki sidebar and Home page also reference an `integration-guides/` subdirectory that doesn't exist; those will be fixed directly in the wiki repo (wikis don't take PRs).

## Test plan
- [x] `git diff` confirms only the broken row is removed
- [x] Surrounding rows (Quick Start, API Reference, Workflow Guide, Wiki) all resolve to real wiki pages
- [ ] Verify rendered README on the PR page shows no orphan formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)