### PR TITLE
docs(claim): improve claim documentation discoverability and coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Agent: advance_item(trigger="start", itemId="a3f2",
 | **[Quick Start Guide](https://github.com/jpicklyk/task-orchestrator/wiki/quick-start)** | Full setup walkthrough with first work item |
 | **[API Reference](https://github.com/jpicklyk/task-orchestrator/wiki/api-reference)** | All 13 tools — parameters, response shapes, actor attribution |
 | **[Workflow Guide](https://github.com/jpicklyk/task-orchestrator/wiki/workflow-guide)** | Schemas, phase gates, dependencies, lifecycle modes |
+| **[Fleet Deployment](https://github.com/jpicklyk/task-orchestrator/wiki/fleet-deployment)** | Multi-agent operators: identity policy, SQLite tuning, capacity planning, claim disclosure |
 | **[Wiki](https://github.com/jpicklyk/task-orchestrator/wiki)** | Full documentation hub |
 | **[Changelog](CHANGELOG.md)** | Release history |
 | **[Contributing](CONTRIBUTING.md)** | Developer setup and contribution process |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -152,7 +152,7 @@ This means that in deployments where non-Claude-Code clients connect to the serv
 
 - **SQLite database**: Stored on a Docker volume (`mcp-task-data`) or a local file path. Ensure appropriate file permissions on the host mount. The database is not encrypted at rest — use disk-level encryption if required.
 - **Config files**: `.taskorchestrator/config.yaml` is mounted read-only (`:ro`) in Docker. It contains workflow rules and optional JWKS endpoints, not credentials. JWKS URIs point to public key endpoints — no secrets are stored in config.
-- **No secrets in actor claims**: The `actor.proof` field should contain a JWT token, not raw credentials. The `claimedBy` field (when the claim mechanism is implemented) should contain an identifier (session ID, container name, JWT `jti`), not secrets. These values appear in audit trails and diagnostic tool responses.
+- **No secrets in actor claims**: The `actor.proof` field should contain a JWT token, not raw credentials. The `claimedBy` field on a `WorkItem` should contain an identifier (session ID, container name, JWT `jti`, or `did:web` identifier), not secrets. These values appear in audit trails and diagnostic tool responses.
 
 ### Threat Model Summary
 
@@ -164,9 +164,9 @@ This means that in deployments where non-Claude-Code clients connect to the serv
 | Actor impersonation (forged claims) | JWKS verification of JWT signatures | Available, opt-in |
 | Eavesdropping on HTTP transport | TLS via reverse proxy | Operator responsibility |
 | Database file access on host | File permissions on Docker volume mount | Operator responsibility |
-| Rogue agent disrupting workflow | Optimistic locking prevents data corruption; actor audit trail provides forensics | Partial — operational guardrails, not prevention |
+| Rogue agent disrupting workflow | Optimistic locking prevents data corruption; `claim_item` enforces exclusive ownership on `advance_item` for claimed items; actor audit trail provides forensics | Partial — operational guardrails, not prevention |
 
 ### Future Considerations
 
 - **Verification gating (opt-in)**: A future `auditing.require_verified_actor: true` flag could optionally reject write operations when actor verification fails, converting the accountability layer into an access control layer for high-security deployments. This would apply to write operations only (`advance_item`, `manage_notes`, `claim_item`) and would be opt-in to preserve the current low-friction single-team experience. This is not currently planned — the existing design (accountability, not access control) is intentional and sufficient for the database-per-tenant isolation model.
-- **Claim identity and verified actors**: When the claim mechanism (#117) is implemented, `claim_item` should prefer the verified `actor.id` from a JWKS-validated JWT over the self-reported `agentId` parameter. When JWKS is configured and a verified actor is present, the verified identity becomes authoritative for claim ownership. When JWKS is not configured, `agentId` is trusted as-is. This is a targeted integration between the claim and verification layers — not a blanket authentication gate. See #117 for the full identity resolution table.
+- **Claim identity and verified actors**: `claim_item` resolves identity via the same `actor` claim used by `advance_item` and `manage_notes`, subject to the deployment's `auditing.degradedModePolicy`. When JWKS verification succeeds, the JWT `sub` becomes authoritative for claim ownership and overrides any per-entry `agentId` supplied on individual claims. Under `degradedModePolicy=reject`, unverified callers cannot place or transition claims. Under `accept-cached` (default), stale-cache verification continues to work during transient JWKS outages. Under `accept-self-reported`, the self-reported `actor.id` is used — this negates the security benefit of JWKS verification when both are configured, and is documented as an explicit opt-out. See [Fleet Deployment Guide](current/docs/fleet-deployment.md#identity-configuration--authdegradedmodepolicy) for cross-org `did:web` recommendations.

--- a/current/docs/Home.md
+++ b/current/docs/Home.md
@@ -43,6 +43,7 @@ After running, restart Claude Code and run `/mcp` to verify the connection. You 
 | [Quick Start](quick-start.md) | Docker setup, first work item, note schemas, key concepts |
 | [API Reference](api-reference.md) | All 13 MCP tools — parameters, response shapes, and examples |
 | [Workflow Guide](workflow-guide.md) | Role lifecycle, triggers, note schemas, dependency patterns, cascade behavior |
+| [Fleet Deployment](fleet-deployment.md) | Multi-agent fleet operators: identity policy, SQLite tuning, capacity planning, claim disclosure, observability |
 | [Integration Guides](integration-guides/index.md) | Progressive tiers from bare MCP tools to self-improving orchestration |
 
 ---

--- a/current/docs/_Sidebar.md
+++ b/current/docs/_Sidebar.md
@@ -17,6 +17,9 @@
 - [API Reference](api-reference.md)
 - [Workflow Guide](workflow-guide.md)
 
+**Operations**
+- [Fleet Deployment](fleet-deployment.md)
+
 **Project**
 - [GitHub Repository](https://github.com/jpicklyk/task-orchestrator)
 - [Container Registry](https://github.com/jpicklyk/task-orchestrator/pkgs/container/task-orchestrator)

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1073,12 +1073,14 @@ claiming a new item auto-releases any prior claim held by the same agent. Claims
 time-bounded (TTL, default 900s). Re-claiming an already-held item refreshes the TTL without
 changing the claim holder.
 
+> **See also:** [Workflow Guide §10 — Claim Mechanism](./workflow-guide.md#10-claim-mechanism-for-multi-agent-fleets) for the agent-side lifecycle, heartbeat pattern, and discovery patterns. [Fleet Deployment Guide](./fleet-deployment.md) for `degradedModePolicy`, capacity planning, tiered disclosure, and Claims Troubleshooting.
+
 #### Key Parameters
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `actor` | object | Yes | Actor identity — `{ id, kind, parent?, proof? }`. Verified identity overrides any `agentId` field on individual claim entries. |
-| `claims` | array | No | Items to claim: `[{ itemId (UUID or hex prefix), ttlSeconds? (default 900), agentId? (deprecated — overridden by verified actor) }]`. At least one of `claims` or `releases` must be non-empty. |
+| `claims` | array | No | Items to claim: `[{ itemId (UUID or hex prefix), ttlSeconds? (default 900), agentId? (optional — overridden by verified actor when present) }]`. At least one of `claims` or `releases` must be non-empty. |
 | `releases` | array | No | Items to release: `[{ itemId (UUID or hex prefix) }]`. |
 | `requestId` | string (UUID) | **Yes** | Client-generated UUID for idempotency. Required — `claim_item` is a fleet-mode tool and idempotency is a hard contract. Single-orchestrator deployments do not use `claim_item`; fleet callers are in a multi-agent context where network retries are a real concern. Repeated calls with the same (`actor.id`, `requestId`) within ~10 minutes return the cached response without re-executing. |
 
@@ -1089,7 +1091,8 @@ changing the claim holder.
 - **Terminal items cannot be claimed.** QUEUE, WORK, REVIEW, and BLOCKED items are all claimable.
 - **Identity resolution.** `actor.id` is used as the claim identity, subject to `degradedModePolicy`. If JWKS verification succeeds, the verified `actor.id` (from the JWT `sub` claim) is used; otherwise the self-reported `actor.id` is used (unless `degradedModePolicy=reject`, in which case the claim fails with `rejected_by_policy`).
 - **Passive expiry.** There is no background reaper. Expired claims are filtered at read time. Crash recovery happens automatically via TTL.
-- **DB-side time.** All timestamps (`claimedAt`, `claimExpiresAt`) are set via SQLite `datetime('now', ...)` — they are UTC.
+- **DB-side time.** All timestamps (`claimedAt`, `claimExpiresAt`) are set via SQLite `datetime('now', ...)` — they are UTC. Operators inspecting raw rows must not assume host-local time.
+- **Per-entry `agentId` vs verified `actor.id`.** When the configured verifier resolves a trusted identity from `actor.proof`, that verified id becomes the claim holder and any `agentId` on the individual claim entry is ignored. The server logs a warning when the two disagree. Callers without a verifier configured may still supply `agentId`; it has no special status beyond providing a self-reported identity.
 
 **Claim outcome codes per item:**
 

--- a/current/docs/fleet-deployment.md
+++ b/current/docs/fleet-deployment.md
@@ -4,6 +4,11 @@ This guide is written for operators deploying the MCP Task Orchestrator to produ
 
 For single-agent or local-dev setups, the defaults are appropriate and this guide can be skipped.
 
+**Companion docs:**
+- [API Reference — `claim_item`](api-reference.md#claim_item) — tool spec: parameters, outcome codes, examples
+- [Workflow Guide §10 — Claim Mechanism](workflow-guide.md#10-claim-mechanism-for-multi-agent-fleets) — agent-side lifecycle, heartbeat pattern, discovery
+- This guide — operator-side: identity policy, capacity, disclosure, observability
+
 ---
 
 ## Identity Configuration — `auth.degradedModePolicy`
@@ -210,3 +215,79 @@ The audit log via `auditing.enabled` is the only structured per-operation signal
 If your fleet rollout requires real-time dashboards or alerting on these signals, plan to instrument them at the client side (agent telemetry) or proxy level until server-side metrics are added.
 
 Metrics and observability infrastructure are explicitly deferred to a future release (see issue tracker). The audit log is the recommended bridge for compliance and post-incident review until then.
+
+---
+
+## Claims Troubleshooting
+
+Common operator scenarios when running a multi-agent fleet against the claim mechanism.
+
+### Repeated `already_claimed` on the same item
+
+An agent retrying a claim and getting `already_claimed` back-to-back is **expected** behavior — another agent holds the item and retry will not change that until the existing TTL elapses or the holder explicitly releases.
+
+| Symptom | Recommended response |
+|---|---|
+| `retryAfterMs` < ~10s | Pick a different unclaimed item via `get_next_item`. Holder is actively working. |
+| `retryAfterMs` close to full TTL | Holder either just claimed or just heartbeated. Pick a different item. |
+| Same item, repeated retries, never resolves | Use `get_context(itemId)` to read `claimDetail.originalClaimedAt`. If the value is hours old, suspect a crashed holder — see "Stale `originalClaimedAt`" below. |
+
+`already_claimed` never discloses the competing agent's identity by design (see Tiered Claim Disclosure above). Use `get_context(itemId)` for full diagnostics.
+
+### `rejected_by_policy` on `claim_item` or `advance_item`
+
+This outcome means `degradedModePolicy=reject` is configured and the caller's actor proof did not produce a fully-verified identity (the verifier returned `ABSENT`, `REJECTED`, or `UNAVAILABLE`).
+
+**Recovery checklist:**
+
+1. Check the verifier configuration — `oidc_discovery` URL or `jwks_uri` must be reachable from the server.
+2. Inspect the `verification.metadata` object on the failing call's response — `failureKind` (`crypto | claims | policy | network | internal`) tells you which layer rejected.
+3. If `failureKind=network`, the JWKS endpoint is unreachable. Either restore connectivity or temporarily lower `degradedModePolicy` to `accept-cached` so the stale-cache fallback can serve.
+4. If `failureKind=crypto` or `claims`, the JWT itself is invalid — check `iss`, `aud`, and signing key alignment with the verifier's `algorithms` allowlist.
+
+`rejected_by_policy` is a **batch-level** rejection on `claim_item`: if one item in the batch fails policy, none of the claims succeed. Releases in the same call are not attempted.
+
+### Stale `originalClaimedAt` — diagnosing crashed holders
+
+`originalClaimedAt` records when the *current* agent first claimed the item. It is preserved across heartbeat re-claims and reset only when a different agent claims the same item.
+
+| `originalClaimedAt` age | Interpretation |
+|---|---|
+| < TTL (default 900s) | Fresh claim; agent is most likely working. |
+| 1–10× TTL | Heartbeat-renewed long-running work. Inspect `claimExpiresAt` — if in the future, the agent is alive. |
+| Hours/days old, `claimExpiresAt` in the past | Agent crashed mid-work. Claim is passively expired; any agent can now claim it. |
+| Hours/days old, `claimExpiresAt` still being refreshed | Agent is alive but stuck in a long-running operation, or the heartbeat cadence is too aggressive. Investigate the holder's logs. |
+
+There is no background reaper. Expired claims are filtered at read time — `get_next_item()` will surface items whose holders crashed once their TTL has elapsed.
+
+### Heartbeat scheduling — implementation patterns
+
+The recommended cadence is **TTL/2** (450s for the 900s default). This matches the convention used by Consul, etcd, and other lease-based distributed systems.
+
+**Where to put the heartbeat timer:**
+
+- **Inside the agent's main work loop.** Check elapsed time at each natural checkpoint (note write, file change, tool call) and re-claim if past TTL/2.
+- **As a coroutine/task scheduled at TTL/2.** Simpler to reason about, but the agent must guarantee the timer fires while it's actually progressing — a paused or blocked agent that lets the timer fire anyway is silently extending a stale claim.
+- **Avoid** background-only timers that fire regardless of work progress. Tying the heartbeat to forward progress is what gives crash recovery its meaning.
+
+**Cross-restart behavior:** A re-launched agent process does not preserve its prior claim. After restart, call `claim_item` again — if the prior TTL has not elapsed, the re-claim succeeds (refreshing TTL, preserving `originalClaimedAt`); if it has, the item may have been picked up by another agent and you'll receive `already_claimed`.
+
+### Does completing or cancelling release the claim?
+
+**No.** `advance_item(trigger="complete" | "cancel")` transitions the role but does **not** clear `claimedBy`, `claimedAt`, `claimExpiresAt`, or `originalClaimedAt` on the work item. The claim record remains in place until either the TTL elapses or `claim_item(releases=[...])` is called explicitly.
+
+This is harmless in practice: terminal items cannot be claimed by anyone (the `terminal_item` outcome blocks new claims), so a leftover claim record on a completed item is data noise, not a correctness problem. `reopen` triggers go through the same ownership check as any other transition — if the original claim has not expired, only the original holder can reopen.
+
+**Recommendation:** Well-behaved agents call `claim_item(releases=[{itemId}])` after completing work. Required only if you want the audit trail to show explicit release rather than passive expiry.
+
+### Fleet-wide expired-claim sweep
+
+Operators who want to inventory expired claims (e.g., during incident review) can run:
+
+```
+query_items(operation="search", claimStatus="expired")
+```
+
+Results include only `isClaimed: boolean` per item — identity remains hidden. To get holder identity for a specific stuck item, drill in with `get_context(itemId)`, which is the only surface that exposes `claimDetail.claimedBy`.
+
+No cleanup action is required for correctness. The data is informational — it tells you which agents likely crashed and which work items are now available for re-claim.

--- a/current/docs/workflow-guide.md
+++ b/current/docs/workflow-guide.md
@@ -860,6 +860,8 @@ docker run -e AGENT_CONFIG_DIR=/project -v "$(pwd)"/.taskorchestrator:/project/.
 
 The claim mechanism prevents race conditions between independent agents competing for the same work items. It is optional: single-orchestrator deployments that serialize work dispatch do not need claims.
 
+> **Operators:** see [Fleet Deployment Guide](./fleet-deployment.md) for `degradedModePolicy`, `DATABASE_BUSY_TIMEOUT_MS`, capacity planning, and a Claims Troubleshooting FAQ. The tool-level `claim_item` reference lives in [API Reference](./api-reference.md#claim_item).
+
 ### When to Use Claims
 
 **Skip claims if:**
@@ -886,7 +888,7 @@ advance_item(trigger="complete")    → ownership enforced at completion too
 
 ### Heartbeat Pattern
 
-For long-running work (longer than the TTL — default 900s), re-call `claim_item` before the TTL expires to refresh it. Recommended cadence: **TTL/2 = 450s** for the 900s default.
+For long-running work (longer than the TTL — default 900s), re-call `claim_item` before the TTL expires to refresh it. Recommended cadence: **TTL/2 = 450s** for the 900s default — the same convention used by Consul, etcd, and other lease-based distributed systems.
 
 Re-claiming an already-held item:
 - Refreshes `claimExpiresAt` (new TTL from now)
@@ -895,6 +897,12 @@ Re-claiming an already-held item:
 Operators can inspect `originalClaimedAt` via `get_context(itemId)` to distinguish freshly-claimed items from long-running renewed work.
 
 **Heartbeat write overhead.** Every re-claim is a row `UPDATE` on `work_items`. At 30 agents with TTL=900s, heartbeats produce approximately 4 writes/minute versus 30–60 writes/minute from real work transitions (~7% overhead). This is acceptable for v1. If writer contention from heartbeat traffic becomes a measured bottleneck, the mitigation is splitting heartbeats into a separate `claim_heartbeats` table (a non-breaking repository-layer change deferred to v1.5+).
+
+### Effect of `complete` and `cancel` on the Claim
+
+`advance_item(trigger="complete" | "cancel")` transitions the role but does **not** clear the claim record. `claimedBy`, `claimedAt`, `claimExpiresAt`, and `originalClaimedAt` remain on the item until either the TTL elapses or `claim_item(releases=[...])` is called.
+
+This is harmless: terminal items reject new claims with the `terminal_item` outcome, so a residual claim on a completed item has no functional effect. `reopen` continues to enforce ownership against the original claim if the TTL has not elapsed. Well-behaved agents call `claim_item(releases=[...])` after finishing work to make the audit trail explicit; it is not required for correctness.
 
 ### Crash Recovery via Passive Expiry
 


### PR DESCRIPTION
## Summary

- Adds the orphaned [fleet-deployment.md](current/docs/fleet-deployment.md) guide to README, Home, and sidebar navigation so multi-agent operators can find it. Previously nothing linked to it — users could only discover it by browsing the docs folder directly.
- Cross-links the three claim docs ([`claim_item` API reference](current/docs/api-reference.md), [Workflow Guide §10](current/docs/workflow-guide.md), [Fleet Deployment Guide](current/docs/fleet-deployment.md)) so readers landing in any one of them can navigate to the others.
- Adds a **Claims Troubleshooting** section to fleet-deployment covering operator-facing scenarios that previously had no documented home: repeated `already_claimed` triage, `rejected_by_policy` recovery checklist, stale `originalClaimedAt` interpretation, heartbeat scheduling patterns, the behavior of `complete`/`cancel` on the claim record, and fleet-wide expired-claim sweep.
- Documents in workflow-guide §10 that `advance_item(trigger="complete" \| "cancel")` does **not** clear the claim record (matches the actual behavior of `RoleTransitionHandler.applyTransition`) — addresses an undocumented edge case.
- Cleans up SECURITY.md: removes stale "(when the claim mechanism is implemented)" hedging, updates the threat-model row to reference `claim_item` ownership enforcement, and rewrites the Future Considerations bullet to describe current `degradedModePolicy` behavior with a cross-link to fleet-deployment.
- Corrects the api-reference description of the per-entry `agentId` field — prior text called it "deprecated" when the actual semantic (per `ClaimItemTool` source) is that it is overridden by the verified `actor.id` when JWKS produces a trusted identity. Not a deprecation; no scheduled removal.

## Files

| Type | File | Change |
|---|---|---|
| Discoverability | [README.md](README.md) | Added Fleet Deployment row to docs table |
| Discoverability | [current/docs/Home.md](current/docs/Home.md) | Added Fleet Deployment row to docs table |
| Discoverability | [current/docs/_Sidebar.md](current/docs/_Sidebar.md) | Added Operations section linking to fleet-deployment |
| Cross-link | [current/docs/api-reference.md](current/docs/api-reference.md) | "See also" pointer at top of `claim_item`; corrected agentId language; UTC raw-row note |
| Cross-link | [current/docs/workflow-guide.md](current/docs/workflow-guide.md) | Operator pointer at top of §10; Consul/etcd citation; new complete/cancel subsection |
| Content | [current/docs/fleet-deployment.md](current/docs/fleet-deployment.md) | Companion docs block at top; new Claims Troubleshooting section |
| Cleanup | [SECURITY.md](SECURITY.md) | Removed "(when implemented)" hedging; threat-model row updated; Future Considerations bullet rewritten |

## Test plan

- [ ] Click through every new internal link on GitHub's rendered markdown to confirm anchors resolve
- [ ] Verify [`README.md` wiki link](https://github.com/jpicklyk/task-orchestrator/wiki/fleet-deployment) renders correctly when the wiki sync runs
- [ ] Confirm no claim feature is described as "shipped" or "released" — wording stays "in main" / "now implemented" since no version tag includes it yet
- [ ] Spot-check the Claims Troubleshooting tables render correctly (markdown table syntax)
- [ ] Confirm the "complete/cancel does not clear claim" claim matches `RoleTransitionHandler.applyTransition` (verified during authoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)