### PR TITLE
chore(skills): add trait-pointer review skills

### DIFF
--- a/.claude/skills/migration-review/SKILL.md
+++ b/.claude/skills/migration-review/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: migration-review
+description: SQLite migration assessment for items with the needs-migration-review trait. Evaluates schema changes, table recreation patterns, data migration strategy, and Flyway migration correctness. Invoked via skillPointer when filling migration-assessment notes.
+user-invocable: false
+---
+
+# Migration Review Framework
+
+Evaluate database migration safety for SQLite-specific constraints. This project uses Flyway migrations with SQLite, which has significant limitations compared to PostgreSQL/MySQL.
+
+## Step 1: Identify Schema Changes
+
+Read the changed files and migration SQL to determine:
+- **New columns** — `ALTER TABLE ADD COLUMN` works in SQLite
+- **Modified columns** — SQLite has NO `ALTER COLUMN`. Requires table recreation:
+  1. Create new table with desired schema
+  2. Copy data from old table
+  3. Drop old table
+  4. Rename new table
+- **New tables** — check foreign key ordering in `DirectDatabaseSchemaManager`
+- **Index changes** — `CREATE INDEX` / `DROP INDEX` work normally
+
+## Step 2: SQLite Constraint Check
+
+Verify against known SQLite limitations:
+- [ ] No `ALTER COLUMN` — if modifying existing columns, table recreation pattern is used
+- [ ] No `DROP COLUMN` in older SQLite versions — check if the Docker image's SQLite supports it
+- [ ] Foreign key constraints — new tables must be inserted in correct order in `DirectDatabaseSchemaManager`
+- [ ] `TEXT` affinity — SQLite stores all strings as TEXT regardless of declared type
+- [ ] No concurrent write transactions — migrations must be sequential
+
+## Step 3: Data Migration Strategy
+
+For migrations that modify existing data:
+- [ ] Existing rows handled — default values for new columns, or explicit data migration
+- [ ] Null safety — new NOT NULL columns require a DEFAULT or data backfill
+- [ ] Large table performance — SQLite locks the entire database during writes
+
+## Step 4: Flyway Integration
+
+- [ ] Migration file follows naming: `V{N}__{Description}.sql`
+- [ ] Version number is sequential (no gaps, no conflicts with existing migrations)
+- [ ] Migration is idempotent where possible
+- [ ] `DirectDatabaseSchemaManager` updated if new tables are added (insert in FK dependency order)
+
+## Step 5: Rollback Considerations
+
+- [ ] Can the migration be reversed manually if needed?
+- [ ] Is the schema change backward compatible with the previous application version?
+- [ ] Docker volume data survives container restarts — migration is permanent
+
+## Output
+
+Compose the `migration-assessment` note with findings from each step. Flag any SQLite-specific risks. Reference `project-concerns.md` for additional codebase constraints.

--- a/.claude/skills/perf-review/SKILL.md
+++ b/.claude/skills/perf-review/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: perf-review
+description: Performance impact assessment for items with the needs-perf-review trait. Evaluates hot paths, query patterns, and measurement plans. Invoked via skillPointer when filling performance-baseline notes.
+user-invocable: false
+---
+
+# Performance Review Framework
+
+Evaluate performance impact of changes. This project is a Kotlin MCP server with SQLite via Exposed ORM, handling tool calls synchronously per request.
+
+## Step 1: Hot Path Analysis
+
+Identify which hot paths the change touches:
+- [ ] **Per-request paths** — MCP tool execution (every tool call hits this). New work here adds latency to every request.
+- [ ] **Per-item loops** — operations that iterate over items (search, overview, stalled-item detection). N+1 patterns here scale poorly.
+- [ ] **Startup path** — server initialization, database schema creation, config loading. Affects container startup time.
+- [ ] **Background operations** — cascade detection, dependency resolution. Runs inline, not async.
+
+## Step 2: Database Query Patterns
+
+- [ ] **N+1 queries** — does the change add a query inside a loop? (e.g., `countChildrenByRole` per child in overview). Count total queries for a typical operation.
+- [ ] **Full table scans** — any `selectAll()` without filters on large tables?
+- [ ] **Missing indexes** — new filter conditions that would benefit from an index?
+- [ ] **Transaction scope** — are transactions held open longer than necessary?
+- [ ] **Aggregate vs fetch-all** — using `SELECT COUNT(*)` with `GROUP BY` vs fetching all rows and counting in memory?
+
+## Step 3: JSON/Serialization Cost
+
+- [ ] **Large response payloads** — does the change add fields that significantly increase response size? (e.g., adding `childCounts` to every child in overview)
+- [ ] **Repeated serialization** — same object serialized multiple times in one request?
+- [ ] **String parsing** — `PropertiesHelper.extractTraits()` parses JSON on every call. Acceptable for small objects, flag if called in tight loops.
+
+## Step 4: Complexity Analysis
+
+- [ ] **What is N?** — identify the scaling variable (number of items, children, notes, dependencies)
+- [ ] **Current complexity** — O(1), O(N), O(N*M)? Where does the change sit?
+- [ ] **Realistic scale** — what's the expected N in practice? (Most projects: <100 items, <30 children per root)
+- [ ] **Worst case** — what happens at 1000+ items? Does it degrade gracefully or hit a wall?
+
+## Step 5: Measurement Plan
+
+- [ ] **How to verify** — what should be measured before/after? (query count, response time, payload size)
+- [ ] **Baseline** — document current performance for the affected operation
+- [ ] **Acceptance threshold** — what's the maximum acceptable degradation?
+
+## Output
+
+Compose the `performance-baseline` note with findings from each step. This note is optional (`required: false`) — use it when the change touches known hot paths or adds significant new work.

