### PR TITLE
feat(ci): add link rewriting and integration-guides sync to wiki workflow

### DIFF
--- a/.github/scripts/sync_wiki.py
+++ b/.github/scripts/sync_wiki.py
@@ -1,0 +1,157 @@
+"""Mirror current/docs/ into the GitHub wiki repo with path flattening and link rewriting.
+
+GitHub wikis are flat (no subdirectories) and links must drop the .md extension.
+This script handles both:
+  - integration-guides/<name>.md  ->  integration-guides-<name>.md (flattened)
+  - integration-guides/index.md   ->  Integration-Guides.md       (overview page)
+  - Markdown links rewritten:
+      ](Home.md)                              -> ](Home)
+      ](./api-reference.md#anchor)            -> ](api-reference#anchor)
+      ](integration-guides/bare-mcp.md)       -> ](integration-guides-bare-mcp)
+      ](integration-guides/index.md)          -> ](Integration-Guides)
+      ](../api-reference.md)  (in guides)     -> ](api-reference)
+  - External URLs (https://...md) are left untouched via negative lookahead.
+
+Usage:
+  python sync_wiki.py <source-docs-dir> <wiki-repo-dir>
+  python sync_wiki.py <source-docs-dir> <wiki-repo-dir> --dry-run
+
+Exit code 0 on success. Output lists every file written; absence of output means no-op.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+GUIDES_DIR = "integration-guides"
+INDEX_PAGE = "Integration-Guides"
+
+
+def discover_names(src_dir: Path) -> tuple[list[str], list[str]]:
+    """Return (top_level_stems, guide_stems) discovered from the source directory.
+
+    top_level_stems excludes _Sidebar (underscore-prefix files are not link targets).
+    guide_stems excludes 'index' (which maps to a separate overview page name).
+    """
+    top_level = sorted(
+        p.stem for p in src_dir.glob("*.md") if not p.stem.startswith("_")
+    )
+    guides_dir = src_dir / GUIDES_DIR
+    guide_stems: list[str] = []
+    if guides_dir.is_dir():
+        guide_stems = sorted(p.stem for p in guides_dir.glob("*.md") if p.stem != "index")
+    return top_level, guide_stems
+
+
+def rewrite_links_top_level(text: str, top_level: list[str], guides: list[str]) -> str:
+    """Rewrite Markdown links inside top-level wiki pages (Home, _Sidebar, etc.).
+
+    External URLs (matched by https?:) are left untouched via negative lookahead.
+    """
+    for name in top_level:
+        text = re.sub(
+            rf"\]\((?!https?:)(?:\./)?{re.escape(name)}\.md",
+            f"]({name}",
+            text,
+        )
+    text = re.sub(
+        rf"\]\((?!https?:)(?:\./)?{re.escape(GUIDES_DIR)}/index\.md",
+        f"]({INDEX_PAGE}",
+        text,
+    )
+    for g in guides:
+        text = re.sub(
+            rf"\]\((?!https?:)(?:\./)?{re.escape(GUIDES_DIR)}/{re.escape(g)}\.md",
+            f"]({GUIDES_DIR}-{g}",
+            text,
+        )
+    return text
+
+
+def rewrite_links_guide(text: str, top_level: list[str], guides: list[str]) -> str:
+    """Rewrite Markdown links inside files originating from integration-guides/.
+
+    Guide files reference parents via ../<name>.md and siblings via <name>.md.
+    """
+    for name in top_level:
+        text = re.sub(
+            rf"\]\((?!https?:)\.\./{re.escape(name)}\.md",
+            f"]({name}",
+            text,
+        )
+    text = re.sub(
+        r"\]\((?!https?:)index\.md",
+        f"]({INDEX_PAGE}",
+        text,
+    )
+    for g in guides:
+        text = re.sub(
+            rf"\]\((?!https?:){re.escape(g)}\.md",
+            f"]({GUIDES_DIR}-{g}",
+            text,
+        )
+    return text
+
+
+def transform(src_dir: Path, dst_dir: Path, dry_run: bool = False) -> list[Path]:
+    """Read every .md from src_dir, transform, write to dst_dir. Return paths written."""
+    top_level, guides = discover_names(src_dir)
+    written: list[Path] = []
+
+    for f in sorted(src_dir.glob("*.md")):
+        original = f.read_text(encoding="utf-8")
+        rewritten = rewrite_links_top_level(original, top_level, guides)
+        out = dst_dir / f.name
+        if _write_if_changed(out, rewritten, dry_run):
+            written.append(out)
+
+    guides_src = src_dir / GUIDES_DIR
+    if guides_src.is_dir():
+        for f in sorted(guides_src.glob("*.md")):
+            original = f.read_text(encoding="utf-8")
+            rewritten = rewrite_links_guide(original, top_level, guides)
+            out_name = f"{INDEX_PAGE}.md" if f.stem == "index" else f"{GUIDES_DIR}-{f.stem}.md"
+            out = dst_dir / out_name
+            if _write_if_changed(out, rewritten, dry_run):
+                written.append(out)
+
+    return written
+
+
+def _write_if_changed(out: Path, content: str, dry_run: bool) -> bool:
+    """Write content to out if it differs from existing. Return True if changed."""
+    if out.exists() and out.read_text(encoding="utf-8") == content:
+        return False
+    if dry_run:
+        print(f"would write {out.name}")
+    else:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(content, encoding="utf-8")
+        print(f"wrote {out.name}")
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("src", type=Path, help="Source docs directory (e.g., current/docs)")
+    p.add_argument("dst", type=Path, help="Wiki repo directory (e.g., wiki-repo)")
+    p.add_argument("--dry-run", action="store_true", help="Print actions without writing")
+    args = p.parse_args(argv)
+
+    if not args.src.is_dir():
+        print(f"error: source directory not found: {args.src}", file=sys.stderr)
+        return 2
+    if not args.dst.is_dir():
+        print(f"error: destination directory not found: {args.dst}", file=sys.stderr)
+        return 2
+
+    written = transform(args.src, args.dst, dry_run=args.dry_run)
+    if not written:
+        print("no changes")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_sync_wiki.py
+++ b/.github/scripts/test_sync_wiki.py
@@ -1,0 +1,200 @@
+"""Tests for sync_wiki transform logic."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sync_wiki import (
+    discover_names,
+    rewrite_links_guide,
+    rewrite_links_top_level,
+    transform,
+)
+
+
+@pytest.fixture
+def fake_docs(tmp_path: Path) -> Path:
+    """A minimal source-docs tree mirroring the real layout."""
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "Home.md").write_text(
+        "[Quick Start](quick-start.md)\n"
+        "[API](./api-reference.md#claim_item)\n"
+        "[Overview](integration-guides/index.md)\n"
+        "[Bare](integration-guides/bare-mcp.md)\n"
+        "[External](https://github.com/x/y/blob/main/CHANGELOG.md)\n",
+        encoding="utf-8",
+    )
+    (docs / "_Sidebar.md").write_text(
+        "- [Home](Home.md)\n- [Bare MCP](integration-guides/bare-mcp.md)\n",
+        encoding="utf-8",
+    )
+    (docs / "api-reference.md").write_text("# API\n", encoding="utf-8")
+    (docs / "quick-start.md").write_text("# Quick Start\n", encoding="utf-8")
+    guides = docs / "integration-guides"
+    guides.mkdir()
+    (guides / "index.md").write_text(
+        "[Bare](bare-mcp.md)\n[QS](../quick-start.md)\n", encoding="utf-8"
+    )
+    (guides / "bare-mcp.md").write_text(
+        "[QS](../quick-start.md)\n[API](../api-reference.md#claim_item)\n[Sibling](claude-md-driven.md)\n",
+        encoding="utf-8",
+    )
+    (guides / "claude-md-driven.md").write_text("body\n", encoding="utf-8")
+    return docs
+
+
+def test_discover_names(fake_docs: Path) -> None:
+    top_level, guides = discover_names(fake_docs)
+    assert top_level == ["Home", "api-reference", "quick-start"]
+    assert "_Sidebar" not in top_level
+    assert guides == ["bare-mcp", "claude-md-driven"]
+    assert "index" not in guides
+
+
+def test_rewrite_top_level_drops_md_extension() -> None:
+    out = rewrite_links_top_level(
+        "[X](Home.md)", top_level=["Home"], guides=[]
+    )
+    assert out == "[X](Home)"
+
+
+def test_rewrite_top_level_preserves_anchor() -> None:
+    out = rewrite_links_top_level(
+        "[X](api-reference.md#claim_item)",
+        top_level=["api-reference"],
+        guides=[],
+    )
+    assert out == "[X](api-reference#claim_item)"
+
+
+def test_rewrite_top_level_handles_dot_slash_prefix() -> None:
+    out = rewrite_links_top_level(
+        "[X](./api-reference.md)", top_level=["api-reference"], guides=[]
+    )
+    assert out == "[X](api-reference)"
+
+
+def test_rewrite_top_level_flattens_guides_index() -> None:
+    out = rewrite_links_top_level(
+        "[O](integration-guides/index.md)", top_level=[], guides=[]
+    )
+    assert out == "[O](Integration-Guides)"
+
+
+def test_rewrite_top_level_flattens_guide_files() -> None:
+    out = rewrite_links_top_level(
+        "[B](integration-guides/bare-mcp.md)",
+        top_level=[],
+        guides=["bare-mcp"],
+    )
+    assert out == "[B](integration-guides-bare-mcp)"
+
+
+def test_rewrite_top_level_leaves_external_urls_untouched() -> None:
+    out = rewrite_links_top_level(
+        "[C](https://github.com/x/y/blob/main/CHANGELOG.md)",
+        top_level=["CHANGELOG"],
+        guides=[],
+    )
+    assert "https://github.com/x/y/blob/main/CHANGELOG.md" in out
+
+
+def test_rewrite_guide_handles_parent_refs() -> None:
+    out = rewrite_links_guide(
+        "[QS](../quick-start.md)",
+        top_level=["quick-start"],
+        guides=[],
+    )
+    assert out == "[QS](quick-start)"
+
+
+def test_rewrite_guide_handles_sibling_refs() -> None:
+    out = rewrite_links_guide(
+        "[Sib](claude-md-driven.md)",
+        top_level=[],
+        guides=["claude-md-driven"],
+    )
+    assert out == "[Sib](integration-guides-claude-md-driven)"
+
+
+def test_rewrite_guide_handles_index_ref() -> None:
+    out = rewrite_links_guide("[Up](index.md)", top_level=[], guides=[])
+    assert out == "[Up](Integration-Guides)"
+
+
+def test_rewrite_guide_preserves_anchor_on_parent_ref() -> None:
+    out = rewrite_links_guide(
+        "[API](../api-reference.md#claim_item)",
+        top_level=["api-reference"],
+        guides=[],
+    )
+    assert out == "[API](api-reference#claim_item)"
+
+
+def test_transform_writes_expected_files(fake_docs: Path, tmp_path: Path) -> None:
+    dst = tmp_path / "wiki"
+    dst.mkdir()
+    written = transform(fake_docs, dst)
+    written_names = sorted(p.name for p in written)
+    assert "Home.md" in written_names
+    assert "_Sidebar.md" in written_names
+    assert "Integration-Guides.md" in written_names
+    assert "integration-guides-bare-mcp.md" in written_names
+    assert "integration-guides-claude-md-driven.md" in written_names
+
+
+def test_transform_is_idempotent(fake_docs: Path, tmp_path: Path) -> None:
+    dst = tmp_path / "wiki"
+    dst.mkdir()
+    first = transform(fake_docs, dst)
+    second = transform(fake_docs, dst)
+    assert first, "first run should write something"
+    assert second == [], "second run on unchanged source must be a no-op"
+
+
+def test_transform_rewrites_home_links_correctly(
+    fake_docs: Path, tmp_path: Path
+) -> None:
+    dst = tmp_path / "wiki"
+    dst.mkdir()
+    transform(fake_docs, dst)
+    home = (dst / "Home.md").read_text(encoding="utf-8")
+    assert "(quick-start)" in home
+    assert "(api-reference#claim_item)" in home
+    assert "(Integration-Guides)" in home
+    assert "(integration-guides-bare-mcp)" in home
+    assert "https://github.com/x/y/blob/main/CHANGELOG.md" in home
+    assert ".md)" not in home.replace("CHANGELOG.md)", "")
+
+
+def test_transform_rewrites_guide_links_correctly(
+    fake_docs: Path, tmp_path: Path
+) -> None:
+    dst = tmp_path / "wiki"
+    dst.mkdir()
+    transform(fake_docs, dst)
+    bare = (dst / "integration-guides-bare-mcp.md").read_text(encoding="utf-8")
+    assert "(quick-start)" in bare
+    assert "(api-reference#claim_item)" in bare
+    assert "(integration-guides-claude-md-driven)" in bare
+    assert ".md)" not in bare
+
+
+def test_transform_handles_missing_guides_dir(tmp_path: Path) -> None:
+    src = tmp_path / "docs"
+    src.mkdir()
+    (src / "Home.md").write_text("[X](api-reference.md)\n", encoding="utf-8")
+    (src / "api-reference.md").write_text("body\n", encoding="utf-8")
+    dst = tmp_path / "wiki"
+    dst.mkdir()
+    written = transform(src, dst)
+    assert sorted(p.name for p in written) == ["Home.md", "api-reference.md"]
+
+
+def test_transform_dry_run_writes_nothing(fake_docs: Path, tmp_path: Path) -> None:
+    dst = tmp_path / "wiki"
+    dst.mkdir()
+    transform(fake_docs, dst, dry_run=True)
+    assert list(dst.iterdir()) == []

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,5 +1,13 @@
 name: Sync Docs to Wiki
 
