### PR TITLE
feat(claim): ancestor-claim protection in findClaimable (strict-by-default)

### DIFF
--- a/claude-plugins/task-orchestrator/skills/ralph/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/ralph/SKILL.md
@@ -281,6 +281,12 @@ Solution: Check `query_items(operation="search", claimStatus="claimed")` to see 
 
 ---
 
+**Note: Ralph workers skip sub-items of in-progress features (ancestor-claim filtering)**
+
+When a fleet agent claims a feature using the hybrid topology (Scenario D in the [Fleet Deployment Guide](../../../../../../current/docs/fleet-deployment.md)), the feature's child tasks are automatically protected from Ralph workers with broad selectors. A Ralph drain using `role=queue` will see `no_match` for any candidate whose ancestor is currently claimed by a different agent — this is the correct and desired behavior, not a bug. Ralph workers naturally focus on top-level claimable work; items inside an in-progress orchestration session are shielded. Use `parentId: null` in the filter to explicitly restrict to top-level items and avoid even evaluating sub-items.
+
+---
+
 **Problem: the iteration agent dispatches subagents (Agent tool) and that's confusing the loop**
 
 Cause: The iteration prompt doesn't forbid subagents, but they add complexity (the iteration agent's worktree is the dispatched subagent's working directory too).

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1015,6 +1015,13 @@ requested role (default: `queue`), filters out those with unsatisfied blocking d
 with active claims (unless `includeClaimed=true`), and ranks by priority descending then complexity
 ascending (quick wins first) by default.
 
+**Ancestor-claim filtering (strict mode).** When `includeClaimed=false` (the default), items whose
+ancestor chain contains any live claim are excluded from results — even if the item itself is unclaimed.
+This prevents `get_next_item` from surfacing sub-items of in-progress features to agents that would
+be competing with the feature's orchestrator. Root items (no parent) are unaffected. When
+`includeClaimed=true`, ancestor-claim filtering is NOT applied — that path uses `findForNextItem`
+and is intentionally inclusive.
+
 #### Key Parameters
 
 | Parameter | Type | Required | Description |
@@ -1189,6 +1196,7 @@ The selector filter shape is identical to the `get_next_item` filter parameters 
 - **Passive expiry.** There is no background reaper. Expired claims are filtered at read time. Crash recovery happens automatically via TTL.
 - **DB-side time.** All timestamps (`claimedAt`, `claimExpiresAt`) are set via SQLite `datetime('now', ...)` — they are UTC. Operators inspecting raw rows must not assume host-local time.
 - **Per-entry `agentId` vs verified `actor.id`.** When the configured verifier resolves a trusted identity from `actor.proof`, that verified id becomes the claim holder and any `agentId` on the individual claim entry is ignored. The server logs a warning when the two disagree. Callers without a verifier configured may still supply `agentId`; it has no special status beyond providing a self-reported identity.
+- **Ancestor-claim filtering in selector mode.** When using selector mode, items whose ancestor chain contains a live claim held by a *different* agent are excluded from the eligible set. Items under an ancestor claimed by the *same* agent (the requesting `actor.id`) are retained — enabling the hybrid fleet pattern: claim a feature at the top level, then orchestrate its child sub-tree. Root items (no parent) are unaffected. This filter is applied *before* dependency-blocking and ordering. Items excluded by this filter appear as absent from selector results; the competing agent's identity is never disclosed. **ID-mode claims bypass this filter entirely** — the per-item `claim()` path goes directly to the item, regardless of ancestor claim state.
 
 **Claim outcome codes per item:**
 

