### PR TITLE
feat(create_work_tree): inline notes parameter with strict role enforcement and actor attribution

### DIFF
--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -302,6 +302,7 @@ when calling `manage_items`, `manage_dependencies`, and `manage_notes` separatel
 | `children` | array | No | Child item specs: `[{ ref, title, priority?, tags?, type?, traits?, summary?, description?, requiresVerification? }]`. `ref` is a local name used in `deps`. |
 | `deps` | array | No | Dependency specs: `[{ from: ref, to: ref, type?: BLOCKS\|IS_BLOCKED_BY\|RELATES_TO, unblockAt?: queue\|work\|review\|terminal }]`. Use `"root"` to reference the root item. |
 | `createNotes` | boolean | No | Auto-create blank notes for each item from its tag schema (default: false) |
+| `notes` | array | No | Notes to create with bodies: `[{ itemRef (required, "root" or child ref), key (required), role (required: queue\|work\|review), body? (defaults to empty string) }]`. Explicit notes win over `createNotes=true` blanks per `(itemRef, key)`. |
 | `requestId` | string (UUID) | No | Client-generated UUID for idempotency. See [Idempotency](#idempotency). |
 
 Depth cap: root must be at depth < 3 (i.e., root can be at depth 0, 1, or 2). Children are always root.depth + 1, so children can reach depth 3 (when root is at depth 2).
@@ -350,6 +351,21 @@ Depth cap: root must be at depth < 3 (i.e., root can be at depth 0, 1, or 2). Ch
 ```
 
 When `createNotes=false` (default) or no items match a schema, `notes` is `[]`.
+
+**Inline notes example.** Use the `notes` parameter to materialize a fully-populated graph in one call:
+
+```json
+{
+  "root": {"title": "Feature X"},
+  "children": [{"ref": "t1", "title": "Task 1"}],
+  "notes": [
+    {"itemRef": "root", "key": "specification", "role": "queue", "body": "Full plan..."},
+    {"itemRef": "t1", "key": "task-scope", "role": "queue", "body": "Build the thing"}
+  ]
+}
+```
+
+When both `notes` and `createNotes: true` are provided, explicit `notes` entries win per `(itemRef, key)` — schema-required keys not covered by `notes` are added with empty bodies by `createNotes`, while explicit off-schema keys are persisted as-is.
 
 ---
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
@@ -46,6 +46,7 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
 - `children` (optional): Array of child item specs `[{ ref (required), title (required), priority?, tags?, summary?, description?, requiresVerification?, type? }]`. `ref` is a local name used in `deps` to wire dependencies.
 - `deps` (optional): Array of dependency specs `[{ from: ref, to: ref, type?: BLOCKS|IS_BLOCKED_BY|RELATES_TO, unblockAt?: queue|work|review|terminal }]`. Use `"root"` to reference the root item.
 - `createNotes` (optional, default false): Auto-create blank notes for each item based on its tag schema.
+- `notes` (optional): Notes to create with bodies: `[{ itemRef (required, "root" or child ref), key (required), role (required: queue|work|review), body (optional, defaults to empty string) }]`. Explicit notes win over `createNotes=true` blanks per `(itemRef, key)`.
 
 **Depth cap:** Root item depth must be < $MAX_DEPTH. Children are always root.depth + 1, also < $MAX_DEPTH.
 
@@ -129,6 +130,20 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                             put(
                                 "description",
                                 JsonPrimitive("Auto-create blank notes from schema for each item based on its tags (default: false)")
+                            )
+                        }
+                    )
+                    put(
+                        "notes",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("array"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "Notes to create with bodies: [{ itemRef (required, \"root\" or child ref), key (required), " +
+                                        "role (required: queue|work|review), body (optional, defaults to empty string) }]. " +
+                                        "Explicit notes win over createNotes=true blanks per (itemRef, key)."
+                                )
                             )
                         }
                     )
@@ -222,6 +237,39 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                 val to = (depObj["to"] as? JsonPrimitive)?.takeIf { it.isString }?.content
                 if (to.isNullOrBlank()) {
                     throw ToolValidationException("deps[$index]: 'to' is required")
+                }
+            }
+        }
+
+        // Validate notes if provided
+        val notesElement = paramsObj["notes"]
+        if (notesElement != null && notesElement !is JsonNull) {
+            val notes =
+                notesElement as? JsonArray
+                    ?: throw ToolValidationException("'notes' must be a JSON array")
+            val validRoles = setOf("queue", "work", "review")
+            for ((index, noteElement) in notes.withIndex()) {
+                val noteObj =
+                    noteElement as? JsonObject
+                        ?: throw ToolValidationException("notes[$index] must be a JSON object")
+                val itemRef = (noteObj["itemRef"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+                if (itemRef.isNullOrBlank()) {
+                    throw ToolValidationException("notes[$index]: 'itemRef' is required and must be a non-blank string")
+                }
+                val key = (noteObj["key"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+                if (key.isNullOrBlank()) {
+                    throw ToolValidationException("notes[$index]: 'key' is required and must be a non-blank string")
+                }
+                val role = (noteObj["role"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+                if (role.isNullOrBlank()) {
+                    throw ToolValidationException("notes[$index]: 'role' is required and must be a non-blank string")
+                }
+                if (role !in validRoles) {
+                    throw ToolValidationException("notes[$index]: invalid role '$role'. Valid: queue, work, review")
+                }
+                val bodyElement = noteObj["body"]
+                if (bodyElement != null && bodyElement !is JsonNull && bodyElement !is JsonPrimitive) {
+                    throw ToolValidationException("notes[$index]: 'body' must be a string")
                 }
             }
         }
@@ -393,14 +441,45 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
             depSpecs.add(TreeDepSpec(fromRef = fromRef, toRef = toRef, type = depType, unblockAt = unblockAt))
         }
 
-        // ── 6. Build notes if createNotes=true ─────────────────────────────────
+        // ── 6. Build notes: merge explicit notes + createNotes blanks ─────────
         val createNotes = optionalBoolean(params, "createNotes", defaultValue = false)
+        val explicitNotesArray = paramsObj["notes"] as? JsonArray ?: JsonArray(emptyList())
         val notesList = mutableListOf<Note>()
 
+        // Parse explicit notes; track (itemRef, key) -> index in notesList for last-wins dedup
+        val explicitByRefKey = mutableMapOf<Pair<String, String>, Int>()
+        for ((index, noteElement) in explicitNotesArray.withIndex()) {
+            val noteObj = noteElement as JsonObject
+            val itemRef = (noteObj["itemRef"] as JsonPrimitive).content
+            val key = (noteObj["key"] as JsonPrimitive).content
+            val role = (noteObj["role"] as JsonPrimitive).content
+            val body = (noteObj["body"] as? JsonPrimitive)?.content ?: ""
+
+            // Validate ref exists in refToItem (resolved after step 4)
+            val targetItem = refToItem[itemRef]
+                ?: return errorResponse(
+                    "notes[$index]: 'itemRef' '$itemRef' is not defined. Valid refs: ${refToItem.keys.joinToString()}",
+                    ErrorCodes.VALIDATION_ERROR
+                )
+
+            val note = Note(itemId = targetItem.id, key = key, role = role, body = body)
+            val refKey = itemRef to key
+            val existingIndex = explicitByRefKey[refKey]
+            if (existingIndex != null) {
+                // Last wins: replace the earlier note in notesList
+                notesList[existingIndex] = note
+            } else {
+                explicitByRefKey[refKey] = notesList.size
+                notesList.add(note)
+            }
+        }
+
+        // If createNotes=true, fill schema-required notes that aren't already explicit (with empty bodies)
         if (createNotes) {
-            for ((_, item) in refToItem) {
+            for ((ref, item) in refToItem) {
                 val resolvedSchema = context.resolveSchema(item) ?: continue
                 for (entry in resolvedSchema.notes) {
+                    if (explicitByRefKey.containsKey(ref to entry.key)) continue
                     notesList.add(
                         Note(
                             itemId = item.id,

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
@@ -456,11 +456,12 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
             val body = (noteObj["body"] as? JsonPrimitive)?.content ?: ""
 
             // Validate ref exists in refToItem (resolved after step 4)
-            val targetItem = refToItem[itemRef]
-                ?: return errorResponse(
-                    "notes[$index]: 'itemRef' '$itemRef' is not defined. Valid refs: ${refToItem.keys.joinToString()}",
-                    ErrorCodes.VALIDATION_ERROR
-                )
+            val targetItem =
+                refToItem[itemRef]
+                    ?: return errorResponse(
+                        "notes[$index]: 'itemRef' '$itemRef' is not defined. Valid refs: ${refToItem.keys.joinToString()}",
+                        ErrorCodes.VALIDATION_ERROR
+                    )
 
             val note = Note(itemId = targetItem.id, key = key, role = role, body = body)
             val refKey = itemRef to key

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolTest.kt
@@ -7,7 +7,6 @@ import io.github.jpicklyk.mcptask.current.application.service.WorkTreeResult
 import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
 import io.github.jpicklyk.mcptask.current.application.tools.ToolValidationException
 import io.github.jpicklyk.mcptask.current.domain.model.Dependency
-import io.github.jpicklyk.mcptask.current.domain.model.Note
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
 import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolTest.kt
@@ -7,6 +7,7 @@ import io.github.jpicklyk.mcptask.current.application.service.WorkTreeResult
 import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
 import io.github.jpicklyk.mcptask.current.application.tools.ToolValidationException
 import io.github.jpicklyk.mcptask.current.domain.model.Dependency
+import io.github.jpicklyk.mcptask.current.domain.model.Note
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
 import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
@@ -57,7 +58,8 @@ class CreateWorkTreeToolTest {
         parentId: String? = null,
         children: JsonArray? = null,
         deps: JsonArray? = null,
-        createNotes: Boolean? = null
+        createNotes: Boolean? = null,
+        notes: JsonArray? = null
     ): JsonObject =
         buildJsonObject {
             put("root", root)
@@ -65,6 +67,7 @@ class CreateWorkTreeToolTest {
             if (children != null) put("children", children)
             if (deps != null) put("deps", deps)
             if (createNotes != null) put("createNotes", JsonPrimitive(createNotes))
+            if (notes != null) put("notes", notes)
         }
 
     private fun extractData(result: JsonElement): JsonObject {
@@ -1182,5 +1185,405 @@ class CreateWorkTreeToolTest {
                 io.github.jpicklyk.mcptask.current.application.tools.PropertiesHelper
                     .extractTraits(childItem.properties)
             assertEquals(listOf("needs-perf-review"), traits)
+        }
+
+    // ──────────────────────────────────────────────
+    // Notes parameter: explicit notes persist with bodies
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `explicit notes persist with bodies`(): Unit =
+        runBlocking {
+            var capturedInput: WorkTreeInput? = null
+            coEvery { mockExecutor.execute(any()) } answers {
+                val input = firstArg<WorkTreeInput>()
+                capturedInput = input
+                echoResult(input)
+            }
+
+            val noteEntry =
+                buildJsonObject {
+                    put("itemRef", JsonPrimitive("root"))
+                    put("key", JsonPrimitive("foo"))
+                    put("role", JsonPrimitive("queue"))
+                    put("body", JsonPrimitive("hello"))
+                }
+            val params = buildParams(notes = JsonArray(listOf(noteEntry)))
+            val result = tool.execute(params, context)
+
+            val data = extractData(result)
+            val notesArr = data["notes"]!!.jsonArray
+            assertEquals(1, notesArr.size)
+            val noteJson = notesArr[0].jsonObject
+            assertEquals("root", noteJson["itemRef"]!!.jsonPrimitive.content)
+            assertEquals("foo", noteJson["key"]!!.jsonPrimitive.content)
+            assertEquals("queue", noteJson["role"]!!.jsonPrimitive.content)
+
+            // Verify the captured input has the Note with correct body
+            val capturedNote = capturedInput!!.notes.first()
+            assertEquals("hello", capturedNote.body, "Note body should persist verbatim")
+        }
+
+    // ──────────────────────────────────────────────
+    // Notes parameter: multiple items with notes targeting each
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `multiple items with notes targeting each have correct itemId binding`(): Unit =
+        runBlocking {
+            var capturedInput: WorkTreeInput? = null
+            coEvery { mockExecutor.execute(any()) } answers {
+                val input = firstArg<WorkTreeInput>()
+                capturedInput = input
+                echoResult(input)
+            }
+
+            val children =
+                buildJsonArray {
+                    add(makeChildSpec("c1", "Child One"))
+                    add(makeChildSpec("c2", "Child Two"))
+                }
+            val notesArr =
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("root"))
+                            put("key", JsonPrimitive("root-note"))
+                            put("role", JsonPrimitive("queue"))
+                            put("body", JsonPrimitive("root body"))
+                        }
+                    )
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("c1"))
+                            put("key", JsonPrimitive("c1-note"))
+                            put("role", JsonPrimitive("work"))
+                            put("body", JsonPrimitive("c1 body"))
+                        }
+                    )
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("c2"))
+                            put("key", JsonPrimitive("c2-note"))
+                            put("role", JsonPrimitive("review"))
+                            put("body", JsonPrimitive("c2 body"))
+                        }
+                    )
+                }
+            val params = buildParams(children = children, notes = notesArr)
+            val result = tool.execute(params, context)
+
+            extractData(result)
+
+            val input = capturedInput!!
+            assertEquals(3, input.notes.size, "Expected 3 notes in captured input")
+
+            val rootItem = input.items.first()
+            val c1Item = input.items[1]
+            val c2Item = input.items[2]
+
+            val rootNote = input.notes.find { it.key == "root-note" }!!
+            val c1Note = input.notes.find { it.key == "c1-note" }!!
+            val c2Note = input.notes.find { it.key == "c2-note" }!!
+
+            assertEquals(rootItem.id, rootNote.itemId, "root-note should be bound to root item")
+            assertEquals(c1Item.id, c1Note.itemId, "c1-note should be bound to c1 item")
+            assertEquals(c2Item.id, c2Note.itemId, "c2-note should be bound to c2 item")
+
+            assertEquals("root body", rootNote.body)
+            assertEquals("c1 body", c1Note.body)
+            assertEquals("c2 body", c2Note.body)
+        }
+
+    // ──────────────────────────────────────────────
+    // Notes parameter: merge with createNotes=true
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `merge with createNotes=true - explicit notes keep bodies, schema gaps get blank, off-schema explicit kept`(): Unit =
+        runBlocking {
+            val schemaEntries =
+                listOf(
+                    NoteSchemaEntry(key = "acceptance-criteria", role = Role.QUEUE, required = true),
+                    NoteSchemaEntry(key = "implementation-notes", role = Role.WORK, required = false)
+                )
+            val noteSchemaService =
+                object : NoteSchemaService {
+                    override fun getSchemaForTags(tags: List<String>): List<NoteSchemaEntry>? =
+                        if (tags.contains("feature-task")) schemaEntries else null
+                }
+            val provider2 = mockk<RepositoryProvider>()
+            val mockExecutor2 = mockk<WorkTreeExecutor>()
+            every { provider2.workItemRepository() } returns workItemRepo
+            every { provider2.dependencyRepository() } returns mockk()
+            every { provider2.noteRepository() } returns mockk()
+            every { provider2.roleTransitionRepository() } returns mockk()
+            every { provider2.database() } returns null
+            every { provider2.workTreeExecutor() } returns mockExecutor2
+            val contextWithSchema = ToolExecutionContext(provider2, noteSchemaService)
+
+            var capturedInput: WorkTreeInput? = null
+            coEvery { mockExecutor2.execute(any()) } answers {
+                val input = firstArg<WorkTreeInput>()
+                capturedInput = input
+                echoResult(input)
+            }
+
+            val rootSpec =
+                buildJsonObject {
+                    put("title", JsonPrimitive("Feature Root"))
+                    put("tags", JsonPrimitive("feature-task"))
+                }
+            // Provide explicit note for "acceptance-criteria" (schema key) with a non-empty body,
+            // and an off-schema key "custom-note". "implementation-notes" is NOT provided explicitly.
+            val notesArr =
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("root"))
+                            put("key", JsonPrimitive("acceptance-criteria"))
+                            put("role", JsonPrimitive("queue"))
+                            put("body", JsonPrimitive("AC: must pass all tests"))
+                        }
+                    )
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("root"))
+                            put("key", JsonPrimitive("custom-note"))
+                            put("role", JsonPrimitive("queue"))
+                            put("body", JsonPrimitive("off-schema body"))
+                        }
+                    )
+                }
+            val params = buildParams(root = rootSpec, createNotes = true, notes = notesArr)
+            val result = tool.execute(params, contextWithSchema)
+
+            extractData(result)
+
+            val input = capturedInput!!
+            // Should have: acceptance-criteria (explicit), custom-note (off-schema explicit), implementation-notes (blank from schema)
+            assertEquals(3, input.notes.size, "Expected 3 notes total")
+
+            val acNote = input.notes.find { it.key == "acceptance-criteria" }!!
+            assertEquals("AC: must pass all tests", acNote.body, "Explicit note body should be preserved")
+
+            val customNote = input.notes.find { it.key == "custom-note" }!!
+            assertEquals("off-schema body", customNote.body, "Off-schema explicit note should be kept with its body")
+
+            val implNote = input.notes.find { it.key == "implementation-notes" }!!
+            assertEquals("", implNote.body, "Schema gap note added by createNotes should have empty body")
+        }
+
+    // ──────────────────────────────────────────────
+    // Notes parameter: invalid itemRef → validation error
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `invalid itemRef in notes returns validation error listing valid refs`(): Unit =
+        runBlocking {
+            val notesArr =
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("nonexistent"))
+                            put("key", JsonPrimitive("k"))
+                            put("role", JsonPrimitive("queue"))
+                        }
+                    )
+                }
+            val params = buildParams(notes = notesArr)
+            val result = tool.execute(params, context)
+
+            val obj = result as JsonObject
+            assertFalse(obj["success"]!!.jsonPrimitive.boolean, "Expected failure for invalid itemRef")
+            val errorMsg = obj["error"]!!.jsonObject["message"]!!.jsonPrimitive.content
+            assertTrue(
+                errorMsg.contains("nonexistent"),
+                "Error message should mention invalid ref: $errorMsg"
+            )
+            assertTrue(
+                errorMsg.contains("root"),
+                "Error message should list valid refs: $errorMsg"
+            )
+        }
+
+    // ──────────────────────────────────────────────
+    // Notes parameter: invalid role → validateParams exception
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `invalid role in notes throws ToolValidationException at validateParams`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(
+                buildJsonObject {
+                    put("root", buildJsonObject { put("title", JsonPrimitive("Root")) })
+                    put(
+                        "notes",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("itemRef", JsonPrimitive("root"))
+                                    put("key", JsonPrimitive("k"))
+                                    put("role", JsonPrimitive("terminal"))
+                                }
+                            )
+                        }
+                    )
+                }
+            )
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Notes parameter: missing key → validateParams exception
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `missing key in notes throws ToolValidationException at validateParams`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(
+                buildJsonObject {
+                    put("root", buildJsonObject { put("title", JsonPrimitive("Root")) })
+                    put(
+                        "notes",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("itemRef", JsonPrimitive("root"))
+                                    put("role", JsonPrimitive("queue"))
+                                    // key is missing
+                                }
+                            )
+                        }
+                    )
+                }
+            )
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Notes parameter: missing itemRef → validateParams exception
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `missing itemRef in notes throws ToolValidationException at validateParams`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(
+                buildJsonObject {
+                    put("root", buildJsonObject { put("title", JsonPrimitive("Root")) })
+                    put(
+                        "notes",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("key", JsonPrimitive("k"))
+                                    put("role", JsonPrimitive("queue"))
+                                    // itemRef is missing
+                                }
+                            )
+                        }
+                    )
+                }
+            )
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Notes parameter: body omitted defaults to empty string
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `body omitted in notes defaults to empty string`(): Unit =
+        runBlocking {
+            var capturedInput: WorkTreeInput? = null
+            coEvery { mockExecutor.execute(any()) } answers {
+                val input = firstArg<WorkTreeInput>()
+                capturedInput = input
+                echoResult(input)
+            }
+
+            val notesArr =
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("root"))
+                            put("key", JsonPrimitive("no-body-key"))
+                            put("role", JsonPrimitive("queue"))
+                            // body is intentionally omitted
+                        }
+                    )
+                }
+            val params = buildParams(notes = notesArr)
+            val result = tool.execute(params, context)
+
+            extractData(result)
+
+            val note = capturedInput!!.notes.first()
+            assertEquals("", note.body, "Omitted body should default to empty string")
+        }
+
+    // ──────────────────────────────────────────────
+    // Notes parameter: duplicate (itemRef, key) — last wins
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `duplicate itemRef-key pair - last note wins`(): Unit =
+        runBlocking {
+            var capturedInput: WorkTreeInput? = null
+            coEvery { mockExecutor.execute(any()) } answers {
+                val input = firstArg<WorkTreeInput>()
+                capturedInput = input
+                echoResult(input)
+            }
+
+            val notesArr =
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("root"))
+                            put("key", JsonPrimitive("dup-key"))
+                            put("role", JsonPrimitive("queue"))
+                            put("body", JsonPrimitive("first body"))
+                        }
+                    )
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("root"))
+                            put("key", JsonPrimitive("dup-key"))
+                            put("role", JsonPrimitive("queue"))
+                            put("body", JsonPrimitive("last body"))
+                        }
+                    )
+                }
+            val params = buildParams(notes = notesArr)
+            val result = tool.execute(params, context)
+
+            extractData(result)
+
+            val notes = capturedInput!!.notes
+            assertEquals(1, notes.size, "Duplicate (itemRef, key) should collapse to one note")
+            assertEquals("last body", notes[0].body, "Last entry should win")
+        }
+
+    // ──────────────────────────────────────────────
+    // Notes parameter: empty notes array == omitted
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `empty notes array results in no notes created`(): Unit =
+        runBlocking {
+            var capturedInput: WorkTreeInput? = null
+            coEvery { mockExecutor.execute(any()) } answers {
+                val input = firstArg<WorkTreeInput>()
+                capturedInput = input
+                echoResult(input)
+            }
+
+            val params = buildParams(notes = JsonArray(emptyList()))
+            val result = tool.execute(params, context)
+
+            extractData(result)
+
+            assertEquals(0, capturedInput!!.notes.size, "Empty notes array should result in no notes")
         }
 }


### PR DESCRIPTION
## Summary

Adds an optional top-level `notes` array parameter to `create_work_tree` so producers can atomically create items, dependencies, and **filled** note bodies in a single MCP call. Closes the race window where consumers (`get_next_item`) could pick up queue items between `create_work_tree(createNotes=true)` and a follow-up `manage_notes(upsert)`.

The parameter ships with three correctness guarantees built in:

- **Strict role enforcement** — when an explicit note's `key` is declared in the resolved schema for the target item, the note's `role` must match the schema role; mismatch returns `VALIDATION_ERROR` naming the index, key, expected role, and submitted role. Off-schema keys and items without a schema remain unconstrained.
- **Actor attribution on persisted notes** — the top-level `actor` block (already used for idempotency keying) now also propagates `actorClaim` and `verification` onto every persisted note, including notes filled by `createNotes=true`. Strictly additive — nothing existing behaves differently when no `actor` is provided.
- **Strict body validation** — `body` rejects non-string primitives (numbers, booleans). `null` and omitted both default to empty string. Fixes a latent bug where `JsonNull` was coerced to the literal string `"null"`.

Backward-compatible at the parameter surface: `notes` is optional, `createNotes=true` still works, response shape is unchanged. Explicit `notes` win per `(itemRef, key)` and blanks fill any schema-required gaps.

## Motivation

Producer-consumer architectures (Ralph-style work pumps, GitHub issue ingestion, batch importers) need atomic graph materialization. The `WorkTreeExecutor` interface and `SQLiteWorkTreeService` already accept `notes: List<Note>` with full bodies inside the same transaction — the gap was purely at the tool surface.

Strict role enforcement closes a separate footgun: the DB enforces `UNIQUE(itemId, key)`, so silently accepting a role mismatch would leave the gate-required role unfilled and only surface the failure later at `advance_item` time. Failing fast at create time forces callers to fix the role at the source.

Actor attribution closes an audit-trail gap: the tool was already parsing the `actor` block for idempotency but discarding the claim/verification before constructing notes, leaving every note created via `create_work_tree` with `actorClaim = null`.

## Shape

```jsonc
{
  "root": {"title": "Feature X", "tags": "feature-implementation"},
  "children": [{"ref": "t1", "title": "Task 1"}],
  "deps": [{"from": "root", "to": "t1", "type": "BLOCKS", "unblockAt": "work"}],
  "notes": [
    {"itemRef": "root", "key": "specification", "role": "queue", "body": "Full plan..."},
    {"itemRef": "t1", "key": "task-scope", "role": "queue", "body": "Build the thing"}
  ],
  "actor": {"id": "orchestrator-7", "kind": "orchestrator"}
}
```

Body defaults to empty string when omitted. Last-entry wins for duplicate `(itemRef, key)` (matches `manage_notes` upsert semantics).

When `actor` is provided, every persisted note (both explicit and `createNotes=true` blanks) records the actor claim and verification result for audit purposes.

## Validation

- `body` rejects non-string primitives; `null` and omitted both default to `""`.
- Unknown `itemRef` returns `VALIDATION_ERROR` and no rows are persisted (executor never invoked).
- Schema-declared keys must use the schema role; mismatch returns `VALIDATION_ERROR`.
- Cycle detection on `deps` runs before any inserts; circular dependencies cause full rollback.

## Commit history

- `feat(create_work_tree): add optional notes parameter for atomic graph materialization` — initial parameter and schema fill merge.
- `style(create_work_tree): ktlint fixes for notes parameter`
- `feat(create_work_tree): propagate top-level actor to persisted notes` — actor attribution + body validator tightening + JsonNull coercion fix + 12 new tests.
- `feat(create_work_tree): strict role enforcement against schema for inline notes` — strict-by-default schema role check + 3 net new tests (replaces one prior loose-behavior test).

## Test plan

- [x] 21 new unit tests + 4 new integration tests covering happy paths, validation errors, dedup semantics, body validation, role enforcement (matched/mismatched/off-schema/no-schema), actor propagation across explicit and schema-blank notes, missing/invalid actor handling, and end-to-end persistence round-trips through a real H2 database
- [x] `./gradlew :current:test` — passing
- [x] `./gradlew :current:ktlintCheck` — passing
- [x] Spec written and verified by independent review agent (APPROVE; all 12 acceptance criteria satisfied)
- [x] API compat reviewed (additive parameter, optional, no response-shape changes)

## Tracking

MCP work item: `58cfb79e` (terminal, under "Features" container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)