### PR TITLE
test(get_context): assert claimedAt and claimExpiresAt round-trip as UTC (#117 G3)

### DIFF
--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolClaimTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolClaimTest.kt
@@ -181,6 +181,68 @@ class GetContextToolClaimTest {
             assertNotNull(claimDetail["originalClaimedAt"], "originalClaimedAt should be present in claimDetail")
         }
 
+    @Test
+    fun `item mode claimDetail time fields serialize as UTC ISO-8601 with Z suffix`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            val claimedAtInstant = Instant.parse("2025-06-15T10:30:00Z")
+            val claimExpiresAtInstant = Instant.parse("2025-06-15T10:45:00Z")
+            val item =
+                WorkItem(
+                    id = itemId,
+                    title = "UTC round-trip item",
+                    role = Role.WORK,
+                    claimedBy = "agent-utc-check",
+                    claimedAt = claimedAtInstant,
+                    claimExpiresAt = claimExpiresAtInstant,
+                    originalClaimedAt = claimedAtInstant
+                )
+
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+            coEvery { noteRepo.findByItemId(itemId) } returns Result.Success(emptyList())
+
+            val data = extractData(execute("itemId" to JsonPrimitive(itemId.toString())))
+
+            val claimDetail = data["claimDetail"]?.jsonObject
+            assertNotNull(claimDetail, "claimDetail must be present for a claimed item")
+
+            // claimExpiresAt assertions
+            val expiresAtStr = claimDetail["claimExpiresAt"]?.jsonPrimitive?.content
+            assertNotNull(expiresAtStr, "claimExpiresAt must be present")
+            assertTrue(
+                expiresAtStr.endsWith("Z"),
+                "claimExpiresAt must end with 'Z' (UTC indicator), got: $expiresAtStr"
+            )
+            assertFalse(
+                expiresAtStr.contains("+") || expiresAtStr.matches(Regex(".*[+-]\\d{2}:\\d{2}$")),
+                "claimExpiresAt must not contain a local-tz offset, got: $expiresAtStr"
+            )
+            val parsedExpiresAt = Instant.parse(expiresAtStr) // throws if not valid ISO-8601
+            assertEquals(
+                claimExpiresAtInstant.epochSecond,
+                parsedExpiresAt.epochSecond,
+                "claimExpiresAt round-trip must match original value at seconds precision"
+            )
+
+            // claimedAt assertions
+            val claimedAtStr = claimDetail["claimedAt"]?.jsonPrimitive?.content
+            assertNotNull(claimedAtStr, "claimedAt must be present")
+            assertTrue(
+                claimedAtStr.endsWith("Z"),
+                "claimedAt must end with 'Z' (UTC indicator), got: $claimedAtStr"
+            )
+            assertFalse(
+                claimedAtStr.contains("+") || claimedAtStr.matches(Regex(".*[+-]\\d{2}:\\d{2}$")),
+                "claimedAt must not contain a local-tz offset, got: $claimedAtStr"
+            )
+            val parsedClaimedAt = Instant.parse(claimedAtStr) // throws if not valid ISO-8601
+            assertEquals(
+                claimedAtInstant.epochSecond,
+                parsedClaimedAt.epochSecond,
+                "claimedAt round-trip must match original value at seconds precision"
+            )
+        }
+
     // ──────────────────────────────────────────────
     // Health-check mode — claimSummary (counts only)
     // ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

New TEST-C3 (CRITICAL): verifies that `get_context(itemId)` returns `claimedAt` and `claimExpiresAt` as UTC ISO-8601 strings, defending the L1 late refinement.

Four-layer assertion strategy per field:
- `endsWith("Z")` — catches missing UTC suffix
- Regex `[+-]\d{2}:\d{2}$` — catches `+00:00`-style offsets that violate the no-offset contract
- Inline `Instant.parse()` — throws on bad ISO-8601
- `assertEquals(epochSecond, ...)` — value fidelity

A future refactor switching to `LocalDateTime` or a locale-formatted string would fail at the suffix check before reaching parse. Plan only required `claimExpiresAt` coverage; `claimedAt` is included as above-spec.

## Test Results

1488 tests pass, 0 failures.

## Review

Verdict: pass.

## MCP

Parent: `dcecb9e5` · This PR: `3e5d1e03-6035-4fcf-a572-024fdccb443d` (G3)