--- a/current/docs/fleet-deployment.md
+++ b/current/docs/fleet-deployment.md
@@ -37,6 +37,88 @@ Anything else (specific skill instructions, hook behavior, output-style conventi
 
 ---
 
+## Fleet Topology Patterns
+
+Choose the topology that fits your workload. The four canonical patterns are listed from simplest to most powerful. The **hybrid pattern (Scenario D) is the recommended default for feature-based development work**.
+
+### Scenario A — Pure Orchestration (no claim_item)
+
+A single orchestrator agent owns all dispatch decisions. It calls `advance_item` to move children through the pipeline. No `claim_item` is used.
+
+**Characteristics:**
+- Simple. No identity configuration required.
+- Sequential — one orchestrator dispatches in topological order.
+- Chain continuity is implicit: the orchestrator transitions A→terminal then immediately dispatches B. No inter-agent race possible.
+- Works for single-dev or low-concurrency setups.
+
+**Ancestor-claim behavior:** Not applicable — `claim_item` is never called.
+
+### Scenario B — Pure Claim, Flat Items (no parent→child relationships)
+
+Independent items with no hierarchical relationship. Fleet agents each call `claim_item(selector=...)` and work items from a shared queue.
+
+**Characteristics:**
+- Horizontally scalable. Many agents drain the queue independently.
+- Items are genuinely independent: no shared context, no chain continuity concern.
+- Selector hygiene: use `parentId: null` or specific tag filters to restrict to top-level items.
+
+**Ancestor-claim behavior:** Inert. All items are root-level (depth=0); no ancestor chain to walk. The filter is a no-op.
+
+### Scenario C — Pure Claim, Chains (anti-pattern)
+
+Dependent items (A→B→C) where each item is independently claimed from the queue by competing fleet agents.
+
+**Anti-pattern warning:** This topology has a fundamental limitation — the **post-completion race**. When A completes and its dependency on B is cleared, B becomes claimable by every fleet agent simultaneously. Whichever agent calls `claim_item(selector=...)` first wins B, regardless of which agent has the most context from working A. The system architecture's answer to context continuity is notes as the handoff contract, but notes cannot capture an agent's working mental model.
+
+**Ancestor-claim behavior:** While A is in progress and claimed, B (a child of A) is protected from other agents' broad selectors. However, once A reaches terminal, A's claim is a stale record — the protection expires. B then becomes immediately available to all fleet agents (post-completion race). For tightly-coupled chains, use Scenario D instead.
+
+**When this is acceptable:** If your chain items are genuinely independent (notes provide sufficient handoff), and post-completion races are tolerable or managed by fine-grained selectors, Scenario C may work. Document the tradeoff explicitly.
+
+### Scenario D — Hybrid (RECOMMENDED): Claim at Parent, Orchestrate Sub-tree
+
+Fleet agents claim at the **feature level** (top-level items). Each claiming agent then orchestrates its own sub-tree using `advance_item` — not `claim_item` — for children.
+
+```
+Fleet agent work loop:
+  claim_item(selector={tags:"feature", role:"queue"})  → claim a feature
+    → advance_item(trigger="start") on the feature
+    → advance_item(trigger="start") on child A      [orchestrate, no claim_item]
+    → ... wait for A to complete ...
+    → advance_item(trigger="start") on child B      [orchestrate, no claim_item]
+    → advance_item(trigger="complete") on feature
+  claim_item(releases=[featureId])                    → release
+```
+
+**Why this is the recommended topology:**
+
+1. **No post-completion race.** Sub-items are never exposed to the claim-eligibility pool. The orchestrating agent transitions A→terminal then advances B immediately; no other agent ever sees B in a claimable state.
+2. **Full chain-context continuity.** One agent owns the entire feature sub-tree. Notes from A are in its context when it starts B. No inter-agent handoff required.
+3. **Sub-tree protection.** The ancestor-claim filter ensures other fleet agents (e.g., broad-selector drain workers) cannot accidentally claim sub-items of in-progress features. `claim_item(selector={role:"queue"})` on a competing agent will simply skip children whose ancestor is claimed.
+4. **TTL-as-recovery-vector.** If the orchestrating agent crashes, the feature's claim TTL expires. Recovery agents can then claim the feature and read `session-tracking` notes to resume orchestration. No manual intervention needed.
+
+**Recommended TTL guidance for hybrid pattern:**
+
+| Work unit size | Recommended TTL | Heartbeat cadence |
+|---|---|---|
+| Small feature (1–3 sub-tasks, < 1 hour) | 900s (default) | TTL/2 = 450s |
+| Medium feature (4–10 sub-tasks, 1–4 hours) | 3600s (1 hour) | 1800s (30 min) |
+| Large feature (10+ sub-tasks, multi-hour) | 7200s–14400s | TTL/4 |
+
+Heartbeat: re-call `claim_item(claims=[{itemId: featureId}])` at the recommended cadence while orchestration is in progress. Each heartbeat refreshes `claimExpiresAt` without changing `originalClaimedAt`.
+
+**Selector hygiene for hybrid pattern:** Use `parentId: null` or `tags: "feature"` in your selector to target top-level features. Avoid broad selectors like `role: queue` without a parent filter — these work correctly (the ancestor-claim filter protects sub-items), but they waste eligibility-query bandwidth evaluating candidates that will be filtered.
+
+### Summary Table
+
+| Topology | Claim used? | Ancestor filter impact | Chain continuity | Recommended for |
+|---|---|---|---|---|
+| A — Pure orchestration | No | Not applicable | Implicit (single orchestrator) | Single-dev, sequential pipelines |
+| B — Pure claim, flat | Yes, all items | Inert (all root) | N/A (items independent) | Truly independent parallel work |
+| C — Pure claim, chains | Yes, all items | Protects during A's work, not after | Post-completion race (anti-pattern) | Simple chains with sufficient note handoff |
+| **D — Hybrid (RECOMMENDED)** | **Feature level only** | **Full protection** | **Full (single orchestrator per feature)** | **Feature-based development work** |
+
+---
+
 ## Identity Configuration — `auth.degradedModePolicy`
 
 The `degradedModePolicy` field under `actor_authentication:` in `.taskorchestrator/config.yaml` controls how the server resolves actor identity when JWKS verification cannot produce a fully verified result.

--- a/current/docs/workflow-guide.md
+++ b/current/docs/workflow-guide.md
@@ -929,6 +929,8 @@ advance_item(trigger="complete")    → ownership enforced at completion too
 
 `orderBy: "oldest"` provides fair-share FIFO draining: agents process items in creation order rather than racing to the same high-priority items. When `no_match` is returned, the queue is drained — the agent can idle, exit, or poll after a delay.
 
+**Selector hygiene and ancestor-claim filtering.** In selector mode, items whose ancestor chain contains a live claim held by a *different* agent are automatically excluded from the eligible set. This sub-tree isolation protects in-progress feature orchestration from fleet drain workers picking up child items. Use specific selectors (`parentId: null` to restrict to top-level items, or tag filters such as `tags: "feature"`) when your fleet operates at the top level; broader selectors like `role: queue` will naturally skip sub-items of in-progress features without returning errors. Items excluded by ancestor-claim filtering appear as `no_match` rather than surfacing information about the competing agent's identity. See [Fleet Deployment Guide — Fleet Topology Patterns](./fleet-deployment.md#fleet-topology-patterns) for recommended patterns.
+
 `claimRef` (up to 64 chars) is echoed verbatim in every result and is useful for correlating claim results back to your agent's internal loop state without parsing `itemId` values.
 
 **Idempotency with selector mode.** A `(actor, requestId)` cache hit replays the resolved response verbatim — the same `itemId` is returned, and the selector is **not** re-evaluated against fresh queue state. Use a fresh `requestId` per claim iteration, not per retry of the same iteration.

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommender.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommender.kt
@@ -37,6 +37,17 @@ class NextItemRecommender(
         val roleChangedAfter: Instant? = null,
         val roleChangedBefore: Instant? = null,
         val orderBy: NextItemOrder = NextItemOrder.PRIORITY_THEN_COMPLEXITY,
+        /**
+         * Optional agent identifier forwarded to [WorkItemRepository.findClaimable] for
+         * ancestor-claim sub-tree isolation.
+         *
+         * When non-null, candidates whose ancestor chain contains a live claim held by a
+         * *different* agent are excluded; candidates under the same agent's claimed ancestor
+         * are retained (enabling the hybrid fleet pattern: claim at parent feature, orchestrate
+         * sub-tree below). When null, any live ancestor claim disqualifies the candidate (strict
+         * exclusion for callers without actor context, such as [GetNextItemTool]).
+         */
+        val requestingAgentId: String? = null,
     )
 
     /**
@@ -67,6 +78,7 @@ class NextItemRecommender(
                 roleChangedBefore = criteria.roleChangedBefore,
                 orderBy = criteria.orderBy,
                 limit = OVER_FETCH_LIMIT,
+                requestingAgentId = criteria.requestingAgentId,
             )
 
         if (candidatesResult is Result.Error) {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
@@ -515,7 +515,9 @@ Releases array (`releases`) continues to support N entries — only `claims` is 
                     resolvedSelectorParentId = resolvedUuid
                 }
 
-                val criteria = buildCriteria(selectorObj, resolvedSelectorParentId)
+                val criteria =
+                    buildCriteria(selectorObj, resolvedSelectorParentId)
+                        .copy(requestingAgentId = trustedAgentId)
 
                 when (val recommendResult = context.nextItemRecommender.recommend(criteria, limit = 1)) {
                     is Result.Success -> {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
@@ -44,8 +44,11 @@ Parameters:
 - includeAncestors (optional boolean, default false): when true, each recommended item includes an
   `ancestors` array ordered root-first (direct parent last). Root items (depth=0) get `"ancestors": []`.
 - includeClaimed (optional boolean, default false): When false (default), items with an active
-  (non-expired) claim are filtered out. When true, claimed items are included but only a boolean
-  `isClaimed` field is exposed — the claiming agent's identity is never disclosed.
+  (non-expired) claim are filtered out, AND ancestor-claim sub-tree isolation applies (children
+  of items claimed by another agent are excluded). When true, claimed items are included AND the
+  ancestor-claim filter is NOT applied — admin/inspection callers see the full set, and only a
+  boolean `isClaimed` field is exposed (the claiming agent's identity is never disclosed). Fleet
+  callers should leave this `false` so sub-tree isolation continues to protect in-progress features.
 
 Filter parameters (all optional, any-match semantics where applicable):
 - tags (string, comma-separated): Return only items whose tags contain any of the given values

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
@@ -278,6 +278,25 @@ interface WorkItemRepository {
      * it is not a parameter because claim-eligibility by definition means the item is unclaimed or
      * its claim has expired. All filters are combined with AND logic; tags use OR logic within the list.
      *
+     * **Ancestor-claim filtering (strict-by-default sub-tree isolation):**
+     *
+     * After the initial candidate query, each candidate's ancestor chain is walked to enforce
+     * fleet isolation:
+     *
+     * - When `requestingAgentId` is **non-null**: any candidate whose ancestor chain contains
+     *   a live claim (`claimed_by IS NOT NULL AND claim_expires_at > now`) held by a *different*
+     *   agent is excluded. Candidates whose ancestor is claimed by the *same* agent are retained
+     *   (supporting the hybrid pattern: claim at parent feature, orchestrate sub-tree below).
+     * - When `requestingAgentId` is **null** (default): any candidate whose ancestor chain
+     *   contains a live claim by *any* agent is excluded. This is the strict exclusion mode used
+     *   by read-only callers such as `get_next_item` that do not have actor context.
+     *
+     * Ancestor-claim freshness is evaluated using [dbNow] — the DB-side clock — consistent with
+     * the existing item-level claim exclusion contract. The walk is a batched BFS bounded by
+     * the maximum depth of 3, so the total extra query cost is at most 3 additional round-trips.
+     *
+     * Items with no parent (root items, depth=0) are unaffected by this filter.
+     *
      * @param role              The role to query (required — e.g. QUEUE, WORK, REVIEW).
      * @param parentId          Optional parent UUID to scope results to direct children only.
      * @param tags              Optional list of tags; items matching ANY tag are included.
@@ -290,6 +309,10 @@ interface WorkItemRepository {
      * @param roleChangedBefore Optional upper bound (inclusive) on [WorkItem.roleChangedAt].
      * @param orderBy           Ordering strategy for the result set (default: priority then complexity).
      * @param limit             Maximum number of rows to return (default: 200).
+     * @param requestingAgentId Optional agent identifier for sub-tree isolation. When non-null,
+     *                          only ancestor claims held by a *different* agent disqualify a
+     *                          candidate. When null, any live ancestor claim disqualifies the
+     *                          candidate (strict exclusion for callers without actor context).
      * @return [Result.Success] with the list of matching, claimable items (may be empty), or
      *         [Result.Error] on a database failure.
      */
@@ -306,6 +329,7 @@ interface WorkItemRepository {
         roleChangedBefore: Instant? = null,
         orderBy: NextItemOrder = NextItemOrder.PRIORITY_THEN_COMPLEXITY,
         limit: Int = 200,
+        requestingAgentId: String? = null,
     ): Result<List<WorkItem>>
 
     /**

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
@@ -297,6 +297,12 @@ interface WorkItemRepository {
      *
      * Items with no parent (root items, depth=0) are unaffected by this filter.
      *
+     * **Filter ordering vs. limit:** [limit] is applied to the candidate query *before* the
+     * ancestor-claim filter runs. The returned list size is therefore at most [limit], and may
+     * be smaller — even when more matching items exist in the DB — if some candidates are
+     * excluded by the ancestor walk. Callers that need a guaranteed minimum result size should
+     * over-fetch (e.g. `NextItemRecommender` uses `OVER_FETCH_LIMIT` for this reason).
+     *
      * @param role              The role to query (required — e.g. QUEUE, WORK, REVIEW).
      * @param parentId          Optional parent UUID to scope results to direct children only.
      * @param tags              Optional list of tags; items matching ANY tag are included.

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -714,6 +714,7 @@ class SQLiteWorkItemRepository(
         roleChangedBefore: Instant?,
         orderBy: NextItemOrder,
         limit: Int,
+        requestingAgentId: String?,
     ): Result<List<WorkItem>> =
         databaseManager.suspendedTransaction("Failed to find claimable items") {
             val conditions = mutableListOf<Op<Boolean>>()
@@ -782,9 +783,84 @@ class SQLiteWorkItemRepository(
                         baseQuery.orderBy(WorkItemsTable.createdAt, SortOrder.DESC)
                 }
 
-            val items = orderedQuery.limit(limit).mapNotNull { toWorkItemOrNull(it) }
+            val candidates = orderedQuery.limit(limit).mapNotNull { toWorkItemOrNull(it) }
 
-            Result.Success(items)
+            // -----------------------------------------------------------------------
+            // Ancestor-claim filter (strict-by-default sub-tree isolation)
+            //
+            // For each candidate with a parentId, walk the ancestor chain and disqualify
+            // any candidate whose ancestor has a live claim held by a disqualifying agent.
+            //
+            // Disqualifying ancestor claim condition:
+            //   claimed_by IS NOT NULL
+            //   AND claim_expires_at > dbNow()
+            //   AND (requestingAgentId == null OR claimed_by != requestingAgentId)
+            //
+            // Batched BFS pattern modeled on findAncestorChains (line 843), inlined within
+            // the same suspendedTransaction block to avoid an extra transaction open/close.
+            // -----------------------------------------------------------------------
+            val candidatesWithParents = candidates.filter { it.parentId != null }
+            if (candidatesWithParents.isEmpty()) {
+                // No candidates have ancestors — skip the BFS entirely.
+                return@suspendedTransaction Result.Success(candidates)
+            }
+
+            // BFS: batch-fetch all ancestors for all candidates in minimal round-trips.
+            val ancestorCache = mutableMapOf<String, WorkItem>()
+            val inputEntityIds = candidatesWithParents.map { EntityID(it.id, WorkItemsTable) }
+            val inputItems =
+                WorkItemsTable
+                    .selectAll()
+                    .where { WorkItemsTable.id inList inputEntityIds }
+                    .mapNotNull { toWorkItemOrNull(it) }
+            inputItems.forEach { ancestorCache[it.id.toString()] = it }
+
+            var toFetch =
+                inputItems.mapNotNull { it.parentId }.map { it.toString() }.toSet() - ancestorCache.keys
+            while (toFetch.isNotEmpty()) {
+                val fetchEntityIds = toFetch.map { EntityID(UUID.fromString(it), WorkItemsTable) }
+                val fetched =
+                    WorkItemsTable
+                        .selectAll()
+                        .where { WorkItemsTable.id inList fetchEntityIds }
+                        .mapNotNull { toWorkItemOrNull(it) }
+                fetched.forEach { ancestorCache[it.id.toString()] = it }
+                toFetch = fetched.mapNotNull { it.parentId }.map { it.toString() }.toSet() - ancestorCache.keys
+            }
+
+            // Filter candidates: exclude those with a disqualifying live ancestor claim.
+            val filtered =
+                candidates.filter { candidate ->
+                    if (candidate.parentId == null) {
+                        // Root item — no ancestors to check
+                        true
+                    } else {
+                        // Walk the ancestor chain; disqualify on first violating ancestor.
+                        var parentIdStr = candidate.parentId?.toString()
+                        val visited = mutableSetOf<String>()
+                        var disqualified = false
+                        while (parentIdStr != null && !disqualified) {
+                            if (parentIdStr in visited) break // Cycle guard
+                            visited.add(parentIdStr)
+                            val ancestor = ancestorCache[parentIdStr] ?: break
+                            val ancestorClaimBy = ancestor.claimedBy
+                            val ancestorClaimExpiry = ancestor.claimExpiresAt
+                            if (ancestorClaimBy != null &&
+                                ancestorClaimExpiry != null &&
+                                ancestorClaimExpiry > dbNowInstant
+                            ) {
+                                // Ancestor has a live claim — check if it disqualifies this candidate.
+                                if (requestingAgentId == null || ancestorClaimBy != requestingAgentId) {
+                                    disqualified = true
+                                }
+                            }
+                            parentIdStr = ancestor.parentId?.toString()
+                        }
+                        !disqualified
+                    }
+                }
+
+            Result.Success(filtered)
         }
 
     override suspend fun countByClaimStatus(parentId: UUID?): Result<ClaimStatusCounts> =

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -806,17 +806,13 @@ class SQLiteWorkItemRepository(
             }
 
             // BFS: batch-fetch all ancestors for all candidates in minimal round-trips.
+            // Seed the cache directly from the in-memory candidate rows — no need to re-fetch
+            // them from the DB just to read their parentId fields.
             val ancestorCache = mutableMapOf<String, WorkItem>()
-            val inputEntityIds = candidatesWithParents.map { EntityID(it.id, WorkItemsTable) }
-            val inputItems =
-                WorkItemsTable
-                    .selectAll()
-                    .where { WorkItemsTable.id inList inputEntityIds }
-                    .mapNotNull { toWorkItemOrNull(it) }
-            inputItems.forEach { ancestorCache[it.id.toString()] = it }
+            candidatesWithParents.forEach { ancestorCache[it.id.toString()] = it }
 
             var toFetch =
-                inputItems.mapNotNull { it.parentId }.map { it.toString() }.toSet() - ancestorCache.keys
+                candidatesWithParents.mapNotNull { it.parentId }.map { it.toString() }.toSet() - ancestorCache.keys
             while (toFetch.isNotEmpty()) {
                 val fetchEntityIds = toFetch.map { EntityID(UUID.fromString(it), WorkItemsTable) }
                 val fetched =

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -796,8 +796,8 @@ class SQLiteWorkItemRepository(
             //   AND claim_expires_at > dbNow()
             //   AND (requestingAgentId == null OR claimed_by != requestingAgentId)
             //
-            // Batched BFS pattern modeled on findAncestorChains (line 843), inlined within
-            // the same suspendedTransaction block to avoid an extra transaction open/close.
+            // Batched BFS pattern modeled on findAncestorChains, inlined within the same
+            // suspendedTransaction block to avoid an extra transaction open/close.
             // -----------------------------------------------------------------------
             val candidatesWithParents = candidates.filter { it.parentId != null }
             if (candidatesWithParents.isEmpty()) {
@@ -811,8 +811,9 @@ class SQLiteWorkItemRepository(
             val ancestorCache = mutableMapOf<String, WorkItem>()
             candidatesWithParents.forEach { ancestorCache[it.id.toString()] = it }
 
+            // candidatesWithParents was filtered to parentId != null above, so !! is safe.
             var toFetch =
-                candidatesWithParents.mapNotNull { it.parentId }.map { it.toString() }.toSet() - ancestorCache.keys
+                candidatesWithParents.map { it.parentId!!.toString() }.toSet() - ancestorCache.keys
             while (toFetch.isNotEmpty()) {
                 val fetchEntityIds = toFetch.map { EntityID(UUID.fromString(it), WorkItemsTable) }
                 val fetched =

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommenderTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommenderTest.kt
@@ -79,6 +79,7 @@ class NextItemRecommenderTest {
         roleChangedAfter: Instant? = null,
         roleChangedBefore: Instant? = null,
         orderBy: NextItemOrder = NextItemOrder.PRIORITY_THEN_COMPLEXITY,
+        requestingAgentId: String? = null,
     ) {
         coEvery {
             workItemRepo.findClaimable(
@@ -94,6 +95,7 @@ class NextItemRecommenderTest {
                 roleChangedBefore = roleChangedBefore,
                 orderBy = orderBy,
                 limit = 200,
+                requestingAgentId = requestingAgentId,
             )
         } returns Result.Success(items)
     }
@@ -147,6 +149,7 @@ class NextItemRecommenderTest {
                     roleChangedBefore = roleBefore,
                     orderBy = NextItemOrder.OLDEST_FIRST,
                     limit = 200,
+                    requestingAgentId = null,
                 )
             } returns Result.Success(listOf(item))
             every { dependencyRepo.findByToItemId(item.id) } returns emptyList()
@@ -172,6 +175,7 @@ class NextItemRecommenderTest {
                     roleChangedBefore = roleBefore,
                     orderBy = NextItemOrder.OLDEST_FIRST,
                     limit = 200,
+                    requestingAgentId = null,
                 )
             }
         }
@@ -203,6 +207,7 @@ class NextItemRecommenderTest {
                     roleChangedBefore = null,
                     orderBy = NextItemOrder.PRIORITY_THEN_COMPLEXITY,
                     limit = 200,
+                    requestingAgentId = null,
                 )
             }
         }
@@ -451,6 +456,7 @@ class NextItemRecommenderTest {
                     roleChangedBefore = any(),
                     orderBy = any(),
                     limit = any(),
+                    requestingAgentId = any(),
                 )
             } returns Result.Error(repoError)
 
@@ -458,5 +464,113 @@ class NextItemRecommenderTest {
 
             assertIs<Result.Error>(result)
             assertEquals(repoError, result.error)
+        }
+
+    // -----------------------------------------------------------------------
+    // requestingAgentId round-trips through recommend()
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `requestingAgentId in Criteria is forwarded to findClaimable`(): Unit =
+        runBlocking {
+            val item = workItem()
+            val agentId = "agent-fleet-worker-1"
+
+            // Stub findClaimable specifically for this agentId
+            coEvery {
+                workItemRepo.findClaimable(
+                    role = Role.QUEUE,
+                    parentId = null,
+                    tags = null,
+                    priority = null,
+                    type = null,
+                    complexityMax = null,
+                    createdAfter = null,
+                    createdBefore = null,
+                    roleChangedAfter = null,
+                    roleChangedBefore = null,
+                    orderBy = NextItemOrder.PRIORITY_THEN_COMPLEXITY,
+                    limit = 200,
+                    requestingAgentId = agentId,
+                )
+            } returns Result.Success(listOf(item))
+            every { dependencyRepo.findByToItemId(item.id) } returns emptyList()
+            every { dependencyRepo.findByFromItemId(item.id) } returns emptyList()
+
+            val criteria = NextItemRecommender.Criteria(requestingAgentId = agentId)
+            val result = recommender.recommend(criteria, limit = 1)
+
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size)
+
+            // Verify the agent ID was forwarded to the repository
+            coVerify(exactly = 1) {
+                workItemRepo.findClaimable(
+                    role = Role.QUEUE,
+                    parentId = null,
+                    tags = null,
+                    priority = null,
+                    type = null,
+                    complexityMax = null,
+                    createdAfter = null,
+                    createdBefore = null,
+                    roleChangedAfter = null,
+                    roleChangedBefore = null,
+                    orderBy = NextItemOrder.PRIORITY_THEN_COMPLEXITY,
+                    limit = 200,
+                    requestingAgentId = agentId,
+                )
+            }
+        }
+
+    @Test
+    fun `null requestingAgentId in Criteria forwards null to findClaimable (strict exclusion mode)`(): Unit =
+        runBlocking {
+            val item = workItem()
+
+            coEvery {
+                workItemRepo.findClaimable(
+                    role = Role.QUEUE,
+                    parentId = null,
+                    tags = null,
+                    priority = null,
+                    type = null,
+                    complexityMax = null,
+                    createdAfter = null,
+                    createdBefore = null,
+                    roleChangedAfter = null,
+                    roleChangedBefore = null,
+                    orderBy = NextItemOrder.PRIORITY_THEN_COMPLEXITY,
+                    limit = 200,
+                    requestingAgentId = null,
+                )
+            } returns Result.Success(listOf(item))
+            every { dependencyRepo.findByToItemId(item.id) } returns emptyList()
+            every { dependencyRepo.findByFromItemId(item.id) } returns emptyList()
+
+            // Default Criteria has requestingAgentId = null
+            val criteria = NextItemRecommender.Criteria()
+            val result = recommender.recommend(criteria, limit = 1)
+
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size)
+
+            coVerify(exactly = 1) {
+                workItemRepo.findClaimable(
+                    role = any(),
+                    parentId = any(),
+                    tags = any(),
+                    priority = any(),
+                    type = any(),
+                    complexityMax = any(),
+                    createdAfter = any(),
+                    createdBefore = any(),
+                    roleChangedAfter = any(),
+                    roleChangedBefore = any(),
+                    orderBy = any(),
+                    limit = any(),
+                    requestingAgentId = null,
+                )
+            }
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
@@ -1451,4 +1451,140 @@ class ClaimItemToolTest {
             assertEquals(1, summary["claimsSucceeded"]?.jsonPrimitive?.intOrNull)
             assertEquals(2, summary["releasesSucceeded"]?.jsonPrimitive?.intOrNull)
         }
+
+    // -----------------------------------------------------------------------
+    // Ancestor-claim protection — selector mode
+    // -----------------------------------------------------------------------
+
+    /**
+     * Verifies that the selector path passes the resolved trustedAgentId to the criteria
+     * as requestingAgentId, enabling the repository's ancestor-claim filter to perform
+     * same-agent vs. cross-agent distinction.
+     *
+     * When the recommender returns empty (simulating that the ancestor-claim filter excluded
+     * the only candidate), the outcome must be no_match.
+     */
+    @Test
+    fun `selector mode returns no_match when all candidates excluded by ancestor-claim filter (cross-agent)`(): Unit =
+        runBlocking {
+            // Recommender returns empty — simulates the repository's ancestor-claim filter
+            // having excluded the only candidate because its parent is claimed by a different agent.
+            val recommender = mockk<NextItemRecommender>()
+            coEvery { recommender.recommend(any(), 1) } returns Result.Success(emptyList())
+
+            val result =
+                tool.execute(
+                    params(
+                        claims = listOf(selectorEntry()),
+                        actorId = "agent-y"
+                    ),
+                    defaultContext(nextItemRecommender = recommender)
+                )
+
+            val data = (result as JsonObject)["data"] as JsonObject
+            val first = (data["claimResults"] as JsonArray)[0] as JsonObject
+            assertEquals("no_match", first["outcome"]?.jsonPrimitive?.content, "Selector must return no_match when ancestor-claim filter excludes all candidates")
+            assertEquals("permanent", first["kind"]?.jsonPrimitive?.content)
+        }
+
+    @Test
+    fun `selector mode passes trustedAgentId as requestingAgentId in criteria`(): Unit =
+        runBlocking {
+            val matchedItem = WorkItem(id = itemId1, title = "Eligible Item", role = Role.QUEUE)
+            val recommender = mockk<NextItemRecommender>()
+            val criteriaSlot = slot<NextItemRecommender.Criteria>()
+            coEvery { recommender.recommend(capture(criteriaSlot), 1) } returns Result.Success(listOf(matchedItem))
+            coEvery { workItemRepo.claim(itemId1, "agent-x", 900) } returns ClaimResult.Success(makeSuccessItem(claimedBy = "agent-x"))
+
+            // actor is agent-x — the criteria.requestingAgentId must be set to "agent-x"
+            val result =
+                tool.execute(
+                    params(
+                        claims = listOf(selectorEntry()),
+                        actorId = "agent-x"
+                    ),
+                    defaultContext(nextItemRecommender = recommender)
+                )
+
+            val data = (result as JsonObject)["data"] as JsonObject
+            val first = (data["claimResults"] as JsonArray)[0] as JsonObject
+            assertEquals("success", first["outcome"]?.jsonPrimitive?.content)
+
+            // Verify the criteria had requestingAgentId set to the actor's ID
+            assertEquals(
+                "agent-x",
+                criteriaSlot.captured.requestingAgentId,
+                "Selector path must forward trustedAgentId as requestingAgentId to enable same-agent sub-tree access"
+            )
+        }
+
+    @Test
+    fun `selector mode with same-agent ancestor claim succeeds (agent claims own sub-tree)`(): Unit =
+        runBlocking {
+            // Recommender returns the candidate — simulates repository's same-agent ancestor
+            // exclusion NOT filtering it out (parent claimed by same agent-x)
+            val matchedItem = WorkItem(id = itemId1, title = "Sub-item", role = Role.QUEUE)
+            val recommender = mockk<NextItemRecommender>()
+            coEvery {
+                recommender.recommend(
+                    match { it.requestingAgentId == "agent-x" },
+                    1
+                )
+            } returns Result.Success(listOf(matchedItem))
+            coEvery { workItemRepo.claim(itemId1, "agent-x", 900) } returns ClaimResult.Success(makeSuccessItem(claimedBy = "agent-x"))
+
+            val result =
+                tool.execute(
+                    params(
+                        claims = listOf(selectorEntry()),
+                        actorId = "agent-x"
+                    ),
+                    defaultContext(nextItemRecommender = recommender)
+                )
+
+            val data = (result as JsonObject)["data"] as JsonObject
+            val first = (data["claimResults"] as JsonArray)[0] as JsonObject
+            assertEquals("success", first["outcome"]?.jsonPrimitive?.content, "Same-agent sub-tree claim must succeed")
+        }
+
+    /**
+     * ID-mode claim is NOT affected by the ancestor-claim filter — the per-item `claim()` path
+     * goes directly to the repository, bypassing `findClaimable` entirely. This test documents
+     * that contract: an ID-mode claim on a child item succeeds regardless of who holds the parent.
+     */
+    @Test
+    fun `ID-mode claim is not filtered by ancestor-claim protection (direct path bypasses findClaimable)`(): Unit =
+        runBlocking {
+            // ID-mode claim on itemId1 — repository.claim is called directly.
+            // The ancestor-claim filter in findClaimable is irrelevant for this path.
+            coEvery { workItemRepo.claim(itemId1, agentId, 900) } returns ClaimResult.Success(makeSuccessItem())
+
+            val result = tool.execute(params(claims = listOf(claimEntry(itemId1))), defaultContext())
+
+            val data = (result as JsonObject)["data"] as JsonObject
+            val first = (data["claimResults"] as JsonArray)[0] as JsonObject
+            assertEquals(
+                "success",
+                first["outcome"]?.jsonPrimitive?.content,
+                "ID-mode claim must succeed regardless of ancestor claim state — it uses claim() not findClaimable()"
+            )
+            // Verify findClaimable was NOT called (selector not used)
+            coVerify(exactly = 0) {
+                workItemRepo.findClaimable(
+                    role = any(),
+                    parentId = any(),
+                    tags = any(),
+                    priority = any(),
+                    type = any(),
+                    complexityMax = any(),
+                    createdAfter = any(),
+                    createdBefore = any(),
+                    roleChangedAfter = any(),
+                    roleChangedBefore = any(),
+                    orderBy = any(),
+                    limit = any(),
+                    requestingAgentId = any(),
+                )
+            }
+        }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemToolTest.kt
@@ -1483,7 +1483,11 @@ class ClaimItemToolTest {
 
             val data = (result as JsonObject)["data"] as JsonObject
             val first = (data["claimResults"] as JsonArray)[0] as JsonObject
-            assertEquals("no_match", first["outcome"]?.jsonPrimitive?.content, "Selector must return no_match when ancestor-claim filter excludes all candidates")
+            assertEquals(
+                "no_match",
+                first["outcome"]?.jsonPrimitive?.content,
+                "Selector must return no_match when ancestor-claim filter excludes all candidates"
+            )
             assertEquals("permanent", first["kind"]?.jsonPrimitive?.content)
         }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolTest.kt
@@ -1665,4 +1665,119 @@ class GetNextItemToolTest {
         tool.validateParams(params("complexityMax" to JsonPrimitive(1)))
         tool.validateParams(params("complexityMax" to JsonPrimitive(10)))
     }
+
+    // ──────────────────────────────────────────────
+    // Ancestor-claim filter tests (GetNextItemTool uses strict mode — no actor context)
+    // ──────────────────────────────────────────────
+
+    /**
+     * Create a parent work item with an active claim, to set up ancestor-claim filter scenarios.
+     */
+    private suspend fun createClaimedParent(
+        title: String,
+        claimedBy: String = "test-agent-x"
+    ): WorkItem {
+        val now = java.time.Instant.now()
+        val parent =
+            WorkItem(
+                title = title,
+                depth = 0,
+                claimedBy = claimedBy,
+                claimedAt = now.minusSeconds(60),
+                claimExpiresAt = now.plusSeconds(3600),
+                originalClaimedAt = now.minusSeconds(60)
+            )
+        val result = context.workItemRepository().create(parent)
+        return (result as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+    }
+
+    @Test
+    fun `get_next_item excludes child when parent has active claim (strict ancestor exclusion)`(): Unit =
+        runBlocking {
+            val claimedParent = createClaimedParent("Feature (claimed)")
+            createItem("Sub-task", parentId = claimedParent.id, depth = 1, role = Role.QUEUE)
+            createItem("Root task (unclaimed, no parent)", role = Role.QUEUE)
+
+            val result = tool.execute(params("limit" to JsonPrimitive(10)), context)
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val ids = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }.toSet()
+
+            // Sub-task should be excluded (parent has active claim — strict mode, no agent context)
+            assertTrue(ids.none { id ->
+                val title = recs.find { it.jsonObject["itemId"]!!.jsonPrimitive.content == id }
+                    ?.jsonObject?.get("title")?.jsonPrimitive?.content
+                title == "Sub-task"
+            }, "Sub-task under claimed parent should be excluded from get_next_item results")
+
+            // Root task should be included (no ancestor)
+            assertTrue(ids.any { id ->
+                val title = recs.find { it.jsonObject["itemId"]!!.jsonPrimitive.content == id }
+                    ?.jsonObject?.get("title")?.jsonPrimitive?.content
+                title == "Root task (unclaimed, no parent)"
+            }, "Root task with no parent should be included")
+        }
+
+    @Test
+    fun `get_next_item with includeClaimed=true does NOT apply ancestor-claim filter`(): Unit =
+        runBlocking {
+            val claimedParent = createClaimedParent("Feature (claimed by agent-x)")
+            val subTask = createItem("Sub-task", parentId = claimedParent.id, depth = 1, role = Role.QUEUE)
+
+            // includeClaimed=true uses findForNextItem, not findClaimable — no ancestor filter
+            val result =
+                tool.execute(
+                    params(
+                        "limit" to JsonPrimitive(10),
+                        "includeClaimed" to JsonPrimitive(true),
+                        "includeDetails" to JsonPrimitive(true),
+                    ),
+                    context
+                )
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val ids = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }.toSet()
+
+            // Sub-task should be INCLUDED because includeClaimed=true path uses findForNextItem
+            // which does NOT apply ancestor-claim filtering
+            assertTrue(
+                subTask.id.toString() in ids,
+                "Sub-task should be visible via includeClaimed=true path — ancestor-claim filter not applied there"
+            )
+        }
+
+    @Test
+    fun `get_next_item includes child when parent claim has expired (TTL recovery)`(): Unit =
+        runBlocking {
+            // Parent with EXPIRED claim — TTL has passed
+            val now = java.time.Instant.now()
+            val expiredParent =
+                WorkItem(
+                    title = "Feature (expired claim)",
+                    depth = 0,
+                    claimedBy = "agent-x",
+                    claimedAt = now.minusSeconds(1800),
+                    claimExpiresAt = now.minusSeconds(900), // expired
+                    originalClaimedAt = now.minusSeconds(1800)
+                )
+            val savedExpiredParent =
+                (context.workItemRepository().create(expiredParent)
+                        as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+
+            val subTask = createItem("Sub-task (recovery eligible)", parentId = savedExpiredParent.id, depth = 1, role = Role.QUEUE)
+
+            val result = tool.execute(params("limit" to JsonPrimitive(10), "includeDetails" to JsonPrimitive(true)), context)
+
+            assertTrue(isSuccess(result))
+            val recs = extractRecommendations(result)
+            val ids = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }.toSet()
+
+            // Sub-task should be INCLUDED because parent's claim has expired (TTL recovery)
+            assertTrue(
+                subTask.id.toString() in ids,
+                "Sub-task should be claimable after parent's TTL expires"
+            )
+        }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolTest.kt
@@ -1705,18 +1705,34 @@ class GetNextItemToolTest {
             val ids = recs.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }.toSet()
 
             // Sub-task should be excluded (parent has active claim — strict mode, no agent context)
