### PR TITLE
feat(create_work_tree): propagate top-level actor to persisted notes

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
@@ -268,8 +268,11 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                     throw ToolValidationException("notes[$index]: invalid role '$role'. Valid: queue, work, review")
                 }
                 val bodyElement = noteObj["body"]
-                if (bodyElement != null && bodyElement !is JsonNull && bodyElement !is JsonPrimitive) {
-                    throw ToolValidationException("notes[$index]: 'body' must be a string")
+                if (bodyElement != null && bodyElement !is JsonNull) {
+                    val isStringPrim = (bodyElement as? JsonPrimitive)?.isString == true
+                    if (!isStringPrim) {
+                        throw ToolValidationException("notes[$index]: 'body' must be a string")
+                    }
                 }
             }
         }
@@ -294,28 +297,31 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
         // Resolve trusted actor identity from the top-level actor for the idempotency key.
         // Must be done BEFORE the cache lookup so the cache is keyed on the verified identity,
         // not the self-reported actor.id (bug 3a fix).
+        // Capture the parsed claim and verification so they can be propagated as
+        // attribution metadata on every persisted Note (matches ManageNotesTool semantics).
         val actorObj = paramsObj["actor"] as? JsonObject
+        val parsedActor: ActorParseResult =
+            if (actorObj != null) parseActorClaim(actorObj, context) else ActorParseResult.Absent
+        val noteActorClaim: ActorClaim? =
+            (parsedActor as? ActorParseResult.Success)?.claim
+        val noteVerification: VerificationResult? =
+            (parsedActor as? ActorParseResult.Success)?.verification
         val trustedActorId: String? =
