### PR TITLE
feat(claim): add requestId idempotency parameter to claim_item (#117 G9)

### DIFF
--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1080,7 +1080,7 @@ changing the claim holder.
 | `actor` | object | Yes | Actor identity — `{ id, kind, parent?, proof? }`. Verified identity overrides any `agentId` field on individual claim entries. |
 | `claims` | array | No | Items to claim: `[{ itemId (UUID or hex prefix), ttlSeconds? (default 900), agentId? (deprecated — overridden by verified actor) }]`. At least one of `claims` or `releases` must be non-empty. |
 | `releases` | array | No | Items to release: `[{ itemId (UUID or hex prefix) }]`. |
-| `requestId` | string (UUID) | No | Client-generated UUID for idempotency. Repeated calls with the same (`actor.id`, `requestId`) within ~10 minutes return the cached response without re-executing. |
+| `requestId` | string (UUID) | **Yes** | Client-generated UUID for idempotency. Required — `claim_item` is a fleet-mode tool and idempotency is a hard contract. Single-orchestrator deployments do not use `claim_item`; fleet callers are in a multi-agent context where network retries are a real concern. Repeated calls with the same (`actor.id`, `requestId`) within ~10 minutes return the cached response without re-executing. |
 
 **Claim semantics:**
 
@@ -1225,7 +1225,11 @@ dependency edges). Terminal items are never included.
 
 ## Idempotency
 
-Seven mutating tools accept an optional `requestId: UUID` parameter: `manage_items`, `manage_notes`, `manage_dependencies`, `advance_item`, `create_work_tree`, `complete_tree`, and `claim_item`. For `claim_item` the cache key uses the trusted agent identity (post-`DegradedModePolicy` resolution), matching the actor key used by the claim itself.
+Seven mutating tools support `requestId: UUID` for idempotency: `manage_items`, `manage_notes`, `manage_dependencies`, `advance_item`, `create_work_tree`, `complete_tree`, and `claim_item`.
+
+**`claim_item` requires `requestId` (mandatory).** `claim_item` is a fleet-mode tool by definition — single-orchestrator deployments don't claim items. Fleet deployments using `claim_item` are by definition in a multi-agent context where network retries are a real concern, so `claim_item` enforces idempotency as a contract. Calls missing `requestId` are rejected at validation. For `claim_item`, the cache key uses the trusted agent identity (post-`DegradedModePolicy` resolution), matching the actor key used by the claim itself.
+
+**The other 6 mutating tools keep `requestId` optional.** `manage_items`, `manage_notes`, `manage_dependencies`, `advance_item`, `create_work_tree`, and `complete_tree` serve both orchestrator-mode (single dispatcher, no idempotency needed) and fleet-mode (idempotency desired) callers. Omitting `requestId` skips the cache entirely — execution is always fresh.
 
 **How it works.** When `requestId` and `actor.id` are both present, the server checks an in-memory LRU cache keyed on `(actor.id, requestId)`. If a cached result exists, the original response is returned immediately without re-executing the operation. The cache window is approximately 10 minutes.
 