-            assertTrue(ids.none { id ->
-                val title = recs.find { it.jsonObject["itemId"]!!.jsonPrimitive.content == id }
-                    ?.jsonObject?.get("title")?.jsonPrimitive?.content
-                title == "Sub-task"
-            }, "Sub-task under claimed parent should be excluded from get_next_item results")
+            assertTrue(
+                ids.none { id ->
+                    val title =
+                        recs
+                            .find { it.jsonObject["itemId"]!!.jsonPrimitive.content == id }
+                            ?.jsonObject
+                            ?.get("title")
+                            ?.jsonPrimitive
+                            ?.content
+                    title == "Sub-task"
+                },
+                "Sub-task under claimed parent should be excluded from get_next_item results"
+            )
 
             // Root task should be included (no ancestor)
-            assertTrue(ids.any { id ->
-                val title = recs.find { it.jsonObject["itemId"]!!.jsonPrimitive.content == id }
-                    ?.jsonObject?.get("title")?.jsonPrimitive?.content
-                title == "Root task (unclaimed, no parent)"
-            }, "Root task with no parent should be included")
+            assertTrue(
+                ids.any { id ->
+                    val title =
+                        recs
+                            .find { it.jsonObject["itemId"]!!.jsonPrimitive.content == id }
+                            ?.jsonObject
+                            ?.get("title")
+                            ?.jsonPrimitive
+                            ?.content
+                    title == "Root task (unclaimed, no parent)"
+                },
+                "Root task with no parent should be included"
+            )
         }
 
     @Test