-            if (actorObj != null) {
-                val actorResult = parseActorClaim(actorObj, context)
-                when (actorResult) {
-                    is ActorParseResult.Success -> {
-                        when (
-                            val r =
-                                ActorAware.resolveTrustedActorId(
-                                    actorResult.claim,
-                                    actorResult.verification,
-                                    context.degradedModePolicy
-                                )
-                        ) {
-                            is PolicyResolution.Trusted -> r.trustedId
-                            is PolicyResolution.Rejected -> null
-                        }
+            when (parsedActor) {
+                is ActorParseResult.Success -> {
+                    when (
+                        val r =
+                            ActorAware.resolveTrustedActorId(
+                                parsedActor.claim,
+                                parsedActor.verification,
+                                context.degradedModePolicy
+                            )
+                    ) {
+                        is PolicyResolution.Trusted -> r.trustedId
+                        is PolicyResolution.Rejected -> null
                     }
-                    else -> null
                 }
-            } else {
-                null
+                else -> null
             }
 
         // Atomic getOrCompute: check-compute-store under a single lock to prevent TOCTOU races.
@@ -324,17 +330,21 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
         // re-acquires the IdempotencyCache lock.
         if (requestId != null && trustedActorId != null) {
             return context.idempotencyCache.getOrCompute(trustedActorId, requestId) {
-                runBlocking { executeCreateWorkTree(paramsObj, params, context) }
+                runBlocking {
+                    executeCreateWorkTree(paramsObj, params, context, noteActorClaim, noteVerification)
+                }
             }
         }
 
-        return executeCreateWorkTree(paramsObj, params, context)
+        return executeCreateWorkTree(paramsObj, params, context, noteActorClaim, noteVerification)
     }
 
     private suspend fun executeCreateWorkTree(
         paramsObj: JsonObject,
         params: JsonElement,
-        context: ToolExecutionContext
+        context: ToolExecutionContext,
+        noteActorClaim: ActorClaim? = null,
+        noteVerification: VerificationResult? = null
     ): JsonElement {
         // ── 1. Parse parentId (optional) ──────────────────────────────────────
         val (parentId, parentIdError) = resolveItemId(params, "parentId", context, required = false)
@@ -453,7 +463,9 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
             val itemRef = (noteObj["itemRef"] as JsonPrimitive).content
             val key = (noteObj["key"] as JsonPrimitive).content
             val role = (noteObj["role"] as JsonPrimitive).content
-            val body = (noteObj["body"] as? JsonPrimitive)?.content ?: ""
+            // Only string primitives are accepted as body; JsonNull and omitted both default to "".
+            // (validateParams already rejects non-string non-null primitives.)
+            val body = (noteObj["body"] as? JsonPrimitive)?.takeIf { it.isString }?.content ?: ""
 
             // Validate ref exists in refToItem (resolved after step 4)
             val targetItem =
@@ -463,7 +475,15 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                         ErrorCodes.VALIDATION_ERROR
                     )
 
-            val note = Note(itemId = targetItem.id, key = key, role = role, body = body)
+            val note =
+                Note(
+                    itemId = targetItem.id,
+                    key = key,
+                    role = role,
+                    body = body,
+                    actorClaim = noteActorClaim,
+                    verification = noteVerification
+                )
             val refKey = itemRef to key
             val existingIndex = explicitByRefKey[refKey]
             if (existingIndex != null) {
@@ -486,7 +506,9 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                             itemId = item.id,
                             key = entry.key,
                             role = entry.role.toJsonString(),
-                            body = ""
+                            body = "",
+                            actorClaim = noteActorClaim,
+                            verification = noteVerification
                         )
                     )
                 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
@@ -40,6 +40,8 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
 
 **Idempotency:** Pass `requestId` (client-generated UUID) together with a top-level `actor.id` to enable idempotent retries. Repeated calls with the same (actor, requestId) within ~10 minutes return the cached response without re-executing.
 
+**Actor attribution:** A single top-level `actor` is applied to **every** persisted note in the tree (both explicit `notes` entries and `createNotes=true` schema blanks). This differs from `manage_notes`, which accepts a per-note `actor` block. If the top-level `actor` is malformed (e.g., missing `kind`), idempotency is disabled and attribution is dropped to `null` on each note — the call still proceeds and items/notes are created without an audit identity.
+
 **Parameters:**
 - `root` (required): Root item spec `{ title (required), priority?, tags?, summary?, description?, requiresVerification?, type? }`
 - `parentId` (optional): UUID of existing parent item. If provided, root depth = parent.depth + 1; otherwise depth = 0.
@@ -168,8 +170,13 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                             put(
                                 "description",
                                 JsonPrimitive(
-                                    "Top-level actor for idempotency key resolution: " +
-                                        "{ id (required string), kind (required: orchestrator|subagent|user|external), " +
+                                    "Top-level actor used for two purposes: (1) idempotency key resolution and " +
+                                        "(2) audit attribution on every persisted note in the tree (both explicit " +
+                                        "and createNotes=true schema blanks). A single actor applies to the whole " +
+                                        "tree — unlike manage_notes, this tool does NOT accept a per-note actor. " +
+                                        "If the actor is malformed (e.g., missing kind), idempotency is disabled " +
+                                        "and attribution silently drops to null; the call still succeeds. " +
+                                        "Shape: { id (required string), kind (required: orchestrator|subagent|user|external), " +
                                         "parent? (optional string), proof? (optional string) }"
                                 )
                             )
@@ -343,8 +350,8 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
         paramsObj: JsonObject,
         params: JsonElement,
         context: ToolExecutionContext,
-        noteActorClaim: ActorClaim? = null,
-        noteVerification: VerificationResult? = null
+        noteActorClaim: ActorClaim?,
+        noteVerification: VerificationResult?
     ): JsonElement {
         // ── 1. Parse parentId (optional) ──────────────────────────────────────
         val (parentId, parentIdError) = resolveItemId(params, "parentId", context, required = false)

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolIntegrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolIntegrationTest.kt
@@ -1,0 +1,315 @@
+package io.github.jpicklyk.mcptask.current.application.tools.compound
+
+import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteNoteRepository
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteWorkItemRepository
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.*
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for [CreateWorkTreeTool] using a real H2 in-memory database
+ * and the production [DefaultRepositoryProvider] wiring (which constructs
+ * [io.github.jpicklyk.mcptask.current.infrastructure.service.SQLiteWorkTreeService]
+ * via the same lazy property used in production).
+ *
+ * Unlike [CreateWorkTreeToolTest] (which mocks the executor), these tests verify
+ * that explicit `notes` provided to the tool actually flow through the executor
+ * transaction and persist with the correct itemId binding, role, and verbatim body.
+ */
+class CreateWorkTreeToolIntegrationTest {
+    private lateinit var tool: CreateWorkTreeTool
+    private lateinit var context: ToolExecutionContext
+    private lateinit var workItemRepository: SQLiteWorkItemRepository
+    private lateinit var noteRepository: SQLiteNoteRepository
+    private lateinit var h2Database: Database
+
+    @BeforeEach
+    fun setUp() {
+        val dbName = "create_work_tree_tool_integration_${System.nanoTime()}"
+        h2Database = Database.connect("jdbc:h2:mem:$dbName;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+        val databaseManager = DatabaseManager(h2Database)
+        DirectDatabaseSchemaManager().updateSchema()
+        val repositoryProvider = DefaultRepositoryProvider(databaseManager)
+
+        workItemRepository = repositoryProvider.workItemRepository() as SQLiteWorkItemRepository
+        noteRepository = repositoryProvider.noteRepository() as SQLiteNoteRepository
+
+        tool = CreateWorkTreeTool()
+        context = ToolExecutionContext(repositoryProvider)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Inline notes are persisted end-to-end with bodies and itemId binding intact
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `inline notes are persisted end-to-end with bodies and correct itemId binding`(): Unit =
+        runBlocking {
+            val params =
+                buildJsonObject {
+                    put(
+                        "root",
+                        buildJsonObject {
+                            put("title", JsonPrimitive("Integration Root"))
+                        }
+                    )
+                    put(
+                        "children",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("ref", JsonPrimitive("c1"))
+                                    put("title", JsonPrimitive("Child One"))
+                                }
+                            )
+                        }
+                    )
+                    put(
+                        "notes",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("itemRef", JsonPrimitive("root"))
+                                    put("key", JsonPrimitive("requirements"))
+                                    put("role", JsonPrimitive("queue"))
+                                    put("body", JsonPrimitive("Root requirements body"))
+                                }
+                            )
+                            add(
+                                buildJsonObject {
+                                    put("itemRef", JsonPrimitive("c1"))
+                                    put("key", JsonPrimitive("approach"))
+                                    put("role", JsonPrimitive("work"))
+                                    put("body", JsonPrimitive("Child approach body"))
+                                }
+                            )
+                        }
+                    )
+                }
+
+            val result = tool.execute(params, context) as JsonObject
+            assertTrue(
+                result["success"]!!.jsonPrimitive.boolean,
+                "Expected success; got: $result"
+            )
+
+            val data = result["data"] as JsonObject
+            val rootIdStr = (data["root"] as JsonObject)["id"]!!.jsonPrimitive.content
+            val childrenArr = (data["children"] as JsonArray)
+            val childIdStr = (childrenArr[0] as JsonObject)["id"]!!.jsonPrimitive.content
+            val rootId = UUID.fromString(rootIdStr)
+            val childId = UUID.fromString(childIdStr)
+
+            // Both items are in the DB
+            val rootResult = workItemRepository.getById(rootId)
+            assertTrue(rootResult is Result.Success, "Root item should be in DB; got: $rootResult")
+            val childResult = workItemRepository.getById(childId)
+            assertTrue(childResult is Result.Success, "Child item should be in DB; got: $childResult")
+
+            // Notes persisted with verbatim bodies, correct itemId binding, and roles
+            val rootNoteResult = noteRepository.findByItemIdAndKey(rootId, "requirements")
+            assertTrue(rootNoteResult is Result.Success, "Root note lookup should succeed")
+            val rootNote = (rootNoteResult as Result.Success).data
+            assertNotNull(rootNote, "Root note should exist in DB")
+            assertEquals(rootId, rootNote.itemId, "Root note must be bound to root item")
+            assertEquals("queue", rootNote.role)
+            assertEquals("Root requirements body", rootNote.body, "Root note body must round-trip verbatim")
+
+            val childNoteResult = noteRepository.findByItemIdAndKey(childId, "approach")
+            assertTrue(childNoteResult is Result.Success, "Child note lookup should succeed")
+            val childNote = (childNoteResult as Result.Success).data
+            assertNotNull(childNote, "Child note should exist in DB")
+            assertEquals(childId, childNote.itemId, "Child note must be bound to child item")
+            assertEquals("work", childNote.role)
+            assertEquals("Child approach body", childNote.body, "Child note body must round-trip verbatim")
+        }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Duplicate (itemRef, key) collapses to last-wins after end-to-end persistence
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `duplicate itemRef-key collapses to last-wins in persisted DB row`(): Unit =
+        runBlocking {
+            val params =
+                buildJsonObject {
+                    put(
+                        "root",
+                        buildJsonObject {
+                            put("title", JsonPrimitive("Dedup Root"))
+                        }
+                    )
+                    put(
+                        "notes",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("itemRef", JsonPrimitive("root"))
+                                    put("key", JsonPrimitive("notes"))
+                                    put("role", JsonPrimitive("queue"))
+                                    put("body", JsonPrimitive("first body"))
+                                }
+                            )
+                            add(
+                                buildJsonObject {
+                                    put("itemRef", JsonPrimitive("root"))
+                                    put("key", JsonPrimitive("notes"))
+                                    put("role", JsonPrimitive("queue"))
+                                    put("body", JsonPrimitive("last body"))
+                                }
+                            )
+                        }
+                    )
+                }
+
+            val result = tool.execute(params, context) as JsonObject
+            assertTrue(
+                result["success"]!!.jsonPrimitive.boolean,
+                "Expected success; got: $result"
+            )
+
+            val data = result["data"] as JsonObject
+            val rootIdStr = (data["root"] as JsonObject)["id"]!!.jsonPrimitive.content
+            val rootId = UUID.fromString(rootIdStr)
+
+            // Only one note row exists for (rootId, "notes"), with the LAST body
+            val notesResult = noteRepository.findByItemId(rootId)
+            assertTrue(notesResult is Result.Success, "findByItemId should succeed")
+            val noteList = (notesResult as Result.Success).data
+            assertEquals(
+                1,
+                noteList.size,
+                "Duplicate (itemRef, key) must collapse to exactly one persisted note"
+            )
+            assertEquals("last body", noteList[0].body, "Last entry must win in persisted DB row")
+        }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Invalid itemRef → tool returns error AND no items/notes are persisted
+    //
+    // Validates the failure path: the executor is never invoked, so no rows exist.
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `invalid itemRef returns error and no items or notes persist`(): Unit =
+        runBlocking {
+            // Capture every workItem id we would have created so we can assert nothing landed
+            val rootTitle = "Should Not Persist Root"
+            val params =
+                buildJsonObject {
+                    put(
+                        "root",
+                        buildJsonObject {
+                            put("title", JsonPrimitive(rootTitle))
+                        }
+                    )
+                    put(
+                        "notes",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("itemRef", JsonPrimitive("nonexistent"))
+                                    put("key", JsonPrimitive("k"))
+                                    put("role", JsonPrimitive("queue"))
+                                    put("body", JsonPrimitive("body"))
+                                }
+                            )
+                        }
+                    )
+                }
+
+            val result = tool.execute(params, context) as JsonObject
+            assertEquals(
+                false,
+                result["success"]!!.jsonPrimitive.boolean,
+                "Expected failure for invalid itemRef; got: $result"
+            )
+
+            // The tool short-circuits before invoking the executor — no item or note
+            // should be in the DB. Verify by scanning all work items: none should
+            // have the rootTitle we tried to create.
+            val allItemsResult = workItemRepository.search(query = rootTitle)
+            assertTrue(allItemsResult is Result.Success, "Search should succeed")
+            val foundItems = (allItemsResult as Result.Success).data
+            assertEquals(
+                0,
+                foundItems.size,
+                "No item should have been persisted when notes validation fails; found: ${foundItems.map { it.title }}"
+            )
+        }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Top-level actor attribution persists on the DB row for every note
+    //
+    // Verifies the audit trail is intact end-to-end: actor.id, actor.kind, and
+    // verification metadata round-trip through the executor transaction onto
+    // every persisted note (both explicit and createNotes=true blanks).
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `top-level actor attribution persists on every note via the executor transaction`(): Unit =
+        runBlocking {
+            val params =
+                buildJsonObject {
+                    put(
+                        "root",
+                        buildJsonObject {
+                            put("title", JsonPrimitive("Attributed Root"))
+                        }
+                    )
+                    put(
+                        "notes",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("itemRef", JsonPrimitive("root"))
+                                    put("key", JsonPrimitive("authored-note"))
+                                    put("role", JsonPrimitive("queue"))
+                                    put("body", JsonPrimitive("authored body"))
+                                }
+                            )
+                        }
+                    )
+                    put(
+                        "actor",
+                        buildJsonObject {
+                            put("id", JsonPrimitive("orchestrator-integ"))
+                            put("kind", JsonPrimitive("orchestrator"))
+                        }
+                    )
+                }
+
+            val result = tool.execute(params, context) as JsonObject
+            assertTrue(result["success"]!!.jsonPrimitive.boolean, "Expected success; got: $result")
+
+            val data = result["data"] as JsonObject
+            val rootIdStr = (data["root"] as JsonObject)["id"]!!.jsonPrimitive.content
+            val rootId = UUID.fromString(rootIdStr)
+
+            val noteResult = noteRepository.findByItemIdAndKey(rootId, "authored-note")
+            assertTrue(noteResult is Result.Success, "Note lookup should succeed")
+            val persisted = (noteResult as Result.Success).data
+            assertNotNull(persisted, "Note must exist in DB")
+
+            assertNotNull(persisted.actorClaim, "Persisted note must carry the actor claim")
+            assertEquals("orchestrator-integ", persisted.actorClaim!!.id)
+            assertEquals(
+                io.github.jpicklyk.mcptask.current.domain.model.ActorKind.ORCHESTRATOR,
+                persisted.actorClaim!!.kind
+            )
+            assertNotNull(persisted.verification, "Persisted note must carry the verification result")
+            // NoOpActorVerifier wired in DefaultRepositoryProvider's tool context
+            assertEquals("noop", persisted.verification!!.verifier)
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolTest.kt
@@ -1585,4 +1585,408 @@ class CreateWorkTreeToolTest {
 
             assertEquals(0, capturedInput!!.notes.size, "Empty notes array should result in no notes")
         }
