### PR TITLE
feat: selector-mode claim_item + filter parity for get_next_item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `claim_item` selector mode — atomic find-and-claim in a single call. Each claim entry may now use a `selector` object (instead of `itemId`) to resolve a filter+rank query and claim the top match without the race window of the two-call `get_next_item → claim_item` pattern. New outcomes: `no_match` (`kind=permanent`, no `retryAfterMs`, no `itemId`) when the queue is empty for the given filters; `selectorResolved: true` on success. New `claimRef` field (up to 64 chars) echoed verbatim in every claim result for caller-side correlation. Single-claim-per-call enforced by validation when any selector is present — `claims.size > 1` with a selector returns `validation_error`.
+- `get_next_item` filter parameters: `tags` (comma-separated, any-match), `priority` (`high`|`medium`|`low`), `type` (exact match), `complexityMax` (1–10), `createdAfter` (ISO 8601), `createdBefore` (ISO 8601), `roleChangedAfter` (ISO 8601), `roleChangedBefore` (ISO 8601), `orderBy` (`priority` default | `oldest` FIFO | `newest` recency). Filter shape is identical to `claim_item.selector` — both tools share the same underlying eligibility logic (`NextItemRecommender`).
+- `findClaimable` repository method composing the rich filter surface with active-claim exclusion — single source of truth for "what's eligible next" across both tools.
+- `NextItemRecommender` shared service — encapsulates the recommend+dependency-block logic so `get_next_item` and `claim_item` selector path can never diverge on eligibility semantics.
+- `NextItemOrder` enum — `PRIORITY_THEN_COMPLEXITY`, `OLDEST_FIRST`, `NEWEST_FIRST`.
+
+### Deprecated
+- ID-based multi-claim batches — `claim_item` with `claims.size > 1` using `itemId` entries. Each successive successful claim auto-releases predecessors; a `claims: [A, B, C]` call ends with only C held, even though all three report `success`. **Issue one claim per call.** This path is preserved for backward compatibility and will be rejected in a future major version. Tracked as MCP item `b8ac68a4`. Migration path: switch to selector mode or issue one `claim_item` call per item.
+
+---
+
 ## [3.6.0] - 2026-05-04 (Plugin v3.2.0)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ The MCP server works without the plugin. The plugin makes it seamless with Claud
 | **Graph** | `manage_items`, `query_items`, `create_work_tree`, `complete_tree` | Build and query the work item hierarchy |
 | **Notes** | `manage_notes`, `query_notes` | Persistent phase-scoped documentation |
 | **Dependencies** | `manage_dependencies`, `query_dependencies` | Typed edges with pattern shortcuts (linear, fan-out, fan-in) |
-| **Workflow** | `advance_item`, `get_next_status`, `get_context`, `get_next_item`, `get_blocked_items` | Trigger-based transitions with gate enforcement and dependency validation |
+| **Workflow** | `advance_item`, `get_next_status`, `get_context`, `get_next_item`, `get_blocked_items`, `claim_item` | Trigger-based transitions with gate enforcement, dependency validation, and atomic find-and-claim (selector mode) for multi-agent fleets |
 
 Every tool supports short hex ID prefixes — `advance_item(itemId="a3f2")` instead of full UUIDs.
 

--- a/claude-plugins/task-orchestrator/hooks/session-start.mjs
+++ b/claude-plugins/task-orchestrator/hooks/session-start.mjs
@@ -5,7 +5,7 @@ const output = {
     hookEventName: "SessionStart",
     additionalContext: `## Current (v3) Task Orchestrator — Session Context
 
-**Tool surface (13 tools):** manage_items, query_items, manage_notes, query_notes, manage_dependencies, query_dependencies, advance_item, get_next_item, get_blocked_items, get_next_status, create_work_tree, complete_tree, get_context
+**Tool surface (14 tools):** manage_items, query_items, manage_notes, query_notes, manage_dependencies, query_dependencies, advance_item, claim_item, get_next_item, get_blocked_items, get_next_status, create_work_tree, complete_tree, get_context
 
 **Workflow:**
 - Items progress through roles: queue → work → review → terminal

--- a/claude-plugins/task-orchestrator/skills/ralph/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/ralph/SKILL.md
@@ -215,7 +215,7 @@ node claude-plugins/task-orchestrator/scripts/ralph-loop.mjs \
   --max 10
 ```
 
-User runs it. Each iteration spawns a fresh `claude -p --worktree=ralph-<id>` with the iteration prompt. The agent claims one item, invokes `/schema-workflow` to drive it through whatever phases its schema declares, commits changes, and exits with the outcome marker.
+User runs it. Each iteration spawns a fresh `claude -p --worktree=ralph-<id>` with the iteration prompt. The agent uses `claim_item` selector mode to atomically find and claim one item (a single MCP call — no race window), invokes `/schema-workflow` to drive it through whatever phases its schema declares, commits changes, and exits with the outcome marker.
 
 5 iterations later: 3 terminal, 1 gate-blocked (a required note couldn't be filled — e.g., needed external context the iteration didn't have), 1 errored (test failure unrelated to the fix). Loop exits when consecutive gate failures hit the budget (3) or queue empties — whichever comes first.
 
@@ -271,9 +271,11 @@ Solution: Run with `--dry-run` and inspect the prompt that would be sent. If the
 
 ---
 
-**Problem: claim contention — every iteration gets `skip` with "all candidates already claimed"**
+**Problem: claim contention — every iteration gets `skip` or `no_match` because all candidates are already claimed**
 
 Cause: Stale claims from a crashed previous run, or another worker is already draining. TTL is the recovery mechanism.
+
+Note: With selector mode, `claim_item` returns `no_match` (kind=permanent) when all queue items matching the filter are already claimed, rather than returning an `already_claimed` error. The iteration treats this as a `no-item` exit.
 
 Solution: Check `query_items(operation="search", claimStatus="claimed")` to see who holds claims. If they're all from a crashed `ralph-<pid>-<ts>` actor, wait for TTL expiry (default 30 min per the loop's settings) or release them via `claim_item(releases=[...])` if you know they're stale.
 

--- a/claude-plugins/task-orchestrator/skills/ralph/iteration-prompt.md
+++ b/claude-plugins/task-orchestrator/skills/ralph/iteration-prompt.md
@@ -10,42 +10,44 @@ This prompt is the per-iteration workflow. Operating principles, output discipli
 
 ---
 
-## Step 1 — Find and claim a candidate
+## Step 1 — Atomically find and claim a candidate
 
-Query for unclaimed queue items matching the filter:
+Use `claim_item` selector mode — a single atomic MCP call that finds and claims in one operation, eliminating the race window of a two-call query-then-claim pattern.
 
-```
-query_items(operation="search", role="queue", claimStatus="unclaimed", limit=10, ...)
-```
+Translate the filter expression into selector fields:
 
-Filter key → search arg mapping:
-
-| Filter key | Mapped argument |
+| Filter key | Selector field |
 |---|---|
-| `tag=X` | `tags="X"` (substring match) |
-| `type=X` | `type="X"` |
-| `priority=X` | `priority="X"` |
-| `parentId=X` | `parentId="X"` (full UUID or 4+ char hex prefix) |
-
-If the filter is empty, omit those arguments.
-
-**If zero candidates:** emit `RALPH_OUTCOME: {"status": "no-item"}` and exit.
-
-Order candidates by priority (high → medium → low). For each candidate in order, attempt:
+| `tag=X` | `tags: "X"` (any-match, comma-separated for multiple) |
+| `type=X` | `type: "X"` |
+| `priority=X` | `priority: "X"` |
+| `parentId=X` | `parentId: "X"` (full UUID or 4+ char hex prefix) |
 
 ```
 claim_item(
-  claims=[{ itemId: "<uuid>", ttlSeconds: ${ttl} }],
+  claims=[{
+    selector: {
+      role: "queue",
+      orderBy: "oldest",
+      <...filter fields from expression...>
+    },
+    ttlSeconds: ${ttl},
+    claimRef: "${actor_id}"
+  }],
   requestId: "<fresh-uuid>",
   actor: { id: "${actor_id}", kind: "${actor_kind}" }
 )
 ```
 
+`orderBy: "oldest"` drains the queue in FIFO order (oldest items first), ensuring fair processing across all queue items.
+
+> **Note:** When `selector` is present, the `claims` array must contain exactly one entry. Multi-selector batches are rejected with `validation_error`.
+
 | Result | Action |
 |---|---|
-| `success` | Proceed to Step 2 with the claimed UUID |
-| `already_claimed` | Drop and try the next candidate |
-| All candidates already claimed | Emit `RALPH_OUTCOME: {"status": "skip", "reason": "all candidates already claimed"}` and exit |
+| `success` with `selectorResolved: true` | Proceed to Step 2 with the resolved `itemId` |
+| `no_match` (kind=permanent) | No items match the filter — emit `RALPH_OUTCOME: {"status": "no-item"}` and exit |
+| `already_claimed` | TOCTOU race (rare) — emit `RALPH_OUTCOME: {"status": "skip", "reason": "TOCTOU race on selector resolve"}` and exit |
 | Other error | Emit `RALPH_OUTCOME: {"status": "error", "reason": "claim failed: <message>"}` and exit |
 
 ---

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1167,7 +1167,7 @@ Each entry must have exactly one of `itemId` or `selector`. When any entry uses 
 | Field | Type | Description |
 |---|---|---|
 | `role` | string | Role to search in: `queue`\|`work`\|`review`\|`blocked` (default: `queue`) |
-| `parentId` | string (UUID) | Filter to items under this parent |
+| `parentId` | string (UUID or hex prefix) | Filter to items under this parent (accepts full UUID or 4+ char hex prefix, like other `parentId` fields on the surface) |
 | `tags` | string (comma-separated) | Filter by tags (any-match) |
 | `priority` | string | `high`\|`medium`\|`low` |
 | `type` | string | Item type (exact match) |
@@ -1222,7 +1222,7 @@ The selector filter shape is identical to the `get_next_item` filter parameters 
 
 #### Atomic Find-and-Claim (Selector Mode)
 
-Selector mode atomically resolves a filter+rank query and claims the top match in a single call. This eliminates the inherent race window in the two-call pattern (`get_next_item` → `claim_item(itemId=...)`), where another agent can claim the recommended item between your two calls.
+Selector mode resolves a filter+rank query and claims the top match in a single MCP call. This eliminates the **user-facing** race window of the two-call pattern (`get_next_item` → `claim_item(itemId=...)`), where another agent can claim the recommended item between your two calls. A much smaller server-side window between recommend and claim still exists and surfaces as `already_claimed` — typically rare in practice.
 
 **Request:**
 

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1195,7 +1195,7 @@ The selector filter shape is identical to the `get_next_item` filter parameters 
 | Outcome | Meaning |
 |---|---|
 | `success` | Claim placed or TTL refreshed. Response includes own claim metadata. Selector claims also include `selectorResolved: true`. |
-| `no_match` | Selector found no eligible items; `kind=permanent`. No claim attempted, no `retryAfterMs`, no `itemId`. |
+| `no_match` | Selector found no eligible items; `kind=permanent`, `code="no_match"`. No claim attempted, no `retryAfterMs`, no `itemId`. |
 | `already_claimed` | Another agent holds a live claim. Response includes `retryAfterMs` (no competing agent identity). |
 | `not_found` | No item with that ID. |
 | `terminal_item` | Item is in TERMINAL role; cannot be claimed. |
@@ -1272,6 +1272,7 @@ Selector mode atomically resolves a filter+rank query and claims the top match i
     {
       "outcome": "no_match",
       "kind": "permanent",
+      "code": "no_match",
       "claimRef": "worker-7-round-42"
     }
   ],

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1013,7 +1013,7 @@ Each entry in the `schema` array includes: `key`, `role`, `required`, `descripti
 **Purpose.** Priority-ranked recommendation of the next WorkItem(s) to work on. Finds items in the
 requested role (default: `queue`), filters out those with unsatisfied blocking dependencies and those
 with active claims (unless `includeClaimed=true`), and ranks by priority descending then complexity
-ascending (quick wins first).
+ascending (quick wins first) by default.
 
 #### Key Parameters
 
@@ -1026,16 +1026,65 @@ ascending (quick wins first).
 | `includeAncestors` | boolean | No | Include `ancestors` array on each recommendation (default: false) |
 | `includeClaimed` | boolean | No | When `false` (default), items with an active claim are filtered out. When `true`, claimed items are included but only a boolean `isClaimed` field is added — the claiming agent's identity is never exposed. |
 
+#### Filter Parameters (all optional)
+
+| Parameter | Type | Description |
+|---|---|---|
+| `tags` | string (comma-separated) | Return only items whose tags contain any of the listed values (any-match) |
+| `priority` | string (`high`\|`medium`\|`low`) | Return only items with this exact priority |
+| `type` | string | Return only items of this type (exact match) |
+| `complexityMax` | integer (1–10) | Return only items with complexity ≤ this value |
+| `createdAfter` | string (ISO 8601) | Return only items created after this timestamp |
+| `createdBefore` | string (ISO 8601) | Return only items created before this timestamp |
+| `roleChangedAfter` | string (ISO 8601) | Return only items whose role last changed after this timestamp |
+| `roleChangedBefore` | string (ISO 8601) | Return only items whose role last changed before this timestamp |
+| `orderBy` | string (`priority`\|`oldest`\|`newest`) | Ordering strategy: `priority` (default — HIGH first then complexity ascending / quick wins), `oldest` (createdAt ascending / FIFO drain), `newest` (createdAt descending / recency-biased) |
+
+The tiered claim disclosure contract applies under all filter combinations: `claimedBy` identity is never exposed by this tool, regardless of which filters are active.
+
 **Discovery patterns for multi-role fleets:**
 - Work-group agents: `get_next_item()` (default `role=queue`)
 - Review-group agents: `get_next_item(role="review")`
 - Triage-group agents: `get_next_item(role="blocked")`
 - Fleet health debugging: `get_next_item(includeClaimed=true)` to see claimed items without identity disclosure
+- Fair-share FIFO drain: `get_next_item(orderBy="oldest")` — processes items in creation order
 
 **Example.**
 
 ```json
 { "parentId": "550e8400-e29b-41d4-a716-446655440000", "limit": 3, "includeDetails": true }
+```
+
+#### Filtered Queries
+
+Filter by tag (any-match):
+
+```json
+{ "tags": "task-implementation,feature-task", "limit": 5 }
+```
+
+Filter by priority:
+
+```json
+{ "priority": "high", "role": "queue" }
+```
+
+Filter by maximum complexity (quick wins only):
+
+```json
+{ "complexityMax": 3, "orderBy": "priority" }
+```
+
+Time-window filter — items added to the queue in the last hour:
+
+```json
+{ "createdAfter": "2026-01-01T11:00:00Z", "createdBefore": "2026-01-01T12:00:00Z" }
+```
+
+FIFO queue drain — oldest unclaimed item first:
+
+```json
+{ "orderBy": "oldest" }
 ```
 
 **Response (default — unclaimed items only).**
@@ -1102,9 +1151,34 @@ changing the claim holder.
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `actor` | object | Yes | Actor identity — `{ id, kind, parent?, proof? }`. Verified identity overrides any `agentId` field on individual claim entries. |
-| `claims` | array | No | Items to claim: `[{ itemId (UUID or hex prefix), ttlSeconds? (default 900), agentId? (optional — overridden by verified actor when present) }]`. At least one of `claims` or `releases` must be non-empty. |
+| `claims` | array | No | Items to claim. Each entry uses **ID mode** or **selector mode** (see below). At least one of `claims` or `releases` must be non-empty. |
 | `releases` | array | No | Items to release: `[{ itemId (UUID or hex prefix) }]`. |
 | `requestId` | string (UUID) | **Yes** | Client-generated UUID for idempotency. Required — `claim_item` is a fleet-mode tool and idempotency is a hard contract. Single-orchestrator deployments do not use `claim_item`; fleet callers are in a multi-agent context where network retries are a real concern. Repeated calls with the same (`actor.id`, `requestId`) within ~10 minutes return the cached response without re-executing. |
+
+**`claims[]` entry schema — two mutually exclusive modes:**
+
+- **ID mode:** `{ itemId (required UUID or hex prefix), ttlSeconds? (optional int, default 900, max 86400), agentId? (optional — overridden by verified actor), claimRef? (optional string, max 64 chars — echoed verbatim in the result for caller correlation) }`
+- **Selector mode:** `{ selector (required object — see below), ttlSeconds? (optional int, default 900, max 86400), claimRef? (optional string, max 64 chars — echoed verbatim in the result) }`
+
+Each entry must have exactly one of `itemId` or `selector`. When any entry uses `selector`, the `claims` array must contain exactly 1 entry (see multi-claim batch warning below).
+
+**`selector` object fields** (all optional within the object; the object itself is required in selector mode):
+
+| Field | Type | Description |
+|---|---|---|
+| `role` | string | Role to search in: `queue`\|`work`\|`review`\|`blocked` (default: `queue`) |
+| `parentId` | string (UUID) | Filter to items under this parent |
+| `tags` | string (comma-separated) | Filter by tags (any-match) |
+| `priority` | string | `high`\|`medium`\|`low` |
+| `type` | string | Item type (exact match) |
+| `complexityMax` | integer (1–10) | Maximum complexity |
+| `createdAfter` | string (ISO 8601) | Items created after this timestamp |
+| `createdBefore` | string (ISO 8601) | Items created before this timestamp |
+| `roleChangedAfter` | string (ISO 8601) | Items whose role changed after this timestamp |
+| `roleChangedBefore` | string (ISO 8601) | Items whose role changed before this timestamp |
+| `orderBy` | string | `priority`\|`oldest`\|`newest` (default: `priority`) |
+
+The selector filter shape is identical to the `get_next_item` filter parameters — the two tools share the same underlying eligibility logic (`NextItemRecommender`), so the same filter expression produces the same item ranking in both tools.
 
 **Claim semantics:**
 
@@ -1120,7 +1194,8 @@ changing the claim holder.
 
 | Outcome | Meaning |
 |---|---|
-| `success` | Claim placed or TTL refreshed. Response includes own claim metadata. |
+| `success` | Claim placed or TTL refreshed. Response includes own claim metadata. Selector claims also include `selectorResolved: true`. |
+| `no_match` | Selector found no eligible items; `kind=permanent`. No claim attempted, no `retryAfterMs`, no `itemId`. |
 | `already_claimed` | Another agent holds a live claim. Response includes `retryAfterMs` (no competing agent identity). |
 | `not_found` | No item with that ID. |
 | `terminal_item` | Item is in TERMINAL role; cannot be claimed. |
@@ -1136,12 +1211,87 @@ changing the claim holder.
 
 **Tiered disclosure rule.** On `already_claimed`, the response includes only `retryAfterMs`. The competing agent's identity is never disclosed — this prevents claim sniping and jealousy patterns.
 
-**Example.**
+**Idempotency replay.** A `(actor, requestId)` cache hit replays the resolved response verbatim — including the same `itemId` for selector calls. The selector is **not** re-evaluated against fresh queue state on retry; the first-resolution result is what you get.
+
+> **⚠ Multi-claim batch warning (ID-based claims, deprecated path):**
+> Each successful claim auto-releases all other claims this agent currently holds. In a multi-claim batch, each successive `success` releases its predecessors. A call with `claims: [A, B, C]` ends with **only C held** — A and B are released even though the response reports all three as `success`. **Issue one claim per call.**
+>
+> Selector mode (`selector` field on a claim entry) is single-claim-only by validation: `claims.size > 1` with any selector present returns a `validation_error` immediately.
+>
+> ID-based multi-claim (`claims.size > 1` using `itemId` entries) is preserved for backwards compatibility but is a **deprecated path** — it will be rejected in a future major version. Tracked as MCP item `b8ac68a4`. Migrate to issuing one `claim_item` call per item.
+
+#### Atomic Find-and-Claim (Selector Mode)
+
+Selector mode atomically resolves a filter+rank query and claims the top match in a single call. This eliminates the inherent race window in the two-call pattern (`get_next_item` → `claim_item(itemId=...)`), where another agent can claim the recommended item between your two calls.
+
+**Request:**
+
+```json
+{
+  "claims": [{
+    "selector": {
+      "priority": "high",
+      "complexityMax": 4,
+      "orderBy": "oldest"
+    },
+    "ttlSeconds": 900,
+    "claimRef": "worker-7-round-42"
+  }],
+  "actor": { "id": "worker-agent-7", "kind": "subagent", "parent": "orchestrator-1" },
+  "requestId": "550e8400-e29b-41d4-a716-446655440099"
+}
+```
+
+**Response (item found and claimed):**
+
+```json
+{
+  "claimResults": [
+    {
+      "itemId": "550e8400-e29b-41d4-a716-446655440001",
+      "outcome": "success",
+      "selectorResolved": true,
+      "claimRef": "worker-7-round-42",
+      "claimedBy": "worker-agent-7",
+      "claimedAt": "2026-01-01T12:00:00Z",
+      "claimExpiresAt": "2026-01-01T12:15:00Z",
+      "originalClaimedAt": "2026-01-01T12:00:00Z"
+    }
+  ],
+  "releaseResults": [],
+  "summary": { "claimsTotal": 1, "claimsSucceeded": 1, "claimsFailed": 0,
+               "releasesTotal": 0, "releasesSucceeded": 0, "releasesFailed": 0 }
+}
+```
+
+**Response (no eligible items match the selector):**
+
+```json
+{
+  "claimResults": [
+    {
+      "outcome": "no_match",
+      "kind": "permanent",
+      "claimRef": "worker-7-round-42"
+    }
+  ],
+  "releaseResults": [],
+  "summary": { "claimsTotal": 1, "claimsSucceeded": 0, "claimsFailed": 1,
+               "releasesTotal": 0, "releasesSucceeded": 0, "releasesFailed": 0 }
+}
+```
+
+`no_match` means the queue is genuinely empty for the given filters at this moment. `kind=permanent` signals there is no point retrying with the same filters immediately — the condition will only change when new items enter the queue.
+
+`selectorResolved: true` on success confirms the `itemId` in the result was resolved from the selector, not supplied directly by the caller.
+
+#### Example (ID Mode)
 
 ```json
 {
   "claims": [{ "itemId": "550e8400-e29b-41d4-a716-446655440001", "ttlSeconds": 900 }],
-  "actor": { "id": "worker-agent-7", "kind": "subagent", "parent": "orchestrator-1" }
+  "actor": { "id": "worker-agent-7", "kind": "subagent", "parent": "orchestrator-1" },
+  "requestId": "550e8400-e29b-41d4-a716-000000000001"
 }
 ```
 

--- a/current/docs/fleet-deployment.md
+++ b/current/docs/fleet-deployment.md
@@ -452,7 +452,7 @@ Lifecycle and edge-case behaviors that operators encounter once a claim-mode fle
 
 ### Atomic Claim Acquisition (Selector Mode)
 
-Fleet agents can eliminate the race window inherent in the two-call `get_next_item → claim_item(itemId=...)` pattern by using selector mode instead. The selector resolves a filter+rank query and claims the top match atomically in one call.
+Fleet agents can eliminate the **user-facing** race window inherent in the two-call `get_next_item → claim_item(itemId=...)` pattern by using selector mode instead. The selector resolves a filter+rank query and claims the top match in a single MCP call. (A much smaller server-side window between recommend and claim remains and surfaces as `already_claimed` — typically rare in practice.)
 
 ```json
 {

--- a/current/docs/fleet-deployment.md
+++ b/current/docs/fleet-deployment.md
@@ -450,6 +450,25 @@ Metrics and observability infrastructure are explicitly deferred to a future rel
 
 Lifecycle and edge-case behaviors that operators encounter once a claim-mode fleet is running.
 
+### Atomic Claim Acquisition (Selector Mode)
+
+Fleet agents can eliminate the race window inherent in the two-call `get_next_item → claim_item(itemId=...)` pattern by using selector mode instead. The selector resolves a filter+rank query and claims the top match atomically in one call.
+
+```json
+{
+  "claims": [{
+    "selector": { "orderBy": "oldest", "priority": "high" },
+    "ttlSeconds": 900
+  }],
+  "actor": { "id": "worker-pod-12", "kind": "subagent" },
+  "requestId": "<fresh UUID per iteration>"
+}
+```
+
+`orderBy: "oldest"` (createdAt ascending) provides **fair-share queue draining**: agents process items in FIFO order rather than competing for the same high-priority items simultaneously. When all eligible items are claimed, agents receive `outcome: "no_match"` with `kind: "permanent"` — signal to idle or poll after a delay.
+
+The filter shape accepted by `claim_item.selector` is identical to the `get_next_item` filter parameters — both tools share the same underlying eligibility logic.
+
 ### Graceful Drain
 
 There is no built-in drain command. The intended sequence to stop a TO instance with active claims:

--- a/current/docs/quick-start.md
+++ b/current/docs/quick-start.md
@@ -225,8 +225,11 @@ create_work_tree(
   ]
 )
 
-# Find the next thing to work on
+# Find the next thing to work on (highest-priority, dependency-unblocked)
 get_next_item()
+
+# Find the next high-priority quick win (complexity ≤ 3)
+get_next_item(priority="high", complexityMax=3)
 
 # Transition an item through its lifecycle
 advance_item(transitions=[{itemId: "<uuid>", trigger: "start"}])

--- a/current/docs/workflow-guide.md
+++ b/current/docs/workflow-guide.md
@@ -894,7 +894,7 @@ advance_item(trigger="complete")    → ownership enforced at completion too
 
 ### Atomic Find-and-Claim (Selector Mode)
 
-The two-call pattern above has an inherent race: between `get_next_item` returning an item ID and `claim_item(itemId=...)` locking it, another agent can claim the same item. For high-concurrency fleets, selector mode eliminates this window by resolving the filter and claiming the top match atomically in one call.
+The two-call pattern above has an inherent race: between `get_next_item` returning an item ID and `claim_item(itemId=...)` locking it, another agent can claim the same item. For high-concurrency fleets, selector mode eliminates the **user-facing** race window by resolving the filter and claiming the top match in a single MCP call. A much smaller server-side window between recommend and claim still exists and surfaces as `already_claimed` — typically rare in practice.
 
 `get_next_item` and `claim_item.selector` accept **identical filter shapes** — the same `tags`, `priority`, `type`, `complexityMax`, `createdAfter/Before`, `roleChangedAfter/Before`, and `orderBy` parameters apply in both tools, backed by the same shared eligibility logic (`NextItemRecommender`).
 

--- a/current/docs/workflow-guide.md
+++ b/current/docs/workflow-guide.md
@@ -877,6 +877,8 @@ The claim mechanism prevents race conditions between independent agents competin
 
 ### Claim Lifecycle
 
+The standard two-call pattern — discover then claim:
+
 ```
 get_next_item()                     → find an unclaimed item
 claim_item(claims=[{itemId, ttl}])  → claim it (auto-releases any prior claim by this agent)
@@ -887,6 +889,49 @@ advance_item(trigger="start")       → ownership enforced: actor must match cla
 claim_item(claims=[{itemId}])       → heartbeat: refresh TTL (if work > TTL/2 = 450s)
 advance_item(trigger="complete")    → ownership enforced at completion too
 ```
+
+> **Deprecation note:** `claim_item` with multiple `itemId` entries in a single `claims` array is a deprecated path. Each successive successful claim auto-releases its predecessors, so only the last claim survives — a `claims: [A, B, C]` call ends with only C held. Issue one claim per call. ID-based multi-claim is preserved for backward compatibility but will be rejected in a future major version (tracked as MCP item `b8ac68a4`). Selector mode (`selector` field) is single-claim-only by validation and is the recommended migration path.
+
+### Atomic Find-and-Claim (Selector Mode)
+
+The two-call pattern above has an inherent race: between `get_next_item` returning an item ID and `claim_item(itemId=...)` locking it, another agent can claim the same item. For high-concurrency fleets, selector mode eliminates this window by resolving the filter and claiming the top match atomically in one call.
+
+`get_next_item` and `claim_item.selector` accept **identical filter shapes** — the same `tags`, `priority`, `type`, `complexityMax`, `createdAfter/Before`, `roleChangedAfter/Before`, and `orderBy` parameters apply in both tools, backed by the same shared eligibility logic (`NextItemRecommender`).
+
+**Selector mode lifecycle:**
+
+```
+claim_item(claims=[{ selector: { priority: "high", complexityMax: 4, orderBy: "oldest" }, ttlSeconds: 900 }],
+           actor={...}, requestId=<uuid>)
+  outcome=success, selectorResolved=true → proceed with advance_item + work (itemId is in the result)
+  outcome=no_match, kind=permanent       → queue is empty for these filters; back off or wait
+  outcome=already_claimed                → TOCTOU race (rare); retry immediately with a fresh requestId
+advance_item(trigger="start")       → ownership enforced: actor must match claimedBy
+  ... do work ...
+claim_item(claims=[{itemId}])       → heartbeat: refresh TTL (use the itemId from the selector result)
+advance_item(trigger="complete")    → ownership enforced at completion too
+```
+
+**Fleet drain pattern using selector mode:**
+
+```json
+// Each agent calls this loop independently — no coordination needed
+{
+  "claims": [{
+    "selector": { "orderBy": "oldest" },
+    "ttlSeconds": 900,
+    "claimRef": "worker-7-drain-loop"
+  }],
+  "actor": { "id": "worker-agent-7", "kind": "subagent" },
+  "requestId": "<fresh UUID per iteration>"
+}
+```
+
+`orderBy: "oldest"` provides fair-share FIFO draining: agents process items in creation order rather than racing to the same high-priority items. When `no_match` is returned, the queue is drained — the agent can idle, exit, or poll after a delay.
+
+`claimRef` (up to 64 chars) is echoed verbatim in every result and is useful for correlating claim results back to your agent's internal loop state without parsing `itemId` values.
+
+**Idempotency with selector mode.** A `(actor, requestId)` cache hit replays the resolved response verbatim — the same `itemId` is returned, and the selector is **not** re-evaluated against fresh queue state. Use a fresh `requestId` per claim iteration, not per retry of the same iteration.
 
 ### Heartbeat Pattern
 
@@ -960,8 +1005,11 @@ get_context(itemId="uuid")
 | Cancel an item                    | `advance_item(transitions=[{itemId, trigger:"cancel"}])`        |
 | Reopen a terminal item           | `advance_item(transitions=[{itemId, trigger:"reopen"}])`        |
 | Filter by phase                   | `query_items(operation="search", role="work")`                  |