+# Mirrors current/docs/ into the GitHub wiki repo. The wiki is treated as a
+# published artifact; canonical source is current/docs/. Manual edits to the
+# wiki between sync runs will be overwritten.
+#
+# If the default GITHUB_TOKEN is rejected by org policy when pushing to the
+# wiki, replace `secrets.GITHUB_TOKEN` below with a PAT secret (e.g.
+# `secrets.WIKI_SYNC_PAT`) granted `repo` scope.
+
 on:
   push:
     branches:
@@ -12,7 +20,20 @@ permissions:
   contents: write
 
 jobs:
+  test-transform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pytest
+      - name: Run transform unit tests
+        working-directory: .github/scripts
+        run: python -m pytest test_sync_wiki.py -v
+
   sync-wiki:
+    needs: test-transform
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -20,13 +41,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Clone wiki repository
         run: |
           git clone "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git" wiki-repo
 
-      - name: Copy docs to wiki
-        run: |
-          cp current/docs/*.md wiki-repo/
+      - name: Transform docs into wiki layout
+        run: python .github/scripts/sync_wiki.py current/docs wiki-repo
 
       - name: Configure git identity
         working-directory: wiki-repo


### PR DESCRIPTION
## Summary

- Replaces the existing `cp current/docs/*.md wiki-repo/` step with a Python transform that handles path flattening and Markdown link rewriting.
- Fixes the root cause of the 2026-04-30 wiki breakage (broken links + 7 missing integration-guides pages). The existing workflow had been faithfully copying broken-format files top-level only, hence the public wiki drift.
- Adds 17 pytest unit tests in a new `test-transform` job that gates the wiki push.

## What changed

| File | Change |
|------|--------|
| `.github/workflows/sync-wiki.yml` | Added `test-transform` job (runs pytest); replaced `cp` step with `python sync_wiki.py current/docs wiki-repo` |
| `.github/scripts/sync_wiki.py` | NEW — transform CLI: discovers source files, applies path flattening (`integration-guides/X.md` → `integration-guides-X.md`, `index.md` → `Integration-Guides.md`), rewrites Markdown links (drops `.md`, preserves anchors, leaves external URLs alone via negative lookahead), idempotent writes |
| `.github/scripts/test_sync_wiki.py` | NEW — 17 unit tests covering discovery, link rewriting, anchor preservation, external URL safety, idempotency, missing-guides-dir handling, dry-run |

## Acceptance verification

Ran the script locally against a fresh clone of the live wiki (commit `7d4dd1b`, the manual Option A fix). Output: `no changes`. Reset that clone to `b1c3b69` (pre-fix state) and re-ran: produced byte-identical output to `7d4dd1b` (same `13 files changed, 1323 insertions(+), 29 deletions(-)`). The first real run after merge will therefore be a no-op against the current wiki — proving the transform reproduces the manual fix exactly.

## Test plan

- [x] 17 pytest unit tests pass locally (Python 3.13)
- [x] Script run against live wiki state → idempotent (no changes)
- [x] Script run against pre-fix wiki state → produces identical fix to wiki commit `7d4dd1b`
- [ ] **CI**: `test-transform` job passes
- [ ] **Post-merge**: first real `sync-wiki` job runs and produces no commits to the wiki repo (acceptance criterion 5)
- [ ] **Post-merge**: trivially update a doc and verify the workflow pushes the wiki commit correctly

## MCP

Closes `32487a54` — Automated wiki sync from current/docs (GitHub Action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)