### PR TITLE
fix(claim): reject blank actor.id; add validation edge tests (#117 G8)

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
@@ -151,6 +151,17 @@ At least one of `claims` or `releases` must be non-empty.
             throw ToolValidationException("At least one of 'claims' or 'releases' must be non-empty")
         }
 
+        // Validate actor.id is a non-blank string — an empty or whitespace-only id would
+        // result in an untrackable claim holder and must be rejected eagerly.
+        val actorObj = paramsObj?.get("actor") as? JsonObject
+        if (actorObj != null) {
+            val actorId =
+                (actorObj["id"] as? JsonPrimitive)?.content
+            if (actorId != null && actorId.isBlank()) {
+                throw ToolValidationException("actor.id must be a non-blank string")
+            }
+        }
+
         claims?.forEachIndexed { index, element ->
             val obj =
                 element as? JsonObject

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
@@ -459,4 +459,58 @@ class ClaimItemToolTest {
                     "Got: $serialized"
             )
         }
+
+    // -----------------------------------------------------------------------
+    // TEST-I11: claim with empty-string or whitespace-only agentId is rejected at validateParams
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `validateParams throws ToolValidationException when actor id is empty string`() {
+        val p =
+            buildJsonObject {
+                put("claims", buildJsonArray { add(claimEntry(itemId1)) })
+                put("actor", actorJson(id = ""))
+            }
+        assertFailsWith<ToolValidationException>(
+            "Empty actor.id must be rejected at validateParams"
+        ) { tool.validateParams(p) }
+    }
+
+    @Test
+    fun `validateParams throws ToolValidationException when actor id is whitespace only`() {
+        val p =
+            buildJsonObject {
+                put("claims", buildJsonArray { add(claimEntry(itemId1)) })
+                put("actor", actorJson(id = "  "))
+            }
+        assertFailsWith<ToolValidationException>(
+            "Whitespace-only actor.id must be rejected at validateParams"
+        ) { tool.validateParams(p) }
+    }
+
+    // -----------------------------------------------------------------------
+    // NICE-N3: large TTL (86400 seconds / 1 day) is accepted without rejection
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `validateParams accepts large ttlSeconds of 86400 without rejection`() {
+        // Verifies that no upper-bound validation rejects legitimately large TTLs.
+        val p =
+            buildJsonObject {
+                put(
+                    "claims",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put("itemId", itemId1.toString())
+                                put("ttlSeconds", 86400)
+                            }
+                        )
+                    }
+                )
+                put("actor", actorJson())
+            }
+        // Must not throw — large TTLs are valid
+        tool.validateParams(p)
+    }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolTest.kt
@@ -1029,4 +1029,34 @@ class GetNextItemToolTest {
             assertEquals(1, recs.size)
             assertEquals(unclaimedWork.id.toString(), recs[0].jsonObject["itemId"]!!.jsonPrimitive.content)
         }
+
+    // NICE-N2: role=review with includeClaimed=true shows isClaimed=true for a claimed REVIEW item.
+    // This verifies that multi-role scope applies claim-disclosure correctly on non-QUEUE roles.
+    @Test
+    fun `role=review with includeClaimed=true shows isClaimed=true for claimed REVIEW item`(): Unit =
+        runBlocking {
+            val claimedReview = createClaimedItem("Claimed Review Item", role = Role.REVIEW)
+
+            val result =
+                tool.execute(
+                    params(
+                        "role" to JsonPrimitive("review"),
+                        "includeClaimed" to JsonPrimitive(true),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val rec = recs.find { it.jsonObject["itemId"]!!.jsonPrimitive.content == claimedReview.id.toString() }
+            assertNotNull(rec, "Claimed REVIEW item should appear when includeClaimed=true")
+
+            val isClaimed = rec.jsonObject["isClaimed"]
+            assertNotNull(isClaimed, "isClaimed field must be present when includeClaimed=true")
+            assertTrue(isClaimed.jsonPrimitive.boolean, "isClaimed should be true for an actively claimed REVIEW item")
+
+            // Tiered disclosure: claimedBy identity must not be leaked
+            assertNull(rec.jsonObject["claimedBy"], "claimedBy must not be disclosed even for REVIEW items")
+        }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseConfigTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/DatabaseConfigTest.kt
@@ -64,6 +64,13 @@ class DatabaseConfigTest {
     }
 
     @Test
+    fun `returns default 5000 when env var is whitespace only`() {
+        // NICE-N4: "   ".toLongOrNull() returns null, so whitespace must fall back to the default.
+        val result = DatabaseConfig.resolveBusyTimeoutMs("   ")
+        assertEquals(5000L, result)
+    }
+
+    @Test
     fun `returns default when env var is a decimal float string`() {
         val result = DatabaseConfig.resolveBusyTimeoutMs("5000.5")
         assertEquals(5000L, result)


### PR DESCRIPTION
## Summary

Production fix + 4 new tests:

- **Production fix:** `ClaimItemTool.validateParams()` now rejects `actor.id` that is empty or whitespace-only (uses Kotlin's `.isBlank()`). Previously a blank `actor.id` would be stored as the claim holder, making the claim untrackable.
- **TEST-I11**: blank-actor rejection tested with both empty-string and whitespace variants.
- **NICE-N2**: `get_next_item(role="review", includeClaimed=true)` for a claimed REVIEW-role item — confirms `isClaimed: true` boolean disclosure works at non-QUEUE roles AND no `claimedBy` JSON key leakage.
- **NICE-N3**: large TTL (86400 seconds / 1 day) accepted without rejection (no upper-bound enforcement; documents the contract).
- **NICE-N4**: `DATABASE_BUSY_TIMEOUT_MS` env var with whitespace-only value falls back to 5000ms default — `String.toLongOrNull()` returns null for whitespace, existing `?: DEFAULT` branch handles it.

## Test Results

1492 tests pass, 0 failures.

## Review

Verdict: pass. Production change scoped to one validation guard.

## MCP

Parent: `dcecb9e5` · This PR: `8d09549d-87bb-443f-9734-6efd421cdb3c` (G8)