### PR TITLE
refactor(config): rename auditing section to actor_authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking Changes
+
+- **Config section renamed**: `auditing:` → `actor_authentication:`. The section configures actor-claim authentication policy (JWT verifier, JWKS sources, DID trust, degraded-mode policy), which the prior name did not describe. Migration: `sed -i 's/^auditing:/actor_authentication:/' .taskorchestrator/config.yaml`. The MCP server emits a clear startup error pointing to the new key when legacy `auditing:` is encountered. Inner `verifier:` block name is unchanged.
+
 ## [3.4.0] - 2026-04-29 (Plugin v3.1.2)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ Add to `gradle/libs.versions.toml` (`[versions]` + `[libraries]`), then referenc
 - `MCP_HTTP_PORT` — HTTP port (default: `3001`)
 - `LOG_LEVEL` — DEBUG / INFO / WARN / ERROR (default: `INFO`)
 - `FLYWAY_REPAIR` — run repair and exit (default: `false`)
-- `DEGRADED_MODE_POLICY` — overrides `auditing.degraded_mode_policy` in config; values: `accept-cached` (default) | `accept-self-reported` | `reject`; invalid value = startup failure
+- `DEGRADED_MODE_POLICY` — overrides `actor_authentication.degraded_mode_policy` in config; values: `accept-cached` (default) | `accept-self-reported` | `reject`; invalid value = startup failure
 
 **Migration files:** `current/src/main/resources/db/migration/`
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Multi-agent workflows need infrastructure the model doesn't provide. When an orc
 
 ## A Different Approach
 
