### PR TITLE
feat(create_work_tree): strict role enforcement against schema for inline notes

### DIFF
--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -302,7 +302,7 @@ when calling `manage_items`, `manage_dependencies`, and `manage_notes` separatel
 | `children` | array | No | Child item specs: `[{ ref, title, priority?, tags?, type?, traits?, summary?, description?, requiresVerification? }]`. `ref` is a local name used in `deps`. |
 | `deps` | array | No | Dependency specs: `[{ from: ref, to: ref, type?: BLOCKS\|IS_BLOCKED_BY\|RELATES_TO, unblockAt?: queue\|work\|review\|terminal }]`. Use `"root"` to reference the root item. |
 | `createNotes` | boolean | No | Auto-create blank notes for each item from its tag schema (default: false) |
-| `notes` | array | No | Notes to create with bodies: `[{ itemRef (required, "root" or child ref), key (required), role (required: queue\|work\|review), body? (defaults to empty string) }]`. Explicit notes win over `createNotes=true` blanks per `(itemRef, key)`. |
+| `notes` | array | No | Notes to create with bodies: `[{ itemRef (required, "root" or child ref), key (required), role (required: queue\|work\|review), body? (defaults to empty string) }]`. Explicit notes win over `createNotes=true` blanks per `(itemRef, key)`. **Strict role enforcement:** when an explicit note's `key` is declared in the resolved schema for the target item, the note's `role` must equal the schema role; mismatch returns `VALIDATION_ERROR`. Off-schema keys and items without a schema are unconstrained. |
 | `requestId` | string (UUID) | No | Client-generated UUID for idempotency. See [Idempotency](#idempotency). |
 
 Depth cap: root must be at depth < 3 (i.e., root can be at depth 0, 1, or 2). Children are always root.depth + 1, so children can reach depth 3 (when root is at depth 2).
@@ -366,6 +366,8 @@ When `createNotes=false` (default) or no items match a schema, `notes` is `[]`.
 ```
 
 When both `notes` and `createNotes: true` are provided, explicit `notes` entries win per `(itemRef, key)` — schema-required keys not covered by `notes` are added with empty bodies by `createNotes`, while explicit off-schema keys are persisted as-is.
+
+**Strict role enforcement.** If an explicit note's `key` matches a key declared in the resolved schema for its target item, the note's `role` MUST equal the schema's role. Mismatch returns `VALIDATION_ERROR` with a message naming the index, key, expected role, and submitted role. The DB enforces `UNIQUE(itemId, key)`, so allowing a role mismatch would silently leave the gate-required role unfilled and break later `advance_item` transitions. Off-schema keys (not declared by the schema) and items with no schema match remain unconstrained — they may use any valid role.
 
 ---
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
@@ -48,7 +48,7 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
 - `children` (optional): Array of child item specs `[{ ref (required), title (required), priority?, tags?, summary?, description?, requiresVerification?, type? }]`. `ref` is a local name used in `deps` to wire dependencies.
 - `deps` (optional): Array of dependency specs `[{ from: ref, to: ref, type?: BLOCKS|IS_BLOCKED_BY|RELATES_TO, unblockAt?: queue|work|review|terminal }]`. Use `"root"` to reference the root item.
 - `createNotes` (optional, default false): Auto-create blank notes for each item based on its tag schema.
-- `notes` (optional): Notes to create with bodies: `[{ itemRef (required, "root" or child ref), key (required), role (required: queue|work|review), body (optional, defaults to empty string) }]`. Explicit notes win over `createNotes=true` blanks per `(itemRef, key)`.
+- `notes` (optional): Notes to create with bodies: `[{ itemRef (required, "root" or child ref), key (required), role (required: queue|work|review), body (optional, defaults to empty string) }]`. Explicit notes win over `createNotes=true` blanks per `(itemRef, key)`. **Strict role enforcement:** when an explicit note's `key` is declared in the resolved schema for the target item, the note's `role` must equal the schema role; mismatch is rejected with `VALIDATION_ERROR`. Off-schema keys and items without a schema are unconstrained.
 
 **Depth cap:** Root item depth must be < $MAX_DEPTH. Children are always root.depth + 1, also < $MAX_DEPTH.
 
@@ -144,7 +144,10 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                                 JsonPrimitive(
                                     "Notes to create with bodies: [{ itemRef (required, \"root\" or child ref), key (required), " +
                                         "role (required: queue|work|review), body (optional, defaults to empty string) }]. " +
-                                        "Explicit notes win over createNotes=true blanks per (itemRef, key)."
+                                        "Explicit notes win over createNotes=true blanks per (itemRef, key). " +
+                                        "Strict role enforcement: when an explicit key is declared in the resolved schema " +
+                                        "for the target item, the role must match the schema role; mismatch is rejected. " +
+                                        "Off-schema keys and items without a schema are unconstrained."
                                 )
                             )
                         }
@@ -463,6 +466,11 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
         val explicitNotesArray = paramsObj["notes"] as? JsonArray ?: JsonArray(emptyList())
         val notesList = mutableListOf<Note>()
 
+        // Resolve schemas once per item; reused for strict role enforcement on
+        // explicit notes AND for createNotes=true schema-blank fill.
+        val itemSchemas: Map<String, WorkItemSchema?> =
+            refToItem.mapValues { (_, item) -> context.resolveSchema(item) }
+
         // Parse explicit notes; track (itemRef, key) -> index in notesList for last-wins dedup
         val explicitByRefKey = mutableMapOf<Pair<String, String>, Int>()
         for ((index, noteElement) in explicitNotesArray.withIndex()) {
@@ -481,6 +489,29 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                         "notes[$index]: 'itemRef' '$itemRef' is not defined. Valid refs: ${refToItem.keys.joinToString()}",
                         ErrorCodes.VALIDATION_ERROR
                     )
+
+            // Strict role enforcement: when the resolved schema for this item declares the
+            // same key, the explicit note's role must match the schema role. The DB has a
+            // UNIQUE(itemId, key) constraint, so only one note per key can exist; allowing
+            // a role mismatch would silently leave the gate-required role unfilled.
+            // Off-schema keys are unconstrained — callers may add arbitrary auxiliary notes.
+            // Items with no schema match are also unconstrained.
+            val schema = itemSchemas[itemRef]
+            if (schema != null) {
+                val schemaEntry = schema.notes.firstOrNull { it.key == key }
+                if (schemaEntry != null) {
+                    val expectedRole = schemaEntry.role.toJsonString()
+                    if (role != expectedRole) {
+                        return errorResponse(
+                            "notes[$index]: key '$key' is declared in the schema for itemRef " +
+                                "'$itemRef' with role '$expectedRole', but the explicit note has " +
+                                "role '$role'. Schema-declared keys must use the schema role; " +
+                                "off-schema keys may use any valid role.",
+                            ErrorCodes.VALIDATION_ERROR
+                        )
+                    }
+                }
+            }
 
             val note =
                 Note(
@@ -505,7 +536,7 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
         // If createNotes=true, fill schema-required notes that aren't already explicit (with empty bodies)
         if (createNotes) {
             for ((ref, item) in refToItem) {
-                val resolvedSchema = context.resolveSchema(item) ?: continue
+                val resolvedSchema = itemSchemas[ref] ?: continue
                 for (entry in resolvedSchema.notes) {
                     if (explicitByRefKey.containsKey(ref to entry.key)) continue
                     notesList.add(

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolTest.kt
@@ -1679,20 +1679,79 @@ class CreateWorkTreeToolTest {
         }
 
     // ──────────────────────────────────────────────
-    // Notes parameter: explicit note with same key but different role
-    // suppresses the schema-required entry
+    // Strict role enforcement: explicit note with same key but different role
+    // from a schema entry is REJECTED with VALIDATION_ERROR
     //
-    // Documents the dedup-by-(ref, key) contract: explicit notes always win,
-    // even if their role differs from the schema declaration. This matches the
-    // database unique constraint on (itemId, key) — only one note per key can
-    // exist for an item, regardless of role. Callers are responsible for
-    // matching schema roles when they intend to satisfy a gate; otherwise the
-    // gate-required note will be unfilled at the expected role and gate
-    // enforcement will reject the transition later.
+    // The DB enforces UNIQUE(itemId, key), so silently accepting a role mismatch
+    // would leave the gate-required role unfilled — gate enforcement would later
+    // reject the transition. Strict-by-default fails fast at create time so the
+    // caller fixes the role at the source.
     // ──────────────────────────────────────────────
 
     @Test
-    fun `explicit note with same key but different role overrides schema entry`(): Unit =
+    fun `explicit note with role mismatching schema is rejected with VALIDATION_ERROR`(): Unit =
+        runBlocking {
+            val schemaEntries =
+                listOf(
+                    NoteSchemaEntry(key = "acceptance-criteria", role = Role.QUEUE, required = true)
+                )
+            val noteSchemaService =
+                object : NoteSchemaService {
+                    override fun getSchemaForTags(tags: List<String>): List<NoteSchemaEntry>? =
+                        if (tags.contains("feature-task")) schemaEntries else null
+                }
+            val provider2 = mockk<RepositoryProvider>()
+            val mockExecutor2 = mockk<WorkTreeExecutor>()
+            every { provider2.workItemRepository() } returns workItemRepo
+            every { provider2.dependencyRepository() } returns mockk()
+            every { provider2.noteRepository() } returns mockk()
+            every { provider2.roleTransitionRepository() } returns mockk()
+            every { provider2.database() } returns null
+            every { provider2.workTreeExecutor() } returns mockExecutor2
+            val contextWithSchema = ToolExecutionContext(provider2, noteSchemaService)
+
+            // Executor must NOT be invoked when validation rejects the request
+            coEvery { mockExecutor2.execute(any()) } answers {
+                throw IllegalStateException("Executor should not have been called for invalid role")
+            }
+
+            val rootSpec =
+                buildJsonObject {
+                    put("title", JsonPrimitive("Feature Root"))
+                    put("tags", JsonPrimitive("feature-task"))
+                }
+            val notesArr =
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("root"))
+                            put("key", JsonPrimitive("acceptance-criteria"))
+                            put("role", JsonPrimitive("work")) // schema says queue
+                            put("body", JsonPrimitive("body"))
+                        }
+                    )
+                }
+            val params = buildParams(root = rootSpec, notes = notesArr)
+            val result = tool.execute(params, contextWithSchema)
+
+            val obj = result as JsonObject
+            assertFalse(
+                obj["success"]!!.jsonPrimitive.boolean,
+                "Expected failure for role mismatch with schema; got: $result"
+            )
+            val errMsg = obj["error"]!!.jsonObject["message"]!!.jsonPrimitive.content
+            assertTrue(errMsg.contains("acceptance-criteria"), "Error must name the key: $errMsg")
+            assertTrue(errMsg.contains("queue"), "Error must name the expected role: $errMsg")
+            assertTrue(errMsg.contains("work"), "Error must name the submitted role: $errMsg")
+        }
+
+    // ──────────────────────────────────────────────
+    // Strict mode: explicit note with role MATCHING the schema is accepted
+    // (sanity check that the matched-role happy path still works)
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `explicit note with role matching schema is accepted`(): Unit =
         runBlocking {
             val schemaEntries =
                 listOf(
@@ -1725,39 +1784,132 @@ class CreateWorkTreeToolTest {
                     put("title", JsonPrimitive("Feature Root"))
                     put("tags", JsonPrimitive("feature-task"))
                 }
-            // Schema declares acceptance-criteria at role=queue, but caller submits
-            // it at role=work. Dedup-by-(ref, key) suppresses the schema entry.
             val notesArr =
                 buildJsonArray {
                     add(
                         buildJsonObject {
                             put("itemRef", JsonPrimitive("root"))
                             put("key", JsonPrimitive("acceptance-criteria"))
-                            put("role", JsonPrimitive("work"))
-                            put("body", JsonPrimitive("explicit body at wrong role"))
+                            put("role", JsonPrimitive("queue")) // matches schema
+                            put("body", JsonPrimitive("AC body"))
                         }
                     )
                 }
-            val params = buildParams(root = rootSpec, createNotes = true, notes = notesArr)
+            val params = buildParams(root = rootSpec, notes = notesArr)
             val result = tool.execute(params, contextWithSchema)
 
             extractData(result)
 
-            val input = capturedInput!!
-            assertEquals(
-                1,
-                input.notes.size,
-                "Schema entry should be suppressed by explicit (ref, key) match — only the explicit note remains"
-            )
+            val note = capturedInput!!.notes.first()
+            assertEquals("acceptance-criteria", note.key)
+            assertEquals("queue", note.role)
+            assertEquals("AC body", note.body)
+        }
 
-            val note = input.notes.first()
+    // ──────────────────────────────────────────────
+    // Strict mode: off-schema explicit note may use any valid role
+    //
+    // Only schema-DECLARED keys are role-constrained. Off-schema keys remain
+    // unconstrained — callers may add arbitrary auxiliary notes.
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `off-schema explicit note with arbitrary role is accepted`(): Unit =
+        runBlocking {
+            val schemaEntries =
+                listOf(
+                    NoteSchemaEntry(key = "acceptance-criteria", role = Role.QUEUE, required = true)
+                )
+            val noteSchemaService =
+                object : NoteSchemaService {
+                    override fun getSchemaForTags(tags: List<String>): List<NoteSchemaEntry>? =
+                        if (tags.contains("feature-task")) schemaEntries else null
+                }
+            val provider2 = mockk<RepositoryProvider>()
+            val mockExecutor2 = mockk<WorkTreeExecutor>()
+            every { provider2.workItemRepository() } returns workItemRepo
+            every { provider2.dependencyRepository() } returns mockk()
+            every { provider2.noteRepository() } returns mockk()
+            every { provider2.roleTransitionRepository() } returns mockk()
+            every { provider2.database() } returns null
+            every { provider2.workTreeExecutor() } returns mockExecutor2
+            val contextWithSchema = ToolExecutionContext(provider2, noteSchemaService)
+
+            var capturedInput: WorkTreeInput? = null
+            coEvery { mockExecutor2.execute(any()) } answers {
+                val input = firstArg<WorkTreeInput>()
+                capturedInput = input
+                echoResult(input)
+            }
+
+            val rootSpec =
+                buildJsonObject {
+                    put("title", JsonPrimitive("Feature Root"))
+                    put("tags", JsonPrimitive("feature-task"))
+                }
+            // "ad-hoc-note" is NOT in the schema — role is unconstrained.
+            val notesArr =
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("root"))
+                            put("key", JsonPrimitive("ad-hoc-note"))
+                            put("role", JsonPrimitive("review"))
+                            put("body", JsonPrimitive("custom auxiliary note"))
+                        }
+                    )
+                }
+            val params = buildParams(root = rootSpec, notes = notesArr)
+            val result = tool.execute(params, contextWithSchema)
+
+            extractData(result)
+
+            val note = capturedInput!!.notes.first()
+            assertEquals("ad-hoc-note", note.key)
+            assertEquals("review", note.role, "Off-schema keys may use any role")
+            assertEquals("custom auxiliary note", note.body)
+        }
+
+    // ──────────────────────────────────────────────
+    // Strict mode: items with NO schema match — role is unconstrained
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `explicit note for item with no matching schema is unconstrained`(): Unit =
+        runBlocking {
+            // The default test context uses NoOpNoteSchemaService → no schemas exist
+            var capturedInput: WorkTreeInput? = null
+            coEvery { mockExecutor.execute(any()) } answers {
+                val input = firstArg<WorkTreeInput>()
+                capturedInput = input
+                echoResult(input)
+            }
+
+            val notesArr =
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("itemRef", JsonPrimitive("root"))
+                            // Use a key string that COULD be a schema key in some other config —
+                            // here it has no schema match, so any role is accepted.
+                            put("key", JsonPrimitive("acceptance-criteria"))
+                            put("role", JsonPrimitive("work"))
+                            put("body", JsonPrimitive("no-schema body"))
+                        }
+                    )
+                }
+            val params = buildParams(notes = notesArr)
+            val result = tool.execute(params, context)
+
+            extractData(result)
+
+            val note = capturedInput!!.notes.first()
             assertEquals("acceptance-criteria", note.key)
             assertEquals(
                 "work",
                 note.role,
-                "Caller-supplied role wins over schema role on (ref, key) collision"
+                "Without a resolved schema, no role constraint applies"
             )
-            assertEquals("explicit body at wrong role", note.body)
         }
 
     // ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Second of three stacked recovery PRs (see #166). Adds strict role enforcement: when an explicit note's `key` is declared in the resolved schema for the target item, the note's `role` must equal the schema role; mismatch returns `VALIDATION_ERROR`.

**Base branch:** \`feat/create-work-tree-actor-attribution\` (#166). Merge **after** #166 lands.

## Why strict-by-default

The DB enforces \`UNIQUE(itemId, key)\`, so silently accepting a role mismatch would leave the gate-required role unfilled. The schema-required note for that key would never be filled, and the failure would only surface later at \`advance_item\` time. Strict-by-default fails fast at create time so callers fix the role at the source.

This is the initial contract for a brand-new parameter (\`notes\`), not a breaking change to existing behavior. The parameter shipped in #164 with permissive role handling; this PR tightens it before broader adoption.

## Scope

- Schema-declared keys must use the schema role; mismatch is rejected with a clear error message naming the index, key, expected role, and submitted role.
- Off-schema keys (not declared in the resolved schema) remain unconstrained — callers may add arbitrary auxiliary notes with any valid role.
- Items with no schema match are unconstrained.
- Schemas are resolved once per item into a reusable \`itemSchemas\` map and reused for both strict-mode validation and the existing \`createNotes=true\` schema-blank fill loop.

## Test plan

- [x] **4 new unit tests** in \`CreateWorkTreeToolTest.kt\`:
  - rejection on mismatch (with executor never invoked)
  - acceptance on matching role
  - off-schema keys unconstrained
  - items without schema unconstrained
- [x] Replaces the prior loose-behavior test from #166 that documented the suppressed-schema-entry pattern (the test was added with the actor work to lock in current behavior; now superseded by strict mode)
- [x] \`./gradlew :current:test\` — passing
- [x] \`./gradlew :current:ktlintCheck\` — passing

## Stack

1. #166 — actor attribution + body validator
2. **This PR** — strict role enforcement (depends on #166)
3. Next — doc accuracy fixes (depends on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)