-| Claim an item (fleet)             | `claim_item(claims=[{itemId, ttlSeconds:900}], actor={id, kind})` |
-| Release a claim                   | `claim_item(releases=[{itemId}], actor={id, kind})` |
-| Heartbeat (refresh TTL)           | `claim_item(claims=[{itemId}], actor={id, kind})` — same as claim, TTL refreshed |
+| Claim an item (fleet, ID mode)    | `claim_item(claims=[{itemId, ttlSeconds:900}], actor={id, kind}, requestId=<uuid>)` |
+| Claim next eligible (selector)    | `claim_item(claims=[{selector:{orderBy:"oldest"}}], actor={id, kind}, requestId=<uuid>)` |
+| Release a claim                   | `claim_item(releases=[{itemId}], actor={id, kind}, requestId=<uuid>)` |
+| Heartbeat (refresh TTL)           | `claim_item(claims=[{itemId}], actor={id, kind}, requestId=<uuid>)` — same as claim, TTL refreshed |
 | Find expired claims               | `query_items(operation="search", claimStatus="expired")` |
 | Diagnose stalled claim            | `get_context(itemId="uuid")` — returns `claimDetail` with `claimedBy` |
+| Filter next item by tag           | `get_next_item(tags="task-implementation", priority="high")` |
+| FIFO queue drain                  | `get_next_item(orderBy="oldest")` |

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommender.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommender.kt
@@ -44,8 +44,8 @@ class NextItemRecommender(
      * Returns the top [limit] unblocked, claimable work items that match [criteria].
      *
      * Algorithm:
-     * 1. Over-fetch up to 200 candidates from [WorkItemRepository.findClaimable] (active-claim
-     *    exclusion is always applied by the repository).
+     * 1. Over-fetch up to [OVER_FETCH_LIMIT] candidates from [WorkItemRepository.findClaimable]
+     *    (active-claim exclusion is always applied by the repository).
      * 2. Propagate repository errors immediately.
      * 3. Walk each candidate through [isBlocked] and discard blocked items.
      * 4. Take the top [limit] unblocked items and return them as [Result.Success].
@@ -67,7 +67,7 @@ class NextItemRecommender(
                 roleChangedAfter = criteria.roleChangedAfter,
                 roleChangedBefore = criteria.roleChangedBefore,
                 orderBy = criteria.orderBy,
-                limit = 200,
+                limit = OVER_FETCH_LIMIT,
             )
 
         if (candidatesResult is Result.Error) {
@@ -90,8 +90,11 @@ class NextItemRecommender(
      *
      * RELATES_TO dependencies carry no blocking semantics and are ignored.
      * If a blocker item cannot be fetched (e.g. deleted), the dependency is skipped conservatively.
+     *
+     * Visibility: `internal` so [GetNextItemTool]'s includeClaimed=true path can reuse this
+     * method directly instead of duplicating the dependency-walk logic.
      */
-    private suspend fun isBlocked(item: WorkItem): Boolean {
+    internal suspend fun isBlocked(item: WorkItem): Boolean {
         // Check BLOCKS deps where this item is the target (dep.toItemId = item.id)
         val incomingDeps = dependencyRepo.findByToItemId(item.id)
         for (dep in incomingDeps) {
@@ -131,5 +134,14 @@ class NextItemRecommender(
         }
 
         return false
+    }
+
+    private companion object {
+        /**
+         * Pre-fetch budget for [recommend]. Sized to leave room for the dependency-blocking
+         * filter to drop candidates without starving the caller's `limit` (default 1, max 20
+         * for `get_next_item`). Increase if blocking-filter drop rates are observed to climb.
+         */
+        const val OVER_FETCH_LIMIT = 200
     }
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommender.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommender.kt
@@ -1,0 +1,131 @@
+package io.github.jpicklyk.mcptask.current.application.service
+
+import io.github.jpicklyk.mcptask.current.domain.model.DependencyType
+import io.github.jpicklyk.mcptask.current.domain.model.NextItemOrder
+import io.github.jpicklyk.mcptask.current.domain.model.Priority
+import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Service that wraps `findClaimable` + dependency-blocking walk into a single
+ * "what's eligible next" recommendation query.
+ *
+ * Phase 3 (GetNextItemTool) and Phase 4 (ClaimItemTool selector) share this service
+ * so there is one authoritative source of truth for "what item should an agent pick up next."
+ */
+class NextItemRecommender(
+    private val workItemRepo: WorkItemRepository,
+    private val dependencyRepo: DependencyRepository,
+) {
+    /**
+     * Filter criteria for [recommend].  All fields mirror the parameters of
+     * [WorkItemRepository.findClaimable]; the service maps them 1:1 to the repository call.
+     */
+    data class Criteria(
+        val role: Role = Role.QUEUE,
+        val parentId: UUID? = null,
+        val tags: List<String>? = null,
+        val priority: Priority? = null,
+        val type: String? = null,
+        val complexityMax: Int? = null,
+        val createdAfter: Instant? = null,
+        val createdBefore: Instant? = null,
+        val roleChangedAfter: Instant? = null,
+        val roleChangedBefore: Instant? = null,
+        val orderBy: NextItemOrder = NextItemOrder.PRIORITY_THEN_COMPLEXITY,
+    )
+
+    /**
+     * Returns the top [limit] unblocked, claimable work items that match [criteria].
+     *
+     * Algorithm:
+     * 1. Over-fetch up to 200 candidates from [WorkItemRepository.findClaimable] (active-claim
+     *    exclusion is always applied by the repository).
+     * 2. Propagate repository errors immediately.
+     * 3. Walk each candidate through [isBlocked] and discard blocked items.
+     * 4. Take the top [limit] unblocked items and return them as [Result.Success].
+     */
+    suspend fun recommend(criteria: Criteria, limit: Int): Result<List<WorkItem>> {
+        val candidatesResult = workItemRepo.findClaimable(
+            role = criteria.role,
+            parentId = criteria.parentId,
+            tags = criteria.tags,
+            priority = criteria.priority,
+            type = criteria.type,
+            complexityMax = criteria.complexityMax,
+            createdAfter = criteria.createdAfter,
+            createdBefore = criteria.createdBefore,
+            roleChangedAfter = criteria.roleChangedAfter,
+            roleChangedBefore = criteria.roleChangedBefore,
+            orderBy = criteria.orderBy,
+            limit = 200,
+        )
+
+        if (candidatesResult is Result.Error) {
+            return candidatesResult
+        }
+
+        val candidates = (candidatesResult as Result.Success).data
+
+        val unblocked = candidates.filter { item -> !isBlocked(item) }
+
+        return Result.Success(unblocked.take(limit))
+    }
+
+    /**
+     * Returns true if [item] is dependency-blocked by any unsatisfied dependency.
+     *
+     * Checks two dependency directions:
+     * - Incoming BLOCKS deps (`dep.toItemId == item.id`): the blocker is `dep.fromItemId`.
+     * - Outgoing IS_BLOCKED_BY deps (`dep.fromItemId == item.id`): the blocker is `dep.toItemId`.
+     *
+     * RELATES_TO dependencies carry no blocking semantics and are ignored.
+     * If a blocker item cannot be fetched (e.g. deleted), the dependency is skipped conservatively.
+     */
+    private suspend fun isBlocked(item: WorkItem): Boolean {
+        // Check BLOCKS deps where this item is the target (dep.toItemId = item.id)
+        val incomingDeps = dependencyRepo.findByToItemId(item.id)
+        for (dep in incomingDeps) {
+            if (dep.type == DependencyType.BLOCKS) {
+                val threshold = dep.effectiveUnblockRole() ?: continue
+                val thresholdRole = Role.fromString(threshold) ?: continue
+                // Blocker is dep.fromItemId
+                val blockerResult = workItemRepo.getById(dep.fromItemId)
+                val blocker =
+                    when (blockerResult) {
+                        is Result.Success -> blockerResult.data
+                        is Result.Error -> continue // Skip — can't determine blocker state
+                    }
+                if (!Role.isAtOrBeyond(blocker.role, thresholdRole)) {
+                    return true // Unsatisfied dependency
+                }
+            }
+        }
+
+        // Check IS_BLOCKED_BY deps where this item is the source (dep.fromItemId = item.id)
+        val outgoingDeps = dependencyRepo.findByFromItemId(item.id)
+        for (dep in outgoingDeps) {
+            if (dep.type == DependencyType.IS_BLOCKED_BY) {
+                val threshold = dep.effectiveUnblockRole() ?: continue
+                val thresholdRole = Role.fromString(threshold) ?: continue
+                // Blocker is dep.toItemId
+                val blockerResult = workItemRepo.getById(dep.toItemId)
+                val blocker =
+                    when (blockerResult) {
+                        is Result.Success -> blockerResult.data
+                        is Result.Error -> continue // Skip — can't determine blocker state
+                    }
+                if (!Role.isAtOrBeyond(blocker.role, thresholdRole)) {
+                    return true // Unsatisfied dependency
+                }
+            }
+        }
+
+        return false
+    }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommender.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommender.kt
@@ -50,21 +50,25 @@ class NextItemRecommender(
      * 3. Walk each candidate through [isBlocked] and discard blocked items.
      * 4. Take the top [limit] unblocked items and return them as [Result.Success].
      */
-    suspend fun recommend(criteria: Criteria, limit: Int): Result<List<WorkItem>> {
-        val candidatesResult = workItemRepo.findClaimable(
-            role = criteria.role,
-            parentId = criteria.parentId,
-            tags = criteria.tags,
-            priority = criteria.priority,
-            type = criteria.type,
-            complexityMax = criteria.complexityMax,
-            createdAfter = criteria.createdAfter,
-            createdBefore = criteria.createdBefore,
-            roleChangedAfter = criteria.roleChangedAfter,
-            roleChangedBefore = criteria.roleChangedBefore,
-            orderBy = criteria.orderBy,
-            limit = 200,
-        )
+    suspend fun recommend(
+        criteria: Criteria,
+        limit: Int
+    ): Result<List<WorkItem>> {
+        val candidatesResult =
+            workItemRepo.findClaimable(
+                role = criteria.role,
+                parentId = criteria.parentId,
+                tags = criteria.tags,
+                priority = criteria.priority,
+                type = criteria.type,
+                complexityMax = criteria.complexityMax,
+                createdAfter = criteria.createdAfter,
+                createdBefore = criteria.createdBefore,
+                roleChangedAfter = criteria.roleChangedAfter,
+                roleChangedBefore = criteria.roleChangedBefore,
+                orderBy = criteria.orderBy,
+                limit = 200,
+            )
 
         if (candidatesResult is Result.Error) {
             return candidatesResult

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommender.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommender.kt
@@ -13,10 +13,9 @@ import java.util.UUID
 
 /**
  * Service that wraps `findClaimable` + dependency-blocking walk into a single
- * "what's eligible next" recommendation query.
- *
- * Phase 3 (GetNextItemTool) and Phase 4 (ClaimItemTool selector) share this service
- * so there is one authoritative source of truth for "what item should an agent pick up next."
+ * "what's eligible next" recommendation query. Both `GetNextItemTool` and the
+ * selector path of `ClaimItemTool` call into this service so there is one
+ * authoritative source of truth for "what item should an agent pick up next."
  */
 class NextItemRecommender(
     private val workItemRepo: WorkItemRepository,
@@ -76,9 +75,19 @@ class NextItemRecommender(
 
         val candidates = (candidatesResult as Result.Success).data
 
-        val unblocked = candidates.filter { item -> !isBlocked(item) }
+        // Early-exit walk: stop once we have `limit` unblocked items. Sequences cannot
+        // call suspending isBlocked, so this is a manual loop. Each isBlocked() call costs
+        // 2 DB queries; for the dominant selector limit=1 case this caps the walk at the
+        // first unblocked candidate instead of all 200 over-fetched.
+        val unblocked = mutableListOf<WorkItem>()
+        for (item in candidates) {
+            if (!isBlocked(item)) {
+                unblocked.add(item)
+                if (unblocked.size >= limit) break
+            }
+        }
 
-        return Result.Success(unblocked.take(limit))
+        return Result.Success(unblocked)
     }
 
     /**
@@ -136,12 +145,16 @@ class NextItemRecommender(
         return false
     }
 
-    private companion object {
+    companion object {
         /**
          * Pre-fetch budget for [recommend]. Sized to leave room for the dependency-blocking
          * filter to drop candidates without starving the caller's `limit` (default 1, max 20
          * for `get_next_item`). Increase if blocking-filter drop rates are observed to climb.
+         *
+         * `internal` so [GetNextItemTool]'s includeClaimed=true path can reference the same
+         * value when it invokes `findForNextItem` directly (the recommender is bypassed
+         * because findClaimable always excludes active claims).
          */
-        const val OVER_FETCH_LIMIT = 200
+        internal const val OVER_FETCH_LIMIT = 200
     }
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
@@ -3,6 +3,7 @@ package io.github.jpicklyk.mcptask.current.application.tools
 import io.github.jpicklyk.mcptask.current.application.service.ActorVerifier
 import io.github.jpicklyk.mcptask.current.application.service.IdempotencyCache
 import io.github.jpicklyk.mcptask.current.application.service.McpLoggingService
+import io.github.jpicklyk.mcptask.current.application.service.NextItemRecommender
 import io.github.jpicklyk.mcptask.current.application.service.NoOpActorVerifier
 import io.github.jpicklyk.mcptask.current.application.service.NoOpMcpLoggingService
 import io.github.jpicklyk.mcptask.current.application.service.NoOpNoteSchemaService
@@ -36,7 +37,12 @@ class ToolExecutionContext(
     private val mcpLoggingService: McpLoggingService = NoOpMcpLoggingService,
     private val actorVerifier: ActorVerifier = NoOpActorVerifier,
     val degradedModePolicy: DegradedModePolicy = DegradedModePolicy.ACCEPT_CACHED,
-    val idempotencyCache: IdempotencyCache = IdempotencyCache()
+    val idempotencyCache: IdempotencyCache = IdempotencyCache(),
+    val nextItemRecommender: NextItemRecommender =
+        NextItemRecommender(
+            repositoryProvider.workItemRepository(),
+            repositoryProvider.dependencyRepository()
+        ),
 ) {
     /** Access to WorkItem CRUD and query operations. */
     fun workItemRepository(): WorkItemRepository = repositoryProvider.workItemRepository()

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
@@ -160,9 +160,11 @@ in a future major version (tracked separately).
                             put(
                                 "description",
                                 JsonPrimitive(
-                                    "Array of claim requests. Each entry uses either ID mode: { itemId (required UUID or hex prefix), " +
+                                    "Array of claim requests. Each entry uses either ID mode: " +
+                                        "{ itemId (required UUID or hex prefix), " +
                                         "ttlSeconds? (optional int, default 900, min 1, max 86400 — 24 h cap), " +
-                                        "agentId? (optional string, overridden by verified actor), claimRef? (optional string, max 64 chars) } " +
+                                        "agentId? (optional string, overridden by verified actor), " +
+                                        "claimRef? (optional string, max 64 chars) } " +
                                         "or Selector mode: { selector (required object with filter fields), " +
                                         "ttlSeconds? (optional int), claimRef? (optional string, max 64 chars) }. " +
                                         "Exactly one of itemId or selector must be present per entry. " +
@@ -252,10 +254,11 @@ in a future major version (tracked separately).
 
         // Validate claims entries — check for selector mode rules
         if (!claims.isNullOrEmpty()) {
-            val hasAnySelector = claims.any { element ->
-                val obj = element as? JsonObject ?: return@any false
-                obj.containsKey("selector")
-            }
+            val hasAnySelector =
+                claims.any { element ->
+                    val obj = element as? JsonObject ?: return@any false
+                    obj.containsKey("selector")
+                }
 
             // Single-selector-per-call rule: if any entry has selector, claims.size must == 1
             if (hasAnySelector && claims.size > 1) {
@@ -321,8 +324,9 @@ in a future major version (tracked separately).
                     // complexityMax (1..10)
                     val complexityMaxPrim = selectorObj["complexityMax"] as? JsonPrimitive
                     if (complexityMaxPrim != null) {
-                        val v = complexityMaxPrim.content.toIntOrNull()
-                            ?: throw ToolValidationException("claims[$index].selector.complexityMax must be an integer")
+                        val v =
+                            complexityMaxPrim.content.toIntOrNull()
+                                ?: throw ToolValidationException("claims[$index].selector.complexityMax must be an integer")
                         if (v < 1 || v > 10) {
                             throw ToolValidationException(
                                 "claims[$index].selector.complexityMax must be between 1 and 10, got $v"

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
@@ -317,7 +317,7 @@ in a future major version (tracked separately).
                     if (priorityPrim != null) {
                         Priority.fromString(priorityPrim.content)
                             ?: throw ToolValidationException(
-                                "claims[$index].selector.priority must be HIGH, MEDIUM, or LOW, got '${priorityPrim.content}'"
+                                "claims[$index].selector.priority must be high, medium, or low, got '${priorityPrim.content}'"
                             )
                     }
 
@@ -357,16 +357,18 @@ in a future major version (tracked separately).
                             )
                     }
 
-                    // parentId
+                    // parentId — accepts full UUID or hex prefix (4+ chars), matching itemId
+                    // resolution and every other parentId field on the surface (get_next_item,
+                    // manage_items, create_work_tree). Format check only — actual prefix
+                    // resolution happens in execute() before buildCriteria.
                     val parentIdPrim = selectorObj["parentId"] as? JsonPrimitive
                     if (parentIdPrim != null) {
-                        try {
-                            UUID.fromString(parentIdPrim.content)
-                        } catch (_: IllegalArgumentException) {
+                        if (!parentIdPrim.isString || parentIdPrim.content.isBlank()) {
                             throw ToolValidationException(
-                                "claims[$index].selector.parentId must be a valid UUID, got '${parentIdPrim.content}'"
+                                "claims[$index].selector.parentId must be a non-empty string"
                             )
                         }
+                        validateIdStringOrPrefix(parentIdPrim.content, "claims[$index].selector.parentId")
                     }
 
                     // tags — non-blank string
@@ -491,7 +493,33 @@ in a future major version (tracked separately).
                 // --- Selector path ---
                 val selectorObj = claimObj["selector"] as? JsonObject ?: continue
 
-                val criteria = buildCriteria(selectorObj)
+                // Resolve parentId (may be a hex prefix) before building criteria. Format was
+                // already checked in validateParams; resolution here looks up the full UUID
+                // for prefixes via the repository. A failed lookup surfaces as not_found.
+                val selectorParentIdStr = (selectorObj["parentId"] as? JsonPrimitive)?.content
+                var resolvedSelectorParentId: UUID? = null
+                if (selectorParentIdStr != null) {
+                    val (resolvedUuid, idError) = resolveIdString(selectorParentIdStr, context)
+                    if (idError != null) {
+                        claimsFailed++
+                        claimResultsList.add(
+                            buildJsonObject {
+                                put("outcome", JsonPrimitive("not_found"))
+                                put(
+                                    "error",
+                                    JsonPrimitive(
+                                        "Failed to resolve selector.parentId: $selectorParentIdStr"
+                                    )
+                                )
+                                claimRef?.let { put("claimRef", JsonPrimitive(it)) }
+                            }
+                        )
+                        continue
+                    }
+                    resolvedSelectorParentId = resolvedUuid
+                }
+
+                val criteria = buildCriteria(selectorObj, resolvedSelectorParentId)
 
                 when (val recommendResult = context.nextItemRecommender.recommend(criteria, limit = 1)) {
                     is Result.Success -> {
@@ -840,13 +868,18 @@ in a future major version (tracked separately).
 
     /**
      * Builds a [NextItemRecommender.Criteria] from a selector JSON object.
+     *
+     * `parentId` is resolved by the caller via [resolveIdString] (because resolution
+     * of a hex prefix is suspending and may fail with a not_found error) and passed in
+     * here as an already-resolved UUID. Pass null when the selector did not specify a
+     * parentId.
      */
-    private fun buildCriteria(selectorObj: JsonObject): NextItemRecommender.Criteria {
+    private fun buildCriteria(
+        selectorObj: JsonObject,
+        resolvedParentId: UUID?
+    ): NextItemRecommender.Criteria {
         val roleStr = (selectorObj["role"] as? JsonPrimitive)?.content
         val role = roleStr?.let { Role.fromString(it) } ?: Role.QUEUE
-
-        val parentIdStr = (selectorObj["parentId"] as? JsonPrimitive)?.content
-        val parentId = parentIdStr?.let { runCatching { UUID.fromString(it) }.getOrNull() }
 
         val tagsStr = (selectorObj["tags"] as? JsonPrimitive)?.content
         val tags = tagsStr?.split(",")?.map { it.trim() }?.filter { it.isNotBlank() }
@@ -876,7 +909,7 @@ in a future major version (tracked separately).
 
         return NextItemRecommender.Criteria(
             role = role,
-            parentId = parentId,
+            parentId = resolvedParentId,
             tags = tags,
             priority = priority,
             type = type,

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
@@ -284,7 +284,7 @@ in a future major version (tracked separately).
                 }
                 if (!hasItemId && !hasSelector) {
                     throw ToolValidationException(
-                        "claims[$index] must specify either itemId or selector, not neither"
+                        "claims[$index] must specify either itemId or selector — neither was provided"
                     )
                 }
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
@@ -1,5 +1,6 @@
 package io.github.jpicklyk.mcptask.current.application.tools.workflow
 
+import io.github.jpicklyk.mcptask.current.application.service.NextItemRecommender
 import io.github.jpicklyk.mcptask.current.application.tools.ActorAware
 import io.github.jpicklyk.mcptask.current.application.tools.ActorParseResult
 import io.github.jpicklyk.mcptask.current.application.tools.BaseToolDefinition
@@ -9,13 +10,18 @@ import io.github.jpicklyk.mcptask.current.application.tools.ToolCategory
 import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
 import io.github.jpicklyk.mcptask.current.application.tools.ToolValidationException
 import io.github.jpicklyk.mcptask.current.domain.model.ErrorKind
+import io.github.jpicklyk.mcptask.current.domain.model.NextItemOrder
+import io.github.jpicklyk.mcptask.current.domain.model.Priority
+import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.ToolError
 import io.github.jpicklyk.mcptask.current.domain.repository.ClaimResult
 import io.github.jpicklyk.mcptask.current.domain.repository.ReleaseResult
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.modelcontextprotocol.kotlin.sdk.types.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.*
+import java.time.Instant
 import java.util.UUID
 
 /**
@@ -33,6 +39,13 @@ import java.util.UUID
  * - `already_claimed`: returns `retryAfterMs` based on existing claim TTL. Does NOT leak
  *   the competing agent's identity.
  *
+ * **Selector mode:**
+ * - Each claim entry may use `selector` (instead of `itemId`) for atomic find-and-claim.
+ * - Selector resolves a filter+rank query and claims the top match in one call.
+ * - Single-claim-per-call by validation when any selector is present.
+ * - `no_match` outcome (kind=permanent) when the queue is empty for the given filters.
+ * - `claimRef` (optional, ≤64 chars) is echoed in every result for caller correlation.
+ *
  * **Release semantics:**
  * - Only the current claim holder can release; other agents receive `not_claimed_by_you`.
  *
@@ -41,6 +54,10 @@ import java.util.UUID
  * multi-agent context where network retries are a real concern, so idempotency is a hard contract.
  * Repeated calls with the same (actor, requestId) within ~10 minutes return the cached response
  * without re-executing the claim/release operations.
+ *
+ * Idempotency: a (actor, requestId) cache hit replays the resolved response verbatim —
+ * including the same itemId for selector calls. Selector is NOT re-evaluated against fresh
+ * queue state on retry.
  */
 class ClaimItemTool :
     BaseToolDefinition(),
@@ -53,15 +70,42 @@ Atomically claim or release work items. One claim per agent: claiming a new item
 any prior claim held by the same agent.
 
 **Parameters:**
-- `claims` (optional array): Items to claim. Each element: `{ itemId (required UUID or short hex), ttlSeconds? (optional int, default 900, max 86400), agentId? (optional string, overridden by verified actor) }`. The TTL must be between 1 and 86400 seconds (24 hours); values outside this range are rejected.
+- `claims` (optional array): Items to claim. Each element supports two mutually exclusive modes:
+  - ID mode: `{ itemId (required UUID or short hex), ttlSeconds? (optional int, default 900, max 86400), agentId? (optional string, overridden by verified actor), claimRef? (optional string, max 64 chars — echoed in result) }`
+  - Selector mode: `{ selector (required object — see below), ttlSeconds? (optional int, default 900, max 86400), claimRef? (optional string, max 64 chars — echoed in result) }`
+  - Each entry must have exactly one of `itemId` or `selector`.
+  - When any entry uses `selector`, claims array must contain exactly 1 entry (see batch warning below).
 - `releases` (optional array): Items to release. Each element: `{ itemId (required UUID or short hex) }`
 - `actor` (required): `{ id (required string), kind (required: orchestrator|subagent|user|external), parent? (optional string), proof? (optional string) }` — identity used as the claim holder. Verified identity overrides self-reported agentId.
 - `requestId` (required UUID): Client-generated UUID for idempotency. Required — `claim_item` is a fleet-mode tool and idempotency is a hard contract. Repeated calls with the same (actor, requestId) within ~10 minutes return the cached response without re-executing.
 
+**Selector object fields** (all optional except the parent `selector` key itself):
+- `role` (string, default "queue"): role to search in — queue|work|review|blocked
+- `parentId` (string UUID): filter to items under this parent
+- `tags` (string, comma-separated): filter by tags
+- `priority` (string): HIGH|MEDIUM|LOW
+- `type` (string): item type
+- `complexityMax` (int, 1–10): maximum complexity
+- `createdAfter` (string, ISO 8601): items created after this timestamp
+- `createdBefore` (string, ISO 8601): items created before this timestamp
+- `roleChangedAfter` (string, ISO 8601): items whose role changed after this timestamp
+- `roleChangedBefore` (string, ISO 8601): items whose role changed before this timestamp
+- `orderBy` (string): priority|oldest|newest (default: priority)
+
 At least one of `claims` or `releases` must be non-empty.
 
+**⚠ Multi-claim batch semantics (ID-based claims, deprecated path):**
+Each successful claim auto-releases all other claims this agent currently holds.
+In a multi-claim batch, each successive `success` releases its predecessors.
+A call with `claims: [A, B, C]` ends with only C held — A and B are released even
+though the response reports all three as `success`. **Issue one claim per call.**
+Selector mode (`selector` field on a claim entry) is single-claim-only by validation.
+ID-based multi-claim is preserved for backwards compatibility but will be rejected
+in a future major version (tracked separately).
+
 **Claim outcomes per item:**
-- `success` — claim placed or TTL refreshed (same agent re-claim). Response includes own claim metadata.
+- `success` — claim placed or TTL refreshed (same agent re-claim). Response includes own claim metadata. Selector claims also include `selectorResolved: true`.
+- `no_match` — selector found no eligible items; kind=permanent. No claim attempted, no retryAfterMs.
 - `already_claimed` — another agent holds a live claim. Response includes `retryAfterMs` (no competing agent identity).
 - `not_found` — no item with that ID.
 - `terminal_item` — item is in TERMINAL role; cannot be claimed.
@@ -79,6 +123,8 @@ At least one of `claims` or `releases` must be non-empty.
     {
       "itemId": "uuid",
       "outcome": "success",
+      "selectorResolved": true,
+      "claimRef": "my-ref",
       "claimedBy": "agent-id",
       "claimedAt": "2026-01-01T00:00:00Z",
       "claimExpiresAt": "2026-01-01T00:15:00Z",
@@ -114,9 +160,13 @@ At least one of `claims` or `releases` must be non-empty.
                             put(
                                 "description",
                                 JsonPrimitive(
-                                    "Array of claim requests: { itemId (required UUID or hex prefix), " +
+                                    "Array of claim requests. Each entry uses either ID mode: { itemId (required UUID or hex prefix), " +
                                         "ttlSeconds? (optional int, default 900, min 1, max 86400 — 24 h cap), " +
-                                        "agentId? (optional string, overridden by verified actor) }"
+                                        "agentId? (optional string, overridden by verified actor), claimRef? (optional string, max 64 chars) } " +
+                                        "or Selector mode: { selector (required object with filter fields), " +
+                                        "ttlSeconds? (optional int), claimRef? (optional string, max 64 chars) }. " +
+                                        "Exactly one of itemId or selector must be present per entry. " +
+                                        "When any entry uses selector, claims array must contain exactly 1 entry."
                                 )
                             )
                         }
@@ -200,25 +250,156 @@ At least one of `claims` or `releases` must be non-empty.
             }
         }
 
-        claims?.forEachIndexed { index, element ->
-            val obj =
-                element as? JsonObject
-                    ?: throw ToolValidationException("claims[$index] must be a JSON object")
-            val itemIdPrim =
-                obj["itemId"] as? JsonPrimitive
-                    ?: throw ToolValidationException("claims[$index] missing required field: itemId")
-            if (!itemIdPrim.isString || itemIdPrim.content.isBlank()) {
-                throw ToolValidationException("claims[$index].itemId must be a non-empty string")
+        // Validate claims entries — check for selector mode rules
+        if (!claims.isNullOrEmpty()) {
+            val hasAnySelector = claims.any { element ->
+                val obj = element as? JsonObject ?: return@any false
+                obj.containsKey("selector")
             }
-            validateIdStringOrPrefix(itemIdPrim.content, "claims[$index].itemId")
 
-            val ttlPrim = obj["ttlSeconds"] as? JsonPrimitive
-            if (ttlPrim != null) {
-                val ttl =
-                    ttlPrim.content.toIntOrNull()
-                        ?: throw ToolValidationException("claims[$index].ttlSeconds must be a positive integer")
-                if (ttl <= 0) throw ToolValidationException("claims[$index].ttlSeconds must be positive, got $ttl")
-                if (ttl > 86400) throw ToolValidationException("claims[$index].ttlSeconds must not exceed 86400 (24 hours), got $ttl")
+            // Single-selector-per-call rule: if any entry has selector, claims.size must == 1
+            if (hasAnySelector && claims.size > 1) {
+                throw ToolValidationException(
+                    "Selector mode supports a single claim per call. Multi-claim batches conflict " +
+                        "with the one-claim-per-agent rule. To claim multiple items, issue separate calls."
+                )
+            }
+
+            claims.forEachIndexed { index, element ->
+                val obj =
+                    element as? JsonObject
+                        ?: throw ToolValidationException("claims[$index] must be a JSON object")
+
+                val hasItemId = obj.containsKey("itemId")
+                val hasSelector = obj.containsKey("selector")
+
+                // Exactly one of itemId or selector must be present
+                if (hasItemId && hasSelector) {
+                    throw ToolValidationException(
+                        "claims[$index] must specify either itemId or selector, not both"
+                    )
+                }
+                if (!hasItemId && !hasSelector) {
+                    throw ToolValidationException(
+                        "claims[$index] must specify either itemId or selector, not neither"
+                    )
+                }
+
+                if (hasItemId) {
+                    // ID-mode validation
+                    val itemIdPrim =
+                        obj["itemId"] as? JsonPrimitive
+                            ?: throw ToolValidationException("claims[$index].itemId must be a string")
+                    if (!itemIdPrim.isString || itemIdPrim.content.isBlank()) {
+                        throw ToolValidationException("claims[$index].itemId must be a non-empty string")
+                    }
+                    validateIdStringOrPrefix(itemIdPrim.content, "claims[$index].itemId")
+                } else {
+                    // Selector-mode validation
+                    val selectorObj =
+                        obj["selector"] as? JsonObject
+                            ?: throw ToolValidationException("claims[$index].selector must be a JSON object")
+
+                    // role
+                    val rolePrim = selectorObj["role"] as? JsonPrimitive
+                    if (rolePrim != null) {
+                        Role.fromString(rolePrim.content)
+                            ?: throw ToolValidationException(
+                                "claims[$index].selector.role must be one of: ${Role.VALID_NAMES.joinToString()}, got '${rolePrim.content}'"
+                            )
+                    }
+
+                    // priority
+                    val priorityPrim = selectorObj["priority"] as? JsonPrimitive
+                    if (priorityPrim != null) {
+                        Priority.fromString(priorityPrim.content)
+                            ?: throw ToolValidationException(
+                                "claims[$index].selector.priority must be HIGH, MEDIUM, or LOW, got '${priorityPrim.content}'"
+                            )
+                    }
+
+                    // complexityMax (1..10)
+                    val complexityMaxPrim = selectorObj["complexityMax"] as? JsonPrimitive
+                    if (complexityMaxPrim != null) {
+                        val v = complexityMaxPrim.content.toIntOrNull()
+                            ?: throw ToolValidationException("claims[$index].selector.complexityMax must be an integer")
+                        if (v < 1 || v > 10) {
+                            throw ToolValidationException(
+                                "claims[$index].selector.complexityMax must be between 1 and 10, got $v"
+                            )
+                        }
+                    }
+
+                    // createdAfter / createdBefore / roleChangedAfter / roleChangedBefore — ISO 8601
+                    listOf("createdAfter", "createdBefore", "roleChangedAfter", "roleChangedBefore").forEach { field ->
+                        val prim = selectorObj[field] as? JsonPrimitive
+                        if (prim != null) {
+                            try {
+                                Instant.parse(prim.content)
+                            } catch (_: Exception) {
+                                throw ToolValidationException(
+                                    "claims[$index].selector.$field must be an ISO 8601 timestamp, got '${prim.content}'"
+                                )
+                            }
+                        }
+                    }
+
+                    // orderBy
+                    val orderByPrim = selectorObj["orderBy"] as? JsonPrimitive
+                    if (orderByPrim != null) {
+                        NextItemOrder.fromString(orderByPrim.content)
+                            ?: throw ToolValidationException(
+                                "claims[$index].selector.orderBy must be priority, oldest, or newest, got '${orderByPrim.content}'"
+                            )
+                    }
+
+                    // parentId
+                    val parentIdPrim = selectorObj["parentId"] as? JsonPrimitive
+                    if (parentIdPrim != null) {
+                        try {
+                            UUID.fromString(parentIdPrim.content)
+                        } catch (_: IllegalArgumentException) {
+                            throw ToolValidationException(
+                                "claims[$index].selector.parentId must be a valid UUID, got '${parentIdPrim.content}'"
+                            )
+                        }
+                    }
+
+                    // tags — non-blank string
+                    val tagsPrim = selectorObj["tags"] as? JsonPrimitive
+                    if (tagsPrim != null && tagsPrim.content.isBlank()) {
+                        throw ToolValidationException("claims[$index].selector.tags must be a non-blank string")
+                    }
+
+                    // type — non-blank string
+                    val typePrim = selectorObj["type"] as? JsonPrimitive
+                    if (typePrim != null && typePrim.content.isBlank()) {
+                        throw ToolValidationException("claims[$index].selector.type must be a non-blank string")
+                    }
+                }
+
+                // claimRef — max 64 chars, non-blank when present
+                val claimRefPrim = obj["claimRef"] as? JsonPrimitive
+                if (claimRefPrim != null) {
+                    if (claimRefPrim.content.isBlank()) {
+                        throw ToolValidationException("claims[$index].claimRef must be a non-blank string when present")
+                    }
+                    if (claimRefPrim.content.length > 64) {
+                        throw ToolValidationException(
+                            "claims[$index].claimRef must not exceed 64 characters, got ${claimRefPrim.content.length}"
+                        )
+                    }
+                }
+
+                // ttlSeconds
+                val ttlPrim = obj["ttlSeconds"] as? JsonPrimitive
+                if (ttlPrim != null) {
+                    val ttl =
+                        ttlPrim.content.toIntOrNull()
+                            ?: throw ToolValidationException("claims[$index].ttlSeconds must be a positive integer")
+                    if (ttl <= 0) throw ToolValidationException("claims[$index].ttlSeconds must be positive, got $ttl")
+                    if (ttl > 86400) throw ToolValidationException("claims[$index].ttlSeconds must not exceed 86400 (24 hours), got $ttl")
+                }
             }
         }
 
@@ -297,114 +478,266 @@ At least one of `claims` or `releases` must be non-empty.
         // --- Process claims ---
         for (element in claimsArray) {
             val claimObj = element as? JsonObject ?: continue
-            val itemIdStr = (claimObj["itemId"] as? JsonPrimitive)?.content ?: continue
             val ttlSeconds = (claimObj["ttlSeconds"] as? JsonPrimitive)?.content?.toIntOrNull() ?: 900
+            val claimRef = (claimObj["claimRef"] as? JsonPrimitive)?.content
 
-            // Resolve ID (full UUID or prefix)
-            val (itemId, idError) = resolveIdString(itemIdStr, context)
-            if (idError != null) {
-                claimsFailed++
-                claimResultsList.add(
-                    buildJsonObject {
-                        put("itemId", JsonPrimitive(itemIdStr))
-                        put("outcome", JsonPrimitive("not_found"))
-                        put("error", JsonPrimitive("Failed to resolve item ID: $itemIdStr"))
-                    }
-                )
-                continue
-            }
+            val hasSelector = claimObj.containsKey("selector")
 
-            // Log if caller-supplied agentId differs from verified id.
-            val callerAgentId = (claimObj["agentId"] as? JsonPrimitive)?.content
-            if (callerAgentId != null && callerAgentId != trustedAgentId) {
-                logger.debug(
-                    "claim_item: caller-supplied agentId='{}' overridden by verified trustedAgentId='{}'",
-                    callerAgentId,
-                    trustedAgentId
-                )
-            }
+            if (hasSelector) {
+                // --- Selector path ---
+                val selectorObj = claimObj["selector"] as? JsonObject ?: continue
 
-            when (val result = context.workItemRepository().claim(itemId!!, trustedAgentId, ttlSeconds)) {
-                is ClaimResult.Success -> {
-                    claimsSucceeded++
-                    val item = result.item
-                    claimResultsList.add(
-                        buildJsonObject {
-                            put("itemId", JsonPrimitive(item.id.toString()))
-                            put("outcome", JsonPrimitive("success"))
-                            put("claimedBy", JsonPrimitive(item.claimedBy ?: trustedAgentId))
-                            item.claimedAt?.let { put("claimedAt", JsonPrimitive(it.toString())) }
-                            item.claimExpiresAt?.let { put("claimExpiresAt", JsonPrimitive(it.toString())) }
-                            item.originalClaimedAt?.let {
-                                put("originalClaimedAt", JsonPrimitive(it.toString()))
+                val criteria = buildCriteria(selectorObj)
+
+                when (val recommendResult = context.nextItemRecommender.recommend(criteria, limit = 1)) {
+                    is Result.Success -> {
+                        val items = recommendResult.data
+                        if (items.isEmpty()) {
+                            // no_match: queue is empty for this filter — permanent outcome
+                            claimsFailed++
+                            claimResultsList.add(
+                                buildJsonObject {
+                                    put("outcome", JsonPrimitive("no_match"))
+                                    put("kind", JsonPrimitive(ErrorKind.PERMANENT.toJsonString()))
+                                    put("code", JsonPrimitive("no_match"))
+                                    claimRef?.let { put("claimRef", JsonPrimitive(it)) }
+                                }
+                            )
+                            continue
+                        }
+
+                        // Resolved: take the top item and claim it
+                        val resolvedItem = items.first()
+                        val resolvedItemId = resolvedItem.id
+
+                        // Log if caller-supplied agentId differs from verified id.
+                        val callerAgentId = (claimObj["agentId"] as? JsonPrimitive)?.content
+                        if (callerAgentId != null && callerAgentId != trustedAgentId) {
+                            logger.debug(
+                                "claim_item: caller-supplied agentId='{}' overridden by verified trustedAgentId='{}'",
+                                callerAgentId,
+                                trustedAgentId
+                            )
+                        }
+
+                        when (val claimResult = context.workItemRepository().claim(resolvedItemId, trustedAgentId, ttlSeconds)) {
+                            is ClaimResult.Success -> {
+                                claimsSucceeded++
+                                val item = claimResult.item
+                                claimResultsList.add(
+                                    buildJsonObject {
+                                        put("itemId", JsonPrimitive(item.id.toString()))
+                                        put("outcome", JsonPrimitive("success"))
+                                        put("selectorResolved", JsonPrimitive(true))
+                                        claimRef?.let { put("claimRef", JsonPrimitive(it)) }
+                                        put("claimedBy", JsonPrimitive(item.claimedBy ?: trustedAgentId))
+                                        item.claimedAt?.let { put("claimedAt", JsonPrimitive(it.toString())) }
+                                        item.claimExpiresAt?.let { put("claimExpiresAt", JsonPrimitive(it.toString())) }
+                                        item.originalClaimedAt?.let {
+                                            put("originalClaimedAt", JsonPrimitive(it.toString()))
+                                        }
+                                    }
+                                )
+                            }
+
+                            is ClaimResult.AlreadyClaimed -> {
+                                // TOCTOU: item was claimed between recommend() and claim()
+                                claimsFailed++
+                                val alreadyClaimedError =
+                                    ToolError(
+                                        kind = ErrorKind.TRANSIENT,
+                                        code = "already_claimed",
+                                        message = "Item ${claimResult.itemId} is already claimed by another agent",
+                                        retryAfterMs = claimResult.retryAfterMs,
+                                        contendedItemId = claimResult.itemId
+                                    )
+                                claimResultsList.add(
+                                    buildJsonObject {
+                                        put("itemId", JsonPrimitive(claimResult.itemId.toString()))
+                                        put("outcome", JsonPrimitive("already_claimed"))
+                                        put("kind", JsonPrimitive(alreadyClaimedError.kind.toJsonString()))
+                                        put("contendedItemId", JsonPrimitive(alreadyClaimedError.contendedItemId!!.toString()))
+                                        alreadyClaimedError.retryAfterMs?.let { put("retryAfterMs", JsonPrimitive(it)) }
+                                        claimRef?.let { put("claimRef", JsonPrimitive(it)) }
+                                    }
+                                )
+                            }
+
+                            is ClaimResult.NotFound -> {
+                                claimsFailed++
+                                claimResultsList.add(
+                                    buildJsonObject {
+                                        put("itemId", JsonPrimitive(claimResult.itemId.toString()))
+                                        put("outcome", JsonPrimitive("not_found"))
+                                        claimRef?.let { put("claimRef", JsonPrimitive(it)) }
+                                    }
+                                )
+                            }
+
+                            is ClaimResult.TerminalItem -> {
+                                claimsFailed++
+                                claimResultsList.add(
+                                    buildJsonObject {
+                                        put("itemId", JsonPrimitive(claimResult.itemId.toString()))
+                                        put("outcome", JsonPrimitive("terminal_item"))
+                                        claimRef?.let { put("claimRef", JsonPrimitive(it)) }
+                                    }
+                                )
+                            }
+
+                            is ClaimResult.DBError -> {
+                                claimsFailed++
+                                val dbError =
+                                    ToolError(
+                                        kind = ErrorKind.TRANSIENT,
+                                        code = "db_error",
+                                        message = "Database error during claim operation",
+                                        contendedItemId = claimResult.itemId
+                                    )
+                                claimResultsList.add(
+                                    buildJsonObject {
+                                        put("itemId", JsonPrimitive(claimResult.itemId.toString()))
+                                        put("outcome", JsonPrimitive("db_error"))
+                                        put("kind", JsonPrimitive(dbError.kind.toJsonString()))
+                                        put("code", JsonPrimitive(dbError.code))
+                                        put("message", JsonPrimitive(dbError.message))
+                                        put("contendedItemId", JsonPrimitive(dbError.contendedItemId!!.toString()))
+                                        claimRef?.let { put("claimRef", JsonPrimitive(it)) }
+                                    }
+                                )
                             }
                         }
-                    )
-                }
+                    }
 
-                is ClaimResult.AlreadyClaimed -> {
-                    claimsFailed++
-                    // Emit ToolError fields (kind, retryAfterMs, contendedItemId) so agents can make
-                    // retry decisions without string-parsing. Tiered disclosure: no competing agent identity.
-                    val alreadyClaimedError =
-                        ToolError(
-                            kind = ErrorKind.TRANSIENT,
-                            code = "already_claimed",
-                            message = "Item ${result.itemId} is already claimed by another agent",
-                            retryAfterMs = result.retryAfterMs,
-                            contendedItemId = result.itemId
+                    is Result.Error -> {
+                        claimsFailed++
+                        claimResultsList.add(
+                            buildJsonObject {
+                                put("outcome", JsonPrimitive("db_error"))
+                                put("kind", JsonPrimitive(ErrorKind.TRANSIENT.toJsonString()))
+                                put("code", JsonPrimitive("db_error"))
+                                put("message", JsonPrimitive("Database error during selector recommendation"))
+                                claimRef?.let { put("claimRef", JsonPrimitive(it)) }
+                            }
                         )
-                    claimResultsList.add(
-                        buildJsonObject {
-                            put("itemId", JsonPrimitive(result.itemId.toString()))
-                            put("outcome", JsonPrimitive("already_claimed"))
-                            put("kind", JsonPrimitive(alreadyClaimedError.kind.toJsonString()))
-                            put("contendedItemId", JsonPrimitive(alreadyClaimedError.contendedItemId!!.toString()))
-                            // Tiered disclosure: retryAfterMs only — no competing agent identity.
-                            alreadyClaimedError.retryAfterMs?.let { put("retryAfterMs", JsonPrimitive(it)) }
-                        }
-                    )
+                    }
                 }
+            } else {
+                // --- ID-based path (existing logic) ---
+                val itemIdStr = (claimObj["itemId"] as? JsonPrimitive)?.content ?: continue
 
-                is ClaimResult.NotFound -> {
+                // Resolve ID (full UUID or prefix)
+                val (itemId, idError) = resolveIdString(itemIdStr, context)
+                if (idError != null) {
                     claimsFailed++
                     claimResultsList.add(
                         buildJsonObject {
-                            put("itemId", JsonPrimitive(result.itemId.toString()))
+                            put("itemId", JsonPrimitive(itemIdStr))
                             put("outcome", JsonPrimitive("not_found"))
+                            put("error", JsonPrimitive("Failed to resolve item ID: $itemIdStr"))
+                            claimRef?.let { put("claimRef", JsonPrimitive(it)) }
                         }
+                    )
+                    continue
+                }
+
+                // Log if caller-supplied agentId differs from verified id.
+                val callerAgentId = (claimObj["agentId"] as? JsonPrimitive)?.content
+                if (callerAgentId != null && callerAgentId != trustedAgentId) {
+                    logger.debug(
+                        "claim_item: caller-supplied agentId='{}' overridden by verified trustedAgentId='{}'",
+                        callerAgentId,
+                        trustedAgentId
                     )
                 }
 
-                is ClaimResult.TerminalItem -> {
-                    claimsFailed++
-                    claimResultsList.add(
-                        buildJsonObject {
-                            put("itemId", JsonPrimitive(result.itemId.toString()))
-                            put("outcome", JsonPrimitive("terminal_item"))
-                        }
-                    )
-                }
-
-                is ClaimResult.DBError -> {
-                    claimsFailed++
-                    val dbError =
-                        ToolError(
-                            kind = ErrorKind.TRANSIENT,
-                            code = "db_error",
-                            message = "Database error during claim operation",
-                            contendedItemId = result.itemId
+                when (val result = context.workItemRepository().claim(itemId!!, trustedAgentId, ttlSeconds)) {
+                    is ClaimResult.Success -> {
+                        claimsSucceeded++
+                        val item = result.item
+                        claimResultsList.add(
+                            buildJsonObject {
+                                put("itemId", JsonPrimitive(item.id.toString()))
+                                put("outcome", JsonPrimitive("success"))
+                                claimRef?.let { put("claimRef", JsonPrimitive(it)) }
+                                put("claimedBy", JsonPrimitive(item.claimedBy ?: trustedAgentId))
+                                item.claimedAt?.let { put("claimedAt", JsonPrimitive(it.toString())) }
+                                item.claimExpiresAt?.let { put("claimExpiresAt", JsonPrimitive(it.toString())) }
+                                item.originalClaimedAt?.let {
+                                    put("originalClaimedAt", JsonPrimitive(it.toString()))
+                                }
+                            }
                         )
-                    claimResultsList.add(
-                        buildJsonObject {
-                            put("itemId", JsonPrimitive(result.itemId.toString()))
-                            put("outcome", JsonPrimitive("db_error"))
-                            put("kind", JsonPrimitive(dbError.kind.toJsonString()))
-                            put("code", JsonPrimitive(dbError.code))
-                            put("message", JsonPrimitive(dbError.message))
-                            put("contendedItemId", JsonPrimitive(dbError.contendedItemId!!.toString()))
-                        }
-                    )
+                    }
+
+                    is ClaimResult.AlreadyClaimed -> {
+                        claimsFailed++
+                        // Emit ToolError fields (kind, retryAfterMs, contendedItemId) so agents can make
+                        // retry decisions without string-parsing. Tiered disclosure: no competing agent identity.
+                        val alreadyClaimedError =
+                            ToolError(
+                                kind = ErrorKind.TRANSIENT,
+                                code = "already_claimed",
+                                message = "Item ${result.itemId} is already claimed by another agent",
+                                retryAfterMs = result.retryAfterMs,
+                                contendedItemId = result.itemId
+                            )
+                        claimResultsList.add(
+                            buildJsonObject {
+                                put("itemId", JsonPrimitive(result.itemId.toString()))
+                                put("outcome", JsonPrimitive("already_claimed"))
+                                put("kind", JsonPrimitive(alreadyClaimedError.kind.toJsonString()))
+                                put("contendedItemId", JsonPrimitive(alreadyClaimedError.contendedItemId!!.toString()))
+                                // Tiered disclosure: retryAfterMs only — no competing agent identity.
+                                alreadyClaimedError.retryAfterMs?.let { put("retryAfterMs", JsonPrimitive(it)) }
+                                claimRef?.let { put("claimRef", JsonPrimitive(it)) }
+                            }
+                        )
+                    }
+
+                    is ClaimResult.NotFound -> {
+                        claimsFailed++
+                        claimResultsList.add(
+                            buildJsonObject {
+                                put("itemId", JsonPrimitive(result.itemId.toString()))
+                                put("outcome", JsonPrimitive("not_found"))
+                                claimRef?.let { put("claimRef", JsonPrimitive(it)) }
+                            }
+                        )
+                    }
+
+                    is ClaimResult.TerminalItem -> {
+                        claimsFailed++
+                        claimResultsList.add(
+                            buildJsonObject {
+                                put("itemId", JsonPrimitive(result.itemId.toString()))
+                                put("outcome", JsonPrimitive("terminal_item"))
+                                claimRef?.let { put("claimRef", JsonPrimitive(it)) }
+                            }
+                        )
+                    }
+
+                    is ClaimResult.DBError -> {
+                        claimsFailed++
+                        val dbError =
+                            ToolError(
+                                kind = ErrorKind.TRANSIENT,
+                                code = "db_error",
+                                message = "Database error during claim operation",
+                                contendedItemId = result.itemId
+                            )
+                        claimResultsList.add(
+                            buildJsonObject {
+                                put("itemId", JsonPrimitive(result.itemId.toString()))
+                                put("outcome", JsonPrimitive("db_error"))
+                                put("kind", JsonPrimitive(dbError.kind.toJsonString()))
+                                put("code", JsonPrimitive(dbError.code))
+                                put("message", JsonPrimitive(dbError.message))
+                                put("contendedItemId", JsonPrimitive(dbError.contendedItemId!!.toString()))
+                                claimRef?.let { put("claimRef", JsonPrimitive(it)) }
+                            }
+                        )
+                    }
                 }
             }
         }
@@ -499,6 +832,57 @@ At least one of `claims` or `releases` must be non-empty.
             }
 
         return successResponse(data)
+    }
+
+    /**
+     * Builds a [NextItemRecommender.Criteria] from a selector JSON object.
+     */
+    private fun buildCriteria(selectorObj: JsonObject): NextItemRecommender.Criteria {
+        val roleStr = (selectorObj["role"] as? JsonPrimitive)?.content
+        val role = roleStr?.let { Role.fromString(it) } ?: Role.QUEUE
+
+        val parentIdStr = (selectorObj["parentId"] as? JsonPrimitive)?.content
+        val parentId = parentIdStr?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+
+        val tagsStr = (selectorObj["tags"] as? JsonPrimitive)?.content
+        val tags = tagsStr?.split(",")?.map { it.trim() }?.filter { it.isNotBlank() }
+
+        val priorityStr = (selectorObj["priority"] as? JsonPrimitive)?.content
+        val priority = priorityStr?.let { Priority.fromString(it) }
+
+        val type = (selectorObj["type"] as? JsonPrimitive)?.content
+
+        val complexityMaxStr = (selectorObj["complexityMax"] as? JsonPrimitive)?.content
+        val complexityMax = complexityMaxStr?.toIntOrNull()
+
+        val createdAfterStr = (selectorObj["createdAfter"] as? JsonPrimitive)?.content
+        val createdAfter = createdAfterStr?.let { runCatching { Instant.parse(it) }.getOrNull() }
+
+        val createdBeforeStr = (selectorObj["createdBefore"] as? JsonPrimitive)?.content
+        val createdBefore = createdBeforeStr?.let { runCatching { Instant.parse(it) }.getOrNull() }
+
+        val roleChangedAfterStr = (selectorObj["roleChangedAfter"] as? JsonPrimitive)?.content
+        val roleChangedAfter = roleChangedAfterStr?.let { runCatching { Instant.parse(it) }.getOrNull() }
+
+        val roleChangedBeforeStr = (selectorObj["roleChangedBefore"] as? JsonPrimitive)?.content
+        val roleChangedBefore = roleChangedBeforeStr?.let { runCatching { Instant.parse(it) }.getOrNull() }
+
+        val orderByStr = (selectorObj["orderBy"] as? JsonPrimitive)?.content
+        val orderBy = orderByStr?.let { NextItemOrder.fromString(it) } ?: NextItemOrder.PRIORITY_THEN_COMPLEXITY
+
+        return NextItemRecommender.Criteria(
+            role = role,
+            parentId = parentId,
+            tags = tags,
+            priority = priority,
+            type = type,
+            complexityMax = complexityMax,
+            createdAfter = createdAfter,
+            createdBefore = createdBefore,
+            roleChangedAfter = roleChangedAfter,
+            roleChangedBefore = roleChangedBefore,
+            orderBy = orderBy,
+        )
     }
 
     override fun userSummary(

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
@@ -317,5 +317,4 @@ Parameters:
 
         return if (total == 1) "Next: $title" else "Next: $title (+${total - 1} more)"
     }
-
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
@@ -227,7 +227,6 @@ Filter parameters (all optional, any-match semantics where applicable):
             )
         }
 
-        // Legacy parameters
         validateIdOrPrefix(params, "parentId", required = false)
         val limit = optionalInt(params, "limit")
         if (limit != null && (limit < 1 || limit > 20)) {
@@ -314,7 +313,7 @@ Filter parameters (all optional, any-match semantics where applicable):
             NextItemRecommender.Criteria(
                 role = targetRole,
                 parentId = parentId,
-                tags = tags?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() },
+                tags = tags?.split(",")?.map { it.trim() }?.filter { it.isNotBlank() },
                 priority = parsedPriority,
                 type = type,
                 complexityMax = complexityMax,
@@ -345,7 +344,7 @@ Filter parameters (all optional, any-match semantics where applicable):
                         role = targetRole,
                         parentId = parentId,
                         excludeActiveClaims = false,
-                        limit = 200
+                        limit = NextItemRecommender.OVER_FETCH_LIMIT
                     )
 
                 val candidates =
@@ -357,13 +356,14 @@ Filter parameters (all optional, any-match semantics where applicable):
                 // Apply new filters in-memory for the includeClaimed=true path.
                 // Tag matching mirrors the DB-side semantics in SQLiteWorkItemRepository.buildTagFilter:
                 // exact-token match against comma-separated tags (NOT substring match).
+                // Uses isNotBlank to reject whitespace-only tokens (consistent with ClaimItemTool's selector path).
                 val filtered =
                     candidates.filter { item ->
                         (
                             criteria.tags == null ||
                                 item.tags?.let { t ->
                                     val itemTokens =
-                                        t.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                                        t.split(",").map { it.trim() }.filter { it.isNotBlank() }
                                     criteria.tags.any { tag -> tag in itemTokens }
                                 } == true
                         ) &&
@@ -377,12 +377,11 @@ Filter parameters (all optional, any-match semantics where applicable):
                     }
 
                 // Apply ordering
-                val priorityOrder = mapOf(Priority.HIGH to 0, Priority.MEDIUM to 1, Priority.LOW to 2)
                 val sorted =
                     when (parsedOrderBy) {
                         NextItemOrder.PRIORITY_THEN_COMPLEXITY ->
                             filtered.sortedWith(
-                                compareBy<WorkItem> { priorityOrder[it.priority] ?: 99 }.thenBy { it.complexity }
+                                compareBy<WorkItem> { PRIORITY_ORDER[it.priority] ?: 99 }.thenBy { it.complexity }
                             )
                         NextItemOrder.OLDEST_FIRST -> filtered.sortedBy { it.createdAt }
                         NextItemOrder.NEWEST_FIRST -> filtered.sortedByDescending { it.createdAt }
@@ -390,8 +389,16 @@ Filter parameters (all optional, any-match semantics where applicable):
 
                 // Filter dependency-blocked items — reuse the recommender's internal isBlocked
                 // so this path and the default path can never diverge on dependency-walk semantics.
-                val unblocked = sorted.filter { item -> !context.nextItemRecommender.isBlocked(item) }
-                unblocked.take(limit)
+                // Early-exit walk: stop once we have `limit` unblocked items (Sequences cannot
+                // call suspending isBlocked, so a manual loop with break is the simplest form).
+                val unblocked = mutableListOf<WorkItem>()
+                for (item in sorted) {
+                    if (!context.nextItemRecommender.isBlocked(item)) {
+                        unblocked.add(item)
+                        if (unblocked.size >= limit) break
+                    }
+                }
+                unblocked
             }
 
         // Resolve ancestor chains once for all recommendations if requested
@@ -477,5 +484,10 @@ Filter parameters (all optional, any-match semantics where applicable):
             } ?: "unknown"
 
         return if (total == 1) "Next: $title" else "Next: $title (+${total - 1} more)"
+    }
+
+    private companion object {
+        /** In-memory priority ordering for the includeClaimed=true path (mirrors the DB CASE expression). */
+        val PRIORITY_ORDER = mapOf(Priority.HIGH to 0, Priority.MEDIUM to 1, Priority.LOW to 2)
     }
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
@@ -185,14 +185,20 @@ Filter parameters (all optional, any-match semantics where applicable):
                         "roleChangedAfter",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("ISO 8601 timestamp — return only items whose role last changed after this point"))
+                            put(
+                                "description",
+                                JsonPrimitive("ISO 8601 timestamp — return only items whose role last changed after this point")
+                            )
                         }
                     )
                     put(
                         "roleChangedBefore",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
-                            put("description", JsonPrimitive("ISO 8601 timestamp — return only items whose role last changed before this point"))
+                            put(
+                                "description",
+                                JsonPrimitive("ISO 8601 timestamp — return only items whose role last changed before this point")
+                            )
                         }
                     )
                     put(
@@ -243,8 +249,10 @@ Filter parameters (all optional, any-match semantics where applicable):
             )
         }
 
-        val tagsStr = optionalString(params, "tags")
-        if (tagsStr != null && tagsStr.isBlank()) {
+        // Read the raw JsonPrimitive for tags so we can detect blank-string explicitly.
+        // optionalString() collapses blank strings to null, which would silently bypass this check.
+        val tagsRaw = (params as? JsonObject)?.get("tags") as? JsonPrimitive
+        if (tagsRaw != null && tagsRaw.isString && tagsRaw.content.isBlank()) {
             throw ToolValidationException("validation_error: tags must be a non-blank string when provided")
         }
 
@@ -297,23 +305,25 @@ Filter parameters (all optional, any-match semantics where applicable):
         val parsedCreatedBefore = optionalString(params, "createdBefore")?.let { Instant.parse(it) }
         val parsedRoleChangedAfter = optionalString(params, "roleChangedAfter")?.let { Instant.parse(it) }
         val parsedRoleChangedBefore = optionalString(params, "roleChangedBefore")?.let { Instant.parse(it) }
-        val parsedOrderBy = NextItemOrder.fromString(optionalString(params, "orderBy"))
-            ?: NextItemOrder.PRIORITY_THEN_COMPLEXITY
+        val parsedOrderBy =
+            NextItemOrder.fromString(optionalString(params, "orderBy"))
+                ?: NextItemOrder.PRIORITY_THEN_COMPLEXITY
 
         // Build criteria and delegate to NextItemRecommender (standard path: active claims excluded)
-        val criteria = NextItemRecommender.Criteria(
-            role = targetRole,
-            parentId = parentId,
-            tags = tags?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() },
-            priority = parsedPriority,
-            type = type,
-            complexityMax = complexityMax,
-            createdAfter = parsedCreatedAfter,
-            createdBefore = parsedCreatedBefore,
-            roleChangedAfter = parsedRoleChangedAfter,
-            roleChangedBefore = parsedRoleChangedBefore,
-            orderBy = parsedOrderBy,
-        )
+        val criteria =
+            NextItemRecommender.Criteria(
+                role = targetRole,
+                parentId = parentId,
+                tags = tags?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() },
+                priority = parsedPriority,
+                type = type,
+                complexityMax = complexityMax,
+                createdAfter = parsedCreatedAfter,
+                createdBefore = parsedCreatedBefore,
+                roleChangedAfter = parsedRoleChangedAfter,
+                roleChangedBefore = parsedRoleChangedBefore,
+                orderBy = parsedOrderBy,
+            )
 
         val workItemRepo = context.workItemRepository()
 
@@ -322,54 +332,57 @@ Filter parameters (all optional, any-match semantics where applicable):
         // findForNextItem(excludeActiveClaims=false), then apply new filters in-memory and run
         // the same dependency-blocking walk. The new filters do NOT change the includeClaimed
         // disclosure contract — claimedBy/claimedAt are never exposed in either path.
-        val recommendations: List<WorkItem> = if (!includeClaimed) {
-            when (val result = context.nextItemRecommender.recommend(criteria, limit)) {
-                is Result.Success -> result.data
-                is Result.Error -> return errorResponse(result.error.message, ErrorCodes.DATABASE_ERROR)
-            }
-        } else {
-            val dependencyRepo = context.dependencyRepository()
-            val candidatesResult =
-                workItemRepo.findForNextItem(
-                    role = targetRole,
-                    parentId = parentId,
-                    excludeActiveClaims = false,
-                    limit = 200
-                )
-
-            val candidates =
-                when (candidatesResult) {
-                    is Result.Success -> candidatesResult.data
-                    is Result.Error -> return errorResponse(candidatesResult.error.message, ErrorCodes.DATABASE_ERROR)
+        val recommendations: List<WorkItem> =
+            if (!includeClaimed) {
+                when (val result = context.nextItemRecommender.recommend(criteria, limit)) {
+                    is Result.Success -> result.data
+                    is Result.Error -> return errorResponse(result.error.message, ErrorCodes.DATABASE_ERROR)
                 }
-
-            // Apply new filters in-memory for the includeClaimed=true path
-            val filtered = candidates.filter { item ->
-                (criteria.tags == null || item.tags?.let { t -> criteria.tags.any { tag -> t.contains(tag) } } == true) &&
-                    (criteria.priority == null || item.priority == criteria.priority) &&
-                    (criteria.type == null || item.type == criteria.type) &&
-                    (criteria.complexityMax == null || (item.complexity != null && item.complexity <= criteria.complexityMax)) &&
-                    (criteria.createdAfter == null || !item.createdAt.isBefore(criteria.createdAfter)) &&
-                    (criteria.createdBefore == null || !item.createdAt.isAfter(criteria.createdBefore)) &&
-                    (criteria.roleChangedAfter == null || !item.roleChangedAt.isBefore(criteria.roleChangedAfter)) &&
-                    (criteria.roleChangedBefore == null || !item.roleChangedAt.isAfter(criteria.roleChangedBefore))
-            }
-
-            // Apply ordering
-            val priorityOrder = mapOf(Priority.HIGH to 0, Priority.MEDIUM to 1, Priority.LOW to 2)
-            val sorted = when (parsedOrderBy) {
-                NextItemOrder.PRIORITY_THEN_COMPLEXITY ->
-                    filtered.sortedWith(
-                        compareBy<WorkItem> { priorityOrder[it.priority] ?: 99 }.thenBy { it.complexity }
+            } else {
+                val dependencyRepo = context.dependencyRepository()
+                val candidatesResult =
+                    workItemRepo.findForNextItem(
+                        role = targetRole,
+                        parentId = parentId,
+                        excludeActiveClaims = false,
+                        limit = 200
                     )
-                NextItemOrder.OLDEST_FIRST -> filtered.sortedBy { it.createdAt }
-                NextItemOrder.NEWEST_FIRST -> filtered.sortedByDescending { it.createdAt }
-            }
 
-            // Filter dependency-blocked items
-            val unblocked = sorted.filter { item -> !isBlockedInline(item, workItemRepo, dependencyRepo) }
-            unblocked.take(limit)
-        }
+                val candidates =
+                    when (candidatesResult) {
+                        is Result.Success -> candidatesResult.data
+                        is Result.Error -> return errorResponse(candidatesResult.error.message, ErrorCodes.DATABASE_ERROR)
+                    }
+
+                // Apply new filters in-memory for the includeClaimed=true path
+                val filtered =
+                    candidates.filter { item ->
+                        (criteria.tags == null || item.tags?.let { t -> criteria.tags.any { tag -> t.contains(tag) } } == true) &&
+                            (criteria.priority == null || item.priority == criteria.priority) &&
+                            (criteria.type == null || item.type == criteria.type) &&
+                            (criteria.complexityMax == null || (item.complexity != null && item.complexity <= criteria.complexityMax)) &&
+                            (criteria.createdAfter == null || !item.createdAt.isBefore(criteria.createdAfter)) &&
+                            (criteria.createdBefore == null || !item.createdAt.isAfter(criteria.createdBefore)) &&
+                            (criteria.roleChangedAfter == null || !item.roleChangedAt.isBefore(criteria.roleChangedAfter)) &&
+                            (criteria.roleChangedBefore == null || !item.roleChangedAt.isAfter(criteria.roleChangedBefore))
+                    }
+
+                // Apply ordering
+                val priorityOrder = mapOf(Priority.HIGH to 0, Priority.MEDIUM to 1, Priority.LOW to 2)
+                val sorted =
+                    when (parsedOrderBy) {
+                        NextItemOrder.PRIORITY_THEN_COMPLEXITY ->
+                            filtered.sortedWith(
+                                compareBy<WorkItem> { priorityOrder[it.priority] ?: 99 }.thenBy { it.complexity }
+                            )
+                        NextItemOrder.OLDEST_FIRST -> filtered.sortedBy { it.createdAt }
+                        NextItemOrder.NEWEST_FIRST -> filtered.sortedByDescending { it.createdAt }
+                    }
+
+                // Filter dependency-blocked items
+                val unblocked = sorted.filter { item -> !isBlockedInline(item, workItemRepo, dependencyRepo) }
+                unblocked.take(limit)
+            }
 
         // Resolve ancestor chains once for all recommendations if requested
         val ancestorChains: Map<java.util.UUID, List<WorkItem>> =

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
@@ -1,11 +1,13 @@
 package io.github.jpicklyk.mcptask.current.application.tools.workflow
 
+import io.github.jpicklyk.mcptask.current.application.service.NextItemRecommender
 import io.github.jpicklyk.mcptask.current.application.tools.*
 import io.github.jpicklyk.mcptask.current.domain.model.*
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.modelcontextprotocol.kotlin.sdk.types.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.*
+import java.time.Instant
 
 /** Non-terminal roles that `get_next_item` may query. */
 private val VALID_ROLES = setOf("queue", "work", "review", "blocked")
@@ -14,11 +16,11 @@ private val VALID_ROLES = setOf("queue", "work", "review", "blocked")
  * Read-only MCP tool that recommends the next WorkItem(s) to work on.
  *
  * Selection logic:
- * 1. Find all items in the requested role (default: QUEUE)
- * 2. Filter out items with active (non-expired) claims unless includeClaimed=true
- * 3. Filter out blocked items (unsatisfied BLOCKS / IS_BLOCKED_BY dependencies)
- * 4. Sort by priority (HIGH > MEDIUM > LOW), then complexity ascending (quick wins first)
- * 5. Return top `limit` recommendations
+ * 1. Find all items in the requested role (default: QUEUE) matching optional filters.
+ * 2. Filter out items with active (non-expired) claims unless includeClaimed=true.
+ * 3. Filter out dependency-blocked items.
+ * 4. Order by `orderBy` (default: priority then complexity ascending = quick wins first).
+ * 5. Return top `limit` recommendations.
  *
  * Tiered claim disclosure: the response never exposes `claimedBy` or `claimedAt`.
  * When `includeClaimed=true`, only a boolean `isClaimed` field is added to each item.
@@ -32,7 +34,7 @@ Recommends next work item(s) based on role, dependencies, priority, and complexi
 
 Finds items in the requested role (default: queue), filters out those blocked by
 unsatisfied dependencies and those with active claims (unless includeClaimed=true),
-and ranks by priority (high first) then complexity (low first = quick wins).
+and ranks by priority (high first) then complexity (low first = quick wins) by default.
 
 Parameters:
 - role (optional string, default "queue"): Role to query — "queue", "work", "review", or "blocked"
@@ -44,6 +46,20 @@ Parameters:
 - includeClaimed (optional boolean, default false): When false (default), items with an active
   (non-expired) claim are filtered out. When true, claimed items are included but only a boolean
   `isClaimed` field is exposed — the claiming agent's identity is never disclosed.
+
+Filter parameters (all optional, any-match semantics where applicable):
+- tags (string, comma-separated): Return only items whose tags contain any of the given values
+- priority (string: high|medium|low): Return only items with this exact priority
+- type (string): Return only items of this type
+- complexityMax (integer 1..10): Return only items with complexity <= this value
+- createdAfter (string, ISO 8601): Return only items created after this timestamp
+- createdBefore (string, ISO 8601): Return only items created before this timestamp
+- roleChangedAfter (string, ISO 8601): Return only items whose role last changed after this timestamp
+- roleChangedBefore (string, ISO 8601): Return only items whose role last changed before this timestamp
+- orderBy (string: priority|oldest|newest, default "priority"): Ordering strategy —
+  "priority" = HIGH first then complexity ascending (quick wins),
+  "oldest" = createdAt ascending (FIFO / queue drain),
+  "newest" = createdAt descending (recency-biased)
         """.trimIndent()
 
     override val category = ToolCategory.WORKFLOW
@@ -120,6 +136,78 @@ Parameters:
                             )
                         }
                     )
+                    put(
+                        "tags",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put(
+                                "description",
+                                JsonPrimitive("Comma-separated tag values; any-match semantics (item must have at least one)")
+                            )
+                        }
+                    )
+                    put(
+                        "priority",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("Filter by priority: high, medium, or low"))
+                        }
+                    )
+                    put(
+                        "type",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("Filter by item type (exact match)"))
+                        }
+                    )
+                    put(
+                        "complexityMax",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("integer"))
+                            put("description", JsonPrimitive("Maximum complexity (1..10 inclusive); items above this value are excluded"))
+                        }
+                    )
+                    put(
+                        "createdAfter",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("ISO 8601 timestamp — return only items created after this point"))
+                        }
+                    )
+                    put(
+                        "createdBefore",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("ISO 8601 timestamp — return only items created before this point"))
+                        }
+                    )
+                    put(
+                        "roleChangedAfter",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("ISO 8601 timestamp — return only items whose role last changed after this point"))
+                        }
+                    )
+                    put(
+                        "roleChangedBefore",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("ISO 8601 timestamp — return only items whose role last changed before this point"))
+                        }
+                    )
+                    put(
+                        "orderBy",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "Ordering strategy: \"priority\" (default, HIGH first then complexity ASC), " +
+                                        "\"oldest\" (createdAt ASC), \"newest\" (createdAt DESC)"
+                                )
+                            )
+                        }
+                    )
                 },
             required = emptyList()
         )
@@ -133,11 +221,52 @@ Parameters:
             )
         }
 
-        // All other parameters are optional — just validate types if present
+        // Legacy parameters
         validateIdOrPrefix(params, "parentId", required = false)
         val limit = optionalInt(params, "limit")
         if (limit != null && (limit < 1 || limit > 20)) {
             throw ToolValidationException("limit must be between 1 and 20, got: $limit")
+        }
+
+        // New filter parameters — validate only when present
+        val priorityStr = optionalString(params, "priority")
+        if (priorityStr != null && Priority.fromString(priorityStr) == null) {
+            throw ToolValidationException(
+                "validation_error: priority must be one of high, medium, low — got: $priorityStr"
+            )
+        }
+
+        val complexityMax = optionalInt(params, "complexityMax")
+        if (complexityMax != null && (complexityMax < 1 || complexityMax > 10)) {
+            throw ToolValidationException(
+                "validation_error: complexityMax must be between 1 and 10 — got: $complexityMax"
+            )
+        }
+
+        val tagsStr = optionalString(params, "tags")
+        if (tagsStr != null && tagsStr.isBlank()) {
+            throw ToolValidationException("validation_error: tags must be a non-blank string when provided")
+        }
+
+        // ISO 8601 timestamp validations — round-trip via Instant.parse
+        for (field in listOf("createdAfter", "createdBefore", "roleChangedAfter", "roleChangedBefore")) {
+            val raw = optionalString(params, field)
+            if (raw != null) {
+                try {
+                    Instant.parse(raw)
+                } catch (_: Exception) {
+                    throw ToolValidationException(
+                        "validation_error: $field must be a valid ISO 8601 timestamp — got: $raw"
+                    )
+                }
+            }
+        }
+
+        val orderByStr = optionalString(params, "orderBy")
+        if (orderByStr != null && NextItemOrder.fromString(orderByStr) == null) {
+            throw ToolValidationException(
+                "validation_error: orderBy must be one of priority, oldest, newest — got: $orderByStr"
+            )
         }
     }
 
@@ -145,7 +274,7 @@ Parameters:
         params: JsonElement,
         context: ToolExecutionContext
     ): JsonElement {
-        // Parse parameters
+        // Parse legacy parameters
         val roleStr = optionalString(params, "role") ?: "queue"
         val targetRole =
             Role.fromString(roleStr)
@@ -159,79 +288,88 @@ Parameters:
         val includeAncestors = optionalBoolean(params, "includeAncestors", false)
         val includeClaimed = optionalBoolean(params, "includeClaimed", false)
 
+        // Parse new filter parameters
+        val tags = optionalString(params, "tags")
+        val parsedPriority = optionalString(params, "priority")?.let { Priority.fromString(it) }
+        val type = optionalString(params, "type")
+        val complexityMax = optionalInt(params, "complexityMax")
+        val parsedCreatedAfter = optionalString(params, "createdAfter")?.let { Instant.parse(it) }
+        val parsedCreatedBefore = optionalString(params, "createdBefore")?.let { Instant.parse(it) }
+        val parsedRoleChangedAfter = optionalString(params, "roleChangedAfter")?.let { Instant.parse(it) }
+        val parsedRoleChangedBefore = optionalString(params, "roleChangedBefore")?.let { Instant.parse(it) }
+        val parsedOrderBy = NextItemOrder.fromString(optionalString(params, "orderBy"))
+            ?: NextItemOrder.PRIORITY_THEN_COMPLEXITY
+
+        // Build criteria and delegate to NextItemRecommender (standard path: active claims excluded)
+        val criteria = NextItemRecommender.Criteria(
+            role = targetRole,
+            parentId = parentId,
+            tags = tags?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() },
+            priority = parsedPriority,
+            type = type,
+            complexityMax = complexityMax,
+            createdAfter = parsedCreatedAfter,
+            createdBefore = parsedCreatedBefore,
+            roleChangedAfter = parsedRoleChangedAfter,
+            roleChangedBefore = parsedRoleChangedBefore,
+            orderBy = parsedOrderBy,
+        )
+
         val workItemRepo = context.workItemRepository()
-        val dependencyRepo = context.dependencyRepository()
 
-        // Step 1: Find items in the requested role, applying claim filter at the DB level
-        val excludeActiveClaims = !includeClaimed
-        val candidatesResult =
-            workItemRepo.findForNextItem(
-                role = targetRole,
-                parentId = parentId,
-                excludeActiveClaims = excludeActiveClaims,
-                limit = 200
-            )
-
-        val candidates =
-            when (candidatesResult) {
-                is Result.Success -> candidatesResult.data
-                is Result.Error -> return errorResponse(
-                    candidatesResult.error.message,
-                    ErrorCodes.DATABASE_ERROR
+        // includeClaimed=false (default): recommender handles everything — active-claim exclusion
+        // + dependency blocking + ordering. includeClaimed=true: fetch with claims included via
+        // findForNextItem(excludeActiveClaims=false), then apply new filters in-memory and run
+        // the same dependency-blocking walk. The new filters do NOT change the includeClaimed
+        // disclosure contract — claimedBy/claimedAt are never exposed in either path.
+        val recommendations: List<WorkItem> = if (!includeClaimed) {
+            when (val result = context.nextItemRecommender.recommend(criteria, limit)) {
+                is Result.Success -> result.data
+                is Result.Error -> return errorResponse(result.error.message, ErrorCodes.DATABASE_ERROR)
+            }
+        } else {
+            val dependencyRepo = context.dependencyRepository()
+            val candidatesResult =
+                workItemRepo.findForNextItem(
+                    role = targetRole,
+                    parentId = parentId,
+                    excludeActiveClaims = false,
+                    limit = 200
                 )
+
+            val candidates =
+                when (candidatesResult) {
+                    is Result.Success -> candidatesResult.data
+                    is Result.Error -> return errorResponse(candidatesResult.error.message, ErrorCodes.DATABASE_ERROR)
+                }
+
+            // Apply new filters in-memory for the includeClaimed=true path
+            val filtered = candidates.filter { item ->
+                (criteria.tags == null || item.tags?.let { t -> criteria.tags.any { tag -> t.contains(tag) } } == true) &&
+                    (criteria.priority == null || item.priority == criteria.priority) &&
+                    (criteria.type == null || item.type == criteria.type) &&
+                    (criteria.complexityMax == null || (item.complexity != null && item.complexity <= criteria.complexityMax)) &&
+                    (criteria.createdAfter == null || !item.createdAt.isBefore(criteria.createdAfter)) &&
+                    (criteria.createdBefore == null || !item.createdAt.isAfter(criteria.createdBefore)) &&
+                    (criteria.roleChangedAfter == null || !item.roleChangedAt.isBefore(criteria.roleChangedAfter)) &&
+                    (criteria.roleChangedBefore == null || !item.roleChangedAt.isAfter(criteria.roleChangedBefore))
             }
 
-        // Step 2: Filter out blocked items (dependency-blocked, not role-BLOCKED).
-        // isBlocked logic lives in NextItemRecommender; replicated inline here so Phase 3 can
-        // cut execute() over to the recommender in a single focused change (no behaviour change
-        // needed in Phase 2 — findForNextItem / in-memory sort path is preserved as-is).
-        suspend fun isBlockedInline(item: WorkItem): Boolean {
-            val incomingDeps = dependencyRepo.findByToItemId(item.id)
-            for (dep in incomingDeps) {
-                if (dep.type == DependencyType.BLOCKS) {
-                    val threshold = dep.effectiveUnblockRole() ?: continue
-                    val thresholdRole = Role.fromString(threshold) ?: continue
-                    val blockerResult = workItemRepo.getById(dep.fromItemId)
-                    val blocker =
-                        when (blockerResult) {
-                            is Result.Success -> blockerResult.data
-                            is Result.Error -> continue
-                        }
-                    if (!Role.isAtOrBeyond(blocker.role, thresholdRole)) return true
-                }
+            // Apply ordering
+            val priorityOrder = mapOf(Priority.HIGH to 0, Priority.MEDIUM to 1, Priority.LOW to 2)
+            val sorted = when (parsedOrderBy) {
+                NextItemOrder.PRIORITY_THEN_COMPLEXITY ->
+                    filtered.sortedWith(
+                        compareBy<WorkItem> { priorityOrder[it.priority] ?: 99 }.thenBy { it.complexity }
+                    )
+                NextItemOrder.OLDEST_FIRST -> filtered.sortedBy { it.createdAt }
+                NextItemOrder.NEWEST_FIRST -> filtered.sortedByDescending { it.createdAt }
             }
-            val outgoingDeps = dependencyRepo.findByFromItemId(item.id)
-            for (dep in outgoingDeps) {
-                if (dep.type == DependencyType.IS_BLOCKED_BY) {
-                    val threshold = dep.effectiveUnblockRole() ?: continue
-                    val thresholdRole = Role.fromString(threshold) ?: continue
-                    val blockerResult = workItemRepo.getById(dep.toItemId)
-                    val blocker =
-                        when (blockerResult) {
-                            is Result.Success -> blockerResult.data
-                            is Result.Error -> continue
-                        }
-                    if (!Role.isAtOrBeyond(blocker.role, thresholdRole)) return true
-                }
-            }
-            return false
+
+            // Filter dependency-blocked items
+            val unblocked = sorted.filter { item -> !isBlockedInline(item, workItemRepo, dependencyRepo) }
+            unblocked.take(limit)
         }
-
-        val unblockedItems =
-            candidates.filter { item ->
-                !isBlockedInline(item)
-            }
-
-        // Step 3: Sort by priority (HIGH > MEDIUM > LOW), then complexity ascending
-        val priorityOrder = mapOf(Priority.HIGH to 0, Priority.MEDIUM to 1, Priority.LOW to 2)
-        val sorted =
-            unblockedItems.sortedWith(
-                compareBy<WorkItem> { priorityOrder[it.priority] ?: 99 }
-                    .thenBy { it.complexity }
-            )
-
-        // Step 4: Take top `limit`
-        val recommendations = sorted.take(limit)
 
         // Resolve ancestor chains once for all recommendations if requested
         val ancestorChains: Map<java.util.UUID, List<WorkItem>> =
@@ -247,7 +385,7 @@ Parameters:
 
         // Fetch DB-side time once (only needed when includeClaimed=true so isClaimed is accurate).
         // Using DB clock avoids false positives/negatives when JVM and SQLite clocks skew.
-        val dbNowForClaimed: java.time.Instant? =
+        val dbNowForClaimed: Instant? =
             if (includeClaimed && recommendations.any { it.claimedBy != null }) workItemRepo.dbNow() else null
 
         // Build response
@@ -272,7 +410,7 @@ Parameters:
                                 // An item is "actively claimed" when claimedBy is set and claimExpiresAt is in the future.
                                 // Use DB-side now so isClaimed reflects the DB clock.
                                 if (includeClaimed) {
-                                    val now = dbNowForClaimed ?: java.time.Instant.now()
+                                    val now = dbNowForClaimed ?: Instant.now()
                                     val activelyClaimedNow =
                                         item.claimedBy != null &&
                                             item.claimExpiresAt?.isAfter(now) == true
@@ -289,6 +427,46 @@ Parameters:
             }
 
         return successResponse(data)
+    }
+
+    /**
+     * Dependency-blocked check for the includeClaimed=true code path (where the recommender
+     * is bypassed). Mirrors [NextItemRecommender]'s internal isBlocked exactly.
+     */
+    private suspend fun isBlockedInline(
+        item: WorkItem,
+        workItemRepo: io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository,
+        dependencyRepo: io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository,
+    ): Boolean {
+        val incomingDeps = dependencyRepo.findByToItemId(item.id)
+        for (dep in incomingDeps) {
+            if (dep.type == DependencyType.BLOCKS) {
+                val threshold = dep.effectiveUnblockRole() ?: continue
+                val thresholdRole = Role.fromString(threshold) ?: continue
+                val blockerResult = workItemRepo.getById(dep.fromItemId)
+                val blocker =
+                    when (blockerResult) {
+                        is Result.Success -> blockerResult.data
+                        is Result.Error -> continue
+                    }
+                if (!Role.isAtOrBeyond(blocker.role, thresholdRole)) return true
+            }
+        }
+        val outgoingDeps = dependencyRepo.findByFromItemId(item.id)
+        for (dep in outgoingDeps) {
+            if (dep.type == DependencyType.IS_BLOCKED_BY) {
+                val threshold = dep.effectiveUnblockRole() ?: continue
+                val thresholdRole = Role.fromString(threshold) ?: continue
+                val blockerResult = workItemRepo.getById(dep.toItemId)
+                val blocker =
+                    when (blockerResult) {
+                        is Result.Success -> blockerResult.data
+                        is Result.Error -> continue
+                    }
+                if (!Role.isAtOrBeyond(blocker.role, thresholdRole)) return true
+            }
+        }
+        return false
     }
 
     override fun userSummary(

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
@@ -354,10 +354,19 @@ Filter parameters (all optional, any-match semantics where applicable):
                         is Result.Error -> return errorResponse(candidatesResult.error.message, ErrorCodes.DATABASE_ERROR)
                     }
 
-                // Apply new filters in-memory for the includeClaimed=true path
+                // Apply new filters in-memory for the includeClaimed=true path.
+                // Tag matching mirrors the DB-side semantics in SQLiteWorkItemRepository.buildTagFilter:
+                // exact-token match against comma-separated tags (NOT substring match).
                 val filtered =
                     candidates.filter { item ->
-                        (criteria.tags == null || item.tags?.let { t -> criteria.tags.any { tag -> t.contains(tag) } } == true) &&
+                        (
+                            criteria.tags == null ||
+                                item.tags?.let { t ->
+                                    val itemTokens =
+                                        t.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                                    criteria.tags.any { tag -> tag in itemTokens }
+                                } == true
+                        ) &&
                             (criteria.priority == null || item.priority == criteria.priority) &&
                             (criteria.type == null || item.type == criteria.type) &&
                             (criteria.complexityMax == null || (item.complexity != null && item.complexity <= criteria.complexityMax)) &&
@@ -379,8 +388,9 @@ Filter parameters (all optional, any-match semantics where applicable):
                         NextItemOrder.NEWEST_FIRST -> filtered.sortedByDescending { it.createdAt }
                     }
 
-                // Filter dependency-blocked items
-                val unblocked = sorted.filter { item -> !isBlockedInline(item, workItemRepo, dependencyRepo) }
+                // Filter dependency-blocked items — reuse the recommender's internal isBlocked
+                // so this path and the default path can never diverge on dependency-walk semantics.
+                val unblocked = sorted.filter { item -> !context.nextItemRecommender.isBlocked(item) }
                 unblocked.take(limit)
             }
 
@@ -440,46 +450,6 @@ Filter parameters (all optional, any-match semantics where applicable):
             }
 
         return successResponse(data)
-    }
-
-    /**
-     * Dependency-blocked check for the includeClaimed=true code path (where the recommender
-     * is bypassed). Mirrors [NextItemRecommender]'s internal isBlocked exactly.
-     */
-    private suspend fun isBlockedInline(
-        item: WorkItem,
-        workItemRepo: io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository,
-        dependencyRepo: io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository,
-    ): Boolean {
-        val incomingDeps = dependencyRepo.findByToItemId(item.id)
-        for (dep in incomingDeps) {
-            if (dep.type == DependencyType.BLOCKS) {
-                val threshold = dep.effectiveUnblockRole() ?: continue
-                val thresholdRole = Role.fromString(threshold) ?: continue
-                val blockerResult = workItemRepo.getById(dep.fromItemId)
-                val blocker =
-                    when (blockerResult) {
-                        is Result.Success -> blockerResult.data
-                        is Result.Error -> continue
-                    }
-                if (!Role.isAtOrBeyond(blocker.role, thresholdRole)) return true
-            }
-        }
-        val outgoingDeps = dependencyRepo.findByFromItemId(item.id)
-        for (dep in outgoingDeps) {
-            if (dep.type == DependencyType.IS_BLOCKED_BY) {
-                val threshold = dep.effectiveUnblockRole() ?: continue
-                val thresholdRole = Role.fromString(threshold) ?: continue
-                val blockerResult = workItemRepo.getById(dep.toItemId)
-                val blocker =
-                    when (blockerResult) {
-                        is Result.Success -> blockerResult.data
-                        is Result.Error -> continue
-                    }
-                if (!Role.isAtOrBeyond(blocker.role, thresholdRole)) return true
-            }
-        }
-        return false
     }
 
     override fun userSummary(

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
@@ -181,10 +181,45 @@ Parameters:
                 )
             }
 
-        // Step 2: Filter out blocked items (dependency-blocked, not role-BLOCKED)
+        // Step 2: Filter out blocked items (dependency-blocked, not role-BLOCKED).
+        // isBlocked logic lives in NextItemRecommender; replicated inline here so Phase 3 can
+        // cut execute() over to the recommender in a single focused change (no behaviour change
+        // needed in Phase 2 — findForNextItem / in-memory sort path is preserved as-is).
+        suspend fun isBlockedInline(item: WorkItem): Boolean {
+            val incomingDeps = dependencyRepo.findByToItemId(item.id)
+            for (dep in incomingDeps) {
+                if (dep.type == DependencyType.BLOCKS) {
+                    val threshold = dep.effectiveUnblockRole() ?: continue
+                    val thresholdRole = Role.fromString(threshold) ?: continue
+                    val blockerResult = workItemRepo.getById(dep.fromItemId)
+                    val blocker =
+                        when (blockerResult) {
+                            is Result.Success -> blockerResult.data
+                            is Result.Error -> continue
+                        }
+                    if (!Role.isAtOrBeyond(blocker.role, thresholdRole)) return true
+                }
+            }
+            val outgoingDeps = dependencyRepo.findByFromItemId(item.id)
+            for (dep in outgoingDeps) {
+                if (dep.type == DependencyType.IS_BLOCKED_BY) {
+                    val threshold = dep.effectiveUnblockRole() ?: continue
+                    val thresholdRole = Role.fromString(threshold) ?: continue
+                    val blockerResult = workItemRepo.getById(dep.toItemId)
+                    val blocker =
+                        when (blockerResult) {
+                            is Result.Success -> blockerResult.data
+                            is Result.Error -> continue
+                        }
+                    if (!Role.isAtOrBeyond(blocker.role, thresholdRole)) return true
+                }
+            }
+            return false
+        }
+
         val unblockedItems =
             candidates.filter { item ->
-                !isBlocked(item, workItemRepo, dependencyRepo)
+                !isBlockedInline(item)
             }
 
         // Step 3: Sort by priority (HIGH > MEDIUM > LOW), then complexity ascending
@@ -283,62 +318,4 @@ Parameters:
         return if (total == 1) "Next: $title" else "Next: $title (+${total - 1} more)"
     }
 
-    // ──────────────────────────────────────────────
-    // Blocking detection
-    // ──────────────────────────────────────────────
-
-    /**
-     * Checks whether a WorkItem is blocked by any unsatisfied dependency.
-     *
-     * An item is blocked if:
-     * - It has incoming BLOCKS deps (findByToItemId where type=BLOCKS) with unsatisfied blocker
-     * - It has outgoing IS_BLOCKED_BY deps (findByFromItemId where type=IS_BLOCKED_BY) with unsatisfied blocker
-     *
-     * RELATES_TO dependencies are ignored (no blocking semantics).
-     */
-    private suspend fun isBlocked(
-        item: WorkItem,
-        workItemRepo: io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository,
-        dependencyRepo: io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
-    ): Boolean {
-        // Check BLOCKS deps where this item is the target (dep.toItemId = item.id)
-        val incomingDeps = dependencyRepo.findByToItemId(item.id)
-        for (dep in incomingDeps) {
-            if (dep.type == DependencyType.BLOCKS) {
-                val threshold = dep.effectiveUnblockRole() ?: continue
-                val thresholdRole = Role.fromString(threshold) ?: continue
-                // Blocker is dep.fromItemId
-                val blockerResult = workItemRepo.getById(dep.fromItemId)
-                val blocker =
-                    when (blockerResult) {
-                        is Result.Success -> blockerResult.data
-                        is Result.Error -> continue // If we can't fetch, skip this dep
-                    }
-                if (!Role.isAtOrBeyond(blocker.role, thresholdRole)) {
-                    return true // Unsatisfied dependency
-                }
-            }
-        }
-
-        // Check IS_BLOCKED_BY deps where this item is the source (dep.fromItemId = item.id)
-        val outgoingDeps = dependencyRepo.findByFromItemId(item.id)
-        for (dep in outgoingDeps) {
-            if (dep.type == DependencyType.IS_BLOCKED_BY) {
-                val threshold = dep.effectiveUnblockRole() ?: continue
-                val thresholdRole = Role.fromString(threshold) ?: continue
-                // Blocker is dep.toItemId
-                val blockerResult = workItemRepo.getById(dep.toItemId)
-                val blocker =
-                    when (blockerResult) {
-                        is Result.Success -> blockerResult.data
-                        is Result.Error -> continue
-                    }
-                if (!Role.isAtOrBeyond(blocker.role, thresholdRole)) {
-                    return true
-                }
-            }
-        }
-
-        return false
-    }
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/NextItemOrder.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/NextItemOrder.kt
@@ -1,0 +1,33 @@
+package io.github.jpicklyk.mcptask.current.domain.model
+
+/**
+ * Ordering strategy for [io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository.findClaimable].
+ *
+ * - [PRIORITY_THEN_COMPLEXITY] — existing get_next_item ranking (default): HIGH > MEDIUM > LOW,
+ *   then complexity ascending (quick wins first).
+ * - [OLDEST_FIRST] — createdAt ASC; useful for FIFO queue drain (Ralph-style).
+ * - [NEWEST_FIRST] — createdAt DESC; useful for recency-biased selection.
+ */
+enum class NextItemOrder {
+    PRIORITY_THEN_COMPLEXITY,
+    OLDEST_FIRST,
+    NEWEST_FIRST;
+
+    companion object {
+        /**
+         * Parse a nullable string to [NextItemOrder], returning null for unrecognised values.
+         *
+         * Recognised aliases:
+         * - null or "priority" → [PRIORITY_THEN_COMPLEXITY]
+         * - "oldest"          → [OLDEST_FIRST]
+         * - "newest"          → [NEWEST_FIRST]
+         */
+        fun fromString(s: String?): NextItemOrder? =
+            when (s?.lowercase()) {
+                null, "priority" -> PRIORITY_THEN_COMPLEXITY
+                "oldest" -> OLDEST_FIRST
+                "newest" -> NEWEST_FIRST
+                else -> null
+            }
+    }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
@@ -1,5 +1,6 @@
 package io.github.jpicklyk.mcptask.current.domain.repository
 
+import io.github.jpicklyk.mcptask.current.domain.model.NextItemOrder
 import io.github.jpicklyk.mcptask.current.domain.model.Priority
 import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
@@ -267,6 +268,44 @@ interface WorkItemRepository {
         parentId: UUID? = null,
         excludeActiveClaims: Boolean = true,
         limit: Int = 200
+    ): Result<List<WorkItem>>
+
+    /**
+     * Find work items that are eligible to be claimed, combining the filter flexibility of
+     * [findByFilters] with the active-claim exclusion logic of [findForNextItem].
+     *
+     * Active-claim exclusion (`claimed_by IS NULL OR claim_expires_at <= now`) is **always** applied —
+     * it is not a parameter because claim-eligibility by definition means the item is unclaimed or
+     * its claim has expired. All filters are combined with AND logic; tags use OR logic within the list.
+     *
+     * @param role              The role to query (required — e.g. QUEUE, WORK, REVIEW).
+     * @param parentId          Optional parent UUID to scope results to direct children only.
+     * @param tags              Optional list of tags; items matching ANY tag are included.
+     * @param priority          Optional priority filter.
+     * @param type              Optional type string filter (exact match).
+     * @param complexityMax     Optional upper bound (inclusive) on item complexity.
+     * @param createdAfter      Optional lower bound (inclusive) on [WorkItem.createdAt].
+     * @param createdBefore     Optional upper bound (inclusive) on [WorkItem.createdAt].
+     * @param roleChangedAfter  Optional lower bound (inclusive) on [WorkItem.roleChangedAt].
+     * @param roleChangedBefore Optional upper bound (inclusive) on [WorkItem.roleChangedAt].
+     * @param orderBy           Ordering strategy for the result set (default: priority then complexity).
+     * @param limit             Maximum number of rows to return (default: 200).
+     * @return [Result.Success] with the list of matching, claimable items (may be empty), or
+     *         [Result.Error] on a database failure.
+     */
+    suspend fun findClaimable(
+        role: Role,
+        parentId: UUID? = null,
+        tags: List<String>? = null,
+        priority: Priority? = null,
+        type: String? = null,
+        complexityMax: Int? = null,
+        createdAfter: Instant? = null,
+        createdBefore: Instant? = null,
+        roleChangedAfter: Instant? = null,
+        roleChangedBefore: Instant? = null,
+        orderBy: NextItemOrder = NextItemOrder.PRIORITY_THEN_COMPLEXITY,
+        limit: Int = 200,
     ): Result<List<WorkItem>>
 
     /**

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -1,5 +1,6 @@
 package io.github.jpicklyk.mcptask.current.infrastructure.repository
 
+import io.github.jpicklyk.mcptask.current.domain.model.NextItemOrder
 import io.github.jpicklyk.mcptask.current.domain.model.Priority
 import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
@@ -11,7 +12,10 @@ import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.WorkItemsTable
+import org.jetbrains.exposed.v1.core.Case
 import org.jetbrains.exposed.v1.core.CustomFunction
+import org.jetbrains.exposed.v1.core.IntegerColumnType
+import org.jetbrains.exposed.v1.core.LiteralOp
 import org.jetbrains.exposed.v1.core.LowerCase
 import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.ResultRow
@@ -693,6 +697,92 @@ class SQLiteWorkItemRepository(
                     .where { combined }
                     .limit(limit)
                     .mapNotNull { toWorkItemOrNull(it) }
+
+            Result.Success(items)
+        }
+
+    override suspend fun findClaimable(
+        role: Role,
+        parentId: UUID?,
+        tags: List<String>?,
+        priority: Priority?,
+        type: String?,
+        complexityMax: Int?,
+        createdAfter: Instant?,
+        createdBefore: Instant?,
+        roleChangedAfter: Instant?,
+        roleChangedBefore: Instant?,
+        orderBy: NextItemOrder,
+        limit: Int,
+    ): Result<List<WorkItem>> =
+        databaseManager.suspendedTransaction("Failed to find claimable items") {
+            val conditions = mutableListOf<Op<Boolean>>()
+
+            // Role filter — always required
+            conditions.add(WorkItemsTable.role eq role.name.lowercase())
+
+            // Optional parent scope
+            parentId?.let { conditions.add(WorkItemsTable.parentId eq it) }
+
+            // Tag any-match — reuse buildTagFilter (OR logic within list)
+            tags?.takeIf { it.isNotEmpty() }?.let { conditions.add(buildTagFilter(it)) }
+
+            // Priority exact match
+            priority?.let { conditions.add(WorkItemsTable.priority eq it.name.lowercase()) }
+
+            // Type exact match
+            type?.let { conditions.add(WorkItemsTable.type eq it) }
+
+            // Complexity upper bound (inclusive)
+            complexityMax?.let { conditions.add(WorkItemsTable.complexity lessEq it) }
+
+            // Created-at time window
+            createdAfter?.let { conditions.add(WorkItemsTable.createdAt greaterEq it) }
+            createdBefore?.let { conditions.add(WorkItemsTable.createdAt lessEq it) }
+
+            // Role-changed-at time window
+            roleChangedAfter?.let { conditions.add(WorkItemsTable.roleChangedAt greaterEq it) }
+            roleChangedBefore?.let { conditions.add(WorkItemsTable.roleChangedAt lessEq it) }
+
+            // Active-claim exclusion — always applied; claim-eligibility by definition requires this.
+            // Include items where: claimed_by IS NULL  OR  claim_expires_at <= now.
+            // DB-side now avoids JVM/SQLite clock skew.
+            val dbNowInstant = dbNow()
+            conditions.add(WorkItemsTable.claimedBy.isNull() or (WorkItemsTable.claimExpiresAt lessEq dbNowInstant))
+
+            val combined = conditions.reduce { acc, op -> acc and op }
+
+            val baseQuery = WorkItemsTable.selectAll().where { combined }
+
+            // Apply ordering strategy
+            val orderedQuery =
+                when (orderBy) {
+                    NextItemOrder.PRIORITY_THEN_COMPLEXITY -> {
+                        // Sort priority HIGH > MEDIUM > LOW via CASE expression, then complexity ASC.
+                        // Items with null complexity sort last (NULL sorts last in ASC for SQLite/H2).
+                        val priorityOrder =
+                            Case()
+                                .When(
+                                    WorkItemsTable.priority eq Priority.HIGH.name.lowercase(),
+                                    LiteralOp(IntegerColumnType(), 0),
+                                ).When(
+                                    WorkItemsTable.priority eq Priority.MEDIUM.name.lowercase(),
+                                    LiteralOp(IntegerColumnType(), 1),
+                                ).When(
+                                    WorkItemsTable.priority eq Priority.LOW.name.lowercase(),
+                                    LiteralOp(IntegerColumnType(), 2),
+                                ).Else(LiteralOp(IntegerColumnType(), 99))
+                        baseQuery
+                            .orderBy(priorityOrder, SortOrder.ASC)
+                            .orderBy(WorkItemsTable.complexity, SortOrder.ASC_NULLS_LAST)
+                    }
+                    NextItemOrder.OLDEST_FIRST ->
+                        baseQuery.orderBy(WorkItemsTable.createdAt, SortOrder.ASC)
+                    NextItemOrder.NEWEST_FIRST ->
+                        baseQuery.orderBy(WorkItemsTable.createdAt, SortOrder.DESC)
+                }
+
+            val items = orderedQuery.limit(limit).mapNotNull { toWorkItemOrNull(it) }
 
             Result.Success(items)
         }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
@@ -2,6 +2,7 @@ package io.github.jpicklyk.mcptask.current.interfaces.mcp
 
 import io.github.jpicklyk.mcptask.current.application.service.ActorVerifier
 import io.github.jpicklyk.mcptask.current.application.service.IdempotencyCache
+import io.github.jpicklyk.mcptask.current.application.service.NextItemRecommender
 import io.github.jpicklyk.mcptask.current.application.service.NoOpActorVerifier
 import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
 import io.github.jpicklyk.mcptask.current.application.tools.compound.CompleteTreeTool
@@ -91,6 +92,11 @@ class CurrentMcpServer(
             val mcpLoggingService = DefaultMcpLoggingService()
             val (actorVerifier, degradedModePolicy) = createActorVerifierAndPolicy()
             val idempotencyCache = IdempotencyCache()
+            val nextItemRecommender =
+                NextItemRecommender(
+                    repositoryProvider.workItemRepository(),
+                    repositoryProvider.dependencyRepository()
+                )
             val toolContext =
                 ToolExecutionContext(
                     repositoryProvider,
@@ -99,7 +105,8 @@ class CurrentMcpServer(
                     mcpLoggingService,
                     actorVerifier,
                     degradedModePolicy,
-                    idempotencyCache
+                    idempotencyCache,
+                    nextItemRecommender
                 )
             logger.info("Repository provider and tool context initialized")
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommenderTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommenderTest.kt
@@ -302,6 +302,34 @@ class NextItemRecommenderTest {
             assertEquals(1, result.data.size, "Dep with unblockAt=work satisfied when blocker is WORK")
         }
 
+    @Test
+    fun `blocker item that cannot be fetched (deleted or repo error) is skipped conservatively`(): Unit =
+        runBlocking {
+            // The recommender's isBlocked walk has a "skip conservatively" branch when
+            // workItemRepo.getById(blockerId) returns Result.Error (e.g., the blocker was
+            // deleted, or a transient repo failure). The dep is treated as not-blocking
+            // rather than blocking, so the candidate item remains eligible.
+            val missingBlockerId = UUID.randomUUID()
+            val item = workItem(title = "Item with phantom blocker")
+
+            stubFindClaimable(listOf(item))
+            every { dependencyRepo.findByToItemId(item.id) } returns
+                listOf(blocksDep(fromItemId = missingBlockerId, toItemId = item.id))
+            every { dependencyRepo.findByFromItemId(item.id) } returns emptyList()
+            coEvery { workItemRepo.getById(missingBlockerId) } returns
+                Result.Error(RepositoryError.NotFound(missingBlockerId, "WorkItem not found"))
+
+            val result = recommender.recommend(NextItemRecommender.Criteria(), limit = 10)
+
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(
+                1,
+                result.data.size,
+                "Item must remain eligible when its blocker cannot be fetched — the dep is skipped conservatively"
+            )
+            assertEquals(item.id, result.data[0].id)
+        }
+
     // -----------------------------------------------------------------------
     // Limit applied AFTER blocking filter (over-fetch scenario)
     // -----------------------------------------------------------------------

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommenderTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommenderTest.kt
@@ -48,14 +48,22 @@ class NextItemRecommenderTest {
         parentId: UUID? = null,
     ) = WorkItem(id = id, title = title, role = role, priority = priority, complexity = complexity, parentId = parentId)
 
-    private fun blocksDep(fromItemId: UUID, toItemId: UUID, unblockAt: String? = null) =
-        Dependency(fromItemId = fromItemId, toItemId = toItemId, type = DependencyType.BLOCKS, unblockAt = unblockAt)
+    private fun blocksDep(
+        fromItemId: UUID,
+        toItemId: UUID,
+        unblockAt: String? = null
+    ) = Dependency(fromItemId = fromItemId, toItemId = toItemId, type = DependencyType.BLOCKS, unblockAt = unblockAt)
 
-    private fun isBlockedByDep(fromItemId: UUID, toItemId: UUID, unblockAt: String? = null) =
-        Dependency(fromItemId = fromItemId, toItemId = toItemId, type = DependencyType.IS_BLOCKED_BY, unblockAt = unblockAt)
+    private fun isBlockedByDep(
+        fromItemId: UUID,
+        toItemId: UUID,
+        unblockAt: String? = null
+    ) = Dependency(fromItemId = fromItemId, toItemId = toItemId, type = DependencyType.IS_BLOCKED_BY, unblockAt = unblockAt)
 
-    private fun relatesToDep(fromItemId: UUID, toItemId: UUID) =
-        Dependency(fromItemId = fromItemId, toItemId = toItemId, type = DependencyType.RELATES_TO)
+    private fun relatesToDep(
+        fromItemId: UUID,
+        toItemId: UUID
+    ) = Dependency(fromItemId = fromItemId, toItemId = toItemId, type = DependencyType.RELATES_TO)
 
     /** Stub findClaimable to return a fixed list with no dependency activity. */
     private fun stubFindClaimable(
@@ -109,19 +117,20 @@ class NextItemRecommenderTest {
             val roleAfter = Instant.parse("2024-02-01T00:00:00Z")
             val roleBefore = Instant.parse("2024-05-01T00:00:00Z")
 
-            val criteria = NextItemRecommender.Criteria(
-                role = Role.WORK,
-                parentId = parentId,
-                tags = listOf("backend", "api"),
-                priority = Priority.HIGH,
-                type = "feature-task",
-                complexityMax = 3,
-                createdAfter = after,
-                createdBefore = before,
-                roleChangedAfter = roleAfter,
-                roleChangedBefore = roleBefore,
-                orderBy = NextItemOrder.OLDEST_FIRST,
-            )
+            val criteria =
+                NextItemRecommender.Criteria(
+                    role = Role.WORK,
+                    parentId = parentId,
+                    tags = listOf("backend", "api"),
+                    priority = Priority.HIGH,
+                    type = "feature-task",
+                    complexityMax = 3,
+                    createdAfter = after,
+                    createdBefore = before,
+                    roleChangedAfter = roleAfter,
+                    roleChangedBefore = roleBefore,
+                    orderBy = NextItemOrder.OLDEST_FIRST,
+                )
 
             val item = workItem(role = Role.WORK, priority = Priority.HIGH)
             coEvery {
@@ -205,7 +214,7 @@ class NextItemRecommenderTest {
     @Test
     fun `item blocked by BLOCKS dep with unsatisfied blocker is excluded`(): Unit =
         runBlocking {
-            val blocker = workItem(role = Role.QUEUE)  // not yet terminal
+            val blocker = workItem(role = Role.QUEUE) // not yet terminal
             val blocked = workItem()
 
             stubFindClaimable(listOf(blocked))

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommenderTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommenderTest.kt
@@ -1,0 +1,392 @@
+package io.github.jpicklyk.mcptask.current.application.service
+
+import io.github.jpicklyk.mcptask.current.domain.model.Dependency
+import io.github.jpicklyk.mcptask.current.domain.model.DependencyType
+import io.github.jpicklyk.mcptask.current.domain.model.NextItemOrder
+import io.github.jpicklyk.mcptask.current.domain.model.Priority
+import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.RepositoryError
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class NextItemRecommenderTest {
+    private lateinit var workItemRepo: WorkItemRepository
+    private lateinit var dependencyRepo: DependencyRepository
+    private lateinit var recommender: NextItemRecommender
+
+    @BeforeEach
+    fun setUp() {
+        workItemRepo = mockk()
+        dependencyRepo = mockk()
+        recommender = NextItemRecommender(workItemRepo, dependencyRepo)
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private fun workItem(
+        id: UUID = UUID.randomUUID(),
+        title: String = "Item",
+        role: Role = Role.QUEUE,
+        priority: Priority = Priority.MEDIUM,
+        complexity: Int = 5,
+        parentId: UUID? = null,
+    ) = WorkItem(id = id, title = title, role = role, priority = priority, complexity = complexity, parentId = parentId)
+
+    private fun blocksDep(fromItemId: UUID, toItemId: UUID, unblockAt: String? = null) =
+        Dependency(fromItemId = fromItemId, toItemId = toItemId, type = DependencyType.BLOCKS, unblockAt = unblockAt)
+
+    private fun isBlockedByDep(fromItemId: UUID, toItemId: UUID, unblockAt: String? = null) =
+        Dependency(fromItemId = fromItemId, toItemId = toItemId, type = DependencyType.IS_BLOCKED_BY, unblockAt = unblockAt)
+
+    private fun relatesToDep(fromItemId: UUID, toItemId: UUID) =
+        Dependency(fromItemId = fromItemId, toItemId = toItemId, type = DependencyType.RELATES_TO)
+
+    /** Stub findClaimable to return a fixed list with no dependency activity. */
+    private fun stubFindClaimable(
+        items: List<WorkItem>,
+        role: Role = Role.QUEUE,
+        parentId: UUID? = null,
+        tags: List<String>? = null,
+        priority: Priority? = null,
+        type: String? = null,
+        complexityMax: Int? = null,
+        createdAfter: Instant? = null,
+        createdBefore: Instant? = null,
+        roleChangedAfter: Instant? = null,
+        roleChangedBefore: Instant? = null,
+        orderBy: NextItemOrder = NextItemOrder.PRIORITY_THEN_COMPLEXITY,
+    ) {
+        coEvery {
+            workItemRepo.findClaimable(
+                role = role,
+                parentId = parentId,
+                tags = tags,
+                priority = priority,
+                type = type,
+                complexityMax = complexityMax,
+                createdAfter = createdAfter,
+                createdBefore = createdBefore,
+                roleChangedAfter = roleChangedAfter,
+                roleChangedBefore = roleChangedBefore,
+                orderBy = orderBy,
+                limit = 200,
+            )
+        } returns Result.Success(items)
+    }
+
+    /** Stub both dep lookups to return empty lists for all items. */
+    private fun stubNoDependencies() {
+        every { dependencyRepo.findByToItemId(any()) } returns emptyList()
+        every { dependencyRepo.findByFromItemId(any()) } returns emptyList()
+    }
+
+    // -----------------------------------------------------------------------
+    // Filter pass-through to repository
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `criteria fields are passed 1-to-1 to findClaimable`(): Unit =
+        runBlocking {
+            val parentId = UUID.randomUUID()
+            val after = Instant.parse("2024-01-01T00:00:00Z")
+            val before = Instant.parse("2024-06-01T00:00:00Z")
+            val roleAfter = Instant.parse("2024-02-01T00:00:00Z")
+            val roleBefore = Instant.parse("2024-05-01T00:00:00Z")
+
+            val criteria = NextItemRecommender.Criteria(
+                role = Role.WORK,
+                parentId = parentId,
+                tags = listOf("backend", "api"),
+                priority = Priority.HIGH,
+                type = "feature-task",
+                complexityMax = 3,
+                createdAfter = after,
+                createdBefore = before,
+                roleChangedAfter = roleAfter,
+                roleChangedBefore = roleBefore,
+                orderBy = NextItemOrder.OLDEST_FIRST,
+            )
+
+            val item = workItem(role = Role.WORK, priority = Priority.HIGH)
+            coEvery {
+                workItemRepo.findClaimable(
+                    role = Role.WORK,
+                    parentId = parentId,
+                    tags = listOf("backend", "api"),
+                    priority = Priority.HIGH,
+                    type = "feature-task",
+                    complexityMax = 3,
+                    createdAfter = after,
+                    createdBefore = before,
+                    roleChangedAfter = roleAfter,
+                    roleChangedBefore = roleBefore,
+                    orderBy = NextItemOrder.OLDEST_FIRST,
+                    limit = 200,
+                )
+            } returns Result.Success(listOf(item))
+            every { dependencyRepo.findByToItemId(item.id) } returns emptyList()
+            every { dependencyRepo.findByFromItemId(item.id) } returns emptyList()
+
+            val result = recommender.recommend(criteria, limit = 10)
+
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size)
+
+            // Verify the repo was called exactly once with the correct args
+            coVerify(exactly = 1) {
+                workItemRepo.findClaimable(
+                    role = Role.WORK,
+                    parentId = parentId,
+                    tags = listOf("backend", "api"),
+                    priority = Priority.HIGH,
+                    type = "feature-task",
+                    complexityMax = 3,
+                    createdAfter = after,
+                    createdBefore = before,
+                    roleChangedAfter = roleAfter,
+                    roleChangedBefore = roleBefore,
+                    orderBy = NextItemOrder.OLDEST_FIRST,
+                    limit = 200,
+                )
+            }
+        }
+
+    @Test
+    fun `default criteria uses QUEUE role and PRIORITY_THEN_COMPLEXITY order`(): Unit =
+        runBlocking {
+            val criteria = NextItemRecommender.Criteria()
+            val item = workItem()
+
+            stubFindClaimable(listOf(item))
+            stubNoDependencies()
+
+            val result = recommender.recommend(criteria, limit = 1)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size)
+
+            coVerify(exactly = 1) {
+                workItemRepo.findClaimable(
+                    role = Role.QUEUE,
+                    parentId = null,
+                    tags = null,
+                    priority = null,
+                    type = null,
+                    complexityMax = null,
+                    createdAfter = null,
+                    createdBefore = null,
+                    roleChangedAfter = null,
+                    roleChangedBefore = null,
+                    orderBy = NextItemOrder.PRIORITY_THEN_COMPLEXITY,
+                    limit = 200,
+                )
+            }
+        }
+
+    // -----------------------------------------------------------------------
+    // Dependency-blocked items excluded
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `item blocked by BLOCKS dep with unsatisfied blocker is excluded`(): Unit =
+        runBlocking {
+            val blocker = workItem(role = Role.QUEUE)  // not yet terminal
+            val blocked = workItem()
+
+            stubFindClaimable(listOf(blocked))
+            // blocked has an incoming BLOCKS dep from blocker
+            every { dependencyRepo.findByToItemId(blocked.id) } returns
+                listOf(blocksDep(fromItemId = blocker.id, toItemId = blocked.id))
+            every { dependencyRepo.findByFromItemId(blocked.id) } returns emptyList()
+            coEvery { workItemRepo.getById(blocker.id) } returns Result.Success(blocker)
+
+            val result = recommender.recommend(NextItemRecommender.Criteria(), limit = 10)
+
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertTrue(result.data.isEmpty(), "Blocked item should be excluded")
+        }
+
+    @Test
+    fun `item blocked by IS_BLOCKED_BY dep with unsatisfied blocker is excluded`(): Unit =
+        runBlocking {
+            val blocked = workItem()
+            val blocker = workItem(role = Role.QUEUE)
+
+            stubFindClaimable(listOf(blocked))
+            every { dependencyRepo.findByToItemId(blocked.id) } returns emptyList()
+            // blocked IS_BLOCKED_BY blocker
+            every { dependencyRepo.findByFromItemId(blocked.id) } returns
+                listOf(isBlockedByDep(fromItemId = blocked.id, toItemId = blocker.id))
+            coEvery { workItemRepo.getById(blocker.id) } returns Result.Success(blocker)
+
+            val result = recommender.recommend(NextItemRecommender.Criteria(), limit = 10)
+
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertTrue(result.data.isEmpty(), "IS_BLOCKED_BY item should be excluded")
+        }
+
+    @Test
+    fun `item with satisfied BLOCKS dep (blocker at TERMINAL) is included`(): Unit =
+        runBlocking {
+            val blocker = workItem(role = Role.TERMINAL)
+            val item = workItem()
+
+            stubFindClaimable(listOf(item))
+            every { dependencyRepo.findByToItemId(item.id) } returns
+                listOf(blocksDep(fromItemId = blocker.id, toItemId = item.id))
+            every { dependencyRepo.findByFromItemId(item.id) } returns emptyList()
+            coEvery { workItemRepo.getById(blocker.id) } returns Result.Success(blocker)
+
+            val result = recommender.recommend(NextItemRecommender.Criteria(), limit = 10)
+
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size, "Item with satisfied dep should be included")
+        }
+
+    @Test
+    fun `RELATES_TO dep does not block item`(): Unit =
+        runBlocking {
+            val related = workItem(role = Role.QUEUE)
+            val item = workItem()
+
+            stubFindClaimable(listOf(item))
+            every { dependencyRepo.findByToItemId(item.id) } returns
+                listOf(relatesToDep(fromItemId = related.id, toItemId = item.id))
+            every { dependencyRepo.findByFromItemId(item.id) } returns emptyList()
+
+            val result = recommender.recommend(NextItemRecommender.Criteria(), limit = 10)
+
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size, "RELATES_TO dep should not block item")
+        }
+
+    @Test
+    fun `custom unblockAt work is satisfied when blocker is at WORK`(): Unit =
+        runBlocking {
+            val blocker = workItem(role = Role.WORK)
+            val item = workItem()
+
+            stubFindClaimable(listOf(item))
+            every { dependencyRepo.findByToItemId(item.id) } returns
+                listOf(blocksDep(fromItemId = blocker.id, toItemId = item.id, unblockAt = "work"))
+            every { dependencyRepo.findByFromItemId(item.id) } returns emptyList()
+            coEvery { workItemRepo.getById(blocker.id) } returns Result.Success(blocker)
+
+            val result = recommender.recommend(NextItemRecommender.Criteria(), limit = 10)
+
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size, "Dep with unblockAt=work satisfied when blocker is WORK")
+        }
+
+    // -----------------------------------------------------------------------
+    // Limit applied AFTER blocking filter (over-fetch scenario)
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `limit applied after blocking filter — over-fetch returns 5 items, 3 blocked, limit=2 returns top 2 unblocked`(): Unit =
+        runBlocking {
+            val unblockedA = workItem(title = "Unblocked A", priority = Priority.HIGH)
+            val unblockedB = workItem(title = "Unblocked B", priority = Priority.MEDIUM)
+            val blockerX = workItem(role = Role.QUEUE, title = "Blocker X")
+            val blockerY = workItem(role = Role.QUEUE, title = "Blocker Y")
+            val blockerZ = workItem(role = Role.QUEUE, title = "Blocker Z")
+            val blockedC = workItem(title = "Blocked C")
+            val blockedD = workItem(title = "Blocked D")
+            val blockedE = workItem(title = "Blocked E")
+
+            // Repository returns 5 candidates: 2 unblocked + 3 blocked
+            stubFindClaimable(listOf(unblockedA, unblockedB, blockedC, blockedD, blockedE))
+
+            // No incoming/outgoing deps for unblocked items
+            every { dependencyRepo.findByToItemId(unblockedA.id) } returns emptyList()
+            every { dependencyRepo.findByFromItemId(unblockedA.id) } returns emptyList()
+            every { dependencyRepo.findByToItemId(unblockedB.id) } returns emptyList()
+            every { dependencyRepo.findByFromItemId(unblockedB.id) } returns emptyList()
+
+            // Each blocked item has a BLOCKS dep from an unsatisfied blocker
+            every { dependencyRepo.findByToItemId(blockedC.id) } returns
+                listOf(blocksDep(fromItemId = blockerX.id, toItemId = blockedC.id))
+            every { dependencyRepo.findByFromItemId(blockedC.id) } returns emptyList()
+            coEvery { workItemRepo.getById(blockerX.id) } returns Result.Success(blockerX)
+
+            every { dependencyRepo.findByToItemId(blockedD.id) } returns
+                listOf(blocksDep(fromItemId = blockerY.id, toItemId = blockedD.id))
+            every { dependencyRepo.findByFromItemId(blockedD.id) } returns emptyList()
+            coEvery { workItemRepo.getById(blockerY.id) } returns Result.Success(blockerY)
+
+            every { dependencyRepo.findByToItemId(blockedE.id) } returns
+                listOf(blocksDep(fromItemId = blockerZ.id, toItemId = blockedE.id))
+            every { dependencyRepo.findByFromItemId(blockedE.id) } returns emptyList()
+            coEvery { workItemRepo.getById(blockerZ.id) } returns Result.Success(blockerZ)
+
+            // limit=2 → should return exactly the 2 unblocked items, not the blocked ones
+            val result = recommender.recommend(NextItemRecommender.Criteria(), limit = 2)
+
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(2, result.data.size, "Should return exactly 2 items after blocking filter")
+            val ids = result.data.map { it.id }
+            assertTrue(ids.contains(unblockedA.id), "unblockedA should be in result")
+            assertTrue(ids.contains(unblockedB.id), "unblockedB should be in result")
+        }
+
+    // -----------------------------------------------------------------------
+    // Empty result
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `empty repository result returns empty success (not error)`(): Unit =
+        runBlocking {
+            stubFindClaimable(emptyList())
+
+            val result = recommender.recommend(NextItemRecommender.Criteria(), limit = 5)
+
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertTrue(result.data.isEmpty())
+        }
+
+    // -----------------------------------------------------------------------
+    // Repository error propagation
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `repository error propagates as Result Error`(): Unit =
+        runBlocking {
+            val repoError = RepositoryError.DatabaseError("connection failed")
+            coEvery {
+                workItemRepo.findClaimable(
+                    role = any(),
+                    parentId = any(),
+                    tags = any(),
+                    priority = any(),
+                    type = any(),
+                    complexityMax = any(),
+                    createdAfter = any(),
+                    createdBefore = any(),
+                    roleChangedAfter = any(),
+                    roleChangedBefore = any(),
+                    orderBy = any(),
+                    limit = any(),
+                )
+            } returns Result.Error(repoError)
+
+            val result = recommender.recommend(NextItemRecommender.Criteria(), limit = 5)
+
+            assertIs<Result.Error>(result)
+            assertEquals(repoError, result.error)
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommenderTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommenderTest.kt
@@ -382,6 +382,39 @@ class NextItemRecommenderTest {
         }
 
     // -----------------------------------------------------------------------
+    // OVER_FETCH_LIMIT exhaustion — every candidate is blocked
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `all candidates blocked returns empty success without crash (OVER_FETCH_LIMIT exhaustion)`(): Unit =
+        runBlocking {
+            // Simulates the silent-starvation edge case noted in OVER_FETCH_LIMIT KDoc:
+            // every over-fetched candidate fails the dependency-blocking walk. The
+            // recommender must return Result.Success(emptyList()) — not an error, not a
+            // crash. Callers may legitimately receive 0 items even when the underlying
+            // queue has many candidates, if blocking-filter drop rates are high.
+            val blocker = workItem(role = Role.QUEUE, title = "Blocker (not yet at terminal)")
+            val blockedItems = (1..10).map { i -> workItem(title = "Blocked #$i") }
+
+            stubFindClaimable(blockedItems)
+
+            blockedItems.forEach { item ->
+                every { dependencyRepo.findByToItemId(item.id) } returns
+                    listOf(blocksDep(fromItemId = blocker.id, toItemId = item.id))
+                every { dependencyRepo.findByFromItemId(item.id) } returns emptyList()
+            }
+            coEvery { workItemRepo.getById(blocker.id) } returns Result.Success(blocker)
+
+            val result = recommender.recommend(NextItemRecommender.Criteria(), limit = 5)
+
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertTrue(
+                result.data.isEmpty(),
+                "All candidates blocked must yield empty Success — not error, not partial"
+            )
+        }
+
+    // -----------------------------------------------------------------------
     // Empty result
     // -----------------------------------------------------------------------
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolBatchCompositionTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolBatchCompositionTest.kt
@@ -60,7 +60,10 @@ class ClaimItemToolBatchCompositionTest : SQLiteRepositoryTestBase() {
             put("kind", "orchestrator")
         }
 
-    private suspend fun createItem(title: String, role: Role = Role.QUEUE): WorkItem {
+    private suspend fun createItem(
+        title: String,
+        role: Role = Role.QUEUE
+    ): WorkItem {
         val result = repository.create(WorkItem(title = title, role = role))
         assertIs<Result.Success<WorkItem>>(result)
         return result.data
@@ -152,15 +155,20 @@ class ClaimItemToolBatchCompositionTest : SQLiteRepositoryTestBase() {
         }
 
     /**
-     * Selector + multi-release composition: agent holds two items (ITEM_A and ITEM_B),
-     * issues a selector claim (finds ITEM_C from the queue) plus explicit releases for ITEM_A and ITEM_B.
+     * Selector + multi-release composition: ITEM_A is held by agent-other (a different agent),
+     * ITEM_B is held by agent-alpha. The batch from agent-alpha issues a selector claim plus
+     * explicit releases for ITEM_A and ITEM_B.
+     *
+     * Per `findClaimable`'s active-claim exclusion, only ITEM_C is eligible for the selector,
+     * so the resolution is deterministic. The 2-agent setup is required by the
+     * one-claim-per-agent rule: agent-alpha cannot hold both ITEM_A and ITEM_B simultaneously.
      *
      * Expected outcomes:
-     * - claimResults[0]: success for ITEM_C (resolved by selector), selectorResolved=true.
-     * - The claim() call atomically auto-releases ITEM_A (or ITEM_B) for the agent.
-     * - releaseResults: both ITEM_A and ITEM_B release calls — at least one succeeds, one may
-     *   be not_claimed_by_you if it was auto-released by the claim step.
-     * - End-state: only ITEM_C is held by agent-alpha.
+     * - claimResults[0]: success for ITEM_C, selectorResolved=true.
+     * - The claim(ITEM_C) Step 2 atomically auto-releases ITEM_B (agent-alpha's prior claim).
+     * - releaseResults[0] (ITEM_A): not_claimed_by_you (held by agent-other, never by alpha).
+     * - releaseResults[1] (ITEM_B): not_claimed_by_you (auto-released by Step 2 above).
+     * - End-state: ITEM_C held by agent-alpha, ITEM_A still held by agent-other, ITEM_B unclaimed.
      *
      * This test exercises the selector path through the REAL SQLite repository (no mocks)
      * to verify the full chain: selector → findClaimable → blocking-walk → claim().
@@ -168,13 +176,15 @@ class ClaimItemToolBatchCompositionTest : SQLiteRepositoryTestBase() {
     @Test
     fun `selector claim with multi-release resolves queue item and releases held items`(): Unit =
         runBlocking {
+            val agentOther = "agent-other"
             val itemA = createItem("Item A")
             val itemB = createItem("Item B")
             val itemC = createItem("Item C")
 
-            // Pre-state: agent-alpha holds ITEM_A.
-            assertIs<ClaimResult.Success>(repository.claim(itemA.id, agentAlpha, 900))
-            // Also claim ITEM_B in a second call — the claim for ITEM_B auto-releases ITEM_A
+            // Pre-state: ITEM_A held by agent-other, ITEM_B held by agent-alpha.
+            // Two-agent setup ensures ITEM_C is the only unclaimed candidate — selector resolution
+            // is deterministic without depending on tie-breaking.
+            assertIs<ClaimResult.Success>(repository.claim(itemA.id, agentOther, 900))
             assertIs<ClaimResult.Success>(repository.claim(itemB.id, agentAlpha, 900))
 
             val params =
@@ -204,24 +214,50 @@ class ClaimItemToolBatchCompositionTest : SQLiteRepositoryTestBase() {
             val response = tool.execute(params, context()) as JsonObject
             val data = response["data"] as JsonObject
 
-            // --- claimResults: selector resolved ITEM_C and claimed it ---
+            // --- claimResults: selector deterministically resolved ITEM_C ---
             val claimResults = data["claimResults"] as JsonArray
             assertEquals(1, claimResults.size)
             val claimEntry = claimResults[0] as JsonObject
             assertEquals("success", claimEntry["outcome"]!!.jsonPrimitive.content)
-            // selectorResolved flag must be present and true
             assertEquals(true, claimEntry["selectorResolved"]?.jsonPrimitive?.booleanOrNull)
-            // The itemId that was resolved must be ITEM_C (only unclaimed item in queue)
             assertEquals(itemC.id.toString(), claimEntry["itemId"]!!.jsonPrimitive.content)
             assertEquals(agentAlpha, claimEntry["claimedBy"]!!.jsonPrimitive.content)
 
-            // --- summary: 1 claim succeeded ---
+            // --- releaseResults: both A and B return not_claimed_by_you for agent-alpha ---
+            val releaseResults = data["releaseResults"] as JsonArray
+            assertEquals(2, releaseResults.size)
+            val releaseA = releaseResults[0] as JsonObject
+            assertEquals(itemA.id.toString(), releaseA["itemId"]!!.jsonPrimitive.content)
+            assertEquals(
+                "not_claimed_by_you",
+                releaseA["outcome"]!!.jsonPrimitive.content,
+                "ITEM_A is held by agent-other, not agent-alpha — release must report not_claimed_by_you"
+            )
+            val releaseB = releaseResults[1] as JsonObject
+            assertEquals(itemB.id.toString(), releaseB["itemId"]!!.jsonPrimitive.content)
+            assertEquals(
+                "not_claimed_by_you",
+                releaseB["outcome"]!!.jsonPrimitive.content,
+                "ITEM_B was auto-released by claim(ITEM_C) Step 2 — explicit release must report not_claimed_by_you"
+            )
+
+            // --- summary: 1 claim succeeded, 0 releases succeeded ---
             val summary = data["summary"] as JsonObject
             assertEquals(1, summary["claimsSucceeded"]!!.jsonPrimitive.intOrNull)
+            assertEquals(0, summary["releasesSucceeded"]!!.jsonPrimitive.intOrNull)
+            assertEquals(2, summary["releasesFailed"]!!.jsonPrimitive.intOrNull)
 
-            // --- End-state: ITEM_C is claimed by agent-alpha ---
+            // --- End-state: ITEM_C held by agent-alpha, ITEM_A still by agent-other, ITEM_B unclaimed ---
             val itemCAfter = repository.getById(itemC.id)
             assertIs<Result.Success<WorkItem>>(itemCAfter)
             assertEquals(agentAlpha, itemCAfter.data.claimedBy, "ITEM_C must be claimed by agent-alpha")
+
+            val itemAAfter = repository.getById(itemA.id)
+            assertIs<Result.Success<WorkItem>>(itemAAfter)
+            assertEquals(agentOther, itemAAfter.data.claimedBy, "ITEM_A must remain claimed by agent-other")
+
+            val itemBAfter = repository.getById(itemB.id)
+            assertIs<Result.Success<WorkItem>>(itemBAfter)
+            assertNull(itemBAfter.data.claimedBy, "ITEM_B must be unclaimed (auto-released by Step 2)")
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolBatchCompositionTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolBatchCompositionTest.kt
@@ -12,6 +12,7 @@ import io.github.jpicklyk.mcptask.current.test.SQLiteRepositoryTestBase
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.intOrNull
@@ -59,8 +60,8 @@ class ClaimItemToolBatchCompositionTest : SQLiteRepositoryTestBase() {
             put("kind", "orchestrator")
         }
 
-    private suspend fun createItem(title: String): WorkItem {
-        val result = repository.create(WorkItem(title = title, role = Role.QUEUE))
+    private suspend fun createItem(title: String, role: Role = Role.QUEUE): WorkItem {
+        val result = repository.create(WorkItem(title = title, role = role))
         assertIs<Result.Success<WorkItem>>(result)
         return result.data
     }
@@ -148,5 +149,79 @@ class ClaimItemToolBatchCompositionTest : SQLiteRepositoryTestBase() {
             assertIs<Result.Success<WorkItem>>(itemMixedAfter)
             assertEquals(agentAlpha, itemMixedAfter.data.claimedBy)
             assertNotNull(itemMixedAfter.data.claimExpiresAt)
+        }
+
+    /**
+     * Selector + multi-release composition: agent holds two items (ITEM_A and ITEM_B),
+     * issues a selector claim (finds ITEM_C from the queue) plus explicit releases for ITEM_A and ITEM_B.
+     *
+     * Expected outcomes:
+     * - claimResults[0]: success for ITEM_C (resolved by selector), selectorResolved=true.
+     * - The claim() call atomically auto-releases ITEM_A (or ITEM_B) for the agent.
+     * - releaseResults: both ITEM_A and ITEM_B release calls — at least one succeeds, one may
+     *   be not_claimed_by_you if it was auto-released by the claim step.
+     * - End-state: only ITEM_C is held by agent-alpha.
+     *
+     * This test exercises the selector path through the REAL SQLite repository (no mocks)
+     * to verify the full chain: selector → findClaimable → blocking-walk → claim().
+     */
+    @Test
+    fun `selector claim with multi-release resolves queue item and releases held items`(): Unit =
+        runBlocking {
+            val itemA = createItem("Item A")
+            val itemB = createItem("Item B")
+            val itemC = createItem("Item C")
+
+            // Pre-state: agent-alpha holds ITEM_A.
+            assertIs<ClaimResult.Success>(repository.claim(itemA.id, agentAlpha, 900))
+            // Also claim ITEM_B in a second call — the claim for ITEM_B auto-releases ITEM_A
+            assertIs<ClaimResult.Success>(repository.claim(itemB.id, agentAlpha, 900))
+
+            val params =
+                buildJsonObject {
+                    put(
+                        "claims",
+                        buildJsonArray {
+                            // Selector entry — no itemId, uses selector to find from queue
+                            add(
+                                buildJsonObject {
+                                    put("selector", buildJsonObject {})
+                                }
+                            )
+                        }
+                    )
+                    put(
+                        "releases",
+                        buildJsonArray {
+                            add(buildJsonObject { put("itemId", itemA.id.toString()) })
+                            add(buildJsonObject { put("itemId", itemB.id.toString()) })
+                        }
+                    )
+                    put("actor", actor(agentAlpha))
+                    put("requestId", UUID.randomUUID().toString())
+                }
+
+            val response = tool.execute(params, context()) as JsonObject
+            val data = response["data"] as JsonObject
+
+            // --- claimResults: selector resolved ITEM_C and claimed it ---
+            val claimResults = data["claimResults"] as JsonArray
+            assertEquals(1, claimResults.size)
+            val claimEntry = claimResults[0] as JsonObject
+            assertEquals("success", claimEntry["outcome"]!!.jsonPrimitive.content)
+            // selectorResolved flag must be present and true
+            assertEquals(true, claimEntry["selectorResolved"]?.jsonPrimitive?.booleanOrNull)
+            // The itemId that was resolved must be ITEM_C (only unclaimed item in queue)
+            assertEquals(itemC.id.toString(), claimEntry["itemId"]!!.jsonPrimitive.content)
+            assertEquals(agentAlpha, claimEntry["claimedBy"]!!.jsonPrimitive.content)
+
+            // --- summary: 1 claim succeeded ---
+            val summary = data["summary"] as JsonObject
+            assertEquals(1, summary["claimsSucceeded"]!!.jsonPrimitive.intOrNull)
+
+            // --- End-state: ITEM_C is claimed by agent-alpha ---
+            val itemCAfter = repository.getById(itemC.id)
+            assertIs<Result.Success<WorkItem>>(itemCAfter)
+            assertEquals(agentAlpha, itemCAfter.data.claimedBy, "ITEM_C must be claimed by agent-alpha")
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
@@ -1032,6 +1032,59 @@ class ClaimItemToolTest {
     }
 
     @Test
+    fun `validateParams accepts selector parentId as 4-char hex prefix`() {
+        // Selector parentId now accepts UUID or hex prefix (4+ chars), matching every
+        // other parentId field on the surface (get_next_item, manage_items, create_work_tree).
+        val p =
+            buildJsonObject {
+                put(
+                    "claims",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put(
+                                    "selector",
+                                    buildJsonObject { put("parentId", "abcd1234") }
+                                )
+                            }
+                        )
+                    }
+                )
+                put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
+            }
+        // Must not throw — 8-char hex prefix is valid
+        tool.validateParams(p)
+    }
+
+    @Test
+    fun `validateParams rejects selector parentId hex prefix shorter than 4 chars`() {
+        val p =
+            buildJsonObject {
+                put(
+                    "claims",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put(
+                                    "selector",
+                                    buildJsonObject { put("parentId", "abc") }
+                                )
+                            }
+                        )
+                    }
+                )
+                put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
+            }
+        val ex = assertFailsWith<ToolValidationException> { tool.validateParams(p) }
+        assertTrue(
+            ex.message!!.contains("parentId") && ex.message!!.contains("prefix"),
+            "Error must mention parentId and prefix length. Got: ${ex.message}"
+        )
+    }
+
+    @Test
     fun `validateParams throws when claimRef exceeds 64 chars`() {
         val longRef = "a".repeat(65)
         val p =

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
@@ -1078,10 +1078,11 @@ class ClaimItemToolTest {
             coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns ClaimResult.Success(makeSuccessItem())
 
             val selectorFields = buildJsonObject { put("tags", "my-tag") }
-            val result = tool.execute(
-                params(claims = listOf(selectorEntry(selectorFields))),
-                defaultContext(nextItemRecommender = recommender)
-            )
+            val result =
+                tool.execute(
+                    params(claims = listOf(selectorEntry(selectorFields))),
+                    defaultContext(nextItemRecommender = recommender)
+                )
 
             val data = (result as JsonObject)["data"] as JsonObject
             val first = (data["claimResults"] as JsonArray)[0] as JsonObject
@@ -1167,10 +1168,11 @@ class ClaimItemToolTest {
         runBlocking {
             val recommender = mockRecommender(emptyList())
 
-            val result = tool.execute(
-                params(claims = listOf(selectorEntry())),
-                defaultContext(nextItemRecommender = recommender)
-            )
+            val result =
+                tool.execute(
+                    params(claims = listOf(selectorEntry())),
+                    defaultContext(nextItemRecommender = recommender)
+                )
 
             val data = (result as JsonObject)["data"] as JsonObject
             val first = (data["claimResults"] as JsonArray)[0] as JsonObject
@@ -1195,10 +1197,11 @@ class ClaimItemToolTest {
             coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns
                 ClaimResult.AlreadyClaimed(itemId1, retryAfterMs = 5000L)
 
-            val result = tool.execute(
-                params(claims = listOf(selectorEntry())),
-                defaultContext(nextItemRecommender = recommender)
-            )
+            val result =
+                tool.execute(
+                    params(claims = listOf(selectorEntry())),
+                    defaultContext(nextItemRecommender = recommender)
+                )
 
             val data = (result as JsonObject)["data"] as JsonObject
             val first = (data["claimResults"] as JsonArray)[0] as JsonObject
@@ -1214,10 +1217,11 @@ class ClaimItemToolTest {
             val recommender = mockk<NextItemRecommender>()
             val differentItem = WorkItem(id = itemId2, title = "Different Item", role = Role.QUEUE)
             // First call returns matchedItem; second call returns a different item (simulates queue state change)
-            coEvery { recommender.recommend(any(), 1) } returnsMany listOf(
-                Result.Success(listOf(matchedItem)),
-                Result.Success(listOf(differentItem))
-            )
+            coEvery { recommender.recommend(any(), 1) } returnsMany
+                listOf(
+                    Result.Success(listOf(matchedItem)),
+                    Result.Success(listOf(differentItem))
+                )
             coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns ClaimResult.Success(makeSuccessItem(itemId1))
 
             val requestId = UUID.randomUUID().toString()
@@ -1228,17 +1232,19 @@ class ClaimItemToolTest {
 
             // First call — resolves and claims itemId1
             val result1 = tool.execute(p, sharedContext)
-            val first1 = ((result1 as JsonObject)["data"] as JsonObject)["claimResults"].let {
-                (it as JsonArray)[0] as JsonObject
-            }
+            val first1 =
+                ((result1 as JsonObject)["data"] as JsonObject)["claimResults"].let {
+                    (it as JsonArray)[0] as JsonObject
+                }
             assertEquals("success", first1["outcome"]?.jsonPrimitive?.content)
             assertEquals(itemId1.toString(), first1["itemId"]?.jsonPrimitive?.content)
 
             // Second call with same requestId on the same context — must replay the cache, NOT call recommender again
             val result2 = tool.execute(p, sharedContext)
-            val first2 = ((result2 as JsonObject)["data"] as JsonObject)["claimResults"].let {
-                (it as JsonArray)[0] as JsonObject
-            }
+            val first2 =
+                ((result2 as JsonObject)["data"] as JsonObject)["claimResults"].let {
+                    (it as JsonArray)[0] as JsonObject
+                }
             // Replayed from cache — same itemId1, not itemId2
             assertEquals(itemId1.toString(), first2["itemId"]?.jsonPrimitive?.content)
         }
@@ -1248,10 +1254,11 @@ class ClaimItemToolTest {
         runBlocking {
             coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns ClaimResult.Success(makeSuccessItem())
 
-            val result = tool.execute(
-                params(claims = listOf(claimEntryWithRef(itemId1, "task-abc-123"))),
-                defaultContext()
-            )
+            val result =
+                tool.execute(
+                    params(claims = listOf(claimEntryWithRef(itemId1, "task-abc-123"))),
+                    defaultContext()
+                )
 
             val data = (result as JsonObject)["data"] as JsonObject
             val first = (data["claimResults"] as JsonArray)[0] as JsonObject
@@ -1264,10 +1271,11 @@ class ClaimItemToolTest {
         runBlocking {
             val recommender = mockRecommender(emptyList())
 
-            val result = tool.execute(
-                params(claims = listOf(selectorEntry(claimRef = "my-ref-42"))),
-                defaultContext(nextItemRecommender = recommender)
-            )
+            val result =
+                tool.execute(
+                    params(claims = listOf(selectorEntry(claimRef = "my-ref-42"))),
+                    defaultContext(nextItemRecommender = recommender)
+                )
 
             val data = (result as JsonObject)["data"] as JsonObject
             val first = (data["claimResults"] as JsonArray)[0] as JsonObject
@@ -1283,10 +1291,11 @@ class ClaimItemToolTest {
             coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns
                 ClaimResult.AlreadyClaimed(itemId1, retryAfterMs = 1000L)
 
-            val result = tool.execute(
-                params(claims = listOf(selectorEntry(claimRef = "my-ref"))),
-                defaultContext(nextItemRecommender = recommender)
-            )
+            val result =
+                tool.execute(
+                    params(claims = listOf(selectorEntry(claimRef = "my-ref"))),
+                    defaultContext(nextItemRecommender = recommender)
+                )
 
             val data = (result as JsonObject)["data"] as JsonObject
             val first = (data["claimResults"] as JsonArray)[0] as JsonObject

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
@@ -1223,16 +1223,19 @@ class ClaimItemToolTest {
             val requestId = UUID.randomUUID().toString()
             val p = params(claims = listOf(selectorEntry()), requestId = requestId)
 
+            // Use the SAME context object for both calls so the IdempotencyCache is shared.
+            val sharedContext = defaultContext(nextItemRecommender = recommender)
+
             // First call — resolves and claims itemId1
-            val result1 = tool.execute(p, defaultContext(nextItemRecommender = recommender))
+            val result1 = tool.execute(p, sharedContext)
             val first1 = ((result1 as JsonObject)["data"] as JsonObject)["claimResults"].let {
                 (it as JsonArray)[0] as JsonObject
             }
             assertEquals("success", first1["outcome"]?.jsonPrimitive?.content)
             assertEquals(itemId1.toString(), first1["itemId"]?.jsonPrimitive?.content)
 
-            // Second call with same requestId — must replay the cache, NOT call recommender again
-            val result2 = tool.execute(p, defaultContext(nextItemRecommender = recommender))
+            // Second call with same requestId on the same context — must replay the cache, NOT call recommender again
+            val result2 = tool.execute(p, sharedContext)
             val first2 = ((result2 as JsonObject)["data"] as JsonObject)["claimResults"].let {
                 (it as JsonArray)[0] as JsonObject
             }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
@@ -1,20 +1,25 @@
 package io.github.jpicklyk.mcptask.current.application.tools.workflow
 
 import io.github.jpicklyk.mcptask.current.application.service.ActorVerifier
+import io.github.jpicklyk.mcptask.current.application.service.NextItemRecommender
 import io.github.jpicklyk.mcptask.current.application.service.NoOpActorVerifier
 import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
 import io.github.jpicklyk.mcptask.current.application.tools.ToolValidationException
 import io.github.jpicklyk.mcptask.current.domain.model.ActorClaim
 import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
+import io.github.jpicklyk.mcptask.current.domain.model.Priority
+import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.VerificationResult
 import io.github.jpicklyk.mcptask.current.domain.model.VerificationStatus
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.repository.ClaimResult
 import io.github.jpicklyk.mcptask.current.domain.repository.ReleaseResult
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
 import io.github.jpicklyk.mcptask.current.test.MockRepositoryProvider
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonArray
@@ -41,7 +46,7 @@ import kotlin.test.assertTrue
  * Unit tests for [ClaimItemTool] — uses mocked repository, not a real DB.
  *
  * Covers: actor resolution, claim outcomes, release outcomes, tiered disclosure,
- * DegradedModePolicy.REJECT blocking, validation errors.
+ * DegradedModePolicy.REJECT blocking, validation errors, selector mode.
  */
 class ClaimItemToolTest {
     private lateinit var tool: ClaimItemTool
@@ -59,13 +64,37 @@ class ClaimItemToolTest {
             put("kind", "subagent")
         }
 
-    /** Build a claim request object. */
+    /** Build a claim request object (ID mode). */
     private fun claimEntry(
         itemId: UUID,
         ttlSeconds: Int? = null
     ): JsonObject =
         buildJsonObject {
             put("itemId", itemId.toString())
+            ttlSeconds?.let { put("ttlSeconds", it) }
+        }
+
+    /** Build a claim request object with claimRef (ID mode). */
+    private fun claimEntryWithRef(
+        itemId: UUID,
+        claimRef: String,
+        ttlSeconds: Int? = null
+    ): JsonObject =
+        buildJsonObject {
+            put("itemId", itemId.toString())
+            put("claimRef", claimRef)
+            ttlSeconds?.let { put("ttlSeconds", it) }
+        }
+
+    /** Build a selector claim entry. */
+    private fun selectorEntry(
+        selectorFields: JsonObject = buildJsonObject {},
+        claimRef: String? = null,
+        ttlSeconds: Int? = null
+    ): JsonObject =
+        buildJsonObject {
+            put("selector", selectorFields)
+            claimRef?.let { put("claimRef", it) }
             ttlSeconds?.let { put("ttlSeconds", it) }
         }
 
@@ -115,12 +144,24 @@ class ClaimItemToolTest {
         workItemRepo = mockRepo.workItemRepo
     }
 
-    private fun defaultContext(degradedModePolicy: DegradedModePolicy = DegradedModePolicy.ACCEPT_CACHED): ToolExecutionContext =
-        ToolExecutionContext(
-            repositoryProvider = mockRepo.provider,
-            actorVerifier = NoOpActorVerifier,
-            degradedModePolicy = degradedModePolicy
-        )
+    private fun defaultContext(
+        degradedModePolicy: DegradedModePolicy = DegradedModePolicy.ACCEPT_CACHED,
+        nextItemRecommender: NextItemRecommender? = null
+    ): ToolExecutionContext =
+        if (nextItemRecommender != null) {
+            ToolExecutionContext(
+                repositoryProvider = mockRepo.provider,
+                actorVerifier = NoOpActorVerifier,
+                degradedModePolicy = degradedModePolicy,
+                nextItemRecommender = nextItemRecommender,
+            )
+        } else {
+            ToolExecutionContext(
+                repositoryProvider = mockRepo.provider,
+                actorVerifier = NoOpActorVerifier,
+                degradedModePolicy = degradedModePolicy,
+            )
+        }
 
     // -----------------------------------------------------------------------
     // validateParams — error cases
@@ -788,5 +829,511 @@ class ClaimItemToolTest {
 
             // Repository must NOT have been called (policy rejection is a pre-DB guard)
             coVerify(exactly = 0) { workItemRepo.claim(any(), any(), any()) }
+        }
+
+    // -----------------------------------------------------------------------
+    // Selector validation tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `validateParams throws when claim entry has both itemId and selector`() {
+        val p =
+            buildJsonObject {
+                put(
+                    "claims",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put("itemId", itemId1.toString())
+                                put("selector", buildJsonObject {})
+                            }
+                        )
+                    }
+                )
+                put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
+            }
+        val ex = assertFailsWith<ToolValidationException> { tool.validateParams(p) }
+        assertTrue(
+            ex.message!!.contains("not both"),
+            "Error must mention 'not both'. Got: ${ex.message}"
+        )
+    }
+
+    @Test
+    fun `validateParams throws when claim entry has neither itemId nor selector`() {
+        val p =
+            buildJsonObject {
+                put(
+                    "claims",
+                    buildJsonArray {
+                        add(buildJsonObject { put("ttlSeconds", 900) })
+                    }
+                )
+                put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
+            }
+        val ex = assertFailsWith<ToolValidationException> { tool.validateParams(p) }
+        assertTrue(
+            ex.message!!.contains("not neither") || ex.message!!.contains("neither"),
+            "Error must mention 'neither'. Got: ${ex.message}"
+        )
+    }
+
+    @Test
+    fun `validateParams throws when claims has two selector entries`() {
+        val selector = buildJsonObject {}
+        val p =
+            buildJsonObject {
+                put(
+                    "claims",
+                    buildJsonArray {
+                        add(buildJsonObject { put("selector", selector) })
+                        add(buildJsonObject { put("selector", selector) })
+                    }
+                )
+                put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
+            }
+        val ex = assertFailsWith<ToolValidationException> { tool.validateParams(p) }
+        assertTrue(
+            ex.message!!.contains("single claim per call") || ex.message!!.contains("Selector mode"),
+            "Error must mention selector mode constraint. Got: ${ex.message}"
+        )
+    }
+
+    @Test
+    fun `validateParams throws when claims has one selector and one itemId entry`() {
+        val p =
+            buildJsonObject {
+                put(
+                    "claims",
+                    buildJsonArray {
+                        add(buildJsonObject { put("selector", buildJsonObject {}) })
+                        add(buildJsonObject { put("itemId", itemId1.toString()) })
+                    }
+                )
+                put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
+            }
+        val ex = assertFailsWith<ToolValidationException> { tool.validateParams(p) }
+        assertTrue(
+            ex.message!!.contains("single claim per call") || ex.message!!.contains("Selector mode"),
+            "Error must mention selector mode constraint. Got: ${ex.message}"
+        )
+    }
+
+    @Test
+    fun `validateParams accepts valid selector entry with empty selector object`() {
+        val p =
+            buildJsonObject {
+                put("claims", buildJsonArray { add(selectorEntry()) })
+                put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
+            }
+        // Must not throw
+        tool.validateParams(p)
+    }
+
+    @Test
+    fun `validateParams throws for selector with invalid priority`() {
+        val p =
+            buildJsonObject {
+                put(
+                    "claims",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put(
+                                    "selector",
+                                    buildJsonObject { put("priority", "CRITICAL") }
+                                )
+                            }
+                        )
+                    }
+                )
+                put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
+            }
+        val ex = assertFailsWith<ToolValidationException> { tool.validateParams(p) }
+        assertTrue(ex.message!!.contains("priority"), "Error must mention priority. Got: ${ex.message}")
+    }
+
+    @Test
+    fun `validateParams throws for selector with complexityMax out of range`() {
+        val p =
+            buildJsonObject {
+                put(
+                    "claims",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put(
+                                    "selector",
+                                    buildJsonObject { put("complexityMax", 11) }
+                                )
+                            }
+                        )
+                    }
+                )
+                put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
+            }
+        val ex = assertFailsWith<ToolValidationException> { tool.validateParams(p) }
+        assertTrue(ex.message!!.contains("complexityMax"), "Error must mention complexityMax. Got: ${ex.message}")
+    }
+
+    @Test
+    fun `validateParams throws for selector with invalid ISO 8601 timestamp`() {
+        val p =
+            buildJsonObject {
+                put(
+                    "claims",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put(
+                                    "selector",
+                                    buildJsonObject { put("createdAfter", "not-a-timestamp") }
+                                )
+                            }
+                        )
+                    }
+                )
+                put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
+            }
+        val ex = assertFailsWith<ToolValidationException> { tool.validateParams(p) }
+        assertTrue(ex.message!!.contains("createdAfter"), "Error must mention createdAfter. Got: ${ex.message}")
+    }
+
+    @Test
+    fun `validateParams throws for selector with invalid orderBy value`() {
+        val p =
+            buildJsonObject {
+                put(
+                    "claims",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put(
+                                    "selector",
+                                    buildJsonObject { put("orderBy", "random") }
+                                )
+                            }
+                        )
+                    }
+                )
+                put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
+            }
+        val ex = assertFailsWith<ToolValidationException> { tool.validateParams(p) }
+        assertTrue(ex.message!!.contains("orderBy"), "Error must mention orderBy. Got: ${ex.message}")
+    }
+
+    @Test
+    fun `validateParams throws when claimRef exceeds 64 chars`() {
+        val longRef = "a".repeat(65)
+        val p =
+            buildJsonObject {
+                put(
+                    "claims",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put("itemId", itemId1.toString())
+                                put("claimRef", longRef)
+                            }
+                        )
+                    }
+                )
+                put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
+            }
+        val ex = assertFailsWith<ToolValidationException> { tool.validateParams(p) }
+        assertTrue(ex.message!!.contains("claimRef"), "Error must mention claimRef. Got: ${ex.message}")
+    }
+
+    // -----------------------------------------------------------------------
+    // Selector execute tests
+    // -----------------------------------------------------------------------
+
+    private fun mockRecommender(items: List<WorkItem>): NextItemRecommender {
+        val recommender = mockk<NextItemRecommender>()
+        coEvery { recommender.recommend(any(), any()) } returns Result.Success(items)
+        return recommender
+    }
+
+    @Test
+    fun `selector with tags filter claims item when recommender returns match`(): Unit =
+        runBlocking {
+            val matchedItem = WorkItem(id = itemId1, title = "Tagged Item", role = Role.QUEUE)
+            val recommender = mockk<NextItemRecommender>()
+            coEvery {
+                recommender.recommend(
+                    match { it.tags == listOf("my-tag") },
+                    1
+                )
+            } returns Result.Success(listOf(matchedItem))
+            coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns ClaimResult.Success(makeSuccessItem())
+
+            val selectorFields = buildJsonObject { put("tags", "my-tag") }
+            val result = tool.execute(
+                params(claims = listOf(selectorEntry(selectorFields))),
+                defaultContext(nextItemRecommender = recommender)
+            )
+
+            val data = (result as JsonObject)["data"] as JsonObject
+            val first = (data["claimResults"] as JsonArray)[0] as JsonObject
+            assertEquals("success", first["outcome"]?.jsonPrimitive?.content)
+            assertEquals(itemId1.toString(), first["itemId"]?.jsonPrimitive?.content)
+            assertEquals(true, first["selectorResolved"]?.jsonPrimitive?.booleanOrNull)
+        }
+
+    @Test
+    fun `selector with priority filter passes correct criteria to recommender`(): Unit =
+        runBlocking {
+            val matchedItem = WorkItem(id = itemId1, title = "High Priority Item", role = Role.QUEUE)
+            val recommender = mockk<NextItemRecommender>()
+            val criteriaSlot = slot<NextItemRecommender.Criteria>()
+            coEvery { recommender.recommend(capture(criteriaSlot), 1) } returns Result.Success(listOf(matchedItem))
+            coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns ClaimResult.Success(makeSuccessItem())
+
+            val selectorFields = buildJsonObject { put("priority", "HIGH") }
+            tool.execute(
+                params(claims = listOf(selectorEntry(selectorFields))),
+                defaultContext(nextItemRecommender = recommender)
+            )
+
+            assertEquals(Priority.HIGH, criteriaSlot.captured.priority)
+        }
+
+    @Test
+    fun `selector with type filter passes correct type to recommender`(): Unit =
+        runBlocking {
+            val matchedItem = WorkItem(id = itemId1, title = "Typed Item", role = Role.QUEUE)
+            val recommender = mockk<NextItemRecommender>()
+            val criteriaSlot = slot<NextItemRecommender.Criteria>()
+            coEvery { recommender.recommend(capture(criteriaSlot), 1) } returns Result.Success(listOf(matchedItem))
+            coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns ClaimResult.Success(makeSuccessItem())
+
+            val selectorFields = buildJsonObject { put("type", "feature-task") }
+            tool.execute(
+                params(claims = listOf(selectorEntry(selectorFields))),
+                defaultContext(nextItemRecommender = recommender)
+            )
+
+            assertEquals("feature-task", criteriaSlot.captured.type)
+        }
+
+    @Test
+    fun `selector with complexityMax filter passes correct value to recommender`(): Unit =
+        runBlocking {
+            val matchedItem = WorkItem(id = itemId1, title = "Simple Item", role = Role.QUEUE)
+            val recommender = mockk<NextItemRecommender>()
+            val criteriaSlot = slot<NextItemRecommender.Criteria>()
+            coEvery { recommender.recommend(capture(criteriaSlot), 1) } returns Result.Success(listOf(matchedItem))
+            coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns ClaimResult.Success(makeSuccessItem())
+
+            val selectorFields = buildJsonObject { put("complexityMax", 3) }
+            tool.execute(
+                params(claims = listOf(selectorEntry(selectorFields))),
+                defaultContext(nextItemRecommender = recommender)
+            )
+
+            assertEquals(3, criteriaSlot.captured.complexityMax)
+        }
+
+    @Test
+    fun `selector with orderBy oldest passes OLDEST_FIRST order to recommender`(): Unit =
+        runBlocking {
+            val matchedItem = WorkItem(id = itemId1, title = "Oldest Item", role = Role.QUEUE)
+            val recommender = mockk<NextItemRecommender>()
+            val criteriaSlot = slot<NextItemRecommender.Criteria>()
+            coEvery { recommender.recommend(capture(criteriaSlot), 1) } returns Result.Success(listOf(matchedItem))
+            coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns ClaimResult.Success(makeSuccessItem())
+
+            val selectorFields = buildJsonObject { put("orderBy", "oldest") }
+            tool.execute(
+                params(claims = listOf(selectorEntry(selectorFields))),
+                defaultContext(nextItemRecommender = recommender)
+            )
+
+            assertEquals(io.github.jpicklyk.mcptask.current.domain.model.NextItemOrder.OLDEST_FIRST, criteriaSlot.captured.orderBy)
+        }
+
+    @Test
+    fun `selector with no matches returns no_match outcome with kind permanent`(): Unit =
+        runBlocking {
+            val recommender = mockRecommender(emptyList())
+
+            val result = tool.execute(
+                params(claims = listOf(selectorEntry())),
+                defaultContext(nextItemRecommender = recommender)
+            )
+
+            val data = (result as JsonObject)["data"] as JsonObject
+            val first = (data["claimResults"] as JsonArray)[0] as JsonObject
+            assertEquals("no_match", first["outcome"]?.jsonPrimitive?.content)
+            assertEquals("permanent", first["kind"]?.jsonPrimitive?.content)
+            assertEquals("no_match", first["code"]?.jsonPrimitive?.content)
+            // no retryAfterMs for no_match
+            assertNull(first["retryAfterMs"], "no_match must not have retryAfterMs")
+            // no itemId for no_match (nothing was resolved)
+            assertNull(first["itemId"], "no_match must not have itemId")
+            // claimsSucceeded should be 0
+            val summary = data["summary"] as JsonObject
+            assertEquals(0, summary["claimsSucceeded"]?.jsonPrimitive?.intOrNull)
+            assertEquals(1, summary["claimsFailed"]?.jsonPrimitive?.intOrNull)
+        }
+
+    @Test
+    fun `selector TOCTOU — recommender returns item but claim returns AlreadyClaimed`(): Unit =
+        runBlocking {
+            val matchedItem = WorkItem(id = itemId1, title = "Contested Item", role = Role.QUEUE)
+            val recommender = mockRecommender(listOf(matchedItem))
+            coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns
+                ClaimResult.AlreadyClaimed(itemId1, retryAfterMs = 5000L)
+
+            val result = tool.execute(
+                params(claims = listOf(selectorEntry())),
+                defaultContext(nextItemRecommender = recommender)
+            )
+
+            val data = (result as JsonObject)["data"] as JsonObject
+            val first = (data["claimResults"] as JsonArray)[0] as JsonObject
+            assertEquals("already_claimed", first["outcome"]?.jsonPrimitive?.content)
+            // The resolved itemId must be echoed even on TOCTOU failure
+            assertEquals(itemId1.toString(), first["itemId"]?.jsonPrimitive?.content)
+        }
+
+    @Test
+    fun `selector idempotency replay returns same itemId from cache`(): Unit =
+        runBlocking {
+            val matchedItem = WorkItem(id = itemId1, title = "First Queued Item", role = Role.QUEUE)
+            val recommender = mockk<NextItemRecommender>()
+            val differentItem = WorkItem(id = itemId2, title = "Different Item", role = Role.QUEUE)
+            // First call returns matchedItem; second call returns a different item (simulates queue state change)
+            coEvery { recommender.recommend(any(), 1) } returnsMany listOf(
+                Result.Success(listOf(matchedItem)),
+                Result.Success(listOf(differentItem))
+            )
+            coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns ClaimResult.Success(makeSuccessItem(itemId1))
+
+            val requestId = UUID.randomUUID().toString()
+            val p = params(claims = listOf(selectorEntry()), requestId = requestId)
+
+            // First call — resolves and claims itemId1
+            val result1 = tool.execute(p, defaultContext(nextItemRecommender = recommender))
+            val first1 = ((result1 as JsonObject)["data"] as JsonObject)["claimResults"].let {
+                (it as JsonArray)[0] as JsonObject
+            }
+            assertEquals("success", first1["outcome"]?.jsonPrimitive?.content)
+            assertEquals(itemId1.toString(), first1["itemId"]?.jsonPrimitive?.content)
+
+            // Second call with same requestId — must replay the cache, NOT call recommender again
+            val result2 = tool.execute(p, defaultContext(nextItemRecommender = recommender))
+            val first2 = ((result2 as JsonObject)["data"] as JsonObject)["claimResults"].let {
+                (it as JsonArray)[0] as JsonObject
+            }
+            // Replayed from cache — same itemId1, not itemId2
+            assertEquals(itemId1.toString(), first2["itemId"]?.jsonPrimitive?.content)
+        }
+
+    @Test
+    fun `claimRef is echoed on success outcome`(): Unit =
+        runBlocking {
+            coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns ClaimResult.Success(makeSuccessItem())
+
+            val result = tool.execute(
+                params(claims = listOf(claimEntryWithRef(itemId1, "task-abc-123"))),
+                defaultContext()
+            )
+
+            val data = (result as JsonObject)["data"] as JsonObject
+            val first = (data["claimResults"] as JsonArray)[0] as JsonObject
+            assertEquals("success", first["outcome"]?.jsonPrimitive?.content)
+            assertEquals("task-abc-123", first["claimRef"]?.jsonPrimitive?.content)
+        }
+
+    @Test
+    fun `claimRef is echoed on no_match outcome from selector`(): Unit =
+        runBlocking {
+            val recommender = mockRecommender(emptyList())
+
+            val result = tool.execute(
+                params(claims = listOf(selectorEntry(claimRef = "my-ref-42"))),
+                defaultContext(nextItemRecommender = recommender)
+            )
+
+            val data = (result as JsonObject)["data"] as JsonObject
+            val first = (data["claimResults"] as JsonArray)[0] as JsonObject
+            assertEquals("no_match", first["outcome"]?.jsonPrimitive?.content)
+            assertEquals("my-ref-42", first["claimRef"]?.jsonPrimitive?.content)
+        }
+
+    @Test
+    fun `claimRef is echoed on already_claimed outcome from selector`(): Unit =
+        runBlocking {
+            val matchedItem = WorkItem(id = itemId1, title = "Contested", role = Role.QUEUE)
+            val recommender = mockRecommender(listOf(matchedItem))
+            coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns
+                ClaimResult.AlreadyClaimed(itemId1, retryAfterMs = 1000L)
+
+            val result = tool.execute(
+                params(claims = listOf(selectorEntry(claimRef = "my-ref"))),
+                defaultContext(nextItemRecommender = recommender)
+            )
+
+            val data = (result as JsonObject)["data"] as JsonObject
+            val first = (data["claimResults"] as JsonArray)[0] as JsonObject
+            assertEquals("already_claimed", first["outcome"]?.jsonPrimitive?.content)
+            assertEquals("my-ref", first["claimRef"]?.jsonPrimitive?.content)
+        }
+
+    @Test
+    fun `selector with multi-release in same call — selector resolves and both releases succeed`(): Unit =
+        runBlocking {
+            val matchedItem = WorkItem(id = itemId1, title = "Selector Resolved", role = Role.QUEUE)
+            val recommender = mockRecommender(listOf(matchedItem))
+            coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns ClaimResult.Success(makeSuccessItem())
+            coEvery { workItemRepo.release(itemId2, agentId) } returns
+                ReleaseResult.Success(WorkItem(id = itemId2, title = "Released2"))
+            val extraReleaseId = UUID.randomUUID()
+            coEvery { workItemRepo.release(extraReleaseId, agentId) } returns
+                ReleaseResult.Success(WorkItem(id = extraReleaseId, title = "Released3"))
+
+            val p =
+                buildJsonObject {
+                    put("claims", buildJsonArray { add(selectorEntry()) })
+                    put(
+                        "releases",
+                        buildJsonArray {
+                            add(releaseEntry(itemId2))
+                            add(releaseEntry(extraReleaseId))
+                        }
+                    )
+                    put("actor", actorJson())
+                    put("requestId", UUID.randomUUID().toString())
+                }
+
+            val result = tool.execute(p, defaultContext(nextItemRecommender = recommender))
+            val data = (result as JsonObject)["data"] as JsonObject
+
+            val claimResults = data["claimResults"] as JsonArray
+            assertEquals(1, claimResults.size)
+            val claimFirst = claimResults[0] as JsonObject
+            assertEquals("success", claimFirst["outcome"]?.jsonPrimitive?.content)
+            assertEquals(true, claimFirst["selectorResolved"]?.jsonPrimitive?.booleanOrNull)
+
+            val releaseResults = data["releaseResults"] as JsonArray
+            assertEquals(2, releaseResults.size)
+            releaseResults.forEach { r ->
+                assertEquals("success", (r as JsonObject)["outcome"]?.jsonPrimitive?.content)
+            }
+
+            val summary = data["summary"] as JsonObject
+            assertEquals(1, summary["claimsSucceeded"]?.jsonPrimitive?.intOrNull)
+            assertEquals(2, summary["releasesSucceeded"]?.jsonPrimitive?.intOrNull)
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolTest.kt
@@ -1157,14 +1157,18 @@ class GetNextItemToolTest {
             // We need to set the type field — create items with different types via DB directly
             // WorkItem.type defaults to null; filter for null-type items is tested via absence
             // Create via repository with a non-null type string:
-            val typedItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Bug Fix",
-                role = Role.QUEUE,
-                priority = Priority.HIGH,
-                type = "bug"
-            )
-            val createdTyped = (context.workItemRepository().create(typedItem)
-                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val typedItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Bug Fix",
+                    role = Role.QUEUE,
+                    priority = Priority.HIGH,
+                    type = "bug"
+                )
+            val createdTyped =
+                (
+                    context.workItemRepository().create(typedItem)
+                        as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success
+                ).data
 
             val result =
                 tool.execute(
@@ -1210,21 +1214,29 @@ class GetNextItemToolTest {
             val now = java.time.Instant.now()
 
             // Create an item with a past createdAt (simulate via repository directly)
-            val pastItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Old Task",
-                role = Role.QUEUE,
-                createdAt = now.minusSeconds(7200) // 2 hours ago
-            )
-            val createdPast = (context.workItemRepository().create(pastItem)
-                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val pastItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Old Task",
+                    role = Role.QUEUE,
+                    createdAt = now.minusSeconds(7200) // 2 hours ago
+                )
+            val createdPast =
+                (
+                    context.workItemRepository().create(pastItem)
+                        as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success
+                ).data
 
-            val recentItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Recent Task",
-                role = Role.QUEUE,
-                createdAt = now.minusSeconds(60) // 1 minute ago
-            )
-            val createdRecent = (context.workItemRepository().create(recentItem)
-                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val recentItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Recent Task",
+                    role = Role.QUEUE,
+                    createdAt = now.minusSeconds(60) // 1 minute ago
+                )
+            val createdRecent =
+                (
+                    context.workItemRepository().create(recentItem)
+                        as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success
+                ).data
 
             val threshold = now.minusSeconds(3600).toString() // 1 hour ago
 
@@ -1249,21 +1261,29 @@ class GetNextItemToolTest {
         runBlocking {
             val now = java.time.Instant.now()
 
-            val pastItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Old Task",
-                role = Role.QUEUE,
-                createdAt = now.minusSeconds(7200)
-            )
-            val createdPast = (context.workItemRepository().create(pastItem)
-                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val pastItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Old Task",
+                    role = Role.QUEUE,
+                    createdAt = now.minusSeconds(7200)
+                )
+            val createdPast =
+                (
+                    context.workItemRepository().create(pastItem)
+                        as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success
+                ).data
 
-            val recentItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Recent Task",
-                role = Role.QUEUE,
-                createdAt = now.minusSeconds(60)
-            )
-            val createdRecent = (context.workItemRepository().create(recentItem)
-                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val recentItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Recent Task",
+                    role = Role.QUEUE,
+                    createdAt = now.minusSeconds(60)
+                )
+            val createdRecent =
+                (
+                    context.workItemRepository().create(recentItem)
+                        as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success
+                ).data
 
             val threshold = now.minusSeconds(1800).toString() // 30 minutes ago
 
@@ -1288,21 +1308,29 @@ class GetNextItemToolTest {
         runBlocking {
             val now = java.time.Instant.now()
 
-            val oldRoleItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Old Role Change",
-                role = Role.QUEUE,
-                roleChangedAt = now.minusSeconds(7200)
-            )
-            val createdOld = (context.workItemRepository().create(oldRoleItem)
-                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val oldRoleItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Old Role Change",
+                    role = Role.QUEUE,
+                    roleChangedAt = now.minusSeconds(7200)
+                )
+            val createdOld =
+                (
+                    context.workItemRepository().create(oldRoleItem)
+                        as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success
+                ).data
 
-            val recentRoleItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Recent Role Change",
-                role = Role.QUEUE,
-                roleChangedAt = now.minusSeconds(60)
-            )
-            val createdRecent = (context.workItemRepository().create(recentRoleItem)
-                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val recentRoleItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Recent Role Change",
+                    role = Role.QUEUE,
+                    roleChangedAt = now.minusSeconds(60)
+                )
+            val createdRecent =
+                (
+                    context.workItemRepository().create(recentRoleItem)
+                        as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success
+                ).data
 
             val threshold = now.minusSeconds(3600).toString()
 
@@ -1327,21 +1355,29 @@ class GetNextItemToolTest {
         runBlocking {
             val now = java.time.Instant.now()
 
-            val oldRoleItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Old Role Change",
-                role = Role.QUEUE,
-                roleChangedAt = now.minusSeconds(7200)
-            )
-            val createdOld = (context.workItemRepository().create(oldRoleItem)
-                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val oldRoleItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Old Role Change",
+                    role = Role.QUEUE,
+                    roleChangedAt = now.minusSeconds(7200)
+                )
+            val createdOld =
+                (
+                    context.workItemRepository().create(oldRoleItem)
+                        as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success
+                ).data
 
-            val recentRoleItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Recent Role Change",
-                role = Role.QUEUE,
-                roleChangedAt = now.minusSeconds(60)
-            )
-            val createdRecent = (context.workItemRepository().create(recentRoleItem)
-                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val recentRoleItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Recent Role Change",
+                    role = Role.QUEUE,
+                    roleChangedAt = now.minusSeconds(60)
+                )
+            val createdRecent =
+                (
+                    context.workItemRepository().create(recentRoleItem)
+                        as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success
+                ).data
 
             val threshold = now.minusSeconds(1800).toString()
 
@@ -1369,27 +1405,53 @@ class GetNextItemToolTest {
     fun `orderBy=priority returns items HIGH first then by complexity ascending`(): Unit =
         runBlocking {
             val now = java.time.Instant.now()
-            val lowItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Low Priority", role = Role.QUEUE, priority = Priority.LOW, complexity = 2,
-                createdAt = now.minusSeconds(100)
-            )
-            val highComplexItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "High Priority Complex", role = Role.QUEUE, priority = Priority.HIGH, complexity = 8,
-                createdAt = now.minusSeconds(200)
-            )
-            val highSimpleItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "High Priority Simple", role = Role.QUEUE, priority = Priority.HIGH, complexity = 2,
-                createdAt = now.minusSeconds(300)
-            )
-            val medItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Medium Priority", role = Role.QUEUE, priority = Priority.MEDIUM, complexity = 5,
-                createdAt = now.minusSeconds(50)
-            )
+            val lowItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Low Priority",
+                    role = Role.QUEUE,
+                    priority = Priority.LOW,
+                    complexity = 2,
+                    createdAt = now.minusSeconds(100)
+                )
+            val highComplexItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "High Priority Complex",
+                    role = Role.QUEUE,
+                    priority = Priority.HIGH,
+                    complexity = 8,
+                    createdAt = now.minusSeconds(200)
+                )
+            val highSimpleItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "High Priority Simple",
+                    role = Role.QUEUE,
+                    priority = Priority.HIGH,
+                    complexity = 2,
+                    createdAt = now.minusSeconds(300)
+                )
+            val medItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Medium Priority",
+                    role = Role.QUEUE,
+                    priority = Priority.MEDIUM,
+                    complexity = 5,
+                    createdAt = now.minusSeconds(50)
+                )
 
             val repo = context.workItemRepository()
             val createdLow = (repo.create(lowItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
-            val createdHighComplex = (repo.create(highComplexItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
-            val createdHighSimple = (repo.create(highSimpleItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val createdHighComplex =
+                (
+                    repo.create(
+                        highComplexItem
+                    ) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success
+                ).data
+            val createdHighSimple =
+                (
+                    repo.create(
+                        highSimpleItem
+                    ) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success
+                ).data
             val createdMed = (repo.create(medItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
 
             val result =
@@ -1418,18 +1480,27 @@ class GetNextItemToolTest {
             val now = java.time.Instant.now()
             val repo = context.workItemRepository()
 
-            val oldestItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Oldest", role = Role.QUEUE, priority = Priority.LOW,
-                createdAt = now.minusSeconds(3000)
-            )
-            val middleItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Middle", role = Role.QUEUE, priority = Priority.HIGH, // high priority but newer
-                createdAt = now.minusSeconds(2000)
-            )
-            val newestItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Newest", role = Role.QUEUE, priority = Priority.HIGH,
-                createdAt = now.minusSeconds(1000)
-            )
+            val oldestItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Oldest",
+                    role = Role.QUEUE,
+                    priority = Priority.LOW,
+                    createdAt = now.minusSeconds(3000)
+                )
+            val middleItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Middle",
+                    role = Role.QUEUE,
+                    priority = Priority.HIGH, // high priority but newer
+                    createdAt = now.minusSeconds(2000)
+                )
+            val newestItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Newest",
+                    role = Role.QUEUE,
+                    priority = Priority.HIGH,
+                    createdAt = now.minusSeconds(1000)
+                )
 
             val createdOldest = (repo.create(oldestItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
             val createdMiddle = (repo.create(middleItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
@@ -1460,18 +1531,27 @@ class GetNextItemToolTest {
             val now = java.time.Instant.now()
             val repo = context.workItemRepository()
 
-            val oldestItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Oldest", role = Role.QUEUE, priority = Priority.HIGH, // high priority but oldest
-                createdAt = now.minusSeconds(3000)
-            )
-            val middleItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Middle", role = Role.QUEUE, priority = Priority.LOW,
-                createdAt = now.minusSeconds(2000)
-            )
-            val newestItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
-                title = "Newest", role = Role.QUEUE, priority = Priority.LOW,
-                createdAt = now.minusSeconds(1000)
-            )
+            val oldestItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Oldest",
+                    role = Role.QUEUE,
+                    priority = Priority.HIGH, // high priority but oldest
+                    createdAt = now.minusSeconds(3000)
+                )
+            val middleItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Middle",
+                    role = Role.QUEUE,
+                    priority = Priority.LOW,
+                    createdAt = now.minusSeconds(2000)
+                )
+            val newestItem =
+                io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                    title = "Newest",
+                    role = Role.QUEUE,
+                    priority = Priority.LOW,
+                    createdAt = now.minusSeconds(1000)
+                )
 
             val createdOldest = (repo.create(oldestItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
             val createdMiddle = (repo.create(middleItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolTest.kt
@@ -1098,4 +1098,491 @@ class GetNextItemToolTest {
                     "Got: $serialized"
             )
         }
+
+    // ──────────────────────────────────────────────
+    // Filter parameter tests — Phase 3
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `tags filter returns only items matching any given tag`(): Unit =
+        runBlocking {
+            val backendItem = createItem("Backend Task", tags = "backend,api")
+            val frontendItem = createItem("Frontend Task", tags = "frontend,ui")
+            createItem("Untagged Task")
+
+            val result =
+                tool.execute(
+                    params(
+                        "tags" to JsonPrimitive("backend"),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val recIds = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }
+            assertTrue(recIds.contains(backendItem.id.toString()), "backend-tagged item should be returned")
+            assertFalse(recIds.contains(frontendItem.id.toString()), "frontend-only item should not be returned")
+        }
+
+    @Test
+    fun `priority filter returns only items with matching priority`(): Unit =
+        runBlocking {
+            val highItem = createItem("High Priority Task", priority = Priority.HIGH)
+            val lowItem = createItem("Low Priority Task", priority = Priority.LOW)
+            createItem("Medium Priority Task", priority = Priority.MEDIUM)
+
+            val result =
+                tool.execute(
+                    params(
+                        "priority" to JsonPrimitive("high"),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val recIds = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }
+            assertTrue(recIds.contains(highItem.id.toString()), "HIGH priority item should be returned")
+            assertFalse(recIds.contains(lowItem.id.toString()), "LOW priority item should not be returned")
+            assertEquals(1, recIds.size, "Only one HIGH priority item should be returned")
+        }
+
+    @Test
+    fun `type filter returns only items with matching type`(): Unit =
+        runBlocking {
+            val featureTask = createItem("Feature task")
+            // We need to set the type field — create items with different types via DB directly
+            // WorkItem.type defaults to null; filter for null-type items is tested via absence
+            // Create via repository with a non-null type string:
+            val typedItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Bug Fix",
+                role = Role.QUEUE,
+                priority = Priority.HIGH,
+                type = "bug"
+            )
+            val createdTyped = (context.workItemRepository().create(typedItem)
+                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+
+            val result =
+                tool.execute(
+                    params(
+                        "type" to JsonPrimitive("bug"),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val recIds = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }
+            assertTrue(recIds.contains(createdTyped.id.toString()), "type-matched item should be returned")
+            assertFalse(recIds.contains(featureTask.id.toString()), "null-type item should not be returned for type filter")
+        }
+
+    @Test
+    fun `complexityMax filter excludes items above the threshold`(): Unit =
+        runBlocking {
+            val simpleItem = createItem("Simple Task", complexity = 3)
+            val complexItem = createItem("Complex Task", complexity = 8)
+
+            val result =
+                tool.execute(
+                    params(
+                        "complexityMax" to JsonPrimitive(5),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val recIds = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }
+            assertTrue(recIds.contains(simpleItem.id.toString()), "complexity-3 item should be returned with complexityMax=5")
+            assertFalse(recIds.contains(complexItem.id.toString()), "complexity-8 item should be excluded with complexityMax=5")
+        }
+
+    @Test
+    fun `createdAfter filter excludes items created before the threshold`(): Unit =
+        runBlocking {
+            val now = java.time.Instant.now()
+
+            // Create an item with a past createdAt (simulate via repository directly)
+            val pastItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Old Task",
+                role = Role.QUEUE,
+                createdAt = now.minusSeconds(7200) // 2 hours ago
+            )
+            val createdPast = (context.workItemRepository().create(pastItem)
+                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+
+            val recentItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Recent Task",
+                role = Role.QUEUE,
+                createdAt = now.minusSeconds(60) // 1 minute ago
+            )
+            val createdRecent = (context.workItemRepository().create(recentItem)
+                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+
+            val threshold = now.minusSeconds(3600).toString() // 1 hour ago
+
+            val result =
+                tool.execute(
+                    params(
+                        "createdAfter" to JsonPrimitive(threshold),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val recIds = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }
+            assertTrue(recIds.contains(createdRecent.id.toString()), "recent item should be returned after createdAfter threshold")
+            assertFalse(recIds.contains(createdPast.id.toString()), "old item should be excluded by createdAfter filter")
+        }
+
+    @Test
+    fun `createdBefore filter excludes items created after the threshold`(): Unit =
+        runBlocking {
+            val now = java.time.Instant.now()
+
+            val pastItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Old Task",
+                role = Role.QUEUE,
+                createdAt = now.minusSeconds(7200)
+            )
+            val createdPast = (context.workItemRepository().create(pastItem)
+                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+
+            val recentItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Recent Task",
+                role = Role.QUEUE,
+                createdAt = now.minusSeconds(60)
+            )
+            val createdRecent = (context.workItemRepository().create(recentItem)
+                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+
+            val threshold = now.minusSeconds(1800).toString() // 30 minutes ago
+
+            val result =
+                tool.execute(
+                    params(
+                        "createdBefore" to JsonPrimitive(threshold),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val recIds = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }
+            assertTrue(recIds.contains(createdPast.id.toString()), "old item should be returned before createdBefore threshold")
+            assertFalse(recIds.contains(createdRecent.id.toString()), "recent item should be excluded by createdBefore filter")
+        }
+
+    @Test
+    fun `roleChangedAfter filter excludes items whose role changed before the threshold`(): Unit =
+        runBlocking {
+            val now = java.time.Instant.now()
+
+            val oldRoleItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Old Role Change",
+                role = Role.QUEUE,
+                roleChangedAt = now.minusSeconds(7200)
+            )
+            val createdOld = (context.workItemRepository().create(oldRoleItem)
+                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+
+            val recentRoleItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Recent Role Change",
+                role = Role.QUEUE,
+                roleChangedAt = now.minusSeconds(60)
+            )
+            val createdRecent = (context.workItemRepository().create(recentRoleItem)
+                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+
+            val threshold = now.minusSeconds(3600).toString()
+
+            val result =
+                tool.execute(
+                    params(
+                        "roleChangedAfter" to JsonPrimitive(threshold),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val recIds = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }
+            assertTrue(recIds.contains(createdRecent.id.toString()), "recently role-changed item should be returned")
+            assertFalse(recIds.contains(createdOld.id.toString()), "old role-changed item should be excluded")
+        }
+
+    @Test
+    fun `roleChangedBefore filter excludes items whose role changed after the threshold`(): Unit =
+        runBlocking {
+            val now = java.time.Instant.now()
+
+            val oldRoleItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Old Role Change",
+                role = Role.QUEUE,
+                roleChangedAt = now.minusSeconds(7200)
+            )
+            val createdOld = (context.workItemRepository().create(oldRoleItem)
+                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+
+            val recentRoleItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Recent Role Change",
+                role = Role.QUEUE,
+                roleChangedAt = now.minusSeconds(60)
+            )
+            val createdRecent = (context.workItemRepository().create(recentRoleItem)
+                as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+
+            val threshold = now.minusSeconds(1800).toString()
+
+            val result =
+                tool.execute(
+                    params(
+                        "roleChangedBefore" to JsonPrimitive(threshold),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val recIds = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }
+            assertTrue(recIds.contains(createdOld.id.toString()), "old role-changed item should be returned")
+            assertFalse(recIds.contains(createdRecent.id.toString()), "recently role-changed item should be excluded")
+        }
+
+    // ──────────────────────────────────────────────
+    // orderBy tests
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `orderBy=priority returns items HIGH first then by complexity ascending`(): Unit =
+        runBlocking {
+            val now = java.time.Instant.now()
+            val lowItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Low Priority", role = Role.QUEUE, priority = Priority.LOW, complexity = 2,
+                createdAt = now.minusSeconds(100)
+            )
+            val highComplexItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "High Priority Complex", role = Role.QUEUE, priority = Priority.HIGH, complexity = 8,
+                createdAt = now.minusSeconds(200)
+            )
+            val highSimpleItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "High Priority Simple", role = Role.QUEUE, priority = Priority.HIGH, complexity = 2,
+                createdAt = now.minusSeconds(300)
+            )
+            val medItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Medium Priority", role = Role.QUEUE, priority = Priority.MEDIUM, complexity = 5,
+                createdAt = now.minusSeconds(50)
+            )
+
+            val repo = context.workItemRepository()
+            val createdLow = (repo.create(lowItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val createdHighComplex = (repo.create(highComplexItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val createdHighSimple = (repo.create(highSimpleItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val createdMed = (repo.create(medItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+
+            val result =
+                tool.execute(
+                    params(
+                        "orderBy" to JsonPrimitive("priority"),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val recIds = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }
+
+            assertEquals(4, recIds.size)
+            assertEquals(createdHighSimple.id.toString(), recIds[0], "HIGH/complexity2 should be first")
+            assertEquals(createdHighComplex.id.toString(), recIds[1], "HIGH/complexity8 should be second")
+            assertEquals(createdMed.id.toString(), recIds[2], "MEDIUM should be third")
+            assertEquals(createdLow.id.toString(), recIds[3], "LOW should be last")
+        }
+
+    @Test
+    fun `orderBy=oldest returns items by createdAt ascending (FIFO)`(): Unit =
+        runBlocking {
+            val now = java.time.Instant.now()
+            val repo = context.workItemRepository()
+
+            val oldestItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Oldest", role = Role.QUEUE, priority = Priority.LOW,
+                createdAt = now.minusSeconds(3000)
+            )
+            val middleItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Middle", role = Role.QUEUE, priority = Priority.HIGH, // high priority but newer
+                createdAt = now.minusSeconds(2000)
+            )
+            val newestItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Newest", role = Role.QUEUE, priority = Priority.HIGH,
+                createdAt = now.minusSeconds(1000)
+            )
+
+            val createdOldest = (repo.create(oldestItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val createdMiddle = (repo.create(middleItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val createdNewest = (repo.create(newestItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+
+            val result =
+                tool.execute(
+                    params(
+                        "orderBy" to JsonPrimitive("oldest"),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val recIds = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }
+
+            assertEquals(3, recIds.size)
+            assertEquals(createdOldest.id.toString(), recIds[0], "oldest item should be first with orderBy=oldest")
+            assertEquals(createdMiddle.id.toString(), recIds[1])
+            assertEquals(createdNewest.id.toString(), recIds[2], "newest item should be last with orderBy=oldest")
+        }
+
+    @Test
+    fun `orderBy=newest returns items by createdAt descending`(): Unit =
+        runBlocking {
+            val now = java.time.Instant.now()
+            val repo = context.workItemRepository()
+
+            val oldestItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Oldest", role = Role.QUEUE, priority = Priority.HIGH, // high priority but oldest
+                createdAt = now.minusSeconds(3000)
+            )
+            val middleItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Middle", role = Role.QUEUE, priority = Priority.LOW,
+                createdAt = now.minusSeconds(2000)
+            )
+            val newestItem = io.github.jpicklyk.mcptask.current.domain.model.WorkItem(
+                title = "Newest", role = Role.QUEUE, priority = Priority.LOW,
+                createdAt = now.minusSeconds(1000)
+            )
+
+            val createdOldest = (repo.create(oldestItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val createdMiddle = (repo.create(middleItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+            val createdNewest = (repo.create(newestItem) as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+
+            val result =
+                tool.execute(
+                    params(
+                        "orderBy" to JsonPrimitive("newest"),
+                        "limit" to JsonPrimitive(10)
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val recIds = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }
+
+            assertEquals(3, recIds.size)
+            assertEquals(createdNewest.id.toString(), recIds[0], "newest item should be first with orderBy=newest")
+            assertEquals(createdMiddle.id.toString(), recIds[1])
+            assertEquals(createdOldest.id.toString(), recIds[2], "oldest item should be last with orderBy=newest")
+        }
+
+    // ──────────────────────────────────────────────
+    // Validation tests — new parameters
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `invalid priority value fails validation`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(params("priority" to JsonPrimitive("bogus")))
+        }
+    }
+
+    @Test
+    fun `complexityMax below 1 fails validation`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(params("complexityMax" to JsonPrimitive(0)))
+        }
+    }
+
+    @Test
+    fun `complexityMax above 10 fails validation`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(params("complexityMax" to JsonPrimitive(11)))
+        }
+    }
+
+    @Test
+    fun `invalid orderBy value fails validation`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(params("orderBy" to JsonPrimitive("invalid")))
+        }
+    }
+
+    @Test
+    fun `malformed createdAfter ISO 8601 fails validation`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(params("createdAfter" to JsonPrimitive("not-a-date")))
+        }
+    }
+
+    @Test
+    fun `malformed createdBefore ISO 8601 fails validation`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(params("createdBefore" to JsonPrimitive("2024-13-45")))
+        }
+    }
+
+    @Test
+    fun `malformed roleChangedAfter ISO 8601 fails validation`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(params("roleChangedAfter" to JsonPrimitive("not-a-timestamp")))
+        }
+    }
+
+    @Test
+    fun `malformed roleChangedBefore ISO 8601 fails validation`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(params("roleChangedBefore" to JsonPrimitive("yesterday")))
+        }
+    }
+
+    @Test
+    fun `blank tags value fails validation`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(params("tags" to JsonPrimitive("   ")))
+        }
+    }
+
+    @Test
+    fun `valid orderBy=priority passes validation`() {
+        // Should not throw
+        tool.validateParams(params("orderBy" to JsonPrimitive("priority")))
+    }
+
+    @Test
+    fun `valid orderBy=oldest passes validation`() {
+        tool.validateParams(params("orderBy" to JsonPrimitive("oldest")))
+    }
+
+    @Test
+    fun `valid orderBy=newest passes validation`() {
+        tool.validateParams(params("orderBy" to JsonPrimitive("newest")))
+    }
+
+    @Test
+    fun `valid complexityMax boundary values pass validation`() {
+        // Should not throw
+        tool.validateParams(params("complexityMax" to JsonPrimitive(1)))
+        tool.validateParams(params("complexityMax" to JsonPrimitive(10)))
+    }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryFilterTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryFilterTest.kt
@@ -764,16 +764,19 @@ class SQLiteWorkItemRepositoryFilterTest {
             // Unclaimed item — should be included
             repository.create(WorkItem(title = "Unclaimed", role = Role.QUEUE))
 
-            // Actively claimed item — claimExpiresAt in the future → must be excluded
-            val futureExpiry = Instant.now().plusSeconds(900)
+            // Actively claimed item — claimExpiresAt in the future → must be excluded.
+            // Capture `now` once so claimedAt and originalClaimedAt are equal — separate
+            // Instant.now() calls drift by microseconds on Linux CI's high-resolution clock
+            // and trip WorkItem.validate()'s originalClaimedAt <= claimedAt invariant.
+            val now = Instant.now()
             repository.create(
                 WorkItem(
                     title = "Claimed",
                     role = Role.QUEUE,
                     claimedBy = "agent-x",
-                    claimedAt = Instant.now(),
-                    claimExpiresAt = futureExpiry,
-                    originalClaimedAt = Instant.now(),
+                    claimedAt = now,
+                    claimExpiresAt = now.plusSeconds(900),
+                    originalClaimedAt = now,
                 )
             )
 
@@ -789,16 +792,19 @@ class SQLiteWorkItemRepositoryFilterTest {
             // Unclaimed — included
             repository.create(WorkItem(title = "Unclaimed", role = Role.QUEUE))
 
-            // Expired claim — claimExpiresAt in the past → should be included
-            val pastExpiry = Instant.now().minusSeconds(60)
+            // Expired claim — claimExpiresAt in the past → should be included.
+            // Capture `now` once so claimedAt and originalClaimedAt are equal — separate
+            // Instant.now() calls drift by microseconds on Linux CI's high-resolution clock
+            // and trip WorkItem.validate()'s originalClaimedAt <= claimedAt invariant.
+            val now = Instant.now()
             repository.create(
                 WorkItem(
                     title = "Expired claim",
                     role = Role.QUEUE,
                     claimedBy = "agent-y",
-                    claimedAt = Instant.now().minusSeconds(120),
-                    claimExpiresAt = pastExpiry,
-                    originalClaimedAt = Instant.now().minusSeconds(120),
+                    claimedAt = now.minusSeconds(120),
+                    claimExpiresAt = now.minusSeconds(60),
+                    originalClaimedAt = now.minusSeconds(120),
                 )
             )
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryFilterTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryFilterTest.kt
@@ -612,7 +612,9 @@ class SQLiteWorkItemRepositoryFilterTest {
             val t2 = Instant.parse("2025-12-01T00:00:00Z")
 
             repository.create(WorkItem(title = "Old role change", createdAt = t1, modifiedAt = t1, roleChangedAt = t1, role = Role.QUEUE))
-            repository.create(WorkItem(title = "Recent role change", createdAt = t1, modifiedAt = t1, roleChangedAt = t2, role = Role.QUEUE))
+            repository.create(
+                WorkItem(title = "Recent role change", createdAt = t1, modifiedAt = t1, roleChangedAt = t2, role = Role.QUEUE)
+            )
 
             val result = repository.findClaimable(role = Role.QUEUE, roleChangedAfter = Instant.parse("2025-06-01T00:00:00Z"))
             assertIs<Result.Success<List<WorkItem>>>(result)
@@ -627,7 +629,9 @@ class SQLiteWorkItemRepositoryFilterTest {
             val t2 = Instant.parse("2025-12-01T00:00:00Z")
 
             repository.create(WorkItem(title = "Old role change", createdAt = t1, modifiedAt = t1, roleChangedAt = t1, role = Role.QUEUE))
-            repository.create(WorkItem(title = "Recent role change", createdAt = t1, modifiedAt = t1, roleChangedAt = t2, role = Role.QUEUE))
+            repository.create(
+                WorkItem(title = "Recent role change", createdAt = t1, modifiedAt = t1, roleChangedAt = t2, role = Role.QUEUE)
+            )
 
             val result = repository.findClaimable(role = Role.QUEUE, roleChangedBefore = Instant.parse("2025-06-01T00:00:00Z"))
             assertIs<Result.Success<List<WorkItem>>>(result)

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryFilterTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryFilterTest.kt
@@ -1,5 +1,6 @@
 package io.github.jpicklyk.mcptask.current.infrastructure.database.repository
 
+import io.github.jpicklyk.mcptask.current.domain.model.NextItemOrder
 import io.github.jpicklyk.mcptask.current.domain.model.Priority
 import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
@@ -483,5 +484,336 @@ class SQLiteWorkItemRepositoryFilterTest {
             val result = repository.countByFilters(type = "feature")
             assertIs<Result.Success<Int>>(result)
             assertEquals(2, result.data)
+        }
+
+    // =====================================================================
+    // findClaimable tests
+    // =====================================================================
+
+    @Test
+    fun `findClaimable by role filters correctly`() =
+        runBlocking {
+            repository.create(WorkItem(title = "Queue item", role = Role.QUEUE))
+            repository.create(WorkItem(title = "Work item", role = Role.WORK))
+            repository.create(WorkItem(title = "Another queue", role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(2, result.data.size)
+            assertTrue(result.data.all { it.role == Role.QUEUE })
+        }
+
+    @Test
+    fun `findClaimable by parentId filters correctly`() =
+        runBlocking {
+            val parent = WorkItem(title = "Parent", depth = 0)
+            repository.create(parent)
+            repository.create(WorkItem(title = "Child 1", parentId = parent.id, depth = 1, role = Role.QUEUE))
+            repository.create(WorkItem(title = "Child 2", parentId = parent.id, depth = 1, role = Role.QUEUE))
+            repository.create(WorkItem(title = "Orphan", depth = 0, role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE, parentId = parent.id)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(2, result.data.size)
+            assertTrue(result.data.all { it.parentId == parent.id })
+        }
+
+    @Test
+    fun `findClaimable by tags any-match filters correctly`() =
+        runBlocking {
+            repository.create(WorkItem(title = "Bug item", tags = "bug", role = Role.QUEUE))
+            repository.create(WorkItem(title = "Feature item", tags = "feature", role = Role.QUEUE))
+            repository.create(WorkItem(title = "No tags", role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE, tags = listOf("bug", "feature"))
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(2, result.data.size)
+            val titles = result.data.map { it.title }.toSet()
+            assertTrue("Bug item" in titles)
+            assertTrue("Feature item" in titles)
+        }
+
+    @Test
+    fun `findClaimable by priority filters correctly`() =
+        runBlocking {
+            repository.create(WorkItem(title = "High", priority = Priority.HIGH, role = Role.QUEUE))
+            repository.create(WorkItem(title = "Low", priority = Priority.LOW, role = Role.QUEUE))
+            repository.create(WorkItem(title = "Medium", priority = Priority.MEDIUM, role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE, priority = Priority.HIGH)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size)
+            assertEquals("High", result.data[0].title)
+        }
+
+    @Test
+    fun `findClaimable by type filters correctly`() =
+        runBlocking {
+            repository.create(WorkItem(title = "Feature task", type = "feature", role = Role.QUEUE))
+            repository.create(WorkItem(title = "Bug fix", type = "bug", role = Role.QUEUE))
+            repository.create(WorkItem(title = "No type", role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE, type = "feature")
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size)
+            assertEquals("Feature task", result.data[0].title)
+        }
+
+    @Test
+    fun `findClaimable by complexityMax filters correctly`() =
+        runBlocking {
+            repository.create(WorkItem(title = "Simple", complexity = 2, role = Role.QUEUE))
+            repository.create(WorkItem(title = "Moderate", complexity = 5, role = Role.QUEUE))
+            repository.create(WorkItem(title = "Complex", complexity = 9, role = Role.QUEUE))
+            repository.create(WorkItem(title = "No complexity", role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE, complexityMax = 5)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(2, result.data.size)
+            val titles = result.data.map { it.title }.toSet()
+            assertTrue("Simple" in titles)
+            assertTrue("Moderate" in titles)
+        }
+
+    @Test
+    fun `findClaimable by createdAfter filters correctly`() =
+        runBlocking {
+            val t1 = Instant.parse("2025-01-01T00:00:00Z")
+            val t2 = Instant.parse("2025-12-01T00:00:00Z")
+
+            repository.create(WorkItem(title = "Old", createdAt = t1, modifiedAt = t1, roleChangedAt = t1, role = Role.QUEUE))
+            repository.create(WorkItem(title = "New", createdAt = t2, modifiedAt = t2, roleChangedAt = t2, role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE, createdAfter = Instant.parse("2025-06-01T00:00:00Z"))
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size)
+            assertEquals("New", result.data[0].title)
+        }
+
+    @Test
+    fun `findClaimable by createdBefore filters correctly`() =
+        runBlocking {
+            val t1 = Instant.parse("2025-01-01T00:00:00Z")
+            val t2 = Instant.parse("2025-12-01T00:00:00Z")
+
+            repository.create(WorkItem(title = "Old", createdAt = t1, modifiedAt = t1, roleChangedAt = t1, role = Role.QUEUE))
+            repository.create(WorkItem(title = "New", createdAt = t2, modifiedAt = t2, roleChangedAt = t2, role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE, createdBefore = Instant.parse("2025-06-01T00:00:00Z"))
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size)
+            assertEquals("Old", result.data[0].title)
+        }
+
+    @Test
+    fun `findClaimable by roleChangedAfter filters correctly`() =
+        runBlocking {
+            val t1 = Instant.parse("2025-01-01T00:00:00Z")
+            val t2 = Instant.parse("2025-12-01T00:00:00Z")
+
+            repository.create(WorkItem(title = "Old role change", createdAt = t1, modifiedAt = t1, roleChangedAt = t1, role = Role.QUEUE))
+            repository.create(WorkItem(title = "Recent role change", createdAt = t1, modifiedAt = t1, roleChangedAt = t2, role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE, roleChangedAfter = Instant.parse("2025-06-01T00:00:00Z"))
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size)
+            assertEquals("Recent role change", result.data[0].title)
+        }
+
+    @Test
+    fun `findClaimable by roleChangedBefore filters correctly`() =
+        runBlocking {
+            val t1 = Instant.parse("2025-01-01T00:00:00Z")
+            val t2 = Instant.parse("2025-12-01T00:00:00Z")
+
+            repository.create(WorkItem(title = "Old role change", createdAt = t1, modifiedAt = t1, roleChangedAt = t1, role = Role.QUEUE))
+            repository.create(WorkItem(title = "Recent role change", createdAt = t1, modifiedAt = t1, roleChangedAt = t2, role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE, roleChangedBefore = Instant.parse("2025-06-01T00:00:00Z"))
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size)
+            assertEquals("Old role change", result.data[0].title)
+        }
+
+    @Test
+    fun `findClaimable with multiple filters combined`() =
+        runBlocking {
+            val parent = WorkItem(title = "Parent", depth = 0)
+            repository.create(parent)
+
+            repository.create(
+                WorkItem(
+                    title = "Match",
+                    parentId = parent.id,
+                    depth = 1,
+                    role = Role.QUEUE,
+                    priority = Priority.HIGH,
+                    complexity = 3,
+                    tags = "feature,urgent",
+                )
+            )
+            repository.create(
+                WorkItem(
+                    title = "Wrong priority",
+                    parentId = parent.id,
+                    depth = 1,
+                    role = Role.QUEUE,
+                    priority = Priority.LOW,
+                    complexity = 3,
+                    tags = "feature",
+                )
+            )
+            repository.create(
+                WorkItem(
+                    title = "Too complex",
+                    parentId = parent.id,
+                    depth = 1,
+                    role = Role.QUEUE,
+                    priority = Priority.HIGH,
+                    complexity = 8,
+                    tags = "feature",
+                )
+            )
+            repository.create(
+                WorkItem(
+                    title = "Wrong parent",
+                    depth = 0,
+                    role = Role.QUEUE,
+                    priority = Priority.HIGH,
+                    complexity = 2,
+                    tags = "feature",
+                )
+            )
+
+            val result =
+                repository.findClaimable(
+                    role = Role.QUEUE,
+                    parentId = parent.id,
+                    priority = Priority.HIGH,
+                    complexityMax = 3,
+                    tags = listOf("feature"),
+                )
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size)
+            assertEquals("Match", result.data[0].title)
+        }
+
+    @Test
+    fun `findClaimable with PRIORITY_THEN_COMPLEXITY orderBy sorts correctly`() =
+        runBlocking {
+            repository.create(WorkItem(title = "Low-simple", priority = Priority.LOW, complexity = 1, role = Role.QUEUE))
+            repository.create(WorkItem(title = "High-complex", priority = Priority.HIGH, complexity = 9, role = Role.QUEUE))
+            repository.create(WorkItem(title = "High-simple", priority = Priority.HIGH, complexity = 1, role = Role.QUEUE))
+            repository.create(WorkItem(title = "Medium-simple", priority = Priority.MEDIUM, complexity = 2, role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE, orderBy = NextItemOrder.PRIORITY_THEN_COMPLEXITY)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(4, result.data.size)
+            // HIGH items first (lowest complexity first within HIGH), then MEDIUM, then LOW
+            assertEquals("High-simple", result.data[0].title)
+            assertEquals("High-complex", result.data[1].title)
+            assertEquals("Medium-simple", result.data[2].title)
+            assertEquals("Low-simple", result.data[3].title)
+        }
+
+    @Test
+    fun `findClaimable with OLDEST_FIRST orderBy sorts by createdAt ASC`() =
+        runBlocking {
+            val t1 = Instant.parse("2025-01-01T00:00:00Z")
+            val t2 = Instant.parse("2025-06-01T00:00:00Z")
+            val t3 = Instant.parse("2025-12-01T00:00:00Z")
+
+            repository.create(WorkItem(title = "Mid", createdAt = t2, modifiedAt = t2, roleChangedAt = t2, role = Role.QUEUE))
+            repository.create(WorkItem(title = "Old", createdAt = t1, modifiedAt = t1, roleChangedAt = t1, role = Role.QUEUE))
+            repository.create(WorkItem(title = "New", createdAt = t3, modifiedAt = t3, roleChangedAt = t3, role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE, orderBy = NextItemOrder.OLDEST_FIRST)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(3, result.data.size)
+            assertEquals("Old", result.data[0].title)
+            assertEquals("Mid", result.data[1].title)
+            assertEquals("New", result.data[2].title)
+        }
+
+    @Test
+    fun `findClaimable with NEWEST_FIRST orderBy sorts by createdAt DESC`() =
+        runBlocking {
+            val t1 = Instant.parse("2025-01-01T00:00:00Z")
+            val t2 = Instant.parse("2025-06-01T00:00:00Z")
+            val t3 = Instant.parse("2025-12-01T00:00:00Z")
+
+            repository.create(WorkItem(title = "Mid", createdAt = t2, modifiedAt = t2, roleChangedAt = t2, role = Role.QUEUE))
+            repository.create(WorkItem(title = "Old", createdAt = t1, modifiedAt = t1, roleChangedAt = t1, role = Role.QUEUE))
+            repository.create(WorkItem(title = "New", createdAt = t3, modifiedAt = t3, roleChangedAt = t3, role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE, orderBy = NextItemOrder.NEWEST_FIRST)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(3, result.data.size)
+            assertEquals("New", result.data[0].title)
+            assertEquals("Mid", result.data[1].title)
+            assertEquals("Old", result.data[2].title)
+        }
+
+    @Test
+    fun `findClaimable always excludes items with active claims`() =
+        runBlocking {
+            // Unclaimed item — should be included
+            repository.create(WorkItem(title = "Unclaimed", role = Role.QUEUE))
+
+            // Actively claimed item — claimExpiresAt in the future → must be excluded
+            val futureExpiry = Instant.now().plusSeconds(900)
+            repository.create(
+                WorkItem(
+                    title = "Claimed",
+                    role = Role.QUEUE,
+                    claimedBy = "agent-x",
+                    claimedAt = Instant.now(),
+                    claimExpiresAt = futureExpiry,
+                    originalClaimedAt = Instant.now(),
+                )
+            )
+
+            val result = repository.findClaimable(role = Role.QUEUE)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size)
+            assertEquals("Unclaimed", result.data[0].title)
+        }
+
+    @Test
+    fun `findClaimable includes items with expired claims`() =
+        runBlocking {
+            // Unclaimed — included
+            repository.create(WorkItem(title = "Unclaimed", role = Role.QUEUE))
+
+            // Expired claim — claimExpiresAt in the past → should be included
+            val pastExpiry = Instant.now().minusSeconds(60)
+            repository.create(
+                WorkItem(
+                    title = "Expired claim",
+                    role = Role.QUEUE,
+                    claimedBy = "agent-y",
+                    claimedAt = Instant.now().minusSeconds(120),
+                    claimExpiresAt = pastExpiry,
+                    originalClaimedAt = Instant.now().minusSeconds(120),
+                )
+            )
+
+            val result = repository.findClaimable(role = Role.QUEUE)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(2, result.data.size)
+            val titles = result.data.map { it.title }.toSet()
+            assertTrue("Unclaimed" in titles)
+            assertTrue("Expired claim" in titles)
+        }
+
+    @Test
+    fun `findClaimable returns empty list when no matches`() =
+        runBlocking {
+            repository.create(WorkItem(title = "Work item", role = Role.WORK))
+
+            // Query QUEUE — no items in queue
+            val result = repository.findClaimable(role = Role.QUEUE)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertTrue(result.data.isEmpty())
         }
 }


### PR DESCRIPTION
## Summary

- Adds **`selector` mode** to `claim_item` for atomic find-and-claim — eliminates the racy `query_items` → `claim_item` two-call pattern. Single-claim-per-call by validation; new `no_match` outcome (kind=permanent) and `selectorResolved` success marker; optional `claimRef` for caller correlation.
- Adds **filter parity** to `get_next_item` — same 9 optional filter parameters as the selector (`tags`, `priority`, `type`, `complexityMax`, `createdAfter/Before`, `roleChangedAfter/Before`, `orderBy`). Fully backward-compatible (all defaults preserve current behaviour).
- Adds **`NextItemRecommender`** shared service + **`findClaimable`** repository method — single source of truth for "what's eligible next" across both tools.
- Documents the **multi-claim batch deprecation** explicitly in tool description and api-reference. ID-based `claims.size > 1` will be rejected in a future major version (tracked as separate item `b8ac68a4`).
- Updates **Ralph drain skill** to use the new selector pattern with `orderBy: oldest` for FIFO fairness.

Full design at [`plans/selector-claim-and-filter-parity.md`](https://github.com/jpicklyk/task-orchestrator/blob/feat/selector-claim-filter-parity/plans/selector-claim-and-filter-parity.md) (gitignored — review the design here in the PR description and commit messages).

## Phases shipped

| # | Phase | Commit |
|---|-------|--------|
| T1 | findClaimable repo method + NextItemOrder enum + repo tests | `22d29c9` (+ ktlint `9b9d885`) |
| T2 | NextItemRecommender service + ToolExecutionContext wiring | `8af5e41` (+ ktlint `523e32b`) |
| T3 | get_next_item filter parity + tests | `14905b2` |
| T4 | claim_item selector mode + tests | `98f9272` (+ fixup `9897773`) |
| T3+T4 fixes | tags blank-validation + composition test 2-agent setup | `87a3c39` |
| Post-review cleanup | isBlocked internal/reused, in-memory tags exact-token fix, OVER_FETCH_LIMIT constant, blocker-not-found test | `43055e5` |
| T5 | api-reference + workflow-guide + fleet-deployment + quick-start + README + CHANGELOG | `c5802b5` (+ no_match code field `baa4cb5`) |
| T6 | Ralph drain skill + iteration-prompt + session-start.mjs (bonus tool count fix 13→14) | `722c6fc` |
| /simplify pass | perf (lazy isBlocked walk), correctness (isNotBlank consistency), constants (OVER_FETCH_LIMIT ref), hygiene (KDoc/comments) | `855a8c5` |

## Test plan

- [x] `./gradlew :current:test` — 1800 tests pass (1799 baseline + 1 new in `NextItemRecommenderTest` for blocker-not-found skip-conservatively branch)
- [x] `./gradlew :current:ktlintCheck` — clean
- [x] Each filter dimension (tags, priority, type, complexityMax, time-windows) exercised in isolation in repo, service, and tool tests
- [x] Each `orderBy` value (priority/oldest/newest) verified across multiple distinct items
- [x] Selector race (TOCTOU) test via mocked recommender + repo
- [x] Idempotency replay verified (cached `(actor, requestId)` returns same itemId verbatim)
- [x] Validation tests for `claims.size > 1` with selector → `validation_error`
- [x] Both/neither `itemId`/`selector` → `validation_error`
- [x] Existing tests continue to pass without modification (backward compat)
- [x] Per-child code reviews (T1-T6) all PASS or PASS_WITH_OBSERVATIONS
- [x] /simplify pass: 3 parallel reviewer agents (reuse, quality, efficiency); substantive findings applied in `855a8c5`

## Review summary

| Child | Verdict | Status |
|-------|---------|--------|
| T1 (findClaimable + enum + tests) | PASS | All observations deferred (CASE expression de-dup possible if 3rd call site appears) |
| T2 (NextItemRecommender) | PASS_WITH_OBS | All 3 observations FIXED in cleanup commit `43055e5` |
| T3 (get_next_item filters) | PASS_WITH_OBS | Real correctness obs (tags substring vs token) FIXED; visibility obs FIXED; blank-validation deferred as intentional |
| T4 (claim_item selector) | PASS_WITH_OBS | All 3 observations minor/cosmetic, deferred |
| T5 (docs) | PASS_WITH_OBS | no_match `code` field doc gap FIXED; README "13 MCP Tools" stale prose deferred (pre-existing, out of 6-file scope) |
| T6 (plugin skills) | PASS | Clean |
| /simplify | substantive findings applied | Lazy isBlocked early-exit + isNotBlank consistency + OVER_FETCH_LIMIT ref + KDoc cleanup |

## Backward compatibility

- No required parameters added to any existing operation
- Response shape additive only (no field removals/renames; new optional fields)
- Tiered claim disclosure preserved under all new filter combinations
- `claim_item.requestId` still required (existing contract)
- `claim_item` validation tightening (`claims.size > 1` with selector) does NOT affect ID-based callers

## Plugin blast radius

Plugin content is cached. After merge, users with the bundled plugin enabled must run `/mcp` to reconnect the marketplace before:
- Updated Ralph drain pattern takes effect in new sessions
- Updated session-start.mjs tool surface text (count 13→14, claim_item added) takes effect

## MCP tracking

- Parent feature: `5c40233c` (selector-mode claim_item + filter parity)
- Children: `f37f2a38` (T1), `fce32849` (T2), `f9496d42` (T3), `ed6ab253` (T4), `4534dfcb` (T5), `65f984eb` (T6)
- Follow-up breaking-change PR: `b8ac68a4` (tighten claim_item to reject `claims.size > 1` — for next major version)
- Pre-existing inaccuracy noticed: README "13 MCP Tools" prose says 13 (actual 14); needs separate cleanup before next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)