### PR TITLE
docs(create_work_tree): align tool description with actual behavior

### DIFF
--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -301,9 +301,10 @@ when calling `manage_items`, `manage_dependencies`, and `manage_notes` separatel
 | `parentId` | string (UUID) | No | Existing parent; root depth = parent.depth + 1 |
 | `children` | array | No | Child item specs: `[{ ref, title, priority?, tags?, type?, traits?, summary?, description?, requiresVerification? }]`. `ref` is a local name used in `deps`. |
 | `deps` | array | No | Dependency specs: `[{ from: ref, to: ref, type?: BLOCKS\|IS_BLOCKED_BY\|RELATES_TO, unblockAt?: queue\|work\|review\|terminal }]`. Use `"root"` to reference the root item. |
-| `createNotes` | boolean | No | Auto-create blank notes for each item from its tag schema (default: false) |
+| `createNotes` | boolean | No | Auto-create blank notes for each item from its resolved schema (looked up by `type` first, then by `tags`). Default: false. |
 | `notes` | array | No | Notes to create with bodies: `[{ itemRef (required, "root" or child ref), key (required), role (required: queue\|work\|review), body? (defaults to empty string) }]`. Explicit notes win over `createNotes=true` blanks per `(itemRef, key)`. **Strict role enforcement:** when an explicit note's `key` is declared in the resolved schema for the target item, the note's `role` must equal the schema role; mismatch returns `VALIDATION_ERROR`. Off-schema keys and items without a schema are unconstrained. |
