### PR TITLE
docs(spec-quality): add Open Decisions discipline

### DIFF
--- a/.claude/skills/spec-quality/SKILL.md
+++ b/.claude/skills/spec-quality/SKILL.md
@@ -34,6 +34,26 @@ committing to an approach that has a better option sitting next to it.
 *Anti-pattern: strawman alternatives.* "Alternative: rewrite everything from scratch.
 Rejected: too much work." This doesn't force any real thinking.
 
+### Open Decisions
+
+If the spec lists open decisions, naming alternatives, or "options under consideration,"
+resolve every one before materializing MCP work items or dispatching implementation.
+A spec with unresolved choices left in it is not ready to dispatch.
+
+Mid-implementation pivots cost 5-10× the time of a pre-dispatch user round-trip. Once
+an agent is in a worktree, a naming change or interface change requires unwinding
+partial code, retracting commits, re-spec'ing the work, and re-dispatching. Resolving
+the same question before dispatch is a single short conversation.
+
+The orchestrator should pause for a user round-trip rather than dispatch with ambiguity.
+A short pause now is cheaper than a partial implementation later.
+
+If a decision genuinely cannot be resolved at planning time (e.g., depends on a
+measurement only available post-implementation), it isn't an "open decision" — it's a
+deliberate two-phase approach. Document it as such, scope the first phase explicitly,
+and create a separate work item for the second phase. Don't leave the choice latent
+in the spec.
+
 ### Non-Goals
 
 Name what someone might reasonably expect this work to include but that is deliberately
@@ -93,6 +113,7 @@ them, or confirm they still pass with the new behavior.
 Validate spec completeness before advancing past queue phase:
 
 - [ ] At least 2 real alternatives evaluated (not strawmen)
+- [ ] No "open decisions" or "options under consideration" sections remain in the spec
 - [ ] At least 1 non-goal named (scope boundary explicit)
 - [ ] Downstream consumers of changed interfaces traced
 - [ ] 1-2 concrete risk flags identified


### PR DESCRIPTION
## Summary

Adds a new "Open Decisions" discipline to the project-level `spec-quality` skill, between "Alternatives Considered" and "Non-Goals". When a spec lists open decisions, naming alternatives, or "options under consideration," resolve them before materializing MCP work items or dispatching implementation.

The framework already covered HOW to evaluate alternatives ("Alternatives Considered") but not WHEN those alternatives must be closed off. This discipline fills that lifecycle gap. Adds one corresponding checklist item.

## Why

Pattern reinforced across two retrospectives:

- `00b7d2bd` (PR #159 review-fixes): plan had 4 open decisions resolved before materialization — zero clarifying questions back from 5 implementation agents.
- `4bfc4e14` (PR #160 actor_authentication rename): user-driven naming pivot from `verification:` → `actor_authentication:` happened pre-redispatch. Industry research surfaced a future-collision concern (`mcp.authentication:`) that the original spec missed.

Mid-implementation pivots cost 5-10× the time of a pre-dispatch user round-trip — once an agent is in a worktree, a naming change requires unwinding partial code, retracting commits, re-spec'ing the work, and re-dispatching.

The discipline also distinguishes genuinely two-phase work (where a decision depends on a post-implementation measurement) from latent choices left in a spec — the former gets explicit phase scoping; the latter is the failure mode this discipline prevents.

## Test plan

- [ ] No build/test impact — documentation-only edit to a Markdown skill file
- [ ] After merge: verify the skill renders correctly when an agent invokes it via the spec-quality framework reference (queue-phase note filling)

## MCP

Closes proposal item `43c05c0c-8e58-4d0c-a505-1a5eba3f11e8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)