### PR TITLE
docs(claude-md): document orchestration vs claim mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,13 @@ interfaces/mcp/
 
 **Entry point:** `current/src/main/kotlin/io/github/jpicklyk/mcptask/current/CurrentMain.kt`
 
+## Modes of Operation
+
+- **Orchestration** (default) — orchestrator pushes items through phases via `advance_item`
+- **Claim** (opt-in) — consumers pull work via `claim_item`, holding TTL-based ownership before advancing
+
+The optional `actor_authentication` config block adds JWKS-based identity verification — independent of claim mode (claim works without it). See [`current/docs/fleet-deployment.md`](current/docs/fleet-deployment.md).
+
 ## Trait System (Orchestration Signals)
 
 Traits are **composable orchestration signals** declared in `.taskorchestrator/config.yaml` under the `traits:` key. They are NOT merely note requirements. Each trait carries three dimensions:
@@ -177,7 +184,7 @@ Two skill systems — do not confuse them:
 
 ## Documentation
 
-- `current/docs/` — quick-start, api-reference, workflow-guide
+- `current/docs/` — quick-start, api-reference, workflow-guide, fleet-deployment
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary

Adds a small **Modes of Operation** section to `CLAUDE.md` so every working session has a clear mental model of TO's two operating modes from the start, without having to read the source.

## What changed

- New 5-line section between Architecture and Trait System describing the two modes:
  - **Orchestration** (default) — orchestrator pushes items through phases via `advance_item`
  - **Claim** (opt-in) — consumers pull work via `claim_item`, holding TTL-based ownership before advancing
- Clarifies that `actor_authentication` (JWKS-based identity verification) is a **separate** optional layer — not part of claim mode. Claim mode works fully without it.
- Adds `fleet-deployment` to the Documentation file list so the operator-facing doc is discoverable.

## Why

Prior to this change, `CLAUDE.md` only described orchestration mode. `claim_item` was never named, and `actor_authentication` was referenced obliquely via the `DEGRADED_MODE_POLICY` env var with no surrounding context. Three failure modes that were observed in practice:

1. Agents seeing `claim_item` references in tool listings without understanding what it does or when it applies
2. Conflating claim mode with identity enforcement (claim mode is **coordination via TTL ownership**; JWKS is the optional enforcement layer)
3. Treating claim mode as fleet-only when it's actually a consumer pattern usable by single-agent Ralph loops, batch consumers, etc.

The added section is deliberately terse — `CLAUDE.md` is loaded into every session, so every line has to earn its place. Examples (Ralph loops, fleets) and policy values are intentionally left to `current/docs/fleet-deployment.md` rather than duplicated here.

## Net change

`+8 / -1` in a single file (`CLAUDE.md`).

## Test plan

- [x] No code changes — docs-only update
- [ ] Reviewer: confirm the framing (push vs. pull, claim ≠ enforcement, JWKS is separate) matches intent for documenting these as canonical concepts in the project's onboarding doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)