### PR TITLE
feat(claim_item): tighten to single claim per call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+- **`claim_item` now rejects `claims.size > 1`** with error code `multi_claim_not_supported`. Multi-claim was previously silently broken — the repository auto-released all but the last claim while the response reported all as `success`. The behavior is now rejected explicitly at the validation layer. Migration: issue one `claim_item` call per item. The cap derives from the heartbeat write-budget assumption (one TTL refresh per agent per cycle); a future `claim_heartbeats` table mitigation could re-evaluate the constraint. Only `claims` is restricted — the `releases` array remains batchable.
+
 ### Added
-- `claim_item` selector mode — atomic find-and-claim in a single call. Each claim entry may now use a `selector` object (instead of `itemId`) to resolve a filter+rank query and claim the top match without the race window of the two-call `get_next_item → claim_item` pattern. New outcomes: `no_match` (`kind=permanent`, no `retryAfterMs`, no `itemId`) when the queue is empty for the given filters; `selectorResolved: true` on success. New `claimRef` field (up to 64 chars) echoed verbatim in every claim result for caller-side correlation. Single-claim-per-call enforced by validation when any selector is present — `claims.size > 1` with a selector returns `validation_error`.
+- `claim_item` selector mode — atomic find-and-claim in a single call. Each claim entry may now use a `selector` object (instead of `itemId`) to resolve a filter+rank query and claim the top match without the race window of the two-call `get_next_item → claim_item` pattern. New outcomes: `no_match` (`kind=permanent`, no `retryAfterMs`, no `itemId`) when the queue is empty for the given filters; `selectorResolved: true` on success. New `claimRef` field (up to 64 chars) echoed verbatim in every claim result for caller-side correlation. Single-claim-per-call enforced by validation for all claim modes.
 - `get_next_item` filter parameters: `tags` (comma-separated, any-match), `priority` (`high`|`medium`|`low`), `type` (exact match), `complexityMax` (1–10), `createdAfter` (ISO 8601), `createdBefore` (ISO 8601), `roleChangedAfter` (ISO 8601), `roleChangedBefore` (ISO 8601), `orderBy` (`priority` default | `oldest` FIFO | `newest` recency). Filter shape is identical to `claim_item.selector` — both tools share the same underlying eligibility logic (`NextItemRecommender`).
 - `findClaimable` repository method composing the rich filter surface with active-claim exclusion — single source of truth for "what's eligible next" across both tools.
 - `NextItemRecommender` shared service — encapsulates the recommend+dependency-block logic so `get_next_item` and `claim_item` selector path can never diverge on eligibility semantics.
 - `NextItemOrder` enum — `PRIORITY_THEN_COMPLEXITY`, `OLDEST_FIRST`, `NEWEST_FIRST`.
-
-### Deprecated
-- ID-based multi-claim batches — `claim_item` with `claims.size > 1` using `itemId` entries. Each successive successful claim auto-releases predecessors; a `claims: [A, B, C]` call ends with only C held, even though all three report `success`. **Issue one claim per call.** This path is preserved for backward compatibility and will be rejected in a future major version. Tracked as MCP item `b8ac68a4`. Migration path: switch to selector mode or issue one `claim_item` call per item.
 
 ---
 