@@ -1763,8 +1779,10 @@ class GetNextItemToolTest {
                     originalClaimedAt = now.minusSeconds(1800)
                 )
             val savedExpiredParent =
-                (context.workItemRepository().create(expiredParent)
-                        as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success).data
+                (
+                    context.workItemRepository().create(expiredParent)
+                        as io.github.jpicklyk.mcptask.current.domain.repository.Result.Success
+                ).data
 
             val subTask = createItem("Sub-task (recovery eligible)", parentId = savedExpiredParent.id, depth = 1, role = Role.QUEUE)
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryFilterTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryFilterTest.kt
@@ -826,4 +826,289 @@ class SQLiteWorkItemRepositoryFilterTest {
             assertIs<Result.Success<List<WorkItem>>>(result)
             assertTrue(result.data.isEmpty())
         }
+
+    // =====================================================================
+    // findClaimable ancestor-claim filter tests
+    // =====================================================================
+
+    @Test
+    fun `findClaimable root items unaffected by ancestor filter regardless of requestingAgentId`() =
+        runBlocking {
+            // Root item (no parent) — the ancestor-claim filter never applies.
+            repository.create(WorkItem(title = "Root item", role = Role.QUEUE, depth = 0))
+
+            // requestingAgentId=null (strict mode) — root item still claimable
+            val resultStrict = repository.findClaimable(role = Role.QUEUE, requestingAgentId = null)
+            assertIs<Result.Success<List<WorkItem>>>(resultStrict)
+            assertEquals(1, resultStrict.data.size)
+            assertEquals("Root item", resultStrict.data[0].title)
+
+            // requestingAgentId="agent-x" — root item still claimable
+            val resultAgent = repository.findClaimable(role = Role.QUEUE, requestingAgentId = "agent-x")
+            assertIs<Result.Success<List<WorkItem>>>(resultAgent)
+            assertEquals(1, resultAgent.data.size)
+        }
+
+    @Test
+    fun `findClaimable same-agent re-claim eligibility — child included when parent claimed by same agent`() =
+        runBlocking {
+            val now = Instant.now()
+            val parent =
+                WorkItem(
+                    title = "Parent (claimed by agent-x)",
+                    depth = 0,
+                    claimedBy = "agent-x",
+                    claimedAt = now,
+                    claimExpiresAt = now.plusSeconds(900),
+                    originalClaimedAt = now,
+                )
+            val savedParent = (repository.create(parent) as Result.Success).data
+
+            val child =
+                WorkItem(
+                    title = "Child",
+                    parentId = savedParent.id,
+                    depth = 1,
+                    role = Role.QUEUE,
+                )
+            repository.create(child)
+
+            // Same agent — child should be INCLUDED
+            val result = repository.findClaimable(role = Role.QUEUE, requestingAgentId = "agent-x")
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size, "Child under same-agent claimed parent should be claimable")
+            assertEquals("Child", result.data[0].title)
+        }
+
+    @Test
+    fun `findClaimable cross-agent exclusion — child excluded when parent claimed by different agent`() =
+        runBlocking {
+            val now = Instant.now()
+            val parent =
+                WorkItem(
+                    title = "Parent (claimed by agent-x)",
+                    depth = 0,
+                    claimedBy = "agent-x",
+                    claimedAt = now,
+                    claimExpiresAt = now.plusSeconds(900),
+                    originalClaimedAt = now,
+                )
+            val savedParent = (repository.create(parent) as Result.Success).data
+
+            val child =
+                WorkItem(
+                    title = "Child",
+                    parentId = savedParent.id,
+                    depth = 1,
+                    role = Role.QUEUE,
+                )
+            repository.create(child)
+
+            // Different agent — child should be EXCLUDED
+            val result = repository.findClaimable(role = Role.QUEUE, requestingAgentId = "agent-y")
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertTrue(result.data.isEmpty(), "Child under different-agent claimed parent should be excluded")
+        }
+
+    @Test
+    fun `findClaimable null requestingAgentId strict mode — child excluded when parent claimed by anyone`() =
+        runBlocking {
+            val now = Instant.now()
+            val parent =
+                WorkItem(
+                    title = "Parent (claimed)",
+                    depth = 0,
+                    claimedBy = "any-agent",
+                    claimedAt = now,
+                    claimExpiresAt = now.plusSeconds(900),
+                    originalClaimedAt = now,
+                )
+            val savedParent = (repository.create(parent) as Result.Success).data
+
+            val child =
+                WorkItem(
+                    title = "Child",
+                    parentId = savedParent.id,
+                    depth = 1,
+                    role = Role.QUEUE,
+                )
+            repository.create(child)
+
+            // Null requestingAgentId — strict mode: any live ancestor claim excludes the child
+            val result = repository.findClaimable(role = Role.QUEUE, requestingAgentId = null)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertTrue(result.data.isEmpty(), "Strict mode: child under any claimed parent should be excluded")
+        }
+
+    @Test
+    fun `findClaimable multi-level ancestry — claim on grandparent excludes grandchild`() =
+        runBlocking {
+            val now = Instant.now()
+            val grandparent =
+                WorkItem(
+                    title = "Grandparent (claimed by agent-x)",
+                    depth = 0,
+                    claimedBy = "agent-x",
+                    claimedAt = now,
+                    claimExpiresAt = now.plusSeconds(900),
+                    originalClaimedAt = now,
+                )
+            val savedGrandparent = (repository.create(grandparent) as Result.Success).data
+
+            val parent =
+                WorkItem(
+                    title = "Parent (unclaimed)",
+                    parentId = savedGrandparent.id,
+                    depth = 1,
+                    role = Role.WORK,
+                )
+            val savedParent = (repository.create(parent) as Result.Success).data
+
+            val child =
+                WorkItem(
+                    title = "Grandchild",
+                    parentId = savedParent.id,
+                    depth = 2,
+                    role = Role.QUEUE,
+                )
+            repository.create(child)
+
+            // agent-y requesting — grandparent claimed by agent-x — grandchild EXCLUDED
+            val result = repository.findClaimable(role = Role.QUEUE, requestingAgentId = "agent-y")
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertTrue(result.data.isEmpty(), "Grandchild under claimed grandparent should be excluded from cross-agent perspective")
+        }
+
+    @Test
+    fun `findClaimable expired parent claim — child is included after TTL expiry`() =
+        runBlocking {
+            val now = Instant.now()
+            val parent =
+                WorkItem(
+                    title = "Parent (expired claim)",
+                    depth = 0,
+                    claimedBy = "agent-x",
+                    claimedAt = now.minusSeconds(120),
+                    claimExpiresAt = now.minusSeconds(60), // expired
+                    originalClaimedAt = now.minusSeconds(120),
+                )
+            val savedParent = (repository.create(parent) as Result.Success).data
+
+            val child =
+                WorkItem(
+                    title = "Child",
+                    parentId = savedParent.id,
+                    depth = 1,
+                    role = Role.QUEUE,
+                )
+            repository.create(child)
+
+            // Expired parent claim — TTL recovery: child becomes claimable
+            val result = repository.findClaimable(role = Role.QUEUE, requestingAgentId = "agent-y")
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size, "Child should be claimable after parent's TTL expires")
+            assertEquals("Child", result.data[0].title)
+        }
+
+    @Test
+    fun `findClaimable mixed ancestry — grandparent claimed excludes child even if direct parent is unclaimed`() =
+        runBlocking {
+            val now = Instant.now()
+            val grandparent =
+                WorkItem(
+                    title = "Grandparent (claimed by agent-x)",
+                    depth = 0,
+                    claimedBy = "agent-x",
+                    claimedAt = now,
+                    claimExpiresAt = now.plusSeconds(900),
+                    originalClaimedAt = now,
+                )
+            val savedGrandparent = (repository.create(grandparent) as Result.Success).data
+
+            val parent =
+                WorkItem(
+                    title = "Parent (unclaimed)",
+                    parentId = savedGrandparent.id,
+                    depth = 1,
+                )
+            val savedParent = (repository.create(parent) as Result.Success).data
+
+            val child =
+                WorkItem(
+                    title = "Child",
+                    parentId = savedParent.id,
+                    depth = 2,
+                    role = Role.QUEUE,
+                )
+            repository.create(child)
+
+            // Mixed ancestry: grandparent claimed by agent-x, parent unclaimed, agent-y requests
+            // → child EXCLUDED because a live ancestor claim by a different agent exists
+            val result = repository.findClaimable(role = Role.QUEUE, requestingAgentId = "agent-y")
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertTrue(result.data.isEmpty(), "Child should be excluded when any ancestor has a live cross-agent claim")
+        }
+
+    @Test
+    fun `findClaimable multiple candidates — only children under cross-agent claims are excluded`() =
+        runBlocking {
+            val now = Instant.now()
+
+            // Feature A claimed by agent-x (agent-y requesting — this child should be excluded)
+            val featureA =
+                WorkItem(
+                    title = "Feature A (claimed by agent-x)",
+                    depth = 0,
+                    claimedBy = "agent-x",
+                    claimedAt = now,
+                    claimExpiresAt = now.plusSeconds(900),
+                    originalClaimedAt = now,
+                )
+            val savedFeatureA = (repository.create(featureA) as Result.Success).data
+
+            val taskA =
+                WorkItem(
+                    title = "Task A (child of Feature A)",
+                    parentId = savedFeatureA.id,
+                    depth = 1,
+                    role = Role.QUEUE,
+                )
+            repository.create(taskA)
+
+            // Feature B claimed by agent-y (same agent requesting — this child should be included)
+            val featureB =
+                WorkItem(
+                    title = "Feature B (claimed by agent-y)",
+                    depth = 0,
+                    claimedBy = "agent-y",
+                    claimedAt = now,
+                    claimExpiresAt = now.plusSeconds(900),
+                    originalClaimedAt = now,
+                )
+            val savedFeatureB = (repository.create(featureB) as Result.Success).data
+
+            val taskB =
+                WorkItem(
+                    title = "Task B (child of Feature B)",
+                    parentId = savedFeatureB.id,
+                    depth = 1,
+                    role = Role.QUEUE,
+                )
+            repository.create(taskB)
+
+            // Root item (no parent) — always included
+            repository.create(WorkItem(title = "Root task", depth = 0, role = Role.QUEUE))
+
+            // agent-y requesting:
+            // - Task A: excluded (Feature A claimed by agent-x, different agent)
+            // - Task B: included (Feature B claimed by agent-y, same agent)
+            // - Root task: included (no ancestor)
+            val result = repository.findClaimable(role = Role.QUEUE, requestingAgentId = "agent-y")
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(2, result.data.size, "Only Task B (same-agent) and Root task should be returned")
+            val titles = result.data.map { it.title }.toSet()
+            assertTrue("Task B (child of Feature B)" in titles, "Task B should be included")
+            assertTrue("Root task" in titles, "Root task should be included")
+            assertTrue("Task A (child of Feature A)" !in titles, "Task A should be excluded")
+        }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryFilterTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryFilterTest.kt
@@ -983,10 +983,15 @@ class SQLiteWorkItemRepositoryFilterTest {
     fun `findClaimable expired parent claim — child is included after TTL expiry`() =
         runBlocking {
             val now = Instant.now()
+            // Parent is in WORK role (was being orchestrated when the holding agent crashed).
+            // TTL expired without a heartbeat — recovery agent should now see the child as claimable.
+            // Parent itself is in WORK so it's filtered out by the role=QUEUE query, isolating the
+            // assertion to the ancestor-claim filter behavior on the child alone.
             val parent =
                 WorkItem(
-                    title = "Parent (expired claim)",
+                    title = "Parent (expired claim, was in WORK)",
                     depth = 0,
+                    role = Role.WORK,
                     claimedBy = "agent-x",
                     claimedAt = now.minusSeconds(120),
                     claimExpiresAt = now.minusSeconds(60), // expired


### PR DESCRIPTION
## Summary

- Adds ancestor-claim filtering to `findClaimable`: items whose ancestor chain contains a live claim by a different agent are excluded from claim-eligibility results. Strict-by-default; no config toggle.
- Enables the **hybrid fleet pattern** (claim at parent feature, orchestrate sub-tree below) safely — sub-items of an in-progress feature are no longer poachable by other fleet workers.
- Implementation is a post-query batched BFS ancestor walk inside the existing `findClaimable` transaction, bounded by depth-3 hierarchy. Same-agent re-claim of own sub-tree remains allowed; null requesting agent (read-only callers like `get_next_item`) gets strict exclusion of any live ancestor claim.
- Substantive `fleet-deployment.md` rewrite documenting the four canonical fleet topologies and the hybrid pattern as the recommended deployment model. TTL-as-recovery-vector contract documented for crashed-orchestrator scenarios.

## Design context

Full design ADR: MCP item `eb6764db` (`implementation-notes` note) — covers the four-scenario topology framing (pure orchestration / pure claim flat / pure claim chains / hybrid), the strict-by-default + no-toggle decision rationale (claim mode is brand-new; no production users; no legitimate use case for multiple agents on dependent items in the same context), and why options 2/3/5 from the original analysis were rejected.

## Test Results

- **All gradle tests pass**: `:current:test` green (1823 tests; 16 new + 4 contract-tightening updates for MockK).
- **`:current:ktlintCheck` green** after `ktlintFormat` cleanup.
- **New test coverage** (16 tests across 4 files):
  - `SQLiteWorkItemRepositoryFilterTest` — 7 ancestor-claim scenarios (root unaffected, same-agent eligibility, cross-agent exclusion, null-strict mode, multi-level ancestry, TTL recovery, mixed ancestry, multi-candidate)
  - `NextItemRecommenderTest` — 2 (`requestingAgentId` round-trip + null-mode forwarding)
  - `ClaimItemToolTest` — 4 (selector exclusion, criteria threading, same-agent success, ID-mode bypass)
  - `GetNextItemToolTest` — 3 (strict exclusion, includeClaimed bypass, TTL recovery)

## Review

Independent review verdict: **PASS WITH OBSERVATIONS**.

- Plan alignment: all 8 acceptance criteria satisfied; no non-goals violated.
- Test quality: all 16 tests construct meaningful scenarios with specific assertions — no strawman tests.
- Pre-existing test sweep: confirmed no pre-existing tests had parent→child claimability expectations to break.
- API compatibility: no breaking changes (new `findClaimable` parameter has a default; behavioral change to `claim_item` selector mode is design-time given zero production users).

Two observations were logged as follow-up tech-debt items (both low priority):
- `db76d510` — Refactor ancestor-BFS pattern: extract shared helper between `findClaimable` and `findAncestorChains` to eliminate duplication.
- `0b5ac987` — Ralph `iteration-prompt.md`: add agent-facing note about `no_match` outcomes from ancestor-claim filtering.

A third observation (redundant DB round-trip in BFS setup) was applied inline as commit `3085ea1` since it was a 4-line fix with measurable benefit.

## Commits

1. `53e0880` feat(claim): ancestor-claim protection in findClaimable
2. `872fa79` test(claim): fix expired-parent test fixture and apply ktlint formatting
3. `3085ea1` perf(claim): seed ancestor cache from in-memory candidates

## MCP

- Implementation: `a92103d2-9de2-4829-bdaf-1a5690791cfc`
- Design ADR: `eb6764db-3690-4234-889e-a2b0cba17e14`
- Follow-ups: `db76d510-74c1-4b68-8250-c0b1181b14c7`, `0b5ac987-d970-461a-b692-ca026d0de086`

🤖 Generated with [Claude Code](https://claude.com/claude-code)