+
+    // ──────────────────────────────────────────────
+    // Notes parameter: numeric body primitive rejected
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `numeric body primitive throws ToolValidationException at validateParams`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(
+                buildJsonObject {
+                    put("root", buildJsonObject { put("title", JsonPrimitive("Root")) })
+                    put(
+                        "notes",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("itemRef", JsonPrimitive("root"))
+                                    put("key", JsonPrimitive("k"))
+                                    put("role", JsonPrimitive("queue"))
+                                    put("body", JsonPrimitive(42))
+                                }
+                            )
+                        }
+                    )
+                }
+            )
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Notes parameter: boolean body primitive rejected
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `boolean body primitive throws ToolValidationException at validateParams`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(
+                buildJsonObject {
+                    put("root", buildJsonObject { put("title", JsonPrimitive("Root")) })
+                    put(
+                        "notes",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("itemRef", JsonPrimitive("root"))
+                                    put("key", JsonPrimitive("k"))
+                                    put("role", JsonPrimitive("queue"))
+                                    put("body", JsonPrimitive(true))
+                                }
+                            )
+                        }
+                    )
+                }
+            )
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Notes parameter: explicit JsonNull body accepted (treated as empty)
+    //
+    // The validator allows null body (alongside omitted body); both default to "".
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `explicit null body in notes is accepted and treated as empty`(): Unit =
+        runBlocking {
+            var capturedInput: WorkTreeInput? = null
+            coEvery { mockExecutor.execute(any()) } answers {
+                val input = firstArg<WorkTreeInput>()
+                capturedInput = input
+                echoResult(input)
+            }
+
+            val notesArr =
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("root"))
+                            put("key", JsonPrimitive("null-body-key"))
+                            put("role", JsonPrimitive("queue"))
+                            put("body", JsonNull)
+                        }
+                    )
+                }
+            val params = buildParams(notes = notesArr)
+            val result = tool.execute(params, context)
+
+            extractData(result)
+
+            val note = capturedInput!!.notes.first()
+            assertEquals("", note.body, "Explicit null body should default to empty string")
+        }
+
+    // ──────────────────────────────────────────────
+    // Notes parameter: explicit note with same key but different role
+    // suppresses the schema-required entry
+    //
+    // Documents the dedup-by-(ref, key) contract: explicit notes always win,
+    // even if their role differs from the schema declaration. This matches the
+    // database unique constraint on (itemId, key) — only one note per key can
+    // exist for an item, regardless of role. Callers are responsible for
+    // matching schema roles when they intend to satisfy a gate; otherwise the
+    // gate-required note will be unfilled at the expected role and gate
+    // enforcement will reject the transition later.
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `explicit note with same key but different role overrides schema entry`(): Unit =
+        runBlocking {
+            val schemaEntries =
+                listOf(
+                    NoteSchemaEntry(key = "acceptance-criteria", role = Role.QUEUE, required = true)
+                )
+            val noteSchemaService =
+                object : NoteSchemaService {
+                    override fun getSchemaForTags(tags: List<String>): List<NoteSchemaEntry>? =
+                        if (tags.contains("feature-task")) schemaEntries else null
+                }
+            val provider2 = mockk<RepositoryProvider>()
+            val mockExecutor2 = mockk<WorkTreeExecutor>()
+            every { provider2.workItemRepository() } returns workItemRepo
+            every { provider2.dependencyRepository() } returns mockk()
+            every { provider2.noteRepository() } returns mockk()
+            every { provider2.roleTransitionRepository() } returns mockk()
+            every { provider2.database() } returns null
+            every { provider2.workTreeExecutor() } returns mockExecutor2
+            val contextWithSchema = ToolExecutionContext(provider2, noteSchemaService)
+
+            var capturedInput: WorkTreeInput? = null
+            coEvery { mockExecutor2.execute(any()) } answers {
+                val input = firstArg<WorkTreeInput>()
+                capturedInput = input
+                echoResult(input)
+            }
+
+            val rootSpec =
+                buildJsonObject {
+                    put("title", JsonPrimitive("Feature Root"))
+                    put("tags", JsonPrimitive("feature-task"))
+                }
+            // Schema declares acceptance-criteria at role=queue, but caller submits
+            // it at role=work. Dedup-by-(ref, key) suppresses the schema entry.
+            val notesArr =
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("root"))
+                            put("key", JsonPrimitive("acceptance-criteria"))
+                            put("role", JsonPrimitive("work"))
+                            put("body", JsonPrimitive("explicit body at wrong role"))
+                        }
+                    )
+                }
+            val params = buildParams(root = rootSpec, createNotes = true, notes = notesArr)
+            val result = tool.execute(params, contextWithSchema)
+
+            extractData(result)
+
+            val input = capturedInput!!
+            assertEquals(
+                1,
+                input.notes.size,
+                "Schema entry should be suppressed by explicit (ref, key) match — only the explicit note remains"
+            )
+
+            val note = input.notes.first()
+            assertEquals("acceptance-criteria", note.key)
+            assertEquals(
+                "work",
+                note.role,
+                "Caller-supplied role wins over schema role on (ref, key) collision"
+            )
+            assertEquals("explicit body at wrong role", note.body)
+        }
+
+    // ──────────────────────────────────────────────
+    // Actor attribution: top-level actor propagates to every explicit note
+    //
+    // The tool already parses `actor` for idempotency. Those parsed credentials
+    // (claim + verification) MUST also flow through to the actorClaim/verification
+    // fields on every persisted Note so the audit trail records who wrote each note.
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `top-level actor propagates to explicit notes as actorClaim and verification`(): Unit =
+        runBlocking {
+            var capturedInput: WorkTreeInput? = null
+            coEvery { mockExecutor.execute(any()) } answers {
+                val input = firstArg<WorkTreeInput>()
+                capturedInput = input
+                echoResult(input)
+            }
+
+            val actorObj =
+                buildJsonObject {
+                    put("id", JsonPrimitive("orchestrator-test"))
+                    put("kind", JsonPrimitive("orchestrator"))
+                }
+            val notesArr =
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("root"))
+                            put("key", JsonPrimitive("k1"))
+                            put("role", JsonPrimitive("queue"))
+                            put("body", JsonPrimitive("body1"))
+                        }
+                    )
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("root"))
+                            put("key", JsonPrimitive("k2"))
+                            put("role", JsonPrimitive("work"))
+                            put("body", JsonPrimitive("body2"))
+                        }
+                    )
+                }
+
+            val params =
+                buildJsonObject {
+                    put("root", buildJsonObject { put("title", JsonPrimitive("Root")) })
+                    put("notes", notesArr)
+                    put("actor", actorObj)
+                }
+            val result = tool.execute(params, context)
+
+            val obj = result as JsonObject
+            assertTrue(obj["success"]!!.jsonPrimitive.boolean, "Expected success; got: $result")
+
+            val input = capturedInput!!
+            assertEquals(2, input.notes.size, "Expected both notes captured")
+            for (note in input.notes) {
+                assertNotNull(note.actorClaim, "Note '${note.key}' should have actorClaim attached")
+                assertEquals("orchestrator-test", note.actorClaim!!.id)
+                assertEquals(
+                    io.github.jpicklyk.mcptask.current.domain.model.ActorKind.ORCHESTRATOR,
+                    note.actorClaim!!.kind
+                )
+                assertNotNull(note.verification, "Note '${note.key}' should have verification attached")
+                // NoOpActorVerifier returns status=UNCHECKED, verifier="noop"
+                assertEquals("noop", note.verification!!.verifier)
+            }
+        }
+
+    // ──────────────────────────────────────────────
+    // Actor attribution: createNotes=true blanks also receive attribution
+    //
+    // Schema-required notes filled by createNotes=true are written by the same
+    // caller as the explicit notes — they should carry the same actor metadata.
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `actor propagates to createNotes=true schema blanks`(): Unit =
+        runBlocking {
+            val schemaEntries =
+                listOf(
+                    NoteSchemaEntry(key = "auto-blank-note", role = Role.QUEUE, required = true)
+                )
+            val noteSchemaService =
+                object : NoteSchemaService {
+                    override fun getSchemaForTags(tags: List<String>): List<NoteSchemaEntry>? =
+                        if (tags.contains("feature-task")) schemaEntries else null
+                }
+            val provider2 = mockk<RepositoryProvider>()
+            val mockExecutor2 = mockk<WorkTreeExecutor>()
+            every { provider2.workItemRepository() } returns workItemRepo
+            every { provider2.dependencyRepository() } returns mockk()
+            every { provider2.noteRepository() } returns mockk()
+            every { provider2.roleTransitionRepository() } returns mockk()
+            every { provider2.database() } returns null
+            every { provider2.workTreeExecutor() } returns mockExecutor2
+            val contextWithSchema = ToolExecutionContext(provider2, noteSchemaService)
+
+            var capturedInput: WorkTreeInput? = null
+            coEvery { mockExecutor2.execute(any()) } answers {
+                val input = firstArg<WorkTreeInput>()
+                capturedInput = input
+                echoResult(input)
+            }
+
+            val params =
+                buildJsonObject {
+                    put(
+                        "root",
+                        buildJsonObject {
+                            put("title", JsonPrimitive("Feature Root"))
+                            put("tags", JsonPrimitive("feature-task"))
+                        }
+                    )
+                    put("createNotes", JsonPrimitive(true))
+                    put(
+                        "actor",
+                        buildJsonObject {
+                            put("id", JsonPrimitive("subagent-42"))
+                            put("kind", JsonPrimitive("subagent"))
+                        }
+                    )
+                }
+            val result = tool.execute(params, contextWithSchema)
+
+            val obj = result as JsonObject
+            assertTrue(obj["success"]!!.jsonPrimitive.boolean, "Expected success; got: $result")
+
+            val input = capturedInput!!
+            assertEquals(1, input.notes.size, "Expected exactly one schema-blank note")
+            val note = input.notes.first()
+            assertEquals("auto-blank-note", note.key)
+            assertEquals("", note.body, "Schema blank should have empty body")
+            assertNotNull(note.actorClaim, "Schema blank must also carry actor attribution")
+            assertEquals("subagent-42", note.actorClaim!!.id)
+            assertEquals(
+                io.github.jpicklyk.mcptask.current.domain.model.ActorKind.SUBAGENT,
+                note.actorClaim!!.kind
+            )
+        }
+
+    // ──────────────────────────────────────────────
+    // Actor attribution: no actor object → notes have null actorClaim/verification
+    // (preserves backward compatibility for callers that don't pass actor)
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `notes without top-level actor have null actorClaim and verification`(): Unit =
+        runBlocking {
+            var capturedInput: WorkTreeInput? = null
+            coEvery { mockExecutor.execute(any()) } answers {
+                val input = firstArg<WorkTreeInput>()
+                capturedInput = input
+                echoResult(input)
+            }
+
+            val notesArr =
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("root"))
+                            put("key", JsonPrimitive("k"))
+                            put("role", JsonPrimitive("queue"))
+                            put("body", JsonPrimitive("body"))
+                        }
+                    )
+                }
+            val params = buildParams(notes = notesArr) // no actor
+            val result = tool.execute(params, context)
+
+            val obj = result as JsonObject
+            assertTrue(obj["success"]!!.jsonPrimitive.boolean)
+
+            val note = capturedInput!!.notes.first()
+            assertNull(note.actorClaim, "Without an actor block, actorClaim must remain null")
+            assertNull(note.verification, "Without an actor block, verification must remain null")
+        }
+
+    // ──────────────────────────────────────────────
+    // Actor attribution: invalid actor block → notes have null actorClaim
+    // (matches existing behavior where invalid actor disables idempotency without
+    // failing the call — attribution is silently dropped, the call still proceeds)
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `notes with invalid actor block have null actorClaim and call still succeeds`(): Unit =
+        runBlocking {
+            var capturedInput: WorkTreeInput? = null
+            coEvery { mockExecutor.execute(any()) } answers {
+                val input = firstArg<WorkTreeInput>()
+                capturedInput = input
+                echoResult(input)
+            }
+
+            val notesArr =
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("root"))
+                            put("key", JsonPrimitive("k"))
+                            put("role", JsonPrimitive("queue"))
+                            put("body", JsonPrimitive("body"))
+                        }
+                    )
+                }
+            // Invalid actor: missing 'kind' field
+            val invalidActor =
+                buildJsonObject {
+                    put("id", JsonPrimitive("some-id"))
+                    // kind intentionally omitted → ActorParseResult.Invalid
+                }
+            val params =
+                buildJsonObject {
+                    put("root", buildJsonObject { put("title", JsonPrimitive("Root")) })
+                    put("notes", notesArr)
+                    put("actor", invalidActor)
+                }
+            val result = tool.execute(params, context)
+
+            val obj = result as JsonObject
+            assertTrue(
+                obj["success"]!!.jsonPrimitive.boolean,
+                "Invalid actor must not block the call; got: $result"
+            )
+
+            val note = capturedInput!!.notes.first()
+            assertNull(note.actorClaim, "Invalid actor must not produce a partial actorClaim")
+            assertNull(note.verification, "Invalid actor must not produce a partial verification")
+        }
 }