--- a/claude-plugins/task-orchestrator/skills/ralph/iteration-prompt.md
+++ b/claude-plugins/task-orchestrator/skills/ralph/iteration-prompt.md
@@ -41,7 +41,7 @@ claim_item(
 
 `orderBy: "oldest"` drains the queue in FIFO order (oldest items first), ensuring fair processing across all queue items.
 
-> **Note:** When `selector` is present, the `claims` array must contain exactly one entry. Multi-selector batches are rejected with `validation_error`.
+> **Note:** The `claims` array must contain exactly one entry. `claims.size > 1` is rejected with error code `multi_claim_not_supported` regardless of mode.
 
 | Result | Action |
 |---|---|

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1160,7 +1160,7 @@ changing the claim holder.
 - **ID mode:** `{ itemId (required UUID or hex prefix), ttlSeconds? (optional int, default 900, max 86400), agentId? (optional — overridden by verified actor), claimRef? (optional string, max 64 chars — echoed verbatim in the result for caller correlation) }`
 - **Selector mode:** `{ selector (required object — see below), ttlSeconds? (optional int, default 900, max 86400), claimRef? (optional string, max 64 chars — echoed verbatim in the result) }`
 
-Each entry must have exactly one of `itemId` or `selector`. When any entry uses `selector`, the `claims` array must contain exactly 1 entry (see multi-claim batch warning below).
+Each entry must have exactly one of `itemId` or `selector`. The `claims` array must contain at most 1 entry (see single-claim-per-call note below).
 
 **`selector` object fields** (all optional within the object; the object itself is required in selector mode):
 
@@ -1213,12 +1213,11 @@ The selector filter shape is identical to the `get_next_item` filter parameters 
 
 **Idempotency replay.** A `(actor, requestId)` cache hit replays the resolved response verbatim — including the same `itemId` for selector calls. The selector is **not** re-evaluated against fresh queue state on retry; the first-resolution result is what you get.
 
-> **⚠ Multi-claim batch warning (ID-based claims, deprecated path):**
-> Each successful claim auto-releases all other claims this agent currently holds. In a multi-claim batch, each successive `success` releases its predecessors. A call with `claims: [A, B, C]` ends with **only C held** — A and B are released even though the response reports all three as `success`. **Issue one claim per call.**
+> **Single-claim-per-call:** The `claims` array must contain at most 1 entry. `claims.size > 1` returns a `validation_error` with code `multi_claim_not_supported` immediately, regardless of whether entries use `itemId` or `selector` mode.
 >
-> Selector mode (`selector` field on a claim entry) is single-claim-only by validation: `claims.size > 1` with any selector present returns a `validation_error` immediately.
+> The cap derives from the heartbeat write-budget assumption (one TTL refresh per agent per cycle). A future `claim_heartbeats` table mitigation could remove the constraint.
 >
-> ID-based multi-claim (`claims.size > 1` using `itemId` entries) is preserved for backwards compatibility but is a **deprecated path** — it will be rejected in a future major version. Tracked as MCP item `b8ac68a4`. Migrate to issuing one `claim_item` call per item.
+> Releases array (`releases`) continues to support N entries — only `claims` is restricted. Issue one `claim_item` call per item you want to claim.
 
 #### Atomic Find-and-Claim (Selector Mode)
 

--- a/current/docs/workflow-guide.md
+++ b/current/docs/workflow-guide.md
@@ -890,7 +890,7 @@ claim_item(claims=[{itemId}])       → heartbeat: refresh TTL (if work > TTL/2 
 advance_item(trigger="complete")    → ownership enforced at completion too
 ```
 
-> **Deprecation note:** `claim_item` with multiple `itemId` entries in a single `claims` array is a deprecated path. Each successive successful claim auto-releases its predecessors, so only the last claim survives — a `claims: [A, B, C]` call ends with only C held. Issue one claim per call. ID-based multi-claim is preserved for backward compatibility but will be rejected in a future major version (tracked as MCP item `b8ac68a4`). Selector mode (`selector` field) is single-claim-only by validation and is the recommended migration path.
+> **Single-claim-per-call:** `claim_item` enforces `claims.size ≤ 1`. Calls with `claims.size > 1` are rejected immediately with error code `multi_claim_not_supported`, regardless of whether entries use `itemId` or `selector` mode. Issue one `claim_item` call per item. The cap derives from the heartbeat write-budget assumption (one TTL refresh per agent per cycle); a future `claim_heartbeats` table mitigation could re-evaluate the constraint. The `releases` array remains batchable.
 
 ### Atomic Find-and-Claim (Selector Mode)
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
@@ -42,7 +42,7 @@ import java.util.UUID
  * **Selector mode:**
  * - Each claim entry may use `selector` (instead of `itemId`) for atomic find-and-claim.
  * - Selector resolves a filter+rank query and claims the top match in one call.
- * - Single-claim-per-call by validation when any selector is present.
+ * - Single-claim-per-call enforced by validation for all claim modes (`claims.size > 1` rejected).
  * - `no_match` outcome (kind=permanent) when the queue is empty for the given filters.
  * - `claimRef` (optional, ≤64 chars) is echoed in every result for caller correlation.
  *
@@ -74,7 +74,7 @@ any prior claim held by the same agent.
   - ID mode: `{ itemId (required UUID or short hex), ttlSeconds? (optional int, default 900, max 86400), agentId? (optional string, overridden by verified actor), claimRef? (optional string, max 64 chars — echoed in result) }`
   - Selector mode: `{ selector (required object — see below), ttlSeconds? (optional int, default 900, max 86400), claimRef? (optional string, max 64 chars — echoed in result) }`
   - Each entry must have exactly one of `itemId` or `selector`.
-  - When any entry uses `selector`, claims array must contain exactly 1 entry (see batch warning below).
+  - **Single-claim-per-call:** `claims` array must contain at most 1 entry. Use one call per item.
 - `releases` (optional array): Items to release. Each element: `{ itemId (required UUID or short hex) }`
 - `actor` (required): `{ id (required string), kind (required: orchestrator|subagent|user|external), parent? (optional string), proof? (optional string) }` — identity used as the claim holder. Verified identity overrides self-reported agentId.
 - `requestId` (required UUID): Client-generated UUID for idempotency. Required — `claim_item` is a fleet-mode tool and idempotency is a hard contract. Repeated calls with the same (actor, requestId) within ~10 minutes return the cached response without re-executing.
@@ -94,14 +94,10 @@ any prior claim held by the same agent.
 
 At least one of `claims` or `releases` must be non-empty.
 
-**⚠ Multi-claim batch semantics (ID-based claims, deprecated path):**
-Each successful claim auto-releases all other claims this agent currently holds.
-In a multi-claim batch, each successive `success` releases its predecessors.
-A call with `claims: [A, B, C]` ends with only C held — A and B are released even
-though the response reports all three as `success`. **Issue one claim per call.**
-Selector mode (`selector` field on a claim entry) is single-claim-only by validation.
-ID-based multi-claim is preserved for backwards compatibility but will be rejected
-in a future major version (tracked separately).
+**Single-claim-per-call:** `claims` array must contain at most 1 entry. Use one call per item.
+The cap derives from the heartbeat write-budget assumption (one TTL refresh per agent per cycle).
+A future `claim_heartbeats` table mitigation could remove the constraint.
+Releases array (`releases`) continues to support N entries — only `claims` is restricted.
 
 **Claim outcomes per item:**
 - `success` — claim placed or TTL refreshed (same agent re-claim). Response includes own claim metadata. Selector claims also include `selectorResolved: true`.
@@ -160,15 +156,15 @@ in a future major version (tracked separately).
                             put(
                                 "description",
                                 JsonPrimitive(
-                                    "Array of claim requests. Each entry uses either ID mode: " +
+                                    "Array of claim requests. Max 1 entry per call — use one call per item. " +
+                                        "Each entry uses either ID mode: " +
                                         "{ itemId (required UUID or hex prefix), " +
                                         "ttlSeconds? (optional int, default 900, min 1, max 86400 — 24 h cap), " +
                                         "agentId? (optional string, overridden by verified actor), " +
                                         "claimRef? (optional string, max 64 chars) } " +
                                         "or Selector mode: { selector (required object with filter fields), " +
                                         "ttlSeconds? (optional int), claimRef? (optional string, max 64 chars) }. " +
-                                        "Exactly one of itemId or selector must be present per entry. " +
-                                        "When any entry uses selector, claims array must contain exactly 1 entry."
+                                        "Exactly one of itemId or selector must be present per entry."
                                 )
                             )
                         }
@@ -252,19 +248,19 @@ in a future major version (tracked separately).
             }
         }
 
-        // Validate claims entries — check for selector mode rules
+        // Validate claims entries — check for single-claim-per-call rule
         if (!claims.isNullOrEmpty()) {
-            val hasAnySelector =
-                claims.any { element ->
-                    val obj = element as? JsonObject ?: return@any false
-                    obj.containsKey("selector")
-                }
-
-            // Single-selector-per-call rule: if any entry has selector, claims.size must == 1
-            if (hasAnySelector && claims.size > 1) {
+            // Universal single-claim-per-call rule: claims array must contain at most 1 entry.
+            // The cap derives from the heartbeat write-budget assumption (one TTL refresh per agent
+            // per cycle). Multi-claim was previously silently broken for ID-based calls (the
+            // repository auto-released all but the last claim while reporting all as success).
+            if (claims.size > 1) {
                 throw ToolValidationException(
-                    "Selector mode supports a single claim per call. Multi-claim batches conflict " +
-                        "with the one-claim-per-agent rule. To claim multiple items, issue separate calls."
+                    "multi_claim_not_supported: claim_item currently supports one claim per call. " +
+                        "Issue separate calls per item. " +
+                        "(Multi-claim previously silently released all but the last claim — " +
+                        "that footgun is now closed; the cap may be re-evaluated in a future major " +
+                        "version if a use case emerges.)"
                 )
             }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
@@ -371,16 +371,15 @@ class ClaimItemToolTest {
     // -----------------------------------------------------------------------
 
     @Test
-    fun `execute summary reflects correct counts for mixed outcomes`(): Unit =
+    fun `execute summary reflects correct counts for claim success and release`(): Unit =
         runBlocking {
             coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns ClaimResult.Success(makeSuccessItem())
-            coEvery { workItemRepo.claim(itemId2, agentId, 900) } returns ClaimResult.AlreadyClaimed(itemId2, null)
             coEvery { workItemRepo.release(itemId1, agentId) } returns ReleaseResult.Success(WorkItem(id = itemId1, title = "R"))
 
             val result =
                 tool.execute(
                     params(
-                        claims = listOf(claimEntry(itemId1), claimEntry(itemId2)),
+                        claims = listOf(claimEntry(itemId1)),
                         releases = listOf(releaseEntry(itemId1))
                     ),
                     defaultContext()
@@ -388,13 +387,64 @@ class ClaimItemToolTest {
 
             val data = (result as JsonObject)["data"] as JsonObject
             val summary = data["summary"] as JsonObject
-            assertEquals(2, summary["claimsTotal"]?.jsonPrimitive?.intOrNull)
+            assertEquals(1, summary["claimsTotal"]?.jsonPrimitive?.intOrNull)
             assertEquals(1, summary["claimsSucceeded"]?.jsonPrimitive?.intOrNull)
-            assertEquals(1, summary["claimsFailed"]?.jsonPrimitive?.intOrNull)
+            assertEquals(0, summary["claimsFailed"]?.jsonPrimitive?.intOrNull)
             assertEquals(1, summary["releasesTotal"]?.jsonPrimitive?.intOrNull)
             assertEquals(1, summary["releasesSucceeded"]?.jsonPrimitive?.intOrNull)
             assertEquals(0, summary["releasesFailed"]?.jsonPrimitive?.intOrNull)
         }
+
+    @Test
+    fun `validateParams throws multi_claim_not_supported when claims has two ID entries`() {
+        val p =
+            buildJsonObject {
+                put(
+                    "claims",
+                    buildJsonArray {
+                        add(buildJsonObject { put("itemId", itemId1.toString()) })
+                        add(buildJsonObject { put("itemId", itemId2.toString()) })
+                    }
+                )
+                put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
+            }
+        val ex = assertFailsWith<ToolValidationException> { tool.validateParams(p) }
+        assertTrue(
+            ex.message!!.contains("multi_claim_not_supported"),
+            "Error must contain multi_claim_not_supported. Got: ${ex.message}"
+        )
+        assertTrue(
+            ex.message!!.contains("one claim per call"),
+            "Error must mention one claim per call. Got: ${ex.message}"
+        )
+    }
+
+    @Test
+    fun `validateParams accepts single ID claim — size 1 succeeds`() {
+        val p = params(claims = listOf(claimEntry(itemId1)))
+        // Must not throw
+        tool.validateParams(p)
+    }
+
+    @Test
+    fun `validateParams accepts mixed claims size 1 with multiple releases`() {
+        val p =
+            buildJsonObject {
+                put("claims", buildJsonArray { add(buildJsonObject { put("itemId", itemId1.toString()) }) })
+                put(
+                    "releases",
+                    buildJsonArray {
+                        add(buildJsonObject { put("itemId", itemId1.toString()) })
+                        add(buildJsonObject { put("itemId", itemId2.toString()) })
+                    }
+                )
+                put("actor", actorJson())
+                put("requestId", UUID.randomUUID().toString())
+            }
+        // releases.size > 1 is fine; only claims is capped at 1
+        tool.validateParams(p)
+    }
 
     // -----------------------------------------------------------------------
     // Execute — actor required
@@ -897,8 +947,8 @@ class ClaimItemToolTest {
             }
         val ex = assertFailsWith<ToolValidationException> { tool.validateParams(p) }
         assertTrue(
-            ex.message!!.contains("single claim per call") || ex.message!!.contains("Selector mode"),
-            "Error must mention selector mode constraint. Got: ${ex.message}"
+            ex.message!!.contains("multi_claim_not_supported"),
+            "Error must contain multi_claim_not_supported. Got: ${ex.message}"
         )
     }
 
@@ -918,8 +968,8 @@ class ClaimItemToolTest {
             }
         val ex = assertFailsWith<ToolValidationException> { tool.validateParams(p) }
         assertTrue(
-            ex.message!!.contains("single claim per call") || ex.message!!.contains("Selector mode"),
-            "Error must mention selector mode constraint. Got: ${ex.message}"
+            ex.message!!.contains("multi_claim_not_supported"),
+            "Error must contain multi_claim_not_supported. Got: ${ex.message}"
         )
     }
 


### PR DESCRIPTION
## Summary
- Reject `claim_item` calls with `claims.size > 1` at the validation layer with error code `multi_claim_not_supported`. Multi-claim was previously silently broken — the repository auto-released all but the last claim while the response reported every entry as `success`. Closes [b8ac68a4](https://github.com/jpicklyk/task-orchestrator) (Tech Debt: Tighten claim_item to reject claims.size > 1).
- Cap framed as a heartbeat write-budget decision (one TTL refresh per agent per cycle), explicitly leaving room for future re-evaluation if a `claim_heartbeats` table mitigation lands. This avoids painting future work into a corner.
- Releases array remains batchable; mixed `claims+releases` composition preserved; selector mode unchanged (already single-claim-only by validation — that narrower check is now redundant and removed).

## Breaking change
This is intentionally breaking. Callers submitting `claims: [A, B, C]` previously got a misleading "all three success" response while only C was actually held. They now get a `validation_error` with code `multi_claim_not_supported` and a message explaining the migration path. Documented under `### Breaking Changes` in `CHANGELOG.md` ([Unreleased]).

## Test plan
- [x] `./gradlew :current:test` passes (1m 9s, no new failures)
- [x] `./gradlew :current:ktlintCheck` passes (9s)
- [x] New tests: validation rejection on `claims.size > 1` (ID-mode and selector-mode); `claims.size == 1` accepted; mixed claims+releases preserved
- [x] Plugin audit: searched all of `claude-plugins/task-orchestrator/`; 0 callers submit multi-claim today; one wording update in `skills/ralph/iteration-prompt.md` (note text only — selector mode was already single-claim-only by validation)
- [x] Independent review agent verified all 10 acceptance criteria from spec; PASS on `review-checklist`, `api-compatibility`, and `plugin-impact` notes

## Files changed
- `current/.../application/tools/workflow/ClaimItemTool.kt` — validation generalized; kdoc + `description` const + parameter schema text updated
- `current/src/test/.../ClaimItemToolTest.kt` — 3 tests updated, 3 added
- `current/docs/api-reference.md`, `current/docs/workflow-guide.md` — single-claim-per-call note replaces deprecated-multi-claim warning
- `CHANGELOG.md` — entry promoted from `Deprecated` to `Breaking Changes` under `[Unreleased]`
- `claude-plugins/task-orchestrator/skills/ralph/iteration-prompt.md` — note wording aligned with new universal rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)