-| `requestId` | string (UUID) | No | Client-generated UUID for idempotency. See [Idempotency](#idempotency). |
+| `actor` | object | No | Actor claim `{ id, kind: orchestrator\|subagent\|user\|external, parent?, proof? }`. Used for idempotency keying AND propagated as the actor attribution on every persisted note (both explicit and `createNotes=true` blanks). |
+| `requestId` | string (UUID) | No | Client-generated UUID for idempotency. See [Idempotency](#idempotency). Requires `actor` to function. |
 
 Depth cap: root must be at depth < 3 (i.e., root can be at depth 0, 1, or 2). Children are always root.depth + 1, so children can reach depth 3 (when root is at depth 2).
 
@@ -329,19 +330,22 @@ Depth cap: root must be at depth < 3 (i.e., root can be at depth 0, 1, or 2). Ch
 
 ```json
 {
-  "root": { "id": "uuid", "title": "Authentication Feature", "role": "queue", "depth": 0, "tags": "feature" },
+  "root": {
+    "id": "uuid", "title": "Authentication Feature", "role": "queue", "depth": 0, "tags": "feature",
+    "schemaMatch": true, "expectedNotes": [{ "key": "acceptance-criteria", "role": "queue", "required": true, "exists": false }]
+  },
   "children": [
-    { "ref": "t1", "id": "uuid", "title": "Design login flow", "role": "queue", "depth": 1, "tags": null },
-    { "ref": "t2", "id": "uuid", "title": "Implement JWT handler", "role": "queue", "depth": 1, "tags": null }
+    { "ref": "t1", "id": "uuid", "title": "Design login flow", "role": "queue", "depth": 1, "schemaMatch": false, "expectedNotes": [] },
+    { "ref": "t2", "id": "uuid", "title": "Implement JWT handler", "role": "queue", "depth": 1, "schemaMatch": false, "expectedNotes": [] }
   ],
   "dependencies": [
-    { "id": "uuid", "fromRef": "t1", "toRef": "t2", "type": "BLOCKS" }
+    { "id": "uuid", "fromRef": "t1", "toRef": "t2", "type": "BLOCKS", "unblockAt": "work" }
   ],
   "notes": []
 }
 ```
 
-`tags` is included on both `root` and each child when it was set; when not set, the field is omitted (not null). When `createNotes=true` and items have tags matching a schema, the `notes` array is populated with created note entries:
+`tags` on items and `unblockAt` on dependencies are included when set; when not set, the field is omitted (not null). `schemaMatch` and `expectedNotes` are always present; `expectedNotes` is `[]` when no schema matches. When `createNotes=true` and an item's resolved schema (matched by `type` first, then `tags`) declares notes, the `notes` array is populated with created note entries:
 
 ```json
 "notes": [

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
@@ -43,24 +43,34 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
 **Actor attribution:** A single top-level `actor` is applied to **every** persisted note in the tree (both explicit `notes` entries and `createNotes=true` schema blanks). This differs from `manage_notes`, which accepts a per-note `actor` block. If the top-level `actor` is malformed (e.g., missing `kind`), idempotency is disabled and attribution is dropped to `null` on each note — the call still proceeds and items/notes are created without an audit identity.
 
 **Parameters:**
-- `root` (required): Root item spec `{ title (required), priority?, tags?, summary?, description?, requiresVerification?, type? }`
+- `root` (required): Root item spec `{ title (required), priority?, tags?, traits?, summary?, description?, requiresVerification?, type? }`. `traits` is a comma-separated string of trait keys merged into properties.
 - `parentId` (optional): UUID of existing parent item. If provided, root depth = parent.depth + 1; otherwise depth = 0.
-- `children` (optional): Array of child item specs `[{ ref (required), title (required), priority?, tags?, summary?, description?, requiresVerification?, type? }]`. `ref` is a local name used in `deps` to wire dependencies.
+- `children` (optional): Array of child item specs `[{ ref (required), title (required), priority?, tags?, traits?, summary?, description?, requiresVerification?, type? }]`. `ref` is a local name used in `deps` to wire dependencies.
 - `deps` (optional): Array of dependency specs `[{ from: ref, to: ref, type?: BLOCKS|IS_BLOCKED_BY|RELATES_TO, unblockAt?: queue|work|review|terminal }]`. Use `"root"` to reference the root item.
-- `createNotes` (optional, default false): Auto-create blank notes for each item based on its tag schema.
+- `createNotes` (optional, default false): Auto-create blank notes for each item based on its resolved schema (looked up by `type` first, then by `tags`).
 - `notes` (optional): Notes to create with bodies: `[{ itemRef (required, "root" or child ref), key (required), role (required: queue|work|review), body (optional, defaults to empty string) }]`. Explicit notes win over `createNotes=true` blanks per `(itemRef, key)`. **Strict role enforcement:** when an explicit note's `key` is declared in the resolved schema for the target item, the note's `role` must equal the schema role; mismatch is rejected with `VALIDATION_ERROR`. Off-schema keys and items without a schema are unconstrained.
+- `actor` (optional): Actor claim `{ id (required), kind (required: orchestrator|subagent|user|external), parent?, proof? }`. See **Idempotency** and **Actor attribution** above for the two effects.
+- `requestId` (optional): Client-generated UUID. With `actor`, enables idempotent retries (see Idempotency above).
 
 **Depth cap:** Root item depth must be < $MAX_DEPTH. Children are always root.depth + 1, also < $MAX_DEPTH.
 
 **Response:**
 ```json
 {
-  "root": { "id": "uuid", "title": "...", "role": "queue", "depth": 0, "tags": "..." },
-  "children": [{ "ref": "t1", "id": "uuid", "title": "...", "role": "queue", "depth": 1 }],
-  "dependencies": [{ "id": "uuid", "fromRef": "t1", "toRef": "t2", "type": "BLOCKS" }],
+  "root": {
+    "id": "uuid", "title": "...", "role": "queue", "depth": 0, "tags": "...",
+    "schemaMatch": true, "expectedNotes": [{ "key": "...", "role": "queue", "required": true, "exists": false }]
+  },
+  "children": [{
+    "ref": "t1", "id": "uuid", "title": "...", "role": "queue", "depth": 1,
+    "schemaMatch": false, "expectedNotes": []
+  }],
+  "dependencies": [{ "id": "uuid", "fromRef": "t1", "toRef": "t2", "type": "BLOCKS", "unblockAt": "work" }],
   "notes": [{ "itemRef": "t1", "key": "acceptance-criteria", "role": "queue", "id": "uuid" }]
 }
 ```
+
+`tags` on items and `unblockAt` on dependencies are omitted (not null) when not set. `schemaMatch` and `expectedNotes` are always present; `expectedNotes` is `[]` when no schema matches.
         """.trimIndent()
 
     override val category = ToolCategory.ITEM_MANAGEMENT
@@ -84,7 +94,9 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                             put(
                                 "description",
                                 JsonPrimitive(
-                                    "Root item spec: { title (required), priority?, tags?, summary?, description?, requiresVerification?, type? }"
+                                    "Root item spec: { title (required), priority?, tags?, traits?, summary?, " +
+                                        "description?, requiresVerification?, type? }. " +
+                                        "traits is a comma-separated string of trait keys merged into properties."
                                 )
                             )
                         }
@@ -108,7 +120,9 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                             put(
                                 "description",
                                 JsonPrimitive(
-                                    "Child item specs: [{ ref (required local name), title (required), priority?, tags?, summary?, description?, requiresVerification?, type? }]"
+                                    "Child item specs: [{ ref (required local name), title (required), priority?, " +
+                                        "tags?, traits?, summary?, description?, requiresVerification?, type? }]. " +
+                                        "traits is a comma-separated string of trait keys merged into properties."
                                 )
                             )
                         }
@@ -131,7 +145,10 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                             put("type", JsonPrimitive("boolean"))
                             put(
                                 "description",
-                                JsonPrimitive("Auto-create blank notes from schema for each item based on its tags (default: false)")
+                                JsonPrimitive(
+                                    "Auto-create blank notes from each item's resolved schema (looked up by type first, " +
+                                        "then by tags). Default: false."
+                                )
                             )
                         }
                     )


### PR DESCRIPTION
## Summary

Third and final stacked recovery PR (see #166, #167). Pure documentation accuracy — no behavior change.

**Base branch:** \`feat/create-work-tree-strict-roles\` (#167). Merge **after** #167 lands.

## What this fixes

Drift between the tool's documented behavior and the implementation:

- Document \`traits\` field on root and children specs (was supported in \`buildWorkItem\` but undocumented in description and parameter schema).
- Correct \`createNotes\` resolution scope: schemas are resolved by \`type\` first, then by \`tags\` — prior text said "tag schema" only.
- Update response example to include \`schemaMatch\` and \`expectedNotes\` (always present) and \`unblockAt\` on dependencies (when supplied).
- Add \`actor\` and \`requestId\` to the human-readable parameter list (they were in the JSON parameter schema but missing from the description body and api-reference table).
- Note that the top-level \`actor\` block propagates to persisted notes in addition to its idempotency role (relevant after #166 lands).
- Fix api-reference response example showing \`tags: null\` — field is omitted, not nulled, when not set.

No behavior change.

## Stack

1. #166 — actor attribution + body validator
2. #167 — strict role enforcement
3. **This PR** — doc accuracy fixes (depends on #167)

🤖 Generated with [Claude Code](https://claude.com/claude-code)