--- a/.claude/skills/plugin-impact-review/SKILL.md
+++ b/.claude/skills/plugin-impact-review/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: plugin-impact-review
+description: Assessment of plugin skill and hook changes needed after MCP or config changes. Evaluates skill references, hook context, config-format docs, and output style references. Invoked via skillPointer when filling plugin-impact notes.
+user-invocable: false
+---
+
+# Plugin Impact Review Framework
+
+Evaluate which plugin components need updating after changes to MCP tools, config format, or response shapes.
+
+## Step 1: Skill Impact
+
+Search all skill files for references to the changed behavior:
+
+```
+grep -r "<tool-name>\|<config-key>\|<changed-concept>" claude-plugins/task-orchestrator/skills/
+```
+
+For each match:
+- [ ] Does the skill reference the old behavior, field name, or response shape?
+- [ ] Does the skill need updated instructions or examples?
+- [ ] Are trigger phrases still accurate?
+
+## Step 2: Hook Impact
+
+Search hook scripts for references:
+
+```
+grep -r "<tool-name>\|<changed-concept>" claude-plugins/task-orchestrator/hooks/
+```
+
+For each match:
+- [ ] Does the hook inject context that references the old behavior?
+- [ ] Does the hook read tool input/output fields that changed?
+- [ ] Does the hook matcher still target the correct tool name?
+
+## Step 3: Config Format Documentation
+
+Check `claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md`:
+- [ ] YAML structure example reflects current format
+- [ ] Field reference table has all current fields
+- [ ] Descriptions match current behavior
+
+## Step 4: Output Style References
+
+Check output styles for stale references:
+- [ ] `workflow-orchestrator.md` — any references to changed tools, fields, or workflows
+- [ ] Zone 1 (shared core) vs Zone 2/3 (extensions) — changes in Zone 1 must be synced to `workflow-analyst.md`
+
+## Step 5: Plugin Caching
+
+- [ ] Are hook scripts changed? If yes, `/plugin marketplace remove` + re-add required (content cached)
+- [ ] Are skill files changed? `/reload-plugins` sufficient (read at invocation)
+- [ ] Are output styles changed? `/reload-plugins` sufficient
+
+## Output
+
+Compose the `plugin-impact` note listing specific files and sections that need changes. Note `/mcp reconnect` requirements.


### PR DESCRIPTION
## Summary
- Adds three project-level skills referenced as `skillPointer` targets in the trait system but previously untracked on disk
- `migration-review`, `perf-review`, `plugin-impact-review` — each marked `user-invocable: false` so they fire only when an item's trait routes evaluation through `skillPointer`
- Pure additions: no source, config, or test changes

## Skills

| Skill | Trait | Note key | Phase |
|------|-------|---------|-------|
| `migration-review` | `needs-migration-review` | `migration-assessment` | queue |
| `perf-review` | `needs-perf-review` | `performance-baseline` | queue/work |
| `plugin-impact-review` | `needs-plugin-impact-review` | `plugin-impact` | review |

## Test plan
- [x] Frontmatter validates (`name`, `description`, `user-invocable: false`)
- [x] Skills appear in this session's available-skills list, confirming auto-discovery from `.claude/skills/`
- [ ] Next item with a matching trait should resolve `skillPointer` and surface the framework when the assessment note is filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)