-Task Orchestrator is an [MCP server](https://modelcontextprotocol.io) — not a prompt layer. It provides 13 tools that give any MCP-compatible AI agent a persistent work item graph with **server-enforced quality gates**. The enforcement happens at the tool level: if a required design note isn't filled, `advance_item` returns an error. If a dependency isn't satisfied, the transition is blocked. If auditing is enabled and an agent doesn't identify itself, the call is rejected before it reaches the server.
+Task Orchestrator is an [MCP server](https://modelcontextprotocol.io) — not a prompt layer. It provides 13 tools that give any MCP-compatible AI agent a persistent work item graph with **server-enforced quality gates**. The enforcement happens at the tool level: if a required design note isn't filled, `advance_item` returns an error. If a dependency isn't satisfied, the transition is blocked. If actor authentication is enabled and an agent doesn't identify itself, the call is rejected before it reaches the server.
 
 The rules live in the server, not the conversation.
 
@@ -131,10 +131,10 @@ Every `advance_item` transition and `manage_notes` upsert accepts an optional ac
 }
 ```
 
-Enable auditing in config to require it:
+Enable actor authentication in config to require it:
 
 ```yaml
-auditing:
+actor_authentication:
   enabled: true
 ```
 
@@ -164,7 +164,7 @@ Metadata-only queries (`includeBody=false`) let agents check what exists without
 
 ### Design Philosophy
 
-Task Orchestrator enforces workflow structure without imposing methodology. The server owns the guardrails — role transitions, dependency ordering, gate enforcement, and accountability. Agents own everything else. There are no mandatory planning ceremonies, no prescribed development processes, no opinion on how agents approach implementation. Schemas, traits, and auditing are opt-in layers that integrate with your team's development policies through `.taskorchestrator/config.yaml`. As models gain new capabilities, the harness stays out of the way rather than constraining what agents can do.
+Task Orchestrator enforces workflow structure without imposing methodology. The server owns the guardrails — role transitions, dependency ordering, gate enforcement, and accountability. Agents own everything else. There are no mandatory planning ceremonies, no prescribed development processes, no opinion on how agents approach implementation. Schemas, traits, and actor authentication are opt-in layers that integrate with your team's development policies through `.taskorchestrator/config.yaml`. As models gain new capabilities, the harness stays out of the way rather than constraining what agents can do.
 
 ---
 
@@ -253,7 +253,7 @@ The plugin adds workflow automation on top of the MCP server — skills, hooks, 
 | Layer | What it does |
 |-------|-------------|
 | **Skills** | Slash commands for common workflows — `/task-orchestrator:create-item`, `/task-orchestrator:manage-schemas`, `/task-orchestrator:quick-start` |
-| **Hooks** | Automatic context injection at session start, plan mode integration, sub-agent context handoff, auditing enforcement |
+| **Hooks** | Automatic context injection at session start, plan mode integration, sub-agent context handoff, actor attribution enforcement |
 | **Output style** | Workflow Orchestrator mode — Claude plans, delegates to sub-agents, and tracks progress without writing code directly |
 
 The MCP server works without the plugin. The plugin makes it seamless with Claude Code.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -82,18 +82,18 @@ Actor attribution has two layers — **presence enforcement** (is an actor claim
 
 | Concern | Mechanism | Where | Enforcement |
 |---------|-----------|-------|-------------|
-| **Presence** | `auditing.enabled: true` in config | Claude Code plugin hook (client-side) | Blocks tool calls missing `actor` objects |
-| **Authenticity** | `auditing.verifier.type: jwks` in config | MCP server (server-side) | Advisory — recorded in audit trail, does not block operations |
+| **Presence** | `actor_authentication.enabled: true` in config | Claude Code plugin hook (client-side) | Blocks tool calls missing `actor` objects |
+| **Authenticity** | `actor_authentication.verifier.type: jwks` in config | MCP server (server-side) | Advisory — recorded in audit trail, does not block operations |
 
 #### Layer 1: Presence enforcement (plugin hook)
 
-When `auditing.enabled: true` is set in `.taskorchestrator/config.yaml`, the Claude Code plugin hook (`enforce-actor-attribution.mjs`) intercepts `advance_item` and `manage_notes(upsert)` calls **before they reach the server**. If any transition or note element is missing an `actor` object, the call is blocked with an error message.
+When `actor_authentication.enabled: true` is set in `.taskorchestrator/config.yaml`, the Claude Code plugin hook (`enforce-actor-attribution.mjs`) intercepts `advance_item` and `manage_notes(upsert)` calls **before they reach the server**. If any transition or note element is missing an `actor` object, the call is blocked with an error message.
 
 **Important:** This enforcement only applies to Claude Code clients with the task-orchestrator plugin installed. Raw MCP clients connecting directly to the HTTP endpoint bypass the hook entirely. The server itself does not enforce actor presence — tools accept calls without `actor` claims and proceed with `actorClaim = null`.
 
 #### Layer 2: Authenticity verification (server-side JWKS)
 
-When `auditing.verifier.type: jwks` is configured, the server validates the `actor.proof` JWT against the configured JWKS endpoint:
+When `actor_authentication.verifier.type: jwks` is configured, the server validates the `actor.proof` JWT against the configured JWKS endpoint:
 
 1. Two tools (`advance_item` and `manage_notes`) accept an optional `actor` claim:
    ```json
@@ -110,7 +110,7 @@ Configure JWKS when you need a cryptographically verifiable audit trail — e.g.
 **Default configuration:**
 
 ```yaml
-auditing:
+actor_authentication:
   enabled: true        # Plugin hook enforces actor presence on write operations
   verifier:
     type: noop         # Default: no JWT verification. Claims accepted at face value.
@@ -119,7 +119,7 @@ auditing:
 To enable JWKS verification:
 
 ```yaml
-auditing:
+actor_authentication:
   enabled: true
   verifier:
     type: jwks
@@ -138,7 +138,7 @@ the verifier resolves the agent's DID document on-demand and extracts the signin
 **Configuration:**
 
 ```yaml
-auditing:
+actor_authentication:
   enabled: true
   degraded_mode_policy: reject       # recommended for cross-org did:web fleets
   verifier:
@@ -201,7 +201,7 @@ per-issuer — a JWKS refresh failure falls back to the cached key set when `sta
 
 #### Enforcement summary
 
-| Client type | `auditing.enabled: true` | `verifier.type: jwks` |
+| Client type | `actor_authentication.enabled: true` | `verifier.type: jwks` |
 |-------------|------------------------|-----------------------|
 | Claude Code with plugin | Actor presence enforced (hook blocks calls) | JWT verified, result in audit trail |
 | Claude Code without plugin | No enforcement | JWT verified, result in audit trail |
@@ -238,5 +238,5 @@ This means that in deployments where non-Claude-Code clients connect to the serv
 
 ### Future Considerations
 
-- **Verification gating (opt-in)**: A future `auditing.require_verified_actor: true` flag could optionally reject write operations when actor verification fails, converting the accountability layer into an access control layer for high-security deployments. This would apply to write operations only (`advance_item`, `manage_notes`, `claim_item`) and would be opt-in to preserve the current low-friction single-team experience. This is not currently planned — the existing design (accountability, not access control) is intentional and sufficient for the database-per-tenant isolation model.
-- **Claim identity and verified actors**: `claim_item` resolves identity via the same `actor` claim used by `advance_item` and `manage_notes`, subject to the deployment's `auditing.degradedModePolicy`. When JWKS verification succeeds, the JWT `sub` becomes authoritative for claim ownership and overrides any per-entry `agentId` supplied on individual claims. Under `degradedModePolicy=reject`, unverified callers cannot place or transition claims. Under `accept-cached` (default), stale-cache verification continues to work during transient JWKS outages. Under `accept-self-reported`, the self-reported `actor.id` is used — this negates the security benefit of JWKS verification when both are configured, and is documented as an explicit opt-out. See [Fleet Deployment Guide](current/docs/fleet-deployment.md#identity-configuration--authdegradedmodepolicy) for cross-org `did:web` recommendations.
+- **Verification gating (opt-in)**: A future `actor_authentication.require_verified_actor: true` flag could optionally reject write operations when actor verification fails, converting the accountability layer into an access control layer for high-security deployments. This would apply to write operations only (`advance_item`, `manage_notes`, `claim_item`) and would be opt-in to preserve the current low-friction single-team experience. This is not currently planned — the existing design (accountability, not access control) is intentional and sufficient for the database-per-tenant isolation model.
+- **Claim identity and verified actors**: `claim_item` resolves identity via the same `actor` claim used by `advance_item` and `manage_notes`, subject to the deployment's `actor_authentication.degradedModePolicy`. When JWKS verification succeeds, the JWT `sub` becomes authoritative for claim ownership and overrides any per-entry `agentId` supplied on individual claims. Under `degradedModePolicy=reject`, unverified callers cannot place or transition claims. Under `accept-cached` (default), stale-cache verification continues to work during transient JWKS outages. Under `accept-self-reported`, the self-reported `actor.id` is used — this negates the security benefit of JWKS verification when both are configured, and is documented as an explicit opt-out. See [Fleet Deployment Guide](current/docs/fleet-deployment.md#identity-configuration--authdegradedmodepolicy) for cross-org `did:web` recommendations.

--- a/claude-plugins/task-orchestrator/hooks/enforce-actor-attribution.mjs
+++ b/claude-plugins/task-orchestrator/hooks/enforce-actor-attribution.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 // PreToolUse hook — enforces actor attribution on MCP write operations when
-// auditing is enabled in .taskorchestrator/config.yaml.
+// actor_authentication is enabled in .taskorchestrator/config.yaml.
 //
 // Config format:
-//   auditing:
+//   actor_authentication:
 //     enabled: true
 //
 // When enabled, blocks advance_item and manage_notes(upsert) calls that are
@@ -57,35 +57,35 @@ function readConfigContent() {
   return null;
 }
 
-// Returns true only when auditing.enabled is explicitly set to true.
+// Returns true only when actor_authentication.enabled is explicitly set to true.
 // Handles both block YAML and inline forms, strips trailing comments.
-function isAuditingEnabled(configContent) {
+function isActorAuthenticationEnabled(configContent) {
   if (!configContent) return false;
 
-  let inAuditingSection = false;
+  let inActorAuthSection = false;
 
   for (const line of configContent.split('\n')) {
     const trimmed = line.trim();
 
-    // Detect top-level "auditing:" — check for inline form first
-    if (/^auditing\s*:/.test(trimmed)) {
-      // Handle inline: `auditing: { enabled: true }`
-      const inlineMatch = trimmed.match(/^auditing\s*:\s*\{(.+)\}/);
+    // Detect top-level "actor_authentication:" — check for inline form first
+    if (/^actor_authentication\s*:/.test(trimmed)) {
+      // Handle inline: `actor_authentication: { enabled: true }`
+      const inlineMatch = trimmed.match(/^actor_authentication\s*:\s*\{(.+)\}/);
       if (inlineMatch) {
         const inner = inlineMatch[1];
         const enabledMatch = inner.match(/enabled\s*:\s*(\S+)/);
         return enabledMatch ? enabledMatch[1].replace(/#.*$/, '').trim().toLowerCase() === 'true' : false;
       }
-      inAuditingSection = true;
+      inActorAuthSection = true;
       continue;
     }
 
-    // Any other top-level key (non-indented, non-empty) ends the auditing section
-    if (inAuditingSection && /^\S/.test(line)) {
-      inAuditingSection = false;
+    // Any other top-level key (non-indented, non-empty) ends the actor_authentication section
+    if (inActorAuthSection && /^\S/.test(line)) {
+      inActorAuthSection = false;
     }
 
-    if (inAuditingSection) {
+    if (inActorAuthSection) {
       const match = trimmed.match(/^enabled\s*:\s*(.+)/);
       if (match) {
         return match[1].replace(/#.*$/, '').trim().toLowerCase() === 'true';
@@ -97,7 +97,7 @@ function isAuditingEnabled(configContent) {
 }
 
 const configContent = readConfigContent();
-if (!isAuditingEnabled(configContent)) {
+if (!isActorAuthenticationEnabled(configContent)) {
   process.exit(0);
 }
 

--- a/claude-plugins/task-orchestrator/hooks/enforce-actor-attribution.mjs
+++ b/claude-plugins/task-orchestrator/hooks/enforce-actor-attribution.mjs
@@ -117,7 +117,7 @@ if (!missing) {
 
 process.stdout.write(JSON.stringify({
   decision: 'block',
-  reason: 'Auditing is enabled \u2014 actor attribution required. Include an "actor" object ' +
+  reason: 'Actor authentication is enabled \u2014 actor attribution required. Include an "actor" object ' +
     'with "id" (string) and "kind" (orchestrator|subagent|user|external) on every ' +
     'transition/note element. For subagents, include "parent" with the dispatching agent\'s id.'
 }));

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: manage-schemas
-description: "Creates, views, edits, deletes, and validates note schemas for the MCP Task Orchestrator in .taskorchestrator/config.yaml — the templates that define which notes agents must fill at each workflow phase. Also manages the auditing config block: set auditing policy, configure degraded mode, show auditing config, set degradedModePolicy to reject, what's the current degraded mode policy. Use when user says: create schema, show schemas, edit schema, delete schema, validate config, what schemas exist, add a note to schema, remove note from schema, or configure gates."
-argument-hint: "[optional: action + schema name or 'auditing', e.g. 'view bug-fix', 'create research-spike', 'validate', 'set degradedModePolicy reject']"
+description: "Creates, views, edits, deletes, and validates note schemas for the MCP Task Orchestrator in .taskorchestrator/config.yaml — the templates that define which notes agents must fill at each workflow phase. Also manages the actor_authentication config block: set actor authentication policy, configure degraded mode, show actor_authentication config, set degradedModePolicy to reject, what's the current degraded mode policy. Use when user says: create schema, show schemas, edit schema, delete schema, validate config, what schemas exist, add a note to schema, remove note from schema, or configure gates."
+argument-hint: "[optional: action + schema name or 'actor_authentication', e.g. 'view bug-fix', 'create research-spike', 'validate', 'set degradedModePolicy reject']"
 ---
 
 # Manage Schemas — Note Schema Lifecycle
@@ -77,19 +77,25 @@ If the config has a `traits:` section, show a separate traits summary table:
 | needs-migration-review | migration-assessment (queue, req) | migration-review |
 ```
 
-If the config has an `auditing:` section, display the auditing status including verifier type when present:
+If the config has an `actor_authentication:` section, display the actor authentication status including verifier type when present:
 
 ```
-◆ Auditing: enabled, verifier: noop
+◆ Actor authentication: enabled, verifier: noop
 ```
 
 Or with a JWKS verifier and its source:
 
 ```
-◆ Auditing: enabled, verifier: jwks (uri: https://provider.example/.well-known/jwks.json)
+◆ Actor authentication: enabled, verifier: jwks (uri: https://provider.example/.well-known/jwks.json)
 ```
 
-Or `◆ Auditing: disabled` (or omit if the section is absent). When `verifier` is absent, default to `verifier: noop`.
+Or with DID-trust mode:
+
+```
+◆ Actor authentication: enabled, verifier: jwks (DID trust: did:web:agent.example.com, did:web:lair.dev)
+```
+
+Or `◆ Actor authentication: disabled` (or omit if the section is absent). When `verifier` is absent, default to `verifier: noop`. When `did_allowlist` or `did_pattern` is set, show the DID trust variant.
 
 ### EDIT — Modify an Existing Schema
 
@@ -174,21 +180,21 @@ User says: "I edited the config by hand — check it"
 
 ---
 
-## Auditing config
+## Actor authentication config
 
-The `.taskorchestrator/config.yaml` file also has an `auditing:` block:
+The `.taskorchestrator/config.yaml` file also has an `actor_authentication:` block:
 
 ```yaml
-auditing:
+actor_authentication:
   degraded_mode_policy: accept-cached  # accept-cached | accept-self-reported | reject
-  # ... other auditing settings (enabled, verifier)
+  # ... other actor_authentication settings (enabled, verifier)
 ```
 
 When the user wants to view, set, or change `degradedModePolicy`:
 1. Read `.taskorchestrator/config.yaml`
-2. Locate the `auditing:` block (create it if absent)
+2. Locate the `actor_authentication:` block (create it if absent)
 3. For **view**: display the current value (default `accept-cached` if key is absent)
-4. For **changes**: update the `degraded_mode_policy:` field (preserving all other auditing keys)
+4. For **changes**: update the `degraded_mode_policy:` field (preserving all other actor_authentication keys)
 5. Validate the new value is one of: `accept-cached`, `accept-self-reported`, `reject`
 6. Write back
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
@@ -201,19 +201,19 @@ Items with `type: feature-task` use the `work_item_schemas` entry. Items with ta
 
 ---
 
-## Auditing
+## Actor authentication
 
-The `auditing` section is a top-level key alongside `work_item_schemas` and `traits`. It controls whether actor attribution is enforced on write operations.
+The `actor_authentication` section is a top-level key alongside `work_item_schemas` and `traits`. It controls whether actor attribution is enforced on write operations.
 
 ```yaml
-auditing:
+actor_authentication:
   enabled: true
 
 work_item_schemas:
   # ...
 ```
 
-Default: `false` when absent — auditing is opt-in.
+Default: `false` when absent — actor authentication is opt-in.
 
 ### Fields
 
@@ -223,7 +223,7 @@ Default: `false` when absent — auditing is opt-in.
 
 ### Behavior
 
-When `auditing.enabled` is `true`, the plugin's PreToolUse hook blocks `advance_item` and `manage_notes(upsert)` calls that are missing an `actor` object on any element. The agent must retry with actor attribution included.
+When `actor_authentication.enabled` is `true`, the plugin's PreToolUse hook blocks `advance_item` and `manage_notes(upsert)` calls that are missing an `actor` object on any element. The agent must retry with actor attribution included.
 
 When `false` or absent, actor claims are optional — calls pass through with no enforcement. Actor claims can still be provided voluntarily.
 
@@ -244,13 +244,20 @@ The optional `verifier` sub-key enables server-side JWT validation of actor clai
 | `algorithms` | no | list | `[]` | Allowed signing algorithms; empty = accept any |
 | `cache_ttl_seconds` | no | number | `300` | JWKS cache TTL in seconds |
 | `require_sub_match` | no | boolean | `true` | JWT `sub` must match `actor.id` |
+| `stale_on_error` | no | boolean | `true` | Serve stale cached key set if JWKS endpoint is unreachable during refresh. Set `false` to propagate the fetch exception |
+| `did_allowlist` | no | list | `[]` | List of trusted DID strings (exact match against JWT `iss` claim). Non-empty activates DID-trust mode |
+| `did_pattern` | no | string | — | Glob or regex pattern matching trusted DIDs. Non-null activates DID-trust mode. Mutually exclusive with `did_allowlist` |
+| `did_strict_relationship` | no | boolean | `true` | When true, only verification methods referenced from the resolved DID document's `assertionMethod` array are eligible. Set false to allow any key in the document |
+| `did_loose_kid_match` | no | boolean | `true` | Allow single-key fallback when JWT `kid` not found in the resolved DID document AND the eligible-key set has exactly one entry. Multi-key documents always require exact `kid` match |
 
-When `type: jwks`, at least one of `oidc_discovery`, `jwks_uri`, or `jwks_path` is required. Explicit `jwks_uri` and `issuer` values override OIDC-discovered values when both are present.
+When `type: jwks`, at least one of `oidc_discovery`, `jwks_uri`, or `jwks_path` is required for static-JWKS mode. Explicit `jwks_uri` and `issuer` values override OIDC-discovered values when both are present.
+
+> **DID trust fields** apply only to `type: jwks`. Either `did_allowlist` (non-empty) or `did_pattern` (non-null) activates DID-trust mode — they are mutually exclusive. In DID-trust mode, `oidc_discovery`, `jwks_uri`, and `jwks_path` must all be null. The two trust modes are validated at startup.
 
 **Example — OIDC discovery (simplest):**
 
 ```yaml
-auditing:
+actor_authentication:
   enabled: true
   verifier:
     type: jwks
@@ -260,7 +267,7 @@ auditing:
 **Example — File-based (air-gapped):**
 
 ```yaml
-auditing:
+actor_authentication:
   enabled: true
   verifier:
     type: jwks
@@ -270,7 +277,7 @@ auditing:
 **Example — Full config (all options):**
 
 ```yaml
-auditing:
+actor_authentication:
   enabled: true
   verifier:
     type: jwks
@@ -283,6 +290,23 @@ auditing:
     cache_ttl_seconds: 300
     require_sub_match: true
 ```
+
+**Example — DID-rooted trust (per-agent identities):**
+
+```yaml
+actor_authentication:
+  enabled: true
+  verifier:
+    type: jwks
+    algorithms: ["EdDSA", "RS256"]
+    audience: "task-orchestrator"
+    did_allowlist:
+      - "did:web:agent.example.com"
+      - "did:web:lair.dev"
+    did_loose_kid_match: true
+```
+
+When `did_allowlist` or `did_pattern` is set, the verifier resolves the JWT's `iss` claim as a DID and validates the signing key against the resolved DID document's `verificationMethod` entries (subject to `did_strict_relationship`). See `current/docs/fleet-deployment.md` for the full deployment guide.
 
 > **Note:** `enabled` (client-side enforcement) and `verifier` (server-side validation) are independent concerns. A call can pass enforcement (actor present) but have verification fail (bad JWT).
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
@@ -276,14 +276,16 @@ actor_authentication:
 
 **Example — Full config (all options):**
 
+> Static-JWKS mode requires exactly one of `oidc_discovery`, `jwks_uri`, or `jwks_path`. The other two source fields are shown commented out below to illustrate the available options.
+
 ```yaml
 actor_authentication:
   enabled: true
   verifier:
     type: jwks
     oidc_discovery: "https://agentlair.dev/.well-known/openid-configuration"
-    jwks_uri: "https://provider.example/.well-known/jwks.json"
-    jwks_path: ".agentlair/jwks.json"
+    # jwks_uri: "https://provider.example/.well-known/jwks.json"   # alternative source
+    # jwks_path: ".agentlair/jwks.json"                            # alternative source
     issuer: "https://provider.example"
     audience: "task-orchestrator"
     algorithms: ["EdDSA", "RS256"]

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/validate-workflow.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/validate-workflow.md
@@ -15,13 +15,20 @@ Parse the file. If YAML is invalid, report the parse error with line number (if 
 - At least one of `work_item_schemas` or `note_schemas` must exist at the top level
 - Each must be a mapping (not a list or scalar)
 - `traits` is an optional top-level key — if present, must be a mapping
-- `auditing` is an optional top-level key — if present, must be a mapping containing `enabled` (boolean)
-- `auditing.verifier` (if present) must be a mapping
+- `actor_authentication` is an optional top-level key — if present, must be a mapping containing `enabled` (boolean)
+- `actor_authentication.verifier` (if present) must be a mapping
 - `verifier.type` must be one of: `noop`, `jwks` (warn on unknown type)
-- When `type: jwks`: at least one of `oidc_discovery`, `jwks_uri`, `jwks_path` must be set (error if none)
+- When `type: jwks`: at least one of `oidc_discovery`, `jwks_uri`, `jwks_path` must be set (error if none) — unless DID-trust mode is active
 - `algorithms` (if present) must be a list of strings
 - `cache_ttl_seconds` (if present) must be a positive number
 - `require_sub_match` (if present) must be a boolean
+- `stale_on_error` (if present) must be a boolean
+- `did_allowlist` (if present) must be a list of strings
+- `did_pattern` (if present) must be a string
+- `did_strict_relationship` (if present) must be a boolean
+- `did_loose_kid_match` (if present) must be a boolean
+- `did_allowlist` and `did_pattern` are mutually exclusive — error if both are set
+- DID-trust mode (non-empty `did_allowlist` or non-null `did_pattern`) is mutually exclusive with static-JWKS mode (`oidc_discovery`/`jwks_uri`/`jwks_path`) — error if both are configured
 - No other top-level keys expected (warn if found)
 
 ### 3. Schema Entry Structure
@@ -73,7 +80,7 @@ For each note in each schema (and trait):
   work_item_schemas: 3 schemas
   note_schemas: 1 schema (legacy)
   traits: 2 traits
-  auditing: enabled, verifier: jwks
+  actor_authentication: enabled, verifier: jwks
 
   Errors (must fix):
     ✗ bug-fix.fix-summary: missing "required" field
@@ -92,5 +99,5 @@ If no issues are found:
 ```
 ◆ Config Validation — .taskorchestrator/config.yaml
 
-  ✓ Valid — 3 schemas, 2 traits, 14 notes, auditing enabled, no issues found
+  ✓ Valid — 3 schemas, 2 traits, 14 notes, actor_authentication enabled, no issues found
 ```

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1356,16 +1356,16 @@ This is a documentation convention, not enforced by the server. Stage 1 trusts s
 
 ### Enforcing Actor Attribution
 
-Actor claims are **optional by default** — users who don't need auditing pay no extra token cost. To require actor claims on all write operations, enable auditing in `.taskorchestrator/config.yaml`:
+Actor claims are **optional by default** — users who don't need actor authentication pay no extra token cost. To require actor claims on all write operations, enable actor authentication in `.taskorchestrator/config.yaml`:
 
 ```yaml
-auditing:
+actor_authentication:
   enabled: true
 ```
 
 When enabled, the plugin's `PreToolUse` hook blocks any `advance_item` or `manage_notes(upsert)` call where one or more elements are missing an `actor` object. The call never reaches the server — the agent must retry with actor claims included.
 
-When `enabled` is `false` or the `auditing` section is absent, calls pass through with no enforcement. Actor claims can still be provided voluntarily.
+When `enabled` is `false` or the `actor_authentication` section is absent, calls pass through with no enforcement. Actor claims can still be provided voluntarily.
 
 > **Note:** Config changes require an MCP reconnect (`/mcp`) or session restart to take effect.
 
@@ -1377,7 +1377,7 @@ Actor claims are self-reported by convention — the server does not inject them
 - **Instructed subagents** include actor claims only when the delegation prompt tells them to
 - The enforcement hook applies to all callers in the session, including subagents, providing a safety net regardless of prompt quality
 
-For reliable attribution, combine auditing enforcement with explicit delegation instructions:
+For reliable attribution, combine actor authentication enforcement with explicit delegation instructions:
 
 ```
 Include an "actor" object on every advance_item and manage_notes call:
@@ -1386,14 +1386,14 @@ Include an "actor" object on every advance_item and manage_notes call:
 
 ---
 
-## Auditing & Actor Verification
+## Actor Authentication & Verification
 
 ### Verifier Configuration
 
-The `auditing` section in `.taskorchestrator/config.yaml` controls actor attribution enforcement and verification. The `enabled` flag and the `verifier` block are independent — enforcement checks actor presence, while the verifier checks proof validity.
+The `actor_authentication` section in `.taskorchestrator/config.yaml` controls actor attribution enforcement and verification. The `enabled` flag and the `verifier` block are independent — enforcement checks actor presence, while the verifier checks proof validity.
 
 ```yaml
-auditing:
+actor_authentication:
   enabled: true          # Enforce actor claims on write operations
   degraded_mode_policy: accept-cached   # accept-cached (default) | accept-self-reported | reject
   verifier:
@@ -1422,7 +1422,7 @@ Controls how the server resolves actor identity when verification cannot produce
 
 ### `DEGRADED_MODE_POLICY` Environment Variable
 
-The `DEGRADED_MODE_POLICY` environment variable overrides the `auditing.degraded_mode_policy` YAML value. It is evaluated at server startup before any requests are processed.
+The `DEGRADED_MODE_POLICY` environment variable overrides the `actor_authentication.degraded_mode_policy` YAML value. It is evaluated at server startup before any requests are processed.
 
 | Aspect | Detail |
 |---|---|

--- a/current/docs/fleet-deployment.md
+++ b/current/docs/fleet-deployment.md
@@ -30,8 +30,8 @@ Treat the bundled plugin's behavior in claim mode as undefined. Build your own c
 TO publishes the following as the integration seam — the surface fleet implementers build against:
 
 - **MCP tools** — `claim_item` (acquire/heartbeat/release), `advance_item` (with ownership enforcement on claimed items), `get_context(itemId)` (operator diagnostic with full claim detail), `query_items(claimStatus=...)` (filtered discovery, identity-redacted), `get_next_item(includeClaimed=...)` (work discovery)
-- **Configuration** — `.taskorchestrator/config.yaml` `auditing` block (server policy)
-- **Audit log** — actor claims persisted on every write when `auditing.enabled: true`, queryable via `query_notes`
+- **Configuration** — `.taskorchestrator/config.yaml` `actor_authentication` block (server policy)
+- **Audit log** — actor claims persisted on every write when `actor_authentication.enabled: true`, queryable via `query_notes`
 
 Anything else (specific skill instructions, hook behavior, output-style conventions) is implementation detail of the bundled plugin and not part of the fleet contract.
 
@@ -39,10 +39,10 @@ Anything else (specific skill instructions, hook behavior, output-style conventi
 
 ## Identity Configuration — `auth.degradedModePolicy`
 
-The `degradedModePolicy` field under `auditing:` in `.taskorchestrator/config.yaml` controls how the server resolves actor identity when JWKS verification cannot produce a fully verified result.
+The `degradedModePolicy` field under `actor_authentication:` in `.taskorchestrator/config.yaml` controls how the server resolves actor identity when JWKS verification cannot produce a fully verified result.
 
 ```yaml
-auditing:
+actor_authentication:
   enabled: true
   degraded_mode_policy: accept-cached   # see table below
   verifier:
@@ -87,7 +87,7 @@ For deployments where agents from different organizations share a single Task Or
 combine `reject` policy with native DID-trust mode:
 
 ```yaml
-auditing:
+actor_authentication:
   enabled: true
   degraded_mode_policy: reject        # unverified actors cannot claim or advance claimed items
   verifier:
@@ -194,20 +194,20 @@ The four stages below correspond to increasing identity-enforcement strictness. 
 
 | Stage | Config | Server behavior |
 |---|---|---|
-| **0 — Default orchestration** | `auditing.enabled: false` (or absent) | `claim_item` works but is optional. `advance_item` does not enforce ownership. No actor required. |
-| **1 — Auditing on, self-reported identity** | `auditing.enabled: true`, `degraded_mode_policy: accept-self-reported`, no `verifier` | Actor required on writes (when paired with an actor-attribution enforcement layer). `claim_item` enforces ownership on subsequent `advance_item` calls. Identity is self-reported — caller-supplied `actor.id` is trusted unconditionally. |
+| **0 — Default orchestration** | `actor_authentication.enabled: false` (or absent) | `claim_item` works but is optional. `advance_item` does not enforce ownership. No actor required. |
+| **1 — Actor authentication on, self-reported identity** | `actor_authentication.enabled: true`, `degraded_mode_policy: accept-self-reported`, no `verifier` | Actor required on writes (when paired with an actor-attribution enforcement layer). `claim_item` enforces ownership on subsequent `advance_item` calls. Identity is self-reported — caller-supplied `actor.id` is trusted unconditionally. |
 | **2 — Verifier configured, fallback permitted** | + `verifier: { type: jwks, ... }`, `degraded_mode_policy: accept-cached` | When `actor.proof` is present and JWKS is reachable, the JWT `sub` becomes the trusted identity. When JWKS is briefly unreachable, the stale-cache fallback serves. Other non-verified outcomes fall back to self-reported `actor.id` with a WARN log. |
 | **3 — Verification required** | + `degraded_mode_policy: reject` | Operations requiring verified identity are rejected if verification status is not `VERIFIED`. Unclaimed items remain accessible to unverified actors so existing default-mode clients are not broken — only claim and advance-on-claimed flows are gated. |
 
 ### Recommended Sequence
 
-1. **Stage 0 → Stage 1.** Enable auditing in the config. Roll out `actor` plumbing on clients first, then flip `auditing.enabled: true`. Clients that don't pass `actor` will fail writes once attribution enforcement is active.
+1. **Stage 0 → Stage 1.** Enable actor authentication in the config. Roll out `actor` plumbing on clients first, then flip `actor_authentication.enabled: true`. Clients that don't pass `actor` will fail writes once attribution enforcement is active.
 2. **Stage 1 → Stage 2.** Configure the JWKS source and have clients begin attaching `actor.proof` JWTs. Stage 2 is forgiving — clients without `actor.proof` continue to work via self-reported fallback. Use this stage to confirm verification metadata in responses (`verification.status: VERIFIED` for upgraded clients).
 3. **Stage 2 → Stage 3.** Once telemetry confirms all client traffic is producing `VERIFIED` outcomes, flip `degraded_mode_policy: reject`. Any remaining unverified clients will start receiving `rejected_by_policy` on `claim_item` and on `advance_item` for claimed items.
 
 ### Rolling Back
 
-Each stage is reversible. Loosening `degraded_mode_policy` (e.g., `reject` → `accept-cached`) immediately allows previously-rejected operations to succeed. Disabling auditing entirely reverts to default-mode semantics — claims still work, but `advance_item` no longer enforces ownership.
+Each stage is reversible. Loosening `degraded_mode_policy` (e.g., `reject` → `accept-cached`) immediately allows previously-rejected operations to succeed. Disabling actor authentication entirely reverts to default-mode semantics — claims still work, but `advance_item` no longer enforces ownership.
 
 Existing claim records persist across policy changes. If a claim was placed under Stage 2 and the policy is loosened to Stage 1, the claim remains valid; ownership comparison still uses whatever identity scheme was in effect when the claim was placed.
 
@@ -382,7 +382,7 @@ The identity resolution chain:
 | Surface | What gets persisted |
 |---|---|
 | `work_items.claimed_by` | Current claim holder identity |
-| Audit notes (when `auditing.enabled`) | Actor claim object on every write — `id`, `kind`, `parent`, verification metadata |
+| Audit notes (when `actor_authentication.enabled`) | Actor claim object on every write — `id`, `kind`, `parent`, verification metadata |
 | `query_notes` body content | Audit notes are readable via standard note queries |
 
 Operators are responsible for choosing a `sub` value with appropriate sensitivity for their compliance regime. Pseudonymous identifiers (UUIDs, `did:web` identifiers, opaque session tokens) avoid PII concerns entirely. Email-as-`sub` is supported but creates compliance obligations downstream.
@@ -428,9 +428,9 @@ Fleet operators should treat this as a known gap when planning production rollou
 | Per-root claim breakdown | `query_items(operation="overview")` → `claimSummary` per root item |
 | Stalled items (missing required notes) | `get_context()` → `stalledItems` |
 | Recent role transitions | `get_context(since="<timestamp>")` → `recentTransitions` |
-| Audit log | `auditing.enabled: true` in config — actor claims persisted on write operations; queryable via `query_notes` and `get_context` session-resume mode |
+| Audit log | `actor_authentication.enabled: true` in config — actor claims persisted on write operations; queryable via `query_notes` and `get_context` session-resume mode |
 
-The audit log via `auditing.enabled` is the only structured per-operation signal available today. Actor claims (including verification status and `parent` chain) are persisted with each write, enabling post-mortem analysis.
+The audit log via `actor_authentication.enabled` is the only structured per-operation signal available today. Actor claims (including verification status and `parent` chain) are persisted with each write, enabling post-mortem analysis.
 
 ### Known Gaps — Plan Accordingly
 

--- a/current/docs/quick-start.md
+++ b/current/docs/quick-start.md
@@ -122,7 +122,7 @@ Hooks run automatically — no invocation required:
 - **Plan mode** — after plan approval, prompts Claude to create MCP items so persistent tracking stays in sync with the conversation
 - **Subagent start** — passes task context into spawned subagents so they start with full awareness of the current item
 
-**Optional:** Enable auditing to require agents to identify themselves on every write operation — add an `auditing` section with `enabled: true` to `.taskorchestrator/config.yaml`. See [Enforcing Actor Attribution](./api-reference.md#enforcing-actor-attribution) in the API reference.
+**Optional:** Enable actor authentication to require agents to identify themselves on every write operation — add an `actor_authentication` section with `enabled: true` to `.taskorchestrator/config.yaml`. See [Enforcing Actor Attribution](./api-reference.md#enforcing-actor-attribution) in the API reference.
 
 ### Output style
 
@@ -325,7 +325,7 @@ After adding or editing this file, reconnect the MCP server:
 > ```json
 > "-v", "${workspaceFolder}/.agentlair:/project/.agentlair:ro",
 > ```
-> Add this line alongside the `.taskorchestrator` mount. The `.agentlair/` mount is only needed when `verifier.jwks_path` is configured. See [Auditing & Actor Verification](./api-reference.md#auditing--actor-verification) in the API reference for details including Docker network access options.
+> Add this line alongside the `.taskorchestrator` mount. The `.agentlair/` mount is only needed when `verifier.jwks_path` is configured. See [Actor Authentication & Verification](./api-reference.md#actor-authentication--verification) in the API reference for details including Docker network access options.
 
 ---
 

--- a/current/docs/workflow-guide.md
+++ b/current/docs/workflow-guide.md
@@ -696,7 +696,7 @@ Key behaviors:
 - **`get_context` session resume** includes actor/verification on recent transitions
 - **`query_notes`** includes actor/verification on notes that have them
 
-Actor claims are self-reported — the server trusts them as-is in Stage 1. To require actor claims on all write operations, enable auditing in `.taskorchestrator/config.yaml` (set `auditing.enabled: true`). See [Enforcing Actor Attribution](./api-reference.md#enforcing-actor-attribution) in the API reference.
+Actor claims are self-reported — the server trusts them as-is in Stage 1. To require actor claims on all write operations, enable actor authentication in `.taskorchestrator/config.yaml` (set `actor_authentication.enabled: true`). See [Enforcing Actor Attribution](./api-reference.md#enforcing-actor-attribution) in the API reference.
 
 ---
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ActorAuthenticationConfig.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ActorAuthenticationConfig.kt
@@ -72,15 +72,15 @@ enum class DegradedModePolicy {
 }
 
 /**
- * Top-level auditing configuration parsed from `.taskorchestrator/config.yaml`
- * under the `auditing:` key.
+ * Top-level actor authentication configuration parsed from `.taskorchestrator/config.yaml`
+ * under the `actor_authentication:` key.
  *
- * @param enabled Whether auditing is active (default true).
+ * @param enabled Whether actor authentication is active (default true).
  * @param verifier The actor-claim verifier strategy to use.
  * @param degradedModePolicy Controls what happens when actor verification is not fully successful.
  *   See [DegradedModePolicy] for the three values and their security trade-offs.
  */
-data class AuditingConfig(
+data class ActorAuthenticationConfig(
     val enabled: Boolean = true,
     val verifier: VerifierConfig = VerifierConfig.Noop,
     val degradedModePolicy: DegradedModePolicy = DegradedModePolicy.ACCEPT_CACHED

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlActorAuthenticationConfigService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlActorAuthenticationConfigService.kt
@@ -1,6 +1,6 @@
 package io.github.jpicklyk.mcptask.current.infrastructure.config
 
-import io.github.jpicklyk.mcptask.current.domain.model.AuditingConfig
+import io.github.jpicklyk.mcptask.current.domain.model.ActorAuthenticationConfig
 import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
 import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
 import org.slf4j.LoggerFactory
@@ -9,14 +9,14 @@ import java.io.FileReader
 import java.nio.file.Path
 
 /**
- * YAML-backed loader for the `auditing:` section of `.taskorchestrator/config.yaml`.
+ * YAML-backed loader for the `actor_authentication:` section of `.taskorchestrator/config.yaml`.
  *
  * The config path is resolved using the same `AGENT_CONFIG_DIR` environment-variable
  * pattern as [YamlNoteSchemaService].
  *
  * Expected YAML structure:
  * ```yaml
- * auditing:
+ * actor_authentication:
  *   enabled: true
  *   degraded_mode_policy: accept-cached   # accept-cached (default) | accept-self-reported | reject
  *   verifier:
@@ -36,8 +36,8 @@ import java.nio.file.Path
  * For the `jwks` type, exactly one of `oidc_discovery`, `jwks_uri`, or `jwks_path` should be
  * provided. If none is present, a warning is added and the verifier falls back to [VerifierConfig.Noop].
  *
- * If the config file is missing, the `auditing:` section is absent, or any exception occurs
- * during parsing, [AuditingConfig] defaults are returned (`enabled=true`, [VerifierConfig.Noop]).
+ * If the config file is missing, the `actor_authentication:` section is absent, or any exception occurs
+ * during parsing, [ActorAuthenticationConfig] defaults are returned (`enabled=true`, [VerifierConfig.Noop]).
  *
  * ## `DEGRADED_MODE_POLICY` environment variable
  *
@@ -51,22 +51,22 @@ import java.nio.file.Path
  * @param envResolver Injectable resolver for environment variables; defaults to [System::getenv].
  *   Tests inject a fake to avoid mutating the JVM environment.
  */
-class YamlAuditingConfigService(
+class YamlActorAuthenticationConfigService(
     private val configPath: Path = YamlNoteSchemaService.resolveDefaultConfigPath(),
     private val envResolver: (String) -> String? = System::getenv
 ) {
-    private val logger = LoggerFactory.getLogger(YamlAuditingConfigService::class.java)
+    private val logger = LoggerFactory.getLogger(YamlActorAuthenticationConfigService::class.java)
 
     private data class LoadResult(
-        val config: AuditingConfig,
+        val config: ActorAuthenticationConfig,
         val warnings: List<String>
     )
 
     /** Lazily loaded result containing the parsed config and any parse warnings. */
     private val loadResult: LoadResult by lazy { loadConfig() }
 
-    /** Returns the parsed [AuditingConfig]; defaults are returned on any error. */
-    fun getConfig(): AuditingConfig = loadResult.config
+    /** Returns the parsed [ActorAuthenticationConfig]; defaults are returned on any error. */
+    fun getConfig(): ActorAuthenticationConfig = loadResult.config
 
     /** Returns warnings collected during config parsing (empty list if none). */
     fun getWarnings(): List<String> = loadResult.warnings
@@ -107,8 +107,8 @@ class YamlAuditingConfigService(
     private fun loadYamlConfig(): LoadResult {
         val warnings = mutableListOf<String>()
         if (!configPath.toFile().exists()) {
-            logger.debug("No config file found at {}; using default auditing config", configPath)
-            return LoadResult(AuditingConfig(), warnings)
+            logger.debug("No config file found at {}; using default actor_authentication config", configPath)
+            return LoadResult(ActorAuthenticationConfig(), warnings)
         }
 
         return try {
@@ -116,18 +116,26 @@ class YamlAuditingConfigService(
             FileReader(configPath.toFile()).use { reader ->
                 val root =
                     yaml.load<Map<String, Any>>(reader)
-                        ?: return@use LoadResult(AuditingConfig(), warnings)
+                        ?: return@use LoadResult(ActorAuthenticationConfig(), warnings)
 
-                val auditingSection =
-                    root["auditing"] as? Map<String, Any>
+                // Hard cut: legacy auditing: key produces a clear migration error
+                if (root.containsKey("auditing")) {
+                    throw IllegalArgumentException(
+                        "Unknown top-level config key 'auditing:'. " +
+                            "Did you mean 'actor_authentication:'? See CHANGELOG for migration."
+                    )
+                }
+
+                val actorAuthSection =
+                    root["actor_authentication"] as? Map<String, Any>
                         ?: run {
-                            logger.debug("No 'auditing' section in config; using defaults")
-                            return@use LoadResult(AuditingConfig(), warnings)
+                            logger.debug("No 'actor_authentication' section in config; using defaults")
+                            return@use LoadResult(ActorAuthenticationConfig(), warnings)
                         }
 
-                val enabled = (auditingSection["enabled"] as? Boolean) ?: true
+                val enabled = (actorAuthSection["enabled"] as? Boolean) ?: true
 
-                val verifierSection = auditingSection["verifier"] as? Map<String, Any>
+                val verifierSection = actorAuthSection["verifier"] as? Map<String, Any>
                 val verifier =
                     if (verifierSection != null) {
                         parseVerifier(verifierSection, warnings)
@@ -135,10 +143,10 @@ class YamlAuditingConfigService(
                         VerifierConfig.Noop
                     }
 
-                val degradedModePolicy = parseDegradedModePolicy(auditingSection, warnings)
+                val degradedModePolicy = parseDegradedModePolicy(actorAuthSection, warnings)
 
                 LoadResult(
-                    AuditingConfig(
+                    ActorAuthenticationConfig(
                         enabled = enabled,
                         verifier = verifier,
                         degradedModePolicy = degradedModePolicy
@@ -147,25 +155,25 @@ class YamlAuditingConfigService(
                 )
             }
         } catch (e: IllegalArgumentException) {
-            // Config constraint violations (e.g. mutual-exclusion) are surfaced immediately
+            // Config constraint violations (e.g. mutual-exclusion, legacy key) are surfaced immediately
             throw e
         } catch (e: Exception) {
-            val msg = "Failed to load auditing config from '$configPath': ${e.message}"
+            val msg = "Failed to load actor_authentication config from '$configPath': ${e.message}"
             warnings.add(msg)
             logger.warn(msg)
-            LoadResult(AuditingConfig(), warnings)
+            LoadResult(ActorAuthenticationConfig(), warnings)
         }
     }
 
     private fun parseDegradedModePolicy(
-        auditingSection: Map<String, Any>,
+        actorAuthSection: Map<String, Any>,
         warnings: MutableList<String>
     ): DegradedModePolicy {
-        val raw = auditingSection["degraded_mode_policy"] as? String ?: return DegradedModePolicy.ACCEPT_CACHED
+        val raw = actorAuthSection["degraded_mode_policy"] as? String ?: return DegradedModePolicy.ACCEPT_CACHED
         val parsed = DegradedModePolicy.fromConfigString(raw)
         if (parsed == null) {
             val msg =
-                "Unknown auditing.degraded_mode_policy '$raw'; " +
+                "Unknown actor_authentication.degraded_mode_policy '$raw'; " +
                     "valid values: accept-cached, accept-self-reported, reject. Defaulting to accept-cached."
             warnings.add(msg)
             logger.warn(msg)
@@ -211,7 +219,7 @@ class YamlAuditingConfigService(
                             if (jwksPath != null) add("jwks_path")
                         }.joinToString(", ")
                     throw IllegalArgumentException(
-                        "auditing.verifier: DID-trust mode (did_allowlist/did_pattern) is mutually exclusive " +
+                        "actor_authentication.verifier: DID-trust mode (did_allowlist/did_pattern) is mutually exclusive " +
                             "with static JWKS fields; conflicting fields: $conflicting"
                     )
                 }
@@ -219,7 +227,7 @@ class YamlAuditingConfigService(
                 // Neither DID trust nor static JWKS configured — no key source available
                 if (!isDidTrust && !isStaticJwks) {
                     val msg =
-                        "auditing.verifier type 'jwks' requires one of: " +
+                        "actor_authentication.verifier type 'jwks' requires one of: " +
                             "oidc_discovery, jwks_uri, jwks_path (static JWKS mode), " +
                             "or did_allowlist/did_pattern (DID-trust mode); falling back to Noop"
                     warnings.add(msg)
@@ -238,7 +246,7 @@ class YamlAuditingConfigService(
                                 if (jwksPath != null) add("jwks_path")
                             }.joinToString(", ")
                         throw IllegalArgumentException(
-                            "auditing.verifier type 'jwks' requires exactly one of oidc_discovery, " +
+                            "actor_authentication.verifier type 'jwks' requires exactly one of oidc_discovery, " +
                                 "jwks_uri, or jwks_path; multiple were provided: $provided"
                         )
                     }
@@ -257,7 +265,7 @@ class YamlAuditingConfigService(
                 // algorithms is required under type: jwks — no implicit default list
                 if (algorithms.isEmpty()) {
                     throw IllegalArgumentException(
-                        "auditing.verifier type 'jwks' requires a non-empty 'algorithms' allowlist; " +
+                        "actor_authentication.verifier type 'jwks' requires a non-empty 'algorithms' allowlist; " +
                             "supported values include EdDSA, ES256, ES384, ES512, RS256, RS384, RS512"
                     )
                 }
@@ -292,7 +300,7 @@ class YamlAuditingConfigService(
             }
 
             else -> {
-                val msg = "Unknown auditing.verifier type '$type'; falling back to Noop"
+                val msg = "Unknown actor_authentication.verifier type '$type'; falling back to Noop"
                 warnings.add(msg)
                 logger.warn(msg)
                 VerifierConfig.Noop

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
@@ -21,7 +21,7 @@ import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetNextStat
 import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
 import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
 import io.github.jpicklyk.mcptask.current.infrastructure.config.JwksActorVerifier
-import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlAuditingConfigService
+import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlActorAuthenticationConfigService
 import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlNoteSchemaService
 import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlStatusLabelService
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseConfig
@@ -170,8 +170,8 @@ class CurrentMcpServer(
      * Returns a [Pair] of (verifier, policy) so both can be wired into [ToolExecutionContext].
      */
     private fun createActorVerifierAndPolicy(): Pair<ActorVerifier, DegradedModePolicy> {
-        val configService = YamlAuditingConfigService()
-        configService.getWarnings().forEach { logger.warn("Auditing config: {}", it) }
+        val configService = YamlActorAuthenticationConfigService()
+        configService.getWarnings().forEach { logger.warn("Actor authentication config: {}", it) }
         val config = configService.getConfig()
         logger.info("Degraded mode policy: {}", config.degradedModePolicy.toConfigString())
         val verifier =

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/DegradedModePolicyTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/DegradedModePolicyTest.kt
@@ -28,7 +28,7 @@ class DegradedModePolicyTest {
     @Test
     fun `default DegradedModePolicy is ACCEPT_CACHED`() {
         assertEquals(DegradedModePolicy.ACCEPT_CACHED, DegradedModePolicy.ACCEPT_CACHED)
-        // Verify the AuditingConfig default via the enum itself
+        // Verify the ActorAuthenticationConfig default via the enum itself
         val policy = DegradedModePolicy.ACCEPT_CACHED
         assertEquals("accept-cached", policy.toConfigString())
     }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlActorAuthenticationConfigServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlActorAuthenticationConfigServiceTest.kt
@@ -1,6 +1,6 @@
 package io.github.jpicklyk.mcptask.current.infrastructure.config
 
-import io.github.jpicklyk.mcptask.current.domain.model.AuditingConfig
+import io.github.jpicklyk.mcptask.current.domain.model.ActorAuthenticationConfig
 import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
 import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
 import org.junit.jupiter.api.Assertions.*
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.nio.file.Path
 
-class YamlAuditingConfigServiceTest {
+class YamlActorAuthenticationConfigServiceTest {
     @TempDir
     lateinit var tempDir: Path
 
@@ -18,27 +18,27 @@ class YamlAuditingConfigServiceTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `missing config file returns AuditingConfig defaults`() {
+    fun `missing config file returns ActorAuthenticationConfig defaults`() {
         val nonExistentPath = tempDir.resolve("does-not-exist/config.yaml")
-        val service = YamlAuditingConfigService(nonExistentPath)
+        val service = YamlActorAuthenticationConfigService(nonExistentPath)
 
         val config = service.getConfig()
-        assertEquals(AuditingConfig(), config)
+        assertEquals(ActorAuthenticationConfig(), config)
         assertTrue(config.enabled)
         assertEquals(VerifierConfig.Noop, config.verifier)
         assertTrue(service.getWarnings().isEmpty())
     }
 
     @Test
-    fun `config with auditing enabled but no verifier section returns Noop`() {
+    fun `config with actor_authentication enabled but no verifier section returns Noop`() {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   enabled: true
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val config = service.getConfig()
         assertTrue(config.enabled)
@@ -47,7 +47,7 @@ class YamlAuditingConfigServiceTest {
     }
 
     @Test
-    fun `config with no auditing section returns defaults`() {
+    fun `config with no actor_authentication section returns defaults`() {
         val configFile =
             createConfigFile(
                 """
@@ -58,11 +58,65 @@ class YamlAuditingConfigServiceTest {
                       required: false
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val config = service.getConfig()
-        assertEquals(AuditingConfig(), config)
+        assertEquals(ActorAuthenticationConfig(), config)
         assertTrue(service.getWarnings().isEmpty())
+    }
+
+    // -------------------------------------------------------------------------
+    // Legacy auditing: key hard cut
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `legacy auditing key produces clear migration error`() {
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  enabled: true
+                """.trimIndent()
+            )
+        val service = YamlActorAuthenticationConfigService(configFile)
+
+        val ex = assertThrows(IllegalArgumentException::class.java) { service.getConfig() }
+        assertTrue(
+            ex.message?.contains("Unknown top-level config key 'auditing:'") == true,
+            "Expected legacy-key error message, got: ${ex.message}"
+        )
+        assertTrue(
+            ex.message?.contains("Did you mean 'actor_authentication:'") == true,
+            "Expected migration suggestion, got: ${ex.message}"
+        )
+        assertTrue(
+            ex.message?.contains("CHANGELOG") == true,
+            "Expected CHANGELOG reference, got: ${ex.message}"
+        )
+    }
+
+    @Test
+    fun `legacy auditing key with actor_authentication also present produces clear migration error`() {
+        val configFile =
+            createConfigFile(
+                """
+                auditing:
+                  enabled: true
+                actor_authentication:
+                  enabled: true
+                """.trimIndent()
+            )
+        val service = YamlActorAuthenticationConfigService(configFile)
+
+        val ex = assertThrows(IllegalArgumentException::class.java) { service.getConfig() }
+        assertTrue(
+            ex.message?.contains("Unknown top-level config key 'auditing:'") == true,
+            "Expected legacy-key error message, got: ${ex.message}"
+        )
+        assertTrue(
+            ex.message?.contains("Did you mean 'actor_authentication:'") == true,
+            "Expected migration suggestion, got: ${ex.message}"
+        )
     }
 
     // -------------------------------------------------------------------------
@@ -74,13 +128,13 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   enabled: true
                   verifier:
                     type: noop
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         assertEquals(VerifierConfig.Noop, service.getConfig().verifier)
         assertTrue(service.getWarnings().isEmpty())
@@ -95,7 +149,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   enabled: true
                   verifier:
                     type: jwks
@@ -111,7 +165,7 @@ class YamlAuditingConfigServiceTest {
                     require_sub_match: false
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val ex = assertThrows(IllegalArgumentException::class.java) { service.getConfig() }
         assertTrue(ex.message!!.contains("exactly one"), "Expected 'exactly one' in: ${ex.message}")
@@ -123,7 +177,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   enabled: true
                   verifier:
                     type: jwks
@@ -137,7 +191,7 @@ class YamlAuditingConfigServiceTest {
                     require_sub_match: false
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val verifier = service.getConfig().verifier
         assertInstanceOf(VerifierConfig.Jwks::class.java, verifier)
@@ -162,7 +216,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     jwks_path: "/etc/keys/jwks.json"
@@ -170,7 +224,7 @@ class YamlAuditingConfigServiceTest {
                       - EdDSA
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val verifier = service.getConfig().verifier
         assertInstanceOf(VerifierConfig.Jwks::class.java, verifier)
@@ -186,7 +240,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     oidc_discovery: "https://accounts.example.com/.well-known/openid-configuration"
@@ -194,7 +248,7 @@ class YamlAuditingConfigServiceTest {
                       - EdDSA
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val verifier = service.getConfig().verifier
         assertInstanceOf(VerifierConfig.Jwks::class.java, verifier)
@@ -210,7 +264,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
@@ -218,7 +272,7 @@ class YamlAuditingConfigServiceTest {
                       - EdDSA
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val verifier = service.getConfig().verifier
         assertInstanceOf(VerifierConfig.Jwks::class.java, verifier)
@@ -238,13 +292,13 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     issuer: "https://accounts.example.com"
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         assertEquals(VerifierConfig.Noop, service.getConfig().verifier)
         assertTrue(service.getWarnings().isNotEmpty())
@@ -256,12 +310,12 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: magic-unicorn
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         assertEquals(VerifierConfig.Noop, service.getConfig().verifier)
         assertTrue(service.getWarnings().isNotEmpty())
@@ -277,7 +331,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
@@ -287,7 +341,7 @@ class YamlAuditingConfigServiceTest {
                       - PS256
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val verifier = service.getConfig().verifier as VerifierConfig.Jwks
         assertEquals(listOf("RS256", "ES384", "PS256"), verifier.algorithms)
@@ -298,7 +352,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
@@ -306,7 +360,7 @@ class YamlAuditingConfigServiceTest {
                       - EdDSA
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val verifier = service.getConfig().verifier as VerifierConfig.Jwks
         assertTrue(verifier.requireSubMatch)
@@ -317,7 +371,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
@@ -325,7 +379,7 @@ class YamlAuditingConfigServiceTest {
                       - EdDSA
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val verifier = service.getConfig().verifier as VerifierConfig.Jwks
         assertEquals(300L, verifier.cacheTtlSeconds)
@@ -336,13 +390,13 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val ex = assertThrows(IllegalArgumentException::class.java) { service.getConfig() }
         assertTrue(ex.message!!.contains("non-empty 'algorithms'"), "Expected algorithms error in: ${ex.message}")
@@ -353,14 +407,14 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
                     algorithms: []
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val ex = assertThrows(IllegalArgumentException::class.java) { service.getConfig() }
         assertTrue(ex.message!!.contains("non-empty 'algorithms'"), "Expected algorithms error in: ${ex.message}")
@@ -371,7 +425,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
@@ -379,7 +433,7 @@ class YamlAuditingConfigServiceTest {
                       - EdDSA
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val verifier = service.getConfig().verifier as VerifierConfig.Jwks
         assertTrue(verifier.staleOnError)
@@ -390,7 +444,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
@@ -399,7 +453,7 @@ class YamlAuditingConfigServiceTest {
                     stale_on_error: false
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val verifier = service.getConfig().verifier as VerifierConfig.Jwks
         assertFalse(verifier.staleOnError)
@@ -410,7 +464,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
@@ -419,24 +473,24 @@ class YamlAuditingConfigServiceTest {
                     stale_on_error: true
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val verifier = service.getConfig().verifier as VerifierConfig.Jwks
         assertTrue(verifier.staleOnError)
     }
 
     @Test
-    fun `auditing enabled flag false is respected`() {
+    fun `actor_authentication enabled flag false is respected`() {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   enabled: false
                   verifier:
                     type: noop
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         assertFalse(service.getConfig().enabled)
     }
@@ -450,13 +504,13 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   enabled: true
                   verifier:
                     type: noop
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
         assertEquals(DegradedModePolicy.ACCEPT_CACHED, service.getConfig().degradedModePolicy)
         assertTrue(service.getWarnings().isEmpty())
     }
@@ -466,14 +520,14 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   enabled: true
                   degraded_mode_policy: accept-cached
                   verifier:
                     type: noop
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
         assertEquals(DegradedModePolicy.ACCEPT_CACHED, service.getConfig().degradedModePolicy)
         assertTrue(service.getWarnings().isEmpty())
     }
@@ -483,14 +537,14 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   enabled: true
                   degraded_mode_policy: accept-self-reported
                   verifier:
                     type: noop
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
         assertEquals(DegradedModePolicy.ACCEPT_SELF_REPORTED, service.getConfig().degradedModePolicy)
         assertTrue(service.getWarnings().isEmpty())
     }
@@ -500,14 +554,14 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   enabled: true
                   degraded_mode_policy: reject
                   verifier:
                     type: noop
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
         assertEquals(DegradedModePolicy.REJECT, service.getConfig().degradedModePolicy)
         assertTrue(service.getWarnings().isEmpty())
     }
@@ -517,21 +571,21 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   enabled: true
                   degraded_mode_policy: banana
                   verifier:
                     type: noop
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
         assertEquals(DegradedModePolicy.ACCEPT_CACHED, service.getConfig().degradedModePolicy)
         assertTrue(service.getWarnings().isNotEmpty())
         assertTrue(service.getWarnings().any { it.contains("banana") })
     }
 
     @Test
-    fun `AuditingConfig default has degraded_mode_policy ACCEPT_CACHED`() {
+    fun `ActorAuthenticationConfig default has degraded_mode_policy ACCEPT_CACHED`() {
         val configFile =
             createConfigFile(
                 """
@@ -542,7 +596,7 @@ class YamlAuditingConfigServiceTest {
                       required: false
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
         assertEquals(DegradedModePolicy.ACCEPT_CACHED, service.getConfig().degradedModePolicy)
     }
 
@@ -555,7 +609,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   enabled: true
                   degraded_mode_policy: reject
                   verifier:
@@ -563,7 +617,7 @@ class YamlAuditingConfigServiceTest {
                 """.trimIndent()
             )
         // No env var set — YAML value should be used
-        val service = YamlAuditingConfigService(configFile, envResolver = { null })
+        val service = YamlActorAuthenticationConfigService(configFile, envResolver = { null })
         assertEquals(DegradedModePolicy.REJECT, service.getConfig().degradedModePolicy)
     }
 
@@ -572,7 +626,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   enabled: true
                   degraded_mode_policy: reject
                   verifier:
@@ -581,7 +635,7 @@ class YamlAuditingConfigServiceTest {
             )
         // Env var set to accept-self-reported; YAML says reject
         val service =
-            YamlAuditingConfigService(
+            YamlActorAuthenticationConfigService(
                 configFile,
                 envResolver = { name -> if (name == "DEGRADED_MODE_POLICY") "accept-self-reported" else null }
             )
@@ -593,7 +647,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   enabled: true
                   degraded_mode_policy: reject
                   verifier:
@@ -601,7 +655,7 @@ class YamlAuditingConfigServiceTest {
                 """.trimIndent()
             )
         val service =
-            YamlAuditingConfigService(
+            YamlActorAuthenticationConfigService(
                 configFile,
                 envResolver = { name -> if (name == "DEGRADED_MODE_POLICY") "accept-cached" else null }
             )
@@ -610,9 +664,9 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `DEGRADED_MODE_POLICY env var is case-insensitive — REJECT uppercase`() {
-        val configFile = createConfigFile("auditing:\n  enabled: true")
+        val configFile = createConfigFile("actor_authentication:\n  enabled: true")
         val service =
-            YamlAuditingConfigService(
+            YamlActorAuthenticationConfigService(
                 configFile,
                 envResolver = { name -> if (name == "DEGRADED_MODE_POLICY") "REJECT" else null }
             )
@@ -621,9 +675,9 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `DEGRADED_MODE_POLICY env var is case-insensitive — mixed case Reject`() {
-        val configFile = createConfigFile("auditing:\n  enabled: true")
+        val configFile = createConfigFile("actor_authentication:\n  enabled: true")
         val service =
-            YamlAuditingConfigService(
+            YamlActorAuthenticationConfigService(
                 configFile,
                 envResolver = { name -> if (name == "DEGRADED_MODE_POLICY") "Reject" else null }
             )
@@ -632,9 +686,9 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `DEGRADED_MODE_POLICY env var is case-insensitive — lowercase reject`() {
-        val configFile = createConfigFile("auditing:\n  enabled: true")
+        val configFile = createConfigFile("actor_authentication:\n  enabled: true")
         val service =
-            YamlAuditingConfigService(
+            YamlActorAuthenticationConfigService(
                 configFile,
                 envResolver = { name -> if (name == "DEGRADED_MODE_POLICY") "reject" else null }
             )
@@ -643,9 +697,9 @@ class YamlAuditingConfigServiceTest {
 
     @Test
     fun `DEGRADED_MODE_POLICY env var invalid value throws IllegalArgumentException`() {
-        val configFile = createConfigFile("auditing:\n  enabled: true")
+        val configFile = createConfigFile("actor_authentication:\n  enabled: true")
         val service =
-            YamlAuditingConfigService(
+            YamlActorAuthenticationConfigService(
                 configFile,
                 envResolver = { name -> if (name == "DEGRADED_MODE_POLICY") "banana" else null }
             )
@@ -657,7 +711,7 @@ class YamlAuditingConfigServiceTest {
     @Test
     fun `DEGRADED_MODE_POLICY env unset with no YAML section defaults to ACCEPT_CACHED`() {
         val configFile = createConfigFile("note_schemas:\n  default: []")
-        val service = YamlAuditingConfigService(configFile, envResolver = { null })
+        val service = YamlActorAuthenticationConfigService(configFile, envResolver = { null })
         assertEquals(DegradedModePolicy.ACCEPT_CACHED, service.getConfig().degradedModePolicy)
     }
 
@@ -670,7 +724,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     did_allowlist:
@@ -680,7 +734,7 @@ class YamlAuditingConfigServiceTest {
                       - EdDSA
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val verifier = service.getConfig().verifier
         assertInstanceOf(VerifierConfig.Jwks::class.java, verifier)
@@ -700,7 +754,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     did_pattern: "did:web:*.example.com"
@@ -708,7 +762,7 @@ class YamlAuditingConfigServiceTest {
                       - EdDSA
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val verifier = service.getConfig().verifier as VerifierConfig.Jwks
         assertEquals(emptyList<String>(), verifier.didAllowlist)
@@ -723,7 +777,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     did_allowlist:
@@ -733,7 +787,7 @@ class YamlAuditingConfigServiceTest {
                       - EdDSA
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val verifier = service.getConfig().verifier as VerifierConfig.Jwks
         assertEquals(listOf("did:web:explicit.example.com"), verifier.didAllowlist)
@@ -746,7 +800,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     did_allowlist:
@@ -756,7 +810,7 @@ class YamlAuditingConfigServiceTest {
                       - EdDSA
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val verifier = service.getConfig().verifier as VerifierConfig.Jwks
         assertFalse(verifier.didStrictRelationship)
@@ -768,7 +822,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     did_allowlist:
@@ -778,7 +832,7 @@ class YamlAuditingConfigServiceTest {
                       - EdDSA
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val verifier = service.getConfig().verifier as VerifierConfig.Jwks
         assertFalse(verifier.didLooseKidMatch)
@@ -794,7 +848,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     did_allowlist:
@@ -802,7 +856,7 @@ class YamlAuditingConfigServiceTest {
                     jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val ex = assertThrows(IllegalArgumentException::class.java) { service.getConfig() }
         assertTrue(ex.message!!.contains("mutually exclusive"), "Expected 'mutually exclusive' in: ${ex.message}")
@@ -814,7 +868,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     did_allowlist:
@@ -822,7 +876,7 @@ class YamlAuditingConfigServiceTest {
                     jwks_path: "/etc/keys/jwks.json"
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val ex = assertThrows(IllegalArgumentException::class.java) { service.getConfig() }
         assertTrue(ex.message!!.contains("mutually exclusive"), "Expected 'mutually exclusive' in: ${ex.message}")
@@ -834,7 +888,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     did_allowlist:
@@ -842,7 +896,7 @@ class YamlAuditingConfigServiceTest {
                     oidc_discovery: "https://accounts.example.com/.well-known/openid-configuration"
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val ex = assertThrows(IllegalArgumentException::class.java) { service.getConfig() }
         assertTrue(ex.message!!.contains("mutually exclusive"), "Expected 'mutually exclusive' in: ${ex.message}")
@@ -854,14 +908,14 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     did_pattern: "did:web:*.example.com"
                     jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val ex = assertThrows(IllegalArgumentException::class.java) { service.getConfig() }
         assertTrue(ex.message!!.contains("mutually exclusive"), "Expected 'mutually exclusive' in: ${ex.message}")
@@ -873,14 +927,14 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     issuer: "https://accounts.example.com"
                     audience: "mcp-task-orchestrator"
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         assertEquals(VerifierConfig.Noop, service.getConfig().verifier)
         assertTrue(service.getWarnings().isNotEmpty())
@@ -896,7 +950,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
@@ -904,7 +958,7 @@ class YamlAuditingConfigServiceTest {
                       - EdDSA
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val verifier = service.getConfig().verifier as VerifierConfig.Jwks
         assertEquals(emptyList<String>(), verifier.didAllowlist)
@@ -923,7 +977,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     jwks_uri: "https://accounts.example.com/.well-known/jwks.json"
@@ -932,7 +986,7 @@ class YamlAuditingConfigServiceTest {
                       - EdDSA
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val ex = assertThrows(IllegalArgumentException::class.java) { service.getConfig() }
         assertTrue(ex.message!!.contains("multiple were provided"), "Expected 'multiple were provided' in: ${ex.message}")
@@ -945,7 +999,7 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     oidc_discovery: "https://accounts.example.com/.well-known/openid-configuration"
@@ -954,7 +1008,7 @@ class YamlAuditingConfigServiceTest {
                       - EdDSA
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val ex = assertThrows(IllegalArgumentException::class.java) { service.getConfig() }
         assertTrue(ex.message!!.contains("multiple were provided"), "Expected 'multiple were provided' in: ${ex.message}")
@@ -971,14 +1025,14 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     did_allowlist:
                       - "did:web:example.com"
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val ex = assertThrows(IllegalArgumentException::class.java) { service.getConfig() }
         assertTrue(ex.message!!.contains("non-empty 'algorithms'"), "Expected algorithms error in: ${ex.message}")
@@ -989,13 +1043,13 @@ class YamlAuditingConfigServiceTest {
         val configFile =
             createConfigFile(
                 """
-                auditing:
+                actor_authentication:
                   verifier:
                     type: jwks
                     did_pattern: "did:web:*.example.com"
                 """.trimIndent()
             )
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val ex = assertThrows(IllegalArgumentException::class.java) { service.getConfig() }
         assertTrue(ex.message!!.contains("non-empty 'algorithms'"), "Expected algorithms error in: ${ex.message}")
@@ -1009,10 +1063,10 @@ class YamlAuditingConfigServiceTest {
     fun `malformed YAML falls back to defaults gracefully`() {
         val configFile =
             createConfigFile("{{{{invalid yaml!!!")
-        val service = YamlAuditingConfigService(configFile)
+        val service = YamlActorAuthenticationConfigService(configFile)
 
         val config = service.getConfig()
-        assertEquals(AuditingConfig(), config)
+        assertEquals(ActorAuthenticationConfig(), config)
         assertTrue(service.getWarnings().isNotEmpty())
     }
 


### PR DESCRIPTION
## Summary

Renames the top-level `.taskorchestrator/config.yaml` section `auditing:` → `actor_authentication:` (and the underlying classes `AuditingConfig` / `YamlAuditingConfigService` → `ActorAuthenticationConfig` / `YamlActorAuthenticationConfigService`). The section configures actor-claim authentication policy (JWT verifier, JWKS sources, DID trust, degraded-mode policy) — the prior name did not describe its contents.

The new name combines TO's actor-model vocabulary with industry-standard auth terminology (Kubernetes `AuthenticationConfiguration`, Envoy `jwt_authn`) and the `actor_` prefix avoids collision with potential future MCP transport-level `authentication:`.

- **Hard cut** — legacy `auditing:` keys produce a clear startup error: `Unknown top-level config key 'auditing:'. Did you mean 'actor_authentication:'? See CHANGELOG for migration.`
- Inner `verifier:` block name unchanged.
- Runtime types `VerificationResult` / `VerificationStatus` / `VerifierConfig` unchanged — they describe the cryptographic mechanism, one nested layer below the config-section purpose. (Kubernetes uses an analogous split: `AuthenticationConfiguration` config layer producing `Authenticator` types that emit verification outcomes.)

### Bundled cleanup

Documents the DID-trust fields (`did_allowlist`, `did_pattern`, `did_strict_relationship`, `did_loose_kid_match`) that PR #159 added to `VerifierConfig.Jwks` but never propagated to the manage-schemas plugin skill. All four fields, mutual-exclusion rules, and a DID-rooted trust YAML example are now in the plugin reference docs.

### Migration

```bash
sed -i 's/^auditing:/actor_authentication:/' .taskorchestrator/config.yaml
```

CHANGELOG entry under "Unreleased" → Breaking Changes. PR #159's other breaking config changes are also unreleased, so operators upgrading need to update config anyway.

### Files changed

- **Source/tests (5)**: `AuditingConfig.kt` → `ActorAuthenticationConfig.kt`; `YamlAuditingConfigService.kt` → `YamlActorAuthenticationConfigService.kt`; corresponding test renamed + 2 new legacy-key rejection tests; `CurrentMcpServer.kt` import updated; one stale comment in `DegradedModePolicyTest.kt`
- **Docs (8)**: `SECURITY.md`, `README.md`, `CLAUDE.md`, `CHANGELOG.md`, plus `current/docs/{api-reference,fleet-deployment,quick-start,workflow-guide}.md`
- **Plugin (4)**: hook `enforce-actor-attribution.mjs` (8 references + function rename + block-reason string); `manage-schemas/SKILL.md` (description, argument-hint, view section, DID-trust display variant); `manage-schemas/references/{config-format,validate-workflow}.md` (rename + DID fields documented)

## Test plan

- [x] `./gradlew :current:test` — all ~1600 tests pass (including 2 new legacy-key rejection tests)
- [x] `./gradlew :current:ktlintCheck` — clean
- [x] Independent review agent verified plan alignment, naming consistency, hard-cut error correctness, and DID-fields documentation completeness against the actual `VerifierConfig.Jwks` runtime fields
- [ ] After merge: operators with existing `.taskorchestrator/config.yaml` files using `auditing:` must run the sed migration before upgrading the server
- [ ] After merge: `/mcp` reconnect required for the `manage-schemas` skill changes to surface

## MCP

Closes work item `3cbb3758-ce0b-429b-9a00-588a2abe3088`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)