### PR DESCRIPTION
## Summary

Recovers correctness work that was developed during PR #164's review but was never pushed before that PR merged. This is the **first of three** stacked recovery PRs restoring the missing functionality.

The merged PR #164 shipped only the initial parameter implementation. This PR adds the actor-attribution audit trail and tightens the body validator that the review iteration had identified and tested.

## What this PR adds

- **Actor attribution on persisted notes** — the top-level `actor` block was already parsed for idempotency keying in `create_work_tree`, but the parsed `ActorClaim` and `VerificationResult` were discarded before constructing notes. They are now propagated to every persisted `Note` (both explicit `notes` entries AND `createNotes=true` schema blanks). **Note:** the semantics are *not* identical to `ManageNotesTool` — `manage_notes` accepts a per-note `actor` block, whereas `create_work_tree` applies a single top-level `actor` to every note in the tree. This was a deliberate design choice (atomic operation, single audit identity per tree) and is documented in the tool's `actor` parameter description.
- **`body` validator rejects non-string primitives** — `body: 42` and `body: true` were silently coerced to strings (`"42"`, `"true"`) due to a permissive primitive check. Now rejected with `VALIDATION_ERROR`.
- **`JsonNull` body fix** — `body: null` was being coerced to the literal string `"null"` because `JsonNull.content == "null"` in kotlinx.serialization. Now correctly defaults to empty string, matching the validator's "absent" treatment.

## Strictly additive

No existing behavior changes for callers that don't pass `actor`. Notes from `createNotes=true` previously had `actorClaim = null`; they're now populated when `actor` is supplied. No caller can have been depending on the null attribution.

## Test plan

- [x] **8 new unit tests** in `CreateWorkTreeToolTest.kt` covering body validation (numeric, boolean, JsonNull), actor propagation across explicit and schema-blank notes, no-actor case, and invalid-actor case
- [x] **4 new integration tests** in a new `CreateWorkTreeToolIntegrationTest.kt` using a real H2 database — verifies inline notes persist end-to-end with bodies, dedup last-wins persistence, validation-failure rollback, and actor attribution round-trips on the DB row
- [x] `./gradlew :current:test` — passing
- [x] `./gradlew :current:ktlintCheck` — passing

## Forward compatibility note

The new test `explicit note with same key but different role overrides schema entry` documents the current dedup-by-(ref, key) contract: when an explicit note collides with a schema entry on the same key, the explicit role wins. **PR #2 in this stack (commit `578c361` — "strict role enforcement against schema for inline notes") inverts this behavior** and that test will be replaced/inverted accordingly. Reviewers landing PRs out of order should be aware.

## Stack

This PR is part of a three-PR recovery sequence. PRs #2 and #3 will follow, each landing one piece of correctness work that was lost when PR #164 merged before the review-iteration commits had been pushed:

1. **This PR**: actor attribution + body validator
2. Next: strict role enforcement against schema (depends on this PR; will invert the dedup test above)
3. Last: doc accuracy fixes (depends on previous)

🤖 Generated with [Claude Code](https://claude.com/claude-code)