@@ -1233,7 +1237,7 @@ Seven mutating tools accept an optional `requestId: UUID` parameter: `manage_ite
 - Cache is single-instance and in-memory. It is not persisted across server restarts and is not shared across multiple server processes.
 - For `advance_item`, the `actor.id` of the **first** transition in the batch is used as the cache key actor.
 - For `manage_items`, `manage_notes`, `manage_dependencies`, `create_work_tree`, and `complete_tree`, the top-level `actor.id` is used. (Implementation note: these tools extract actor from the request-level field, not per-item fields.)
-- A non-parseable `requestId` string is silently ignored (no cache lookup or store).
+- A non-parseable `requestId` string is silently ignored on the 6 optional tools (no cache lookup or store). For `claim_item`, a non-UUID `requestId` is rejected at validation.
 
 **Usage.** Generate a fresh UUID per logical operation:
 

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1080,6 +1080,7 @@ changing the claim holder.
 | `actor` | object | Yes | Actor identity — `{ id, kind, parent?, proof? }`. Verified identity overrides any `agentId` field on individual claim entries. |
 | `claims` | array | No | Items to claim: `[{ itemId (UUID or hex prefix), ttlSeconds? (default 900), agentId? (deprecated — overridden by verified actor) }]`. At least one of `claims` or `releases` must be non-empty. |
 | `releases` | array | No | Items to release: `[{ itemId (UUID or hex prefix) }]`. |
+| `requestId` | string (UUID) | No | Client-generated UUID for idempotency. Repeated calls with the same (`actor.id`, `requestId`) within ~10 minutes return the cached response without re-executing. |
 
 **Claim semantics:**
 

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1225,7 +1225,7 @@ dependency edges). Terminal items are never included.
 
 ## Idempotency
 
-Six mutating tools accept an optional `requestId: UUID` parameter: `manage_items`, `manage_notes`, `manage_dependencies`, `advance_item`, `create_work_tree`, and `complete_tree`.
+Seven mutating tools accept an optional `requestId: UUID` parameter: `manage_items`, `manage_notes`, `manage_dependencies`, `advance_item`, `create_work_tree`, `complete_tree`, and `claim_item`. For `claim_item` the cache key uses the trusted agent identity (post-`DegradedModePolicy` resolution), matching the actor key used by the claim itself.
 
 **How it works.** When `requestId` and `actor.id` are both present, the server checks an in-memory LRU cache keyed on `(actor.id, requestId)`. If a cached result exists, the original response is returned immediately without re-executing the operation. The cache window is approximately 10 minutes.
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
@@ -35,8 +35,11 @@ import java.util.UUID
  * **Release semantics:**
  * - Only the current claim holder can release; other agents receive `not_claimed_by_you`.
  *
- * Supports `requestId` for idempotency: repeated calls with the same (actor, requestId)
- * within ~10 minutes return the cached response without re-executing the claim/release operations.
+ * Requires `requestId` for idempotency: `claim_item` is a fleet-mode tool by definition.
+ * Single-orchestrator deployments do not use `claim_item`; fleet callers operate in a
+ * multi-agent context where network retries are a real concern, so idempotency is a hard contract.
+ * Repeated calls with the same (actor, requestId) within ~10 minutes return the cached response
+ * without re-executing the claim/release operations.
  */
 class ClaimItemTool :
     BaseToolDefinition(),
@@ -52,7 +55,7 @@ any prior claim held by the same agent.
 - `claims` (optional array): Items to claim. Each element: `{ itemId (required UUID or short hex), ttlSeconds? (optional int, default 900), agentId? (optional string, overridden by verified actor) }`
 - `releases` (optional array): Items to release. Each element: `{ itemId (required UUID or short hex) }`
 - `actor` (required): `{ id (required string), kind (required: orchestrator|subagent|user|external), parent? (optional string), proof? (optional string) }` — identity used as the claim holder. Verified identity overrides self-reported agentId.
-- `requestId` (optional UUID): Client-generated UUID for idempotency. Repeated calls with the same (actor, requestId) within ~10 minutes return the cached response without re-executing.
+- `requestId` (required UUID): Client-generated UUID for idempotency. Required — `claim_item` is a fleet-mode tool and idempotency is a hard contract. Repeated calls with the same (actor, requestId) within ~10 minutes return the cached response without re-executing.
 
 At least one of `claims` or `releases` must be non-empty.
 
@@ -148,21 +151,38 @@ At least one of `claims` or `releases` must be non-empty.
                             put(
                                 "description",
                                 JsonPrimitive(
-                                    "Client-generated UUID for idempotency. Repeated calls with the same (actor, requestId) " +
-                                        "within ~10 minutes return the cached response without re-executing. " +
-                                        "Requires a top-level actor parameter to function."
+                                    "Client-generated UUID for idempotency. Required — claim_item is a fleet-mode tool " +
+                                        "and idempotency is a hard contract. Repeated calls with the same (actor, requestId) " +
+                                        "within ~10 minutes return the cached response without re-executing."
                                 )
                             )
                         }
                     )
                 },
-            required = listOf("actor")
+            required = listOf("actor", "requestId")
         )
 
     override fun validateParams(params: JsonElement) {
         val paramsObj = params as? JsonObject
-        val claims = paramsObj?.get("claims") as? JsonArray
-        val releases = paramsObj?.get("releases") as? JsonArray
+
+        // requestId is required for claim_item — fleet-mode idempotency is a hard contract
+        val requestIdPrim = paramsObj?.get("requestId") as? JsonPrimitive
+        if (requestIdPrim == null || requestIdPrim.content.isBlank()) {
+            throw ToolValidationException(
+                "requestId is required for claim_item. claim_item is a fleet-mode tool — " +
+                    "generate a fresh UUID per call and supply it to enforce idempotency."
+            )
+        }
+        try {
+            UUID.fromString(requestIdPrim.content)
+        } catch (_: IllegalArgumentException) {
+            throw ToolValidationException(
+                "requestId must be a valid UUID, got: '${requestIdPrim.content}'"
+            )
+        }
+
+        val claims = paramsObj.get("claims") as? JsonArray
+        val releases = paramsObj.get("releases") as? JsonArray
         val hasWork = (!claims.isNullOrEmpty()) || (!releases.isNullOrEmpty())
         if (!hasWork) {
             throw ToolValidationException("At least one of 'claims' or 'releases' must be non-empty")
@@ -209,16 +229,8 @@ At least one of `claims` or `releases` must be non-empty.
     ): JsonElement {
         val paramsObj = params as? JsonObject ?: return errorResponse("Parameters must be a JSON object")
 
-        // --- Idempotency: extract requestId before actor resolution so we can return early on cache hit ---
-        val requestIdStr = optionalString(params, "requestId")
-        val requestId =
-            requestIdStr?.let {
-                try {
-                    UUID.fromString(it)
-                } catch (_: IllegalArgumentException) {
-                    null
-                }
-            }
+        // --- Idempotency: requestId is required and already validated as a valid UUID ---
+        val requestId = UUID.fromString(optionalString(params, "requestId")!!)
 
         // --- Actor resolution ---
         val actorObj = paramsObj["actor"] as? JsonObject
@@ -245,10 +257,8 @@ At least one of `claims` or `releases` must be non-empty.
             }
 
         // Check idempotency cache after identity resolution (use trustedAgentId as the key actor)
-        if (requestId != null) {
-            val cached = context.idempotencyCache.get(trustedAgentId, requestId)
-            if (cached != null) return cached as JsonElement
-        }
+        val cached = context.idempotencyCache.get(trustedAgentId, requestId)
+        if (cached != null) return cached as JsonElement
 
         val claimsArray = paramsObj["claims"] as? JsonArray ?: JsonArray(emptyList())
         val releasesArray = paramsObj["releases"] as? JsonArray ?: JsonArray(emptyList())
@@ -424,10 +434,8 @@ At least one of `claims` or `releases` must be non-empty.
 
         val response = successResponse(data)
 
-        // Store result in idempotency cache
-        if (requestId != null) {
-            context.idempotencyCache.put(trustedAgentId, requestId, response)
-        }
+        // Store result in idempotency cache (requestId always present after validation)
+        context.idempotencyCache.put(trustedAgentId, requestId, response)
 
         return response
     }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
@@ -15,6 +15,7 @@ import io.github.jpicklyk.mcptask.current.domain.repository.ReleaseResult
 import io.modelcontextprotocol.kotlin.sdk.types.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.*
+import java.util.UUID
 
 /**
  * MCP tool for atomically claiming or releasing work items.
@@ -34,7 +35,8 @@ import kotlinx.serialization.json.*
  * **Release semantics:**
  * - Only the current claim holder can release; other agents receive `not_claimed_by_you`.
  *
- * Future extension point: a `requestId` parameter for idempotency will be added by item 8.
+ * Supports `requestId` for idempotency: repeated calls with the same (actor, requestId)
+ * within ~10 minutes return the cached response without re-executing the claim/release operations.
  */
 class ClaimItemTool :
     BaseToolDefinition(),
@@ -50,6 +52,7 @@ any prior claim held by the same agent.
 - `claims` (optional array): Items to claim. Each element: `{ itemId (required UUID or short hex), ttlSeconds? (optional int, default 900), agentId? (optional string, overridden by verified actor) }`
 - `releases` (optional array): Items to release. Each element: `{ itemId (required UUID or short hex) }`
 - `actor` (required): `{ id (required string), kind (required: orchestrator|subagent|user|external), parent? (optional string), proof? (optional string) }` — identity used as the claim holder. Verified identity overrides self-reported agentId.
+- `requestId` (optional UUID): Client-generated UUID for idempotency. Repeated calls with the same (actor, requestId) within ~10 minutes return the cached response without re-executing.
 
 At least one of `claims` or `releases` must be non-empty.
 
@@ -138,6 +141,20 @@ At least one of `claims` or `releases` must be non-empty.
                             )
                         }
                     )
+                    put(
+                        "requestId",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "Client-generated UUID for idempotency. Repeated calls with the same (actor, requestId) " +
+                                        "within ~10 minutes return the cached response without re-executing. " +
+                                        "Requires a top-level actor parameter to function."
+                                )
+                            )
+                        }
+                    )
                 },
             required = listOf("actor")
         )
@@ -192,6 +209,17 @@ At least one of `claims` or `releases` must be non-empty.
     ): JsonElement {
         val paramsObj = params as? JsonObject ?: return errorResponse("Parameters must be a JSON object")
 
+        // --- Idempotency: extract requestId before actor resolution so we can return early on cache hit ---
+        val requestIdStr = optionalString(params, "requestId")
+        val requestId =
+            requestIdStr?.let {
+                try {
+                    UUID.fromString(it)
+                } catch (_: IllegalArgumentException) {
+                    null
+                }
+            }
+
         // --- Actor resolution ---
         val actorObj = paramsObj["actor"] as? JsonObject
         val actorResult = parseActorClaim(actorObj, context)
@@ -215,6 +243,12 @@ At least one of `claims` or `releases` must be non-empty.
                     return buildRejectedByPolicyResponse(policyResolution.reason)
                 }
             }
+
+        // Check idempotency cache after identity resolution (use trustedAgentId as the key actor)
+        if (requestId != null) {
+            val cached = context.idempotencyCache.get(trustedAgentId, requestId)
+            if (cached != null) return cached as JsonElement
+        }
 
         val claimsArray = paramsObj["claims"] as? JsonArray ?: JsonArray(emptyList())
         val releasesArray = paramsObj["releases"] as? JsonArray ?: JsonArray(emptyList())
@@ -388,7 +422,14 @@ At least one of `claims` or `releases` must be non-empty.
                 )
             }
 
-        return successResponse(data)
+        val response = successResponse(data)
+
+        // Store result in idempotency cache
+        if (requestId != null) {
+            context.idempotencyCache.put(trustedAgentId, requestId, response)
+        }
+
+        return response
     }
 
     override fun userSummary(

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/IdempotencyToolsTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/IdempotencyToolsTest.kt
@@ -7,16 +7,22 @@ import io.github.jpicklyk.mcptask.current.application.tools.dependency.ManageDep
 import io.github.jpicklyk.mcptask.current.application.tools.items.ManageItemsTool
 import io.github.jpicklyk.mcptask.current.application.tools.notes.ManageNotesTool
 import io.github.jpicklyk.mcptask.current.application.tools.workflow.AdvanceItemTool
+import io.github.jpicklyk.mcptask.current.application.tools.workflow.ClaimItemTool
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.ClaimResult
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
+import io.github.jpicklyk.mcptask.current.test.MockRepositoryProvider
+import io.mockk.coEvery
+import io.mockk.coVerify
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.*
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Instant
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -672,5 +678,156 @@ class IdempotencyToolsTest {
             val items = context.workItemRepository().findRootItems()
             assertTrue(items is Result.Success)
             assertEquals(2, (items as Result.Success).data.size)
+        }
+
+    // ──────────────────────────────────────────────
+    // ClaimItemTool — claim idempotency (TEST-I10a, TEST-I10b)
+    //
+    // NOTE: claim_item's repository.claim() uses SQLite-specific HEX(id) syntax
+    // that is incompatible with H2 in-memory databases. These tests use a mocked
+    // WorkItemRepository (via MockRepositoryProvider) to test the idempotency
+    // wiring directly without hitting DB-level SQL compatibility issues.
+    // ──────────────────────────────────────────────
+
+    private fun buildClaimParams(
+        itemId: String,
+        agentId: String,
+        requestId: String? = null
+    ): JsonObject =
+        buildJsonObject {
+            put(
+                "claims",
+                JsonArray(
+                    listOf(
+                        buildJsonObject {
+                            put("itemId", JsonPrimitive(itemId))
+                            put("ttlSeconds", JsonPrimitive(900))
+                        }
+                    )
+                )
+            )
+            put("actor", actor(agentId))
+            if (requestId != null) {
+                put("requestId", JsonPrimitive(requestId))
+            }
+        }
+
+    private fun claimSuccessItem(
+        id: UUID,
+        claimedBy: String
+    ): WorkItem {
+        val now = Instant.now()
+        return WorkItem(
+            id = id,
+            title = "Test Claim Item",
+            claimedBy = claimedBy,
+            claimedAt = now,
+            claimExpiresAt = now.plusSeconds(900),
+            originalClaimedAt = now
+        )
+    }
+
+    /**
+     * TEST-I10a: claim_item with requestId returns cached response on retry, no double-mutation.
+     *
+     * First call mutates state (places the claim). Second call with same (actor, requestId)
+     * returns the cached response without calling repository.claim() again.
+     * Verified via mock invocation count — claim() is only called once.
+     */
+    @Test
+    fun `claim_item with requestId returns cached response on retry, no double-mutation`() =
+        runBlocking {
+            val mockRepo = MockRepositoryProvider()
+            val claimCache = IdempotencyCache()
+            val claimContext =
+                ToolExecutionContext(
+                    repositoryProvider = mockRepo.provider,
+                    idempotencyCache = claimCache
+                )
+
+            val tool = ClaimItemTool()
+            val itemId = UUID.randomUUID()
+            val requestId = UUID.randomUUID().toString()
+            val agentId = "agent-claimer"
+
+            // Set up mock: claim() returns success
+            coEvery {
+                mockRepo.workItemRepo.claim(itemId, agentId, 900)
+            } returns
+                ClaimResult.Success(
+                    claimSuccessItem(itemId, agentId)
+                )
+
+            val claimParams = buildClaimParams(itemId.toString(), agentId, requestId)
+
+            val firstResult = tool.execute(claimParams, claimContext) as JsonObject
+
+            // Verify first call succeeded
+            val firstData = firstResult["data"] as JsonObject
+            val firstClaimResults = firstData["claimResults"] as JsonArray
+            assertEquals(1, firstClaimResults.size)
+            assertEquals("success", firstClaimResults[0].jsonObject["outcome"]!!.jsonPrimitive.content)
+
+            // Second call: same (actor, requestId) — must return cached response
+            val secondResult = tool.execute(claimParams, claimContext) as JsonObject
+
+            // Responses must be identical (cached)
+            assertEquals(firstResult, secondResult)
+
+            // Verify only ONE cache entry exists
+            assertEquals(1, claimCache.size())
+
+            // The repository.claim() must have been called exactly ONCE (cached on retry)
+            coVerify(exactly = 1) { mockRepo.workItemRepo.claim(itemId, agentId, 900) }
+        }
+
+    /**
+     * TEST-I10b: claim_item without requestId behaves identically to current (no caching).
+     *
+     * Two calls without requestId both hit the repository — repository.claim() is called
+     * twice and no cache entry is created.
+     */
+    @Test
+    fun `claim_item without requestId behaves identically to current no caching`() =
+        runBlocking {
+            val mockRepo = MockRepositoryProvider()
+            val claimCache = IdempotencyCache()
+            val claimContext =
+                ToolExecutionContext(
+                    repositoryProvider = mockRepo.provider,
+                    idempotencyCache = claimCache
+                )
+
+            val tool = ClaimItemTool()
+            val item1Id = UUID.randomUUID()
+            val item2Id = UUID.randomUUID()
+            val agentId = "agent-no-request-id"
+
+            // Set up mock: each item claim returns success
+            coEvery {
+                mockRepo.workItemRepo.claim(item1Id, agentId, 900)
+            } returns
+                ClaimResult.Success(
+                    claimSuccessItem(item1Id, agentId)
+                )
+            coEvery {
+                mockRepo.workItemRepo.claim(item2Id, agentId, 900)
+            } returns
+                ClaimResult.Success(
+                    claimSuccessItem(item2Id, agentId)
+                )
+
+            // First call: claim item1 — no requestId
+            tool.execute(buildClaimParams(item1Id.toString(), agentId, requestId = null), claimContext)
+
+            // Second call: claim item2 — no requestId (should execute fresh, not return cached)
+            tool.execute(buildClaimParams(item2Id.toString(), agentId, requestId = null), claimContext)
+
+            // Cache must remain empty — no requestId means no caching
+            assertEquals(0, claimCache.size(), "Cache must remain empty when requestId is omitted")
+
+            // Both calls should have hit the repository (each claim executed)
+            coVerify(exactly = 1) { mockRepo.workItemRepo.claim(item1Id, agentId, 900) }
+            coVerify(exactly = 1) { mockRepo.workItemRepo.claim(item2Id, agentId, 900) }
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/IdempotencyToolsTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/IdempotencyToolsTest.kt
@@ -22,6 +22,7 @@ import kotlinx.serialization.json.*
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.Instant
 import java.util.UUID
 import kotlin.test.assertEquals
@@ -692,7 +693,7 @@ class IdempotencyToolsTest {
     private fun buildClaimParams(
         itemId: String,
         agentId: String,
-        requestId: String? = null
+        requestId: String
     ): JsonObject =
         buildJsonObject {
             put(
@@ -707,9 +708,26 @@ class IdempotencyToolsTest {
                 )
             )
             put("actor", actor(agentId))
-            if (requestId != null) {
-                put("requestId", JsonPrimitive(requestId))
-            }
+            put("requestId", JsonPrimitive(requestId))
+        }
+
+    private fun buildClaimParamsNoRequestId(
+        itemId: String,
+        agentId: String
+    ): JsonObject =
+        buildJsonObject {
+            put(
+                "claims",
+                JsonArray(
+                    listOf(
+                        buildJsonObject {
+                            put("itemId", JsonPrimitive(itemId))
+                            put("ttlSeconds", JsonPrimitive(900))
+                        }
+                    )
+                )
+            )
+            put("actor", actor(agentId))
         }
 
     private fun claimSuccessItem(
@@ -782,13 +800,14 @@ class IdempotencyToolsTest {
         }
 
     /**
-     * TEST-I10b: claim_item without requestId behaves identically to current (no caching).
+     * TEST-I10b-revised: claim_item without requestId is rejected at validation.
      *
-     * Two calls without requestId both hit the repository — repository.claim() is called
-     * twice and no cache entry is created.
+     * requestId is required for claim_item — fleet-mode idempotency is a hard contract.
+     * A call missing requestId must throw ToolValidationException and must not reach
+     * the repository at all.
      */
     @Test
-    fun `claim_item without requestId behaves identically to current no caching`() =
+    fun `claim_item without requestId is rejected at validation`() =
         runBlocking {
             val mockRepo = MockRepositoryProvider()
             val claimCache = IdempotencyCache()
@@ -799,35 +818,23 @@ class IdempotencyToolsTest {
                 )
 
             val tool = ClaimItemTool()
-            val item1Id = UUID.randomUUID()
-            val item2Id = UUID.randomUUID()
+            val itemId = UUID.randomUUID()
             val agentId = "agent-no-request-id"
 
-            // Set up mock: each item claim returns success
-            coEvery {
-                mockRepo.workItemRepo.claim(item1Id, agentId, 900)
-            } returns
-                ClaimResult.Success(
-                    claimSuccessItem(item1Id, agentId)
-                )
-            coEvery {
-                mockRepo.workItemRepo.claim(item2Id, agentId, 900)
-            } returns
-                ClaimResult.Success(
-                    claimSuccessItem(item2Id, agentId)
-                )
+            val exception =
+                assertThrows<ToolValidationException> {
+                    tool.validateParams(buildClaimParamsNoRequestId(itemId.toString(), agentId))
+                }
 
-            // First call: claim item1 — no requestId
-            tool.execute(buildClaimParams(item1Id.toString(), agentId, requestId = null), claimContext)
+            assertTrue(
+                exception.message!!.contains("requestId is required"),
+                "Exception message must explain that requestId is required, got: ${exception.message}"
+            )
 
-            // Second call: claim item2 — no requestId (should execute fresh, not return cached)
-            tool.execute(buildClaimParams(item2Id.toString(), agentId, requestId = null), claimContext)
+            // Repository must not be called — validation rejected before execution
+            coVerify(exactly = 0) { mockRepo.workItemRepo.claim(any(), any(), any()) }
 
-            // Cache must remain empty — no requestId means no caching
-            assertEquals(0, claimCache.size(), "Cache must remain empty when requestId is omitted")
-
-            // Both calls should have hit the repository (each claim executed)
-            coVerify(exactly = 1) { mockRepo.workItemRepo.claim(item1Id, agentId, 900) }
-            coVerify(exactly = 1) { mockRepo.workItemRepo.claim(item2Id, agentId, 900) }
+            // Cache must be untouched
+            assertEquals(0, claimCache.size(), "Cache must remain empty after validation rejection")
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
@@ -73,11 +73,12 @@ class ClaimItemToolTest {
             put("itemId", itemId.toString())
         }
 
-    /** Build a full tool params object. */
+    /** Build a full tool params object. Always includes requestId (required for claim_item). */
     private fun params(
         claims: List<JsonObject> = emptyList(),
         releases: List<JsonObject> = emptyList(),
-        actorId: String = agentId
+        actorId: String = agentId,
+        requestId: String = UUID.randomUUID().toString()
     ): JsonObject =
         buildJsonObject {
             if (claims.isNotEmpty()) {
@@ -87,6 +88,7 @@ class ClaimItemToolTest {
                 put("releases", buildJsonArray { releases.forEach { add(it) } })
             }
             put("actor", actorJson(actorId))
+            put("requestId", requestId)
         }
 
     private fun makeSuccessItem(
@@ -123,8 +125,36 @@ class ClaimItemToolTest {
     // -----------------------------------------------------------------------
 
     @Test
+    fun `validateParams throws when requestId is absent`() {
+        val p =
+            buildJsonObject {
+                put("claims", buildJsonArray { add(claimEntry(itemId1)) })
+                put("actor", actorJson())
+                // no requestId
+            }
+        val ex = assertFailsWith<ToolValidationException> { tool.validateParams(p) }
+        assert(ex.message!!.contains("requestId is required"))
+    }
+
+    @Test
+    fun `validateParams throws when requestId is not a valid UUID`() {
+        val p =
+            buildJsonObject {
+                put("claims", buildJsonArray { add(claimEntry(itemId1)) })
+                put("actor", actorJson())
+                put("requestId", "not-a-uuid")
+            }
+        val ex = assertFailsWith<ToolValidationException> { tool.validateParams(p) }
+        assert(ex.message!!.contains("valid UUID"))
+    }
+
+    @Test
     fun `validateParams throws when claims and releases are both absent`() {
-        val p = buildJsonObject { put("actor", actorJson()) }
+        val p =
+            buildJsonObject {
+                put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
+            }
         assertFailsWith<ToolValidationException> { tool.validateParams(p) }
     }
 
@@ -135,6 +165,7 @@ class ClaimItemToolTest {
                 put("claims", buildJsonArray {})
                 put("releases", buildJsonArray {})
                 put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
             }
         assertFailsWith<ToolValidationException> { tool.validateParams(p) }
     }
@@ -145,6 +176,7 @@ class ClaimItemToolTest {
             buildJsonObject {
                 put("claims", buildJsonArray { add(buildJsonObject { put("ttlSeconds", 900) }) })
                 put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
             }
         assertFailsWith<ToolValidationException> { tool.validateParams(p) }
     }
@@ -165,6 +197,7 @@ class ClaimItemToolTest {
                     }
                 )
                 put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
             }
         assertFailsWith<ToolValidationException> { tool.validateParams(p) }
     }
@@ -330,6 +363,8 @@ class ClaimItemToolTest {
             val p =
                 buildJsonObject {
                     put("claims", buildJsonArray { add(claimEntry(itemId1)) })
+                    put("requestId", UUID.randomUUID().toString())
+                    // no actor
                 }
 
             val result = tool.execute(p, defaultContext())


### PR DESCRIPTION
## Summary

Closes IMPL-2 from the post-implementation audit — `claim_item` was the one mutating tool missing `requestId` after the original #117 wave. Tightened to **mandatory** on follow-up: `claim_item` is fleet-mode by definition, so idempotency is a contract, not an option.

- Adds **required** `requestId: UUID` parameter to `ClaimItemTool`. The other 6 mutating tools keep `requestId` optional because they're shared between orchestrator-mode (no idempotency needed) and fleet-mode callers; `claim_item` only makes sense in fleet-mode.
- Wires `IdempotencyCache.get()`+`put()` two-step (matches `ManageNotesTool`/`AdvanceItemTool` pattern).
- Cache key uses `trustedAgentId` (post-`DegradedModePolicy` resolution) — same as the other 6 tools.
- Idempotency summary in `api-reference.md` updated from "Six mutating tools" → "Seven" with note about `claim_item`'s post-policy actor key and mandatory contract.

## Test Results

1489 tests pass, 0 failures. 2 new tests in `IdempotencyToolsTest`:
- TEST-I10a: cached response on repeat with same `(actor, requestId)` — `coVerify(exactly = 1)` on the repository call across two tool invocations
- TEST-I10b: without `requestId` the call now fails validation (mandatory parameter); test updated to assert the validation error rather than the repository fallthrough path

## Review

Verdict: pass with observations. "Seven mutating tools" doc fix applied as follow-up commit on this branch. Contract tightening (mandatory `requestId`) applied as third commit after design discussion.

## Commits

1. `8cbabc4` — feat(claim-item): add requestId idempotency parameter (originally optional)
2. `cd76192` — docs(idempotency): list claim_item as the seventh mutating tool
3. `a3810a0` — feat(claim): require requestId on claim_item (#117 G9 contract tightening)

## MCP

Parent: `dcecb9e5` · This PR: `259fdf87-74e0-4df1-b0e6-c8a20870467a` (G9)