### PR TITLE
chore(deps): bump MCP Kotlin SDK to 0.12.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 # Kotlin and Coroutines
-kotlin = "2.2.0"
+kotlin = "2.3.21"
 kotlinCoroutines = "1.10.2"
-kotlinSerialization = "1.9.0"
+kotlinSerialization = "1.11.0"
 
 # MCP SDK
-mcpSdk = "0.11.1"
+mcpSdk = "0.12.0"
 
-# Ktor (version-aligned with MCP SDK's transitive dependency)
+# Ktor (pinned ahead of MCP SDK's bundled 3.3.3; 3.x is backwards-compatible)
 ktor = "3.4.2"
 
 # Database


### PR DESCRIPTION
## Summary

- Bump `io.modelcontextprotocol:kotlin-sdk` from `0.11.1` to `0.12.0`
- Bump `kotlin` from `2.2.0` to `2.3.21` (aligned with SDK's compiler version)
- Bump `kotlinx.serialization` from `1.9.0` to `1.11.0` (aligned with SDK's transitive dep)
- Ktor stays pinned at `3.4.2` (ahead of SDK's bundled `3.3.3`; 3.x is backwards-compatible)

## What's in 0.12.0

- **Bug fixes:** SSE reconnection (stale stream mappings evicted), `CancellationException` now propagates instead of being swallowed
- **New:** `$schema` field on `ToolSchema` (JSON Schema 2020-12 default), server-side tool name validation at registration, `extensions` capability fields
- **Breaking (not affecting this project):** `SamplingMessage.content` restructured — we don't use sampling APIs

## No Source Changes Required

All 14 tool names (`snake_case`) pass the new server-side validation. The one breaking API change (`ClientCapabilities.sampling` type change) doesn't touch any code path in this project.

**Note:** Kotlin 2.3.21 surfaces new null-safety warnings (unnecessary `!!`/`?.` on non-null receivers) in ~8 existing files — warnings only, not blocking. Worth a follow-up cleanup PR.

## Test Results

`./gradlew clean build` — BUILD SUCCESSFUL (1m 25s): 14 tasks including `ktlintCheck` and `test` all passed.

## MCP

`a62d1397-c4f7-4b99-bb11-58be574acf5d`