### PR TITLE
chore(kotlin): clear unnecessary !! warnings from Kotlin 2.3.21

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -560,7 +560,7 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
             val schemaResolver: (WorkItem) -> WorkItemSchema? = { context.resolveSchema(it) }
             val cascadeJsonList = mutableListOf<JsonObject>()
             if (targetRole == Role.TERMINAL) {
-                var cascadeSource = applyResult.item!!
+                var cascadeSource: WorkItem = applyResult.item
                 var depth = 0
                 while (depth < CascadeDetector.MAX_DEPTH) {
                     val events = cascadeDetector.detectCascades(cascadeSource, context.workItemRepository(), schemaResolver)
@@ -643,7 +643,7 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
             // Phase 4b: Start cascade detection (only when reaching WORK)
             // When the first child starts, auto-advance the parent from QUEUE to WORK.
             if (targetRole == Role.WORK) {
-                val startCascadeEvents = cascadeDetector.detectStartCascades(applyResult.item!!, context.workItemRepository())
+                val startCascadeEvents = cascadeDetector.detectStartCascades(applyResult.item, context.workItemRepository())
                 applyCascadeEvents(
                     startCascadeEvents,
                     "Auto-cascaded from child start",
@@ -658,7 +658,7 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
             if (trigger == "reopen" && targetRole == Role.QUEUE) {
                 val reopenCascadeEvents =
                     cascadeDetector.detectReopenCascades(
-                        applyResult.item!!,
+                        applyResult.item,
                         context.workItemRepository(),
                         schemaResolver
                     )

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandlerTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandlerTest.kt
@@ -75,7 +75,7 @@ class RoleTransitionHandlerTest {
             assertFalse(result.success)
             assertNull(result.targetRole)
             assertNotNull(result.error)
-            assertTrue(result.error!!.contains("terminal", ignoreCase = true))
+            assertTrue(result.error.contains("terminal", ignoreCase = true))
         }
 
         @Test
@@ -84,7 +84,7 @@ class RoleTransitionHandlerTest {
             assertFalse(result.success)
             assertNull(result.targetRole)
             assertNotNull(result.error)
-            assertTrue(result.error!!.contains("blocked", ignoreCase = true))
+            assertTrue(result.error.contains("blocked", ignoreCase = true))
         }
 
         // --- complete trigger ---
@@ -115,7 +115,7 @@ class RoleTransitionHandlerTest {
             val result = handler.resolveTransition(Role.TERMINAL, "complete")
             assertFalse(result.success)
             assertNotNull(result.error)
-            assertTrue(result.error!!.contains("terminal", ignoreCase = true))
+            assertTrue(result.error.contains("terminal", ignoreCase = true))
         }
 
         @Test
@@ -123,7 +123,7 @@ class RoleTransitionHandlerTest {
             val result = handler.resolveTransition(Role.BLOCKED, "complete")
             assertFalse(result.success)
             assertNotNull(result.error)
-            assertTrue(result.error!!.contains("blocked", ignoreCase = true))
+            assertTrue(result.error.contains("blocked", ignoreCase = true))
         }
 
         // --- block trigger ---
@@ -147,7 +147,7 @@ class RoleTransitionHandlerTest {
             val result = handler.resolveTransition(Role.TERMINAL, "block")
             assertFalse(result.success)
             assertNotNull(result.error)
-            assertTrue(result.error!!.contains("terminal", ignoreCase = true))
+            assertTrue(result.error.contains("terminal", ignoreCase = true))
         }
 
         @Test
@@ -155,7 +155,7 @@ class RoleTransitionHandlerTest {
             val result = handler.resolveTransition(Role.BLOCKED, "block")
             assertFalse(result.success)
             assertNotNull(result.error)
-            assertTrue(result.error!!.contains("already blocked", ignoreCase = true))
+            assertTrue(result.error.contains("already blocked", ignoreCase = true))
         }
 
         // --- cancel trigger ---
@@ -173,7 +173,7 @@ class RoleTransitionHandlerTest {
             val result = handler.resolveTransition(Role.TERMINAL, "cancel")
             assertFalse(result.success)
             assertNotNull(result.error)
-            assertTrue(result.error!!.contains("terminal", ignoreCase = true))
+            assertTrue(result.error.contains("terminal", ignoreCase = true))
         }
 
         // --- resume trigger (simple overload) ---
@@ -183,7 +183,7 @@ class RoleTransitionHandlerTest {
             val result = handler.resolveTransition(Role.BLOCKED, "resume")
             assertFalse(result.success)
             assertNotNull(result.error)
-            assertTrue(result.error!!.contains("previousRole", ignoreCase = true))
+            assertTrue(result.error.contains("previousRole", ignoreCase = true))
         }
 
         // --- resume trigger (full-item overload) ---
@@ -210,7 +210,7 @@ class RoleTransitionHandlerTest {
             val result = handler.resolveTransition(item, "resume")
             assertFalse(result.success)
             assertNotNull(result.error)
-            assertTrue(result.error!!.contains("previousRole", ignoreCase = true))
+            assertTrue(result.error.contains("previousRole", ignoreCase = true))
         }
 
         @Test
@@ -219,7 +219,7 @@ class RoleTransitionHandlerTest {
             val result = handler.resolveTransition(item, "resume")
             assertFalse(result.success)
             assertNotNull(result.error)
-            assertTrue(result.error!!.contains("not blocked", ignoreCase = true))
+            assertTrue(result.error.contains("not blocked", ignoreCase = true))
         }
 
         // --- unknown trigger ---
@@ -229,7 +229,7 @@ class RoleTransitionHandlerTest {
             val result = handler.resolveTransition(Role.QUEUE, "bogus")
             assertFalse(result.success)
             assertNotNull(result.error)
-            assertTrue(result.error!!.contains("Unknown trigger", ignoreCase = true))
+            assertTrue(result.error.contains("Unknown trigger", ignoreCase = true))
         }
     }
 
@@ -318,7 +318,7 @@ class RoleTransitionHandlerTest {
                 val result = handler.validateTransition(item, Role.WORK, depRepo, workItemRepo)
                 assertFalse(result.valid)
                 assertNotNull(result.error)
-                assertTrue(result.error!!.contains("terminal", ignoreCase = true))
+                assertTrue(result.error.contains("terminal", ignoreCase = true))
             }
 
         @Test
@@ -557,14 +557,14 @@ class RoleTransitionHandlerTest {
 
                 assertTrue(result.success)
                 assertNotNull(result.item)
-                assertEquals(Role.WORK, result.item!!.role)
+                assertEquals(Role.WORK, result.item.role)
                 assertEquals(Role.QUEUE, result.previousRole)
                 assertEquals(Role.WORK, result.newRole)
                 assertNotNull(result.transition)
-                assertEquals("queue", result.transition!!.fromRole)
-                assertEquals("work", result.transition!!.toRole)
-                assertEquals("start", result.transition!!.trigger)
-                assertEquals("Beginning work", result.transition!!.summary)
+                assertEquals("queue", result.transition.fromRole)
+                assertEquals("work", result.transition.toRole)
+                assertEquals("start", result.transition.trigger)
+                assertEquals("Beginning work", result.transition.summary)
 
                 coVerify { workItemRepo.update(match { it.role == Role.WORK }) }
                 coVerify { roleTransitionRepo.create(any()) }
@@ -589,8 +589,9 @@ class RoleTransitionHandlerTest {
                     )
 
                 assertTrue(result.success)
-                assertEquals(Role.BLOCKED, result.item!!.role)
-                assertEquals(Role.WORK, result.item!!.previousRole)
+                val resultItem = assertNotNull(result.item)
+                assertEquals(Role.BLOCKED, resultItem.role)
+                assertEquals(Role.WORK, resultItem.previousRole)
             }
 
         @Test
@@ -612,9 +613,10 @@ class RoleTransitionHandlerTest {
                     )
 
                 assertTrue(result.success)
-                assertEquals(Role.WORK, result.item!!.role)
+                val resultItem = assertNotNull(result.item)
+                assertEquals(Role.WORK, resultItem.role)
                 // previousRole should be cleared when leaving BLOCKED
-                assertNull(result.item!!.previousRole)
+                assertNull(resultItem.previousRole)
             }
 
         @Test
@@ -636,8 +638,9 @@ class RoleTransitionHandlerTest {
                     )
 
                 assertTrue(result.success)
-                assertEquals(Role.TERMINAL, result.item!!.role)
-                assertEquals("cancelled", result.item!!.statusLabel)
+                val resultItem = assertNotNull(result.item)
+                assertEquals(Role.TERMINAL, resultItem.role)
+                assertEquals("cancelled", resultItem.statusLabel)
             }
 
         @Test
@@ -662,7 +665,7 @@ class RoleTransitionHandlerTest {
 
                 assertFalse(result.success)
                 assertNotNull(result.error)
-                assertTrue(result.error!!.contains("Connection lost"))
+                assertTrue(result.error.contains("Connection lost"))
                 assertNull(result.item)
                 assertNull(result.transition)
             }
@@ -694,11 +697,11 @@ class RoleTransitionHandlerTest {
                 assertTrue(result.success)
                 val captured = transitionSlot.captured
                 assertNotNull(captured.actorClaim)
-                assertEquals("orchestrator-1", captured.actorClaim!!.id)
-                assertEquals(ActorKind.ORCHESTRATOR, captured.actorClaim!!.kind)
+                assertEquals("orchestrator-1", captured.actorClaim.id)
+                assertEquals(ActorKind.ORCHESTRATOR, captured.actorClaim.kind)
                 assertNotNull(captured.verification)
-                assertEquals(VerificationStatus.UNCHECKED, captured.verification!!.status)
-                assertEquals("noop", captured.verification!!.verifier)
+                assertEquals(VerificationStatus.UNCHECKED, captured.verification.status)
+                assertEquals("noop", captured.verification.verifier)
             }
 
         @Test

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/WorkTreeServiceIntegrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/WorkTreeServiceIntegrationTest.kt
@@ -490,13 +490,13 @@ class WorkTreeServiceIntegrationTest {
             assertTrue(fetchedNote1Result is Result.Success, "Note 1 lookup should succeed")
             val fetchedNote1 = (fetchedNote1Result as Result.Success).data
             assertTrue(fetchedNote1 != null, "Note 1 should exist in DB")
-            assertEquals("Root requirements note", fetchedNote1!!.body)
+            assertEquals("Root requirements note", fetchedNote1.body)
 
             val fetchedNote2Result = noteRepository.findByItemIdAndKey(childItem.id, "approach")
             assertTrue(fetchedNote2Result is Result.Success, "Note 2 lookup should succeed")
             val fetchedNote2 = (fetchedNote2Result as Result.Success).data
             assertTrue(fetchedNote2 != null, "Note 2 should exist in DB")
-            assertEquals("Child approach note", fetchedNote2!!.body)
+            assertEquals("Child approach note", fetchedNote2.body)
         }
 
     // ──────────────────────────────────────────────────────────────────────────

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolIntegrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolIntegrationTest.kt
@@ -303,13 +303,13 @@ class CreateWorkTreeToolIntegrationTest {
             assertNotNull(persisted, "Note must exist in DB")
 
             assertNotNull(persisted.actorClaim, "Persisted note must carry the actor claim")
-            assertEquals("orchestrator-integ", persisted.actorClaim!!.id)
+            assertEquals("orchestrator-integ", persisted.actorClaim.id)
             assertEquals(
                 io.github.jpicklyk.mcptask.current.domain.model.ActorKind.ORCHESTRATOR,
-                persisted.actorClaim!!.kind
+                persisted.actorClaim.kind
             )
             assertNotNull(persisted.verification, "Persisted note must carry the verification result")
             // NoOpActorVerifier wired in DefaultRepositoryProvider's tool context
-            assertEquals("noop", persisted.verification!!.verifier)
+            assertEquals("noop", persisted.verification.verifier)
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolTest.kt
@@ -1970,14 +1970,14 @@ class CreateWorkTreeToolTest {
             assertEquals(2, input.notes.size, "Expected both notes captured")
             for (note in input.notes) {
                 assertNotNull(note.actorClaim, "Note '${note.key}' should have actorClaim attached")
-                assertEquals("orchestrator-test", note.actorClaim!!.id)
+                assertEquals("orchestrator-test", note.actorClaim.id)
                 assertEquals(
                     io.github.jpicklyk.mcptask.current.domain.model.ActorKind.ORCHESTRATOR,
-                    note.actorClaim!!.kind
+                    note.actorClaim.kind
                 )
                 assertNotNull(note.verification, "Note '${note.key}' should have verification attached")
                 // NoOpActorVerifier returns status=UNCHECKED, verifier="noop"
-                assertEquals("noop", note.verification!!.verifier)
+                assertEquals("noop", note.verification.verifier)
             }
         }
 
@@ -2046,10 +2046,10 @@ class CreateWorkTreeToolTest {
             assertEquals("auto-blank-note", note.key)
             assertEquals("", note.body, "Schema blank should have empty body")
             assertNotNull(note.actorClaim, "Schema blank must also carry actor attribution")
-            assertEquals("subagent-42", note.actorClaim!!.id)
+            assertEquals("subagent-42", note.actorClaim.id)
             assertEquals(
                 io.github.jpicklyk.mcptask.current.domain.model.ActorKind.SUBAGENT,
-                note.actorClaim!!.kind
+                note.actorClaim.kind
             )
         }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsToolTest.kt
@@ -169,7 +169,7 @@ class ManageItemsToolTest {
                                         buildJsonObject {
                                             put("title", JsonPrimitive("Level $i"))
                                             if (currentParentId != null) {
-                                                put("parentId", JsonPrimitive(currentParentId!!))
+                                                put("parentId", JsonPrimitive(currentParentId))
                                             }
                                         }
                                     )

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolTest.kt
@@ -739,7 +739,7 @@ class QueryItemsToolTest {
             // childCounts should be present as an object with role keys
             val childCounts = firstChild["childCounts"]
             assertNotNull(childCounts, "Child should include childCounts object")
-            val childCountsObj = childCounts!!.jsonObject
+            val childCountsObj = childCounts.jsonObject
             assertNotNull(childCountsObj["queue"], "childCounts should have a queue key")
             assertNotNull(childCountsObj["work"], "childCounts should have a work key")
         }
@@ -990,7 +990,7 @@ class QueryItemsToolTest {
             // traits array should be present and contain the expected value
             val traits = withTraitsRoot["traits"]
             assertNotNull(traits, "Root item should include traits array when properties has traits")
-            val traitsArray = traits!!.jsonArray
+            val traitsArray = traits.jsonArray
             assertEquals(1, traitsArray.size)
             assertEquals("needs-migration-review", traitsArray[0].jsonPrimitive.content)
 
@@ -1185,7 +1185,7 @@ class QueryItemsToolTest {
             // Middle Child's childCounts should reflect 1 queue + 1 work grandchild
             val childCounts = middleChild["childCounts"]
             assertNotNull(childCounts, "Middle child should have childCounts")
-            val childCountsObj = childCounts!!.jsonObject
+            val childCountsObj = childCounts.jsonObject
             assertEquals(1, childCountsObj["queue"]!!.jsonPrimitive.int, "Should have 1 grandchild in queue role")
             assertEquals(1, childCountsObj["work"]!!.jsonPrimitive.int, "Should have 1 grandchild in work role")
         }
@@ -1242,7 +1242,7 @@ class QueryItemsToolTest {
             // childCounts must be present with correct grandchild role distribution
             val childCounts = child["childCounts"]
             assertNotNull(childCounts, "Scoped overview child should include childCounts")
-            val childCountsObj = childCounts!!.jsonObject
+            val childCountsObj = childCounts.jsonObject
             assertEquals(1, childCountsObj["queue"]!!.jsonPrimitive.int, "Should have 1 grandchild in queue")
             assertEquals(1, childCountsObj["work"]!!.jsonPrimitive.int, "Should have 1 grandchild in work")
         }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesToolTest.kt
@@ -1097,8 +1097,8 @@ class ManageNotesToolTest {
             val itemUUID = java.util.UUID.fromString(itemId)
             val found = (noteRepo.findByItemIdAndKey(itemUUID, "actor-replace") as Result.Success).data
             assertNotNull(found, "note should exist")
-            assertNotNull(found!!.actorClaim, "actorClaim should be persisted")
-            assertEquals("agent-second", found.actorClaim!!.id)
+            assertNotNull(found.actorClaim, "actorClaim should be persisted")
+            assertEquals("agent-second", found.actorClaim.id)
             assertEquals(io.github.jpicklyk.mcptask.current.domain.model.ActorKind.SUBAGENT, found.actorClaim.kind)
         }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolTest.kt
@@ -731,7 +731,7 @@ class GetContextToolTest {
             val guidancePointer = data["guidancePointer"]
             assertNotNull(guidancePointer)
             assertFalse(guidancePointer is JsonNull)
-            assertEquals("List each criterion as a bullet", guidancePointer!!.jsonPrimitive.content)
+            assertEquals("List each criterion as a bullet", guidancePointer.jsonPrimitive.content)
         }
 
     @Test
@@ -781,7 +781,7 @@ class GetContextToolTest {
             val guidancePointer = data["guidancePointer"]
             assertNotNull(guidancePointer)
             assertFalse(guidancePointer is JsonNull)
-            assertEquals("Use T-shirt sizing: XS/S/M/L/XL", guidancePointer!!.jsonPrimitive.content)
+            assertEquals("Use T-shirt sizing: XS/S/M/L/XL", guidancePointer.jsonPrimitive.content)
         }
 
     @Test
@@ -889,7 +889,7 @@ class GetContextToolTest {
             assertFalse(guidancePointer is JsonNull, "guidancePointer should not be null when work-phase note is missing")
             assertEquals(
                 "Work-phase guidance — this should be the pointer",
-                guidancePointer!!.jsonPrimitive.content,
+                guidancePointer.jsonPrimitive.content,
                 "guidancePointer must return work-phase guidance, not stale queue-phase guidance"
             )
         }
@@ -1055,7 +1055,7 @@ class GetContextToolTest {
             val guidancePointer = stalledItem["guidancePointer"]
             assertNotNull(guidancePointer, "guidancePointer should be present in stalled item")
             assertFalse(guidancePointer is JsonNull, "guidancePointer should not be null when guidance is available")
-            assertEquals("Write the implementation approach here", guidancePointer!!.jsonPrimitive.content)
+            assertEquals("Write the implementation approach here", guidancePointer.jsonPrimitive.content)
         }
 
     @Test
@@ -1135,7 +1135,7 @@ class GetContextToolTest {
             val guidancePointer = stalledItem["guidancePointer"]
             assertNotNull(guidancePointer, "guidancePointer should be present in session-resume stalled item")
             assertFalse(guidancePointer is JsonNull, "guidancePointer should not be null when guidance is available")
-            assertEquals("Describe the implementation", guidancePointer!!.jsonPrimitive.content)
+            assertEquals("Describe the implementation", guidancePointer.jsonPrimitive.content)
         }
 
     // ──────────────────────────────────────────────
@@ -1260,7 +1260,7 @@ class GetContextToolTest {
             assertFalse(guidancePointer is JsonNull)
             assertEquals(
                 "First guidance",
-                guidancePointer!!.jsonPrimitive.content,
+                guidancePointer.jsonPrimitive.content,
                 "guidancePointer should point to the first missing note's guidance"
             )
         }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/NoteTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/NoteTest.kt
@@ -146,7 +146,7 @@ class NoteTest {
         assertEquals(actor, note.actorClaim)
         assertEquals(verification, note.verification)
         assertEquals("agent-1", note.actorClaim!!.id)
-        assertEquals(ActorKind.SUBAGENT, note.actorClaim!!.kind)
+        assertEquals(ActorKind.SUBAGENT, note.actorClaim.kind)
         assertEquals(VerificationStatus.UNCHECKED, note.verification!!.status)
     }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/RoleTransitionTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/domain/model/RoleTransitionTest.kt
@@ -175,7 +175,7 @@ class RoleTransitionTest {
         assertEquals(actor, transition.actorClaim)
         assertEquals(verification, transition.verification)
         assertEquals("agent-42", transition.actorClaim!!.id)
-        assertEquals(ActorKind.SUBAGENT, transition.actorClaim!!.kind)
+        assertEquals(ActorKind.SUBAGENT, transition.actorClaim.kind)
         assertEquals(VerificationStatus.UNCHECKED, transition.verification!!.status)
     }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaServiceTest.kt
@@ -647,8 +647,8 @@ note_schemas:
         assertNotNull(first)
         assertNotNull(second)
         assertNotNull(third)
-        assertEquals(first!!.size, second!!.size)
-        assertEquals(first.size, third!!.size)
+        assertEquals(first.size, second.size)
+        assertEquals(first.size, third.size)
         assertEquals(first[0].key, second[0].key)
         assertEquals(first[0].key, third[0].key)
     }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteNoteRepositoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteNoteRepositoryTest.kt
@@ -190,8 +190,8 @@ class SQLiteNoteRepositoryTest {
             val result = noteRepository.findByItemIdAndKey(testItemId, "specific-key")
             assertIs<Result.Success<Note?>>(result)
             assertNotNull(result.data)
-            assertEquals("Found me", result.data!!.body)
-            assertEquals("specific-key", result.data!!.key)
+            assertEquals("Found me", result.data.body)
+            assertEquals("specific-key", result.data.key)
         }
 
     @Test
@@ -285,13 +285,13 @@ class SQLiteNoteRepositoryTest {
             assertEquals(1, result.data.size)
             val found = result.data[0]
             assertNotNull(found.actorClaim)
-            assertEquals("agent-1", found.actorClaim!!.id)
-            assertEquals(ActorKind.SUBAGENT, found.actorClaim!!.kind)
-            assertEquals("orch-1", found.actorClaim!!.parent)
-            assertNull(found.actorClaim!!.proof)
+            assertEquals("agent-1", found.actorClaim.id)
+            assertEquals(ActorKind.SUBAGENT, found.actorClaim.kind)
+            assertEquals("orch-1", found.actorClaim.parent)
+            assertNull(found.actorClaim.proof)
             assertNotNull(found.verification)
-            assertEquals(VerificationStatus.UNCHECKED, found.verification!!.status)
-            assertEquals("noop", found.verification!!.verifier)
+            assertEquals(VerificationStatus.UNCHECKED, found.verification.status)
+            assertEquals("noop", found.verification.verifier)
         }
 
     @Test
@@ -324,13 +324,13 @@ class SQLiteNoteRepositoryTest {
             val result = noteRepository.findByItemIdAndKey(testItemId, "replace-actor-note")
             assertIs<Result.Success<Note?>>(result)
             assertNotNull(result.data)
-            val found = result.data!!
+            val found = result.data
             assertEquals("second version", found.body)
             assertNotNull(found.actorClaim)
-            assertEquals("agent-2", found.actorClaim!!.id)
-            assertEquals(ActorKind.ORCHESTRATOR, found.actorClaim!!.kind)
+            assertEquals("agent-2", found.actorClaim.id)
+            assertEquals(ActorKind.ORCHESTRATOR, found.actorClaim.kind)
             assertNotNull(found.verification)
-            assertEquals(VerificationStatus.VERIFIED, found.verification!!.status)
+            assertEquals(VerificationStatus.VERIFIED, found.verification.status)
         }
 
     @Test
@@ -348,8 +348,8 @@ class SQLiteNoteRepositoryTest {
             val result = noteRepository.findByItemIdAndKey(testItemId, "no-actor-note")
             assertIs<Result.Success<Note?>>(result)
             assertNotNull(result.data)
-            assertNull(result.data!!.actorClaim)
-            assertNull(result.data!!.verification)
+            assertNull(result.data.actorClaim)
+            assertNull(result.data.verification)
         }
 
     @Test

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteRoleTransitionRepositoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteRoleTransitionRepositoryTest.kt
@@ -362,14 +362,14 @@ class SQLiteRoleTransitionRepositoryTest {
             assertEquals(1, result.data.size)
             val found = result.data[0]
             assertNotNull(found.actorClaim)
-            assertEquals("agent-42", found.actorClaim!!.id)
-            assertEquals(ActorKind.SUBAGENT, found.actorClaim!!.kind)
-            assertEquals("orchestrator-1", found.actorClaim!!.parent)
-            assertEquals("proof-token", found.actorClaim!!.proof)
+            assertEquals("agent-42", found.actorClaim.id)
+            assertEquals(ActorKind.SUBAGENT, found.actorClaim.kind)
+            assertEquals("orchestrator-1", found.actorClaim.parent)
+            assertEquals("proof-token", found.actorClaim.proof)
             assertNotNull(found.verification)
-            assertEquals(VerificationStatus.UNCHECKED, found.verification!!.status)
-            assertEquals("noop", found.verification!!.verifier)
-            assertNull(found.verification!!.reason)
+            assertEquals(VerificationStatus.UNCHECKED, found.verification.status)
+            assertEquals("noop", found.verification.verifier)
+            assertNull(found.verification.reason)
         }
 
     @Test
@@ -432,10 +432,10 @@ class SQLiteRoleTransitionRepositoryTest {
             assertNull(noActorFound.verification)
 
             assertNotNull(actorFound.actorClaim)
-            assertEquals("agent-1", actorFound.actorClaim!!.id)
-            assertEquals(ActorKind.ORCHESTRATOR, actorFound.actorClaim!!.kind)
+            assertEquals("agent-1", actorFound.actorClaim.id)
+            assertEquals(ActorKind.ORCHESTRATOR, actorFound.actorClaim.kind)
             assertNotNull(actorFound.verification)
-            assertEquals(VerificationStatus.VERIFIED, actorFound.verification!!.status)
-            assertEquals("test-verifier", actorFound.verification!!.verifier)
+            assertEquals(VerificationStatus.VERIFIED, actorFound.verification.status)
+            assertEquals("test-verifier", actorFound.verification.verifier)
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryClaimTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryClaimTest.kt
@@ -71,11 +71,11 @@ class SQLiteWorkItemRepositoryClaimTest : SQLiteRepositoryTestBase() {
             assertNotNull(claimed.claimExpiresAt)
             assertNotNull(claimed.originalClaimedAt)
             // claimedAt <= claimExpiresAt
-            assertTrue(claimed.claimedAt!! <= claimed.claimExpiresAt!!)
+            assertTrue(claimed.claimedAt <= claimed.claimExpiresAt)
             // originalClaimedAt == claimedAt on first claim
             assertEquals(
-                claimed.claimedAt!!.toEpochMilli() / 1000L,
-                claimed.originalClaimedAt!!.toEpochMilli() / 1000L,
+                claimed.claimedAt.toEpochMilli() / 1000L,
+                claimed.originalClaimedAt.toEpochMilli() / 1000L,
                 "originalClaimedAt should equal claimedAt on first claim (within 1 second)"
             )
         }
@@ -187,7 +187,7 @@ class SQLiteWorkItemRepositoryClaimTest : SQLiteRepositoryTestBase() {
             assertEquals(item.id, result.itemId)
             // retryAfterMs should be positive (claim is not expired)
             assertNotNull(result.retryAfterMs)
-            assertTrue(result.retryAfterMs!! > 0, "retryAfterMs should be positive for a live claim")
+            assertTrue(result.retryAfterMs > 0, "retryAfterMs should be positive for a live claim")
         }
 
     /**
@@ -766,7 +766,7 @@ class SQLiteWorkItemRepositoryClaimTest : SQLiteRepositoryTestBase() {
             assertNotNull(aAfter.data.originalClaimedAt, "originalClaimedAt must still be set on item-A")
             assertEquals(
                 originalClaimedAt.toEpochMilli() / 1000L,
-                aAfter.data.originalClaimedAt!!.toEpochMilli() / 1000L,
+                aAfter.data.originalClaimedAt.toEpochMilli() / 1000L,
                 "originalClaimedAt on item-A must be unchanged (within 1s)"
             )
             // claimExpiresAt must be unchanged (no re-write happened)

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryTest.kt
@@ -218,7 +218,7 @@ class SQLiteWorkItemRepositoryTest : BaseRepositoryTest() {
             val result = repository.findRoot()
             assertIs<Result.Success<WorkItem?>>(result)
             assertNotNull(result.data)
-            assertEquals("Root", result.data!!.title)
+            assertEquals("Root", result.data.title)
         }
 
     @Test


### PR DESCRIPTION
## Summary
- Kotlin 2.3.21's improved flow analysis surfaced 88 "Unnecessary non-null assertion (!!) on a non-null receiver" warnings across 16 files (1 main, 15 test).
- Removed the redundant `!!` operators where the compiler had already smart-cast the receiver via `assertNotNull` contracts or prior null guards.
- Two spots needed light restructuring rather than a plain `!!` removal:
  - `AdvanceItemTool.kt` — added `: WorkItem` type annotation on `var cascadeSource` so the smart-cast type survives the `var` assignment (it doesn't propagate automatically).
  - `RoleTransitionHandlerTest.kt` — three tests now bind `val resultItem = assertNotNull(result.item)` once and reuse, instead of repeating `result.item!!` (the compiler's smart-cast-through-property-access claim was incorrect here, and removing `!!` produced real type errors).

No behavior change; this is warning-cleanup only.

## Test plan
- [x] `./gradlew :current:compileKotlin :current:compileTestKotlin` — clean, zero remaining "Unnecessary non-null assertion" warnings
- [x] `./gradlew :current:test` — all tests pass
- [x] `./gradlew :current:ktlintCheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)