### PR TITLE
fix(v3.7.0): MCP server startup + FTS5 search broken in production

### DIFF
--- a/current/docs/search-and-discovery.md
+++ b/current/docs/search-and-discovery.md
@@ -23,13 +23,6 @@ Note bodies are indexed analogously in `notes_fts_trigram` and `notes_fts_text`.
 FTS5 tables are maintained by SQLite triggers installed by the V7 database migration. All writes
 to `work_items` and `notes` keep the FTS indexes up to date automatically.
 
-> ¹ **Case-sensitivity caveat.** The trigram tokenizer is configured WITHOUT the `case_sensitive=0`
-> option because the bundled xerial/sqlite-jdbc 3.49.1.0 driver rejects that option with a parse
-> error. Substring matches via trigram are therefore case-sensitive: searching for `auth` will not
-> match a document containing `OAuth`. For case-insensitive concept matching, prefer
-> `matchMode="text"` (which uses the porter+unicode61 tokenizer with `remove_diacritics=2` and
-> implicit lowercasing). Restoring case-insensitive trigram search is tracked as a follow-up that
-> requires a newer SQLite binary in the JDBC driver bundle.
 
 ### matchMode
 
@@ -38,7 +31,7 @@ The `matchMode` parameter controls which table(s) are queried:
 | matchMode | Tables queried | When to use |
 |---|---|---|
 | `"auto"` (default) | Both — trigram + text, fused via RRF | Best coverage; recommended for most searches |
-| `"substring"` | Trigram only | Case-sensitive substring; requires ≥3-char token |
+| `"substring"` | Trigram only | Substring match via trigram; requires ≥3-char token |
 | `"text"` | Text (porter+unicode61) only | Natural language / stemming queries |
 
 ### Reciprocal Rank Fusion (RRF)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
@@ -689,13 +689,20 @@ Operations: get, search, overview
         val repo = context.workItemRepository()
         val searchResult =
             if (repo is SQLiteWorkItemRepository) {
-                repo.ftsSearch(
-                    sanitizedFtsQuery = sanitizedQuery,
-                    matchMode = matchMode,
-                    scope = scope,
-                    limit = limit,
-                    offset = offset,
-                )
+                try {
+                    repo.ftsSearch(
+                        sanitizedFtsQuery = sanitizedQuery,
+                        matchMode = matchMode,
+                        scope = scope,
+                        limit = limit,
+                        offset = offset,
+                    )
+                } catch (e: Exception) {
+                    return errorResponse(
+                        "FTS5 search failed: ${e.message}",
+                        ErrorCodes.INTERNAL_ERROR
+                    )
+                }
             } else {
                 // Non-SQLite environment (H2 tests): return empty result
                 io.github.jpicklyk.mcptask.current.infrastructure.repository.SearchResult(

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/QueryNotesTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/QueryNotesTool.kt
@@ -496,13 +496,20 @@ concept, or identifier across all note bodies.
         val repo = context.noteRepository()
         val searchResult: SearchResult =
             if (repo is SQLiteNoteRepository) {
-                repo.ftsSearch(
-                    sanitizedFtsQuery = sanitizedQuery,
-                    matchMode = matchMode,
-                    scope = scope,
-                    limit = limit,
-                    offset = offset,
-                )
+                try {
+                    repo.ftsSearch(
+                        sanitizedFtsQuery = sanitizedQuery,
+                        matchMode = matchMode,
+                        scope = scope,
+                        limit = limit,
+                        offset = offset,
+                    )
+                } catch (e: Exception) {
+                    return errorResponse(
+                        "FTS5 note search failed: ${e.message}",
+                        ErrorCodes.INTERNAL_ERROR
+                    )
+                }
             } else {
                 // Non-SQLite environment (H2 tests): FTS5 is SQLite-only — return empty result.
                 SearchResult(hits = emptyList(), totalHits = 0, nextOffset = null)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepository.kt
@@ -307,7 +307,7 @@ class SQLiteNoteRepository(
                             n.key AS note_key
                         FROM $ftsTable ft
                         JOIN notes n ON n.rowid = ft.rowid
-                        WHERE ft MATCH ?$extraWhere
+                        WHERE $ftsTable MATCH ?$extraWhere
                         ORDER BY ft.rank
                         LIMIT ${effectiveLimit + offset + 1}
                         """.trimIndent()
@@ -435,7 +435,7 @@ class SQLiteNoteRepository(
             }
         } catch (e: Exception) {
             logger.error("FTS5 note search failed: ${e.message}", e)
-            SearchResult(hits = emptyList(), totalHits = 0, nextOffset = null)
+            throw e
         }
     }
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepository.kt
@@ -312,11 +312,23 @@ class SQLiteNoteRepository(
                         LIMIT ${effectiveLimit + offset + 1}
                         """.trimIndent()
 
-                    exec(sql, args = buildArgs()) { rs ->
+                    // Use ExposedConnection.prepareStatement() + executeQuery() rather than
+                    // Exposed's exec() — when the SQL starts with `WITH RECURSIVE` (the
+                    // subtree CTE for scope.ancestorId), exec() routes through executeUpdate()
+                    // on xerial sqlite-jdbc and rejects SELECT-returning queries with
+                    // "Query returns results". Same fix template as SQLiteWorkItemRepository.findDescendants().
+                    val ps = this.connection.prepareStatement(sql, false)
+                    try {
+                        ps.fillParameters(buildArgs())
+                        val rs = ps.executeQuery()
                         while (rs.next()) {
-                            val rowid = rs.getLong("rowid")
-                            val rank = rs.getDouble("rank")
-                            val snippet = rs.getString("snip") ?: ""
+                            // Exposed's JdbcResultSetApi exposes getObject(Int|String) and
+                            // getString(Int), but NOT getLong/getDouble. Use getObject for
+                            // numerics and cast to Number. Select order:
+                            // 1=ft.rowid, 2=ft.rank, 3=snip, 4=note_id, 5=item_id, 6=note_key.
+                            val rowid = (rs.getObject(1) as Number).toLong()
+                            val rank = (rs.getObject(2) as Number).toDouble()
+                            val snippet = rs.getString(3) ?: ""
                             val rawNoteId = rs.getObject("note_id")
                             val rawItemId = rs.getObject("item_id")
 
@@ -325,9 +337,11 @@ class SQLiteNoteRepository(
 
                             @Suppress("UNCHECKED_CAST")
                             val itemId = uuidType.valueFromDB(rawItemId!!) as java.util.UUID
-                            val noteKey = rs.getString("note_key") ?: ""
+                            val noteKey = rs.getString(6) ?: ""
                             hitMap[rowid] = NoteHit(rowid, rank, snippet, tableName, noteId, itemId, noteKey)
                         }
+                    } finally {
+                        ps.closeIfPossible()
                     }
                 }
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -724,7 +724,7 @@ class SQLiteWorkItemRepository(
                             wi.id AS wi_id
                         FROM $ftsTable ft
                         JOIN work_items wi ON wi.rowid = ft.rowid
-                        WHERE ft MATCH ?$extraWhere
+                        WHERE $ftsTable MATCH ?$extraWhere
                         ORDER BY ft.rank
                         LIMIT ${effectiveLimit + offset + 1}
                         """.trimIndent()
@@ -874,7 +874,7 @@ class SQLiteWorkItemRepository(
             }
         } catch (e: Exception) {
             logger.error("FTS5 search failed: ${e.message}", e)
-            SearchResult(hits = emptyList(), totalHits = 0, nextOffset = null)
+            throw e
         }
     }
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -729,14 +729,28 @@ class SQLiteWorkItemRepository(
                         LIMIT ${effectiveLimit + offset + 1}
                         """.trimIndent()
 
-                    exec(sql, args = buildArgs()) { rs ->
+                    // Use ExposedConnection.prepareStatement() + executeQuery() rather than
+                    // Exposed's exec() — when the SQL starts with `WITH RECURSIVE` (the
+                    // subtree CTE for scope.ancestorId), exec() routes through executeUpdate()
+                    // on xerial sqlite-jdbc and rejects SELECT-returning queries with
+                    // "Query returns results". Same fix template used in findDescendants().
+                    val ps = this.connection.prepareStatement(sql, false)
+                    try {
+                        ps.fillParameters(buildArgs())
+                        val rs = ps.executeQuery()
                         while (rs.next()) {
-                            val rowid = rs.getLong("rowid")
-                            val rank = rs.getDouble("rank")
-                            val snippetTitle = rs.getString("snip_title") ?: ""
-                            val snippetSummary = rs.getString("snip_summary") ?: ""
+                            // Exposed's JdbcResultSetApi exposes getObject(Int|String) and
+                            // getString(Int), but NOT getLong/getDouble. Use getObject for
+                            // numerics and cast to Number. Select order:
+                            // 1=ft.rowid, 2=ft.rank, 3=snip_title, 4=snip_summary, 5=wi_id.
+                            val rowid = (rs.getObject(1) as Number).toLong()
+                            val rank = (rs.getObject(2) as Number).toDouble()
+                            val snippetTitle = rs.getString(3) ?: ""
+                            val snippetSummary = rs.getString(4) ?: ""
                             hitMap[rowid] = FtsHit(rowid, rank, snippetTitle, snippetSummary, tableName)
                         }
+                    } finally {
+                        ps.closeIfPossible()
                     }
                 }
 

--- a/current/src/main/resources/db/migration/V7__FTS5_And_Unbounded_Depth.sql
+++ b/current/src/main/resources/db/migration/V7__FTS5_And_Unbounded_Depth.sql
@@ -24,16 +24,9 @@
 -- and recreates all indexes in their V6-final state.
 --
 -- FK note: notes, dependencies, and role_transitions all declare ON DELETE CASCADE FKs
--- to work_items.id. If the migration connection has PRAGMA foreign_keys=ON, the
--- DROP TABLE work_items below would cascade-delete those child rows. The bundled
--- xerial/sqlite-jdbc driver defaults foreign_keys OFF on a fresh connection, and
--- Flyway opens its own connection separate from DatabaseManager (which sets FKs ON
--- at the application layer). The PRAGMA below makes the requirement explicit; if
--- Flyway runs this migration inside a transaction it is a no-op (PRAGMA
--- foreign_keys cannot change mid-transaction) and the driver-default of OFF still
--- holds. If run outside a transaction it actively enforces the requirement.
-
-PRAGMA foreign_keys = OFF;
+-- to work_items.id. Flyway runs this migration inside a transaction, so PRAGMA
+-- foreign_keys cannot change mid-transaction — the driver default of OFF holds.
+-- No PRAGMA needed: the table recreation below is safe as-is.
 
 CREATE TABLE work_items_new (
     id                   BLOB PRIMARY KEY DEFAULT (randomblob(16)),
@@ -93,11 +86,6 @@ CREATE INDEX idx_work_items_priority      ON work_items(priority);
 CREATE INDEX idx_work_items_role_changed  ON work_items(role, role_changed_at);
 CREATE INDEX idx_work_items_claimed_by    ON work_items(claimed_by);
 CREATE INDEX idx_work_items_claim_expires ON work_items(claim_expires_at);
-
--- Re-enable FK enforcement on this connection for any subsequent DML in the
--- migration. (Connection lifetime is bounded by Flyway; the application's
--- DatabaseManager sets FKs=ON independently on its own connection.)
-PRAGMA foreign_keys = ON;
 
 -- ============================================================
 -- 2. Cycle-detection trigger

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepositoryFtsTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepositoryFtsTest.kt
@@ -13,11 +13,10 @@ import kotlin.test.assertTrue
 /**
  * FTS5 full-text search integration tests for [SQLiteNoteRepository].
  *
- * FTS5 is SQLite-only. Extends [BaseFts5RepositoryTest] which:
- * 1. Creates an in-memory SQLite DB with FTS5 tables
- * 2. Verifies FTS5 MATCH queries work with the production alias pattern
- * 3. Skips all tests via [org.junit.jupiter.api.Assumptions.assumeTrue] when FTS5
- *    is not functional in the bundled xerial/sqlite-jdbc environment
+ * FTS5 is SQLite-only. Extends [BaseFts5RepositoryTest] which creates an in-memory SQLite DB
+ * with the base schema + FTS5 tables. If FTS5 setup fails the test run aborts with a loud
+ * error (not a skip). Repositories use `WHERE <table_name> MATCH ?` (not `WHERE alias MATCH ?`)
+ * to avoid the "no such column: ft" error on Linux/Docker.
  *
  * Test names follow plan §16.5 — communicating agent-visible behaviour.
  */

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepositoryFtsTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepositoryFtsTest.kt
@@ -17,15 +17,14 @@ import kotlin.test.assertTrue
  * FTS5 full-text search integration tests for [SQLiteWorkItemRepository].
  *
  * All tests require a real SQLite connection with FTS5 virtual tables. Extends
- * [BaseFts5RepositoryTest] which:
- * 1. Creates an in-memory SQLite DB with the base schema + FTS5 tables
- * 2. Verifies that FTS5 MATCH queries work with the production alias pattern
- * 3. Calls [org.junit.jupiter.api.Assumptions.assumeTrue] to skip tests gracefully
- *    when FTS5 is not functional in the bundled xerial/sqlite-jdbc environment
+ * [BaseFts5RepositoryTest] which creates an in-memory SQLite DB with the base schema
+ * + FTS5 tables. If FTS5 setup fails the test run aborts with a loud error (not a skip).
  *
  * **Production compatibility note:** The V7 migration uses plain `tokenize='trigram'` (the
  * SQLite default). The `case_sensitive=0` option is NOT used because xerial/sqlite-jdbc 3.49.1.0
  * rejects it with a parse error. These tests match the production tokenizer configuration.
+ * Repositories use `WHERE <table_name> MATCH ?` (not `WHERE alias MATCH ?`) to avoid the
+ * "no such column: ft" error on Linux/Docker.
  *
  * Test names follow plan §16.5 — communicating agent-visible behaviour.
  */
@@ -486,5 +485,43 @@ class SQLiteWorkItemRepositoryFtsTest : BaseFts5RepositoryTest() {
                     )
                 }
             }
+        }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Regression: alias-based MATCH pattern (WHERE ft MATCH ?) bug
+    // ────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Regression guard for the v3.7.0 production bug where `WHERE ft MATCH ?` (alias-based
+     * pattern) caused [org.sqlite.SQLiteException] "no such column: ft" on xerial/sqlite-jdbc
+     * on both Linux Docker and Windows. The fix replaces alias with the table name:
+     * `WHERE work_items_fts_trigram MATCH ?`.
+     *
+     * This test would have returned 0 hits (silently swallowed exception) in the broken code.
+     * After EDIT 1 (repository fix) + EDIT 4 (remove assumeTrue skip), it must return ≥ 1 hit.
+     */
+    @Test
+    fun `ftsSearch returns hits for exact title word — regression guard for alias-based MATCH bug`(): Unit =
+        runBlocking {
+            val uniqueWord = "xyzFts5RegressionGuard"
+            val inserted = createItem(title = "Task with $uniqueWord in title")
+            createItem(title = "Unrelated item without the magic word")
+
+            val result =
+                repo().ftsSearch(
+                    sanitizedFtsQuery = "\"$uniqueWord\"",
+                    matchMode = SearchMatchMode.AUTO,
+                    limit = 10,
+                )
+
+            assertTrue(
+                result.hits.isNotEmpty(),
+                "Expected at least one FTS5 hit for '$uniqueWord' — 0 hits indicates the alias MATCH bug has returned"
+            )
+            val hitIds = result.hits.map { it.itemId }.toSet()
+            assertTrue(
+                inserted.id in hitIds,
+                "Inserted item ${inserted.id} must appear in FTS5 hits. Got: $hitIds"
+            )
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/test/BaseFts5RepositoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/test/BaseFts5RepositoryTest.kt
@@ -6,7 +6,6 @@ import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.BeforeEach
 import java.sql.Connection
 import java.sql.DriverManager
@@ -22,25 +21,14 @@ import java.sql.DriverManager
  * binary does NOT support the `case_sensitive=0` option for the trigram tokenizer — it fails with
  * "parse error in tokenize directive". The V7 Flyway migration therefore uses plain
  * `tokenize='trigram'` (the SQLite default for trigram). This base class matches that syntax.
- * The trigram tokenizer is case-sensitive by default; true case-insensitive substring search
- * would require case_sensitive=0 which is deferred to a future migration on a newer SQLite baseline.
- *
- * Set [requireFts5] = true in test subclasses to call [Assumptions.assumeTrue] when FTS5
- * is not available (the test is then skipped rather than failing).
+ * Trigram search is case-insensitive in practice on SQLite 3.51.2 (lowercase queries match
+ * uppercase titles). True `case_sensitive=0` configuration is deferred to a future migration
+ * on a newer SQLite baseline.
  */
 abstract class BaseFts5RepositoryTest {
     protected lateinit var database: Database
     protected lateinit var databaseManager: DatabaseManager
     protected lateinit var repositoryProvider: DefaultRepositoryProvider
-
-    /** True when FTS5 virtual tables were created successfully. */
-    protected var fts5Available = false
-
-    /**
-     * Override to true in subclasses that require FTS5. When true, tests are assumed-skipped
-     * rather than failing when FTS5 is not available.
-     */
-    open val requireFts5: Boolean get() = true
 
     /** Holds the SQLite in-memory connection open for the lifetime of each test. */
     private lateinit var keepAliveConnection: Connection
@@ -150,9 +138,10 @@ abstract class BaseFts5RepositoryTest {
             )
         }
 
-        // Attempt to create FTS5 virtual tables. Uses 'trigram' without case_sensitive=0
+        // Create FTS5 virtual tables. Uses 'trigram' without case_sensitive=0
         // (matching the V7 Flyway migration) because bundled xerial/sqlite-jdbc 3.49.1.0
         // does not support the case_sensitive parameter in the trigram tokenizer directive.
+        // If this block throws, the test environment itself is broken — let it fail loudly.
         try {
             transaction(db = database) {
                 exec(
@@ -241,67 +230,14 @@ abstract class BaseFts5RepositoryTest {
                 exec("INSERT INTO work_items_fts_text(work_items_fts_text) VALUES ('rebuild')")
                 exec("INSERT INTO notes_fts_trigram(notes_fts_trigram) VALUES ('rebuild')")
                 exec("INSERT INTO notes_fts_text(notes_fts_text) VALUES ('rebuild')")
-
-                fts5Available = true
             }
         } catch (e: Exception) {
-            fts5Available = false
-            println("[BaseFts5RepositoryTest] FTS5 not available: ${e.message}")
+            throw RuntimeException("[BaseFts5RepositoryTest] FTS5 setup failed — test environment is broken: ${e.message}", e)
         }
 
         databaseManager = DatabaseManager(database)
         repositoryProvider = DefaultRepositoryProvider(databaseManager)
-
-        if (fts5Available) {
-            // Verify FTS5 MATCH queries actually work (the repository silently swallows errors).
-            // The production code uses `alias MATCH expr` syntax which fails in some bundled SQLite builds.
-            fts5Available = checkFts5MatchQueryWorks()
-        }
-
-        if (requireFts5) {
-            Assumptions.assumeTrue(fts5Available, "FTS5 search not functional in bundled SQLite — test skipped")
-        }
     }
-
-    /**
-     * Verifies that FTS5 `MATCH` queries work with the repository's query pattern.
-     * The production repositories use `alias MATCH expr` (e.g., `ft MATCH ?`) syntax.
-     * In some bundled xerial/sqlite-jdbc builds this syntax fails with "no such column: ft".
-     *
-     * The repository catches these errors and returns empty results (not an exception),
-     * so we must probe directly via JDBC to detect the failure.
-     *
-     * @return true if FTS5 MATCH queries work correctly in the current SQLite build.
-     */
-    private fun checkFts5MatchQueryWorks(): Boolean =
-        try {
-            // Test the exact query pattern the repositories use:
-            // - alias MATCH expr (the production pattern)
-            // - snippet(fts_table_name, ...) (the production snippet call)
-            var works = false
-            transaction(db = database) {
-                exec(
-                    """
-                    SELECT ft.rowid, ft.rank,
-                           snippet(work_items_fts_trigram, 0, '<mark>', '</mark>', '…', 32) AS snip
-                    FROM work_items_fts_trigram ft
-                    WHERE ft MATCH ?
-                    LIMIT 1
-                    """.trimIndent(),
-                    args =
-                        listOf(
-                            org.jetbrains.exposed.v1.core
-                                .VarCharColumnType(256) to "\"test\""
-                        )
-                ) { _ ->
-                    works = true
-                }
-            }
-            works
-        } catch (e: Exception) {
-            println("[BaseFts5RepositoryTest] FTS5 MATCH query not functional: ${e.message}")
-            false
-        }
 
     @AfterEach
     fun tearDownFts5Database() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,8 +7,8 @@ kotlinSerialization = "1.11.0"
 # MCP SDK
 mcpSdk = "0.12.0"
 
-# Ktor (pinned ahead of MCP SDK's bundled 3.3.3; 3.x is backwards-compatible)
-ktor = "3.4.2"
+# Ktor (pinned to match MCP SDK 0.12.0's bundled version; 3.4.x broke SSE routing API)
+ktor = "3.3.3"
 
 # Database
 sqlite = "3.49.1.0"


### PR DESCRIPTION
## Summary

Two independent v3.7.0 regressions, found in succession during a Docker smoke test of merged `main`. v3.7.0 was never deployed to production, so we fix-forward in this PR before tagging the release. A new Docker CI smoke test is also added as the meta-fix.

### 1. Server startup (original PR scope)

- **Flyway V7 migration**: removed `PRAGMA foreign_keys = OFF/ON` statements that caused Flyway to reject the migration with "mixed transactional and non-transactional statements." These PRAGMAs were already documented in the migration file as no-ops inside a Flyway transaction (SQLite FK pragma cannot change mid-transaction), so removing them is safe.
- **Ktor downgrade**: 3.4.2 → 3.3.3. Ktor 3.4.x broke backwards-compatibility with the SSE routing API (`RoutingKt.sse` signature changed) that MCP SDK 0.12.0 depends on, causing a `NoSuchMethodError` at startup.

Both issues were introduced when `mcpSdk` was bumped to 0.12.0 in #175 and Ktor was pinned "ahead" at 3.4.2 under the assumption that 3.x is fully backwards-compatible. The FTS5 migration in #177 added the PRAGMA statements that Flyway then rejected on first startup.

### 2. FTS5 search returns 0 hits in production

After fixing #1 above, a Docker smoke test of `query_items(operation="search")` revealed it **always returns 0 hits** in production. Three intertwined causes:

- **`<alias> MATCH ?` parse error.** `SQLiteWorkItemRepository.kt:727` and `SQLiteNoteRepository.kt:310` ran `WHERE ft MATCH ?` where `ft` is the JOIN alias on the FTS5 virtual table. The bundled xerial sqlite-jdbc rejects this pattern with `[SQLITE_ERROR] no such column: ft` on both Linux Docker and Windows. Fix: reference the table name in the WHERE clause (`WHERE work_items_fts_trigram MATCH ?`).
- **Silent test-skip masking.** `BaseFts5RepositoryTest.checkFts5MatchQueryWorks()` probed the broken alias pattern then routed failures through `Assumptions.assumeTrue(...)` which **skips** rather than fails. CI was green on both Windows and Linux despite the bug being present everywhere — PR #177's claim that tests "run unconditionally on Docker/Linux" was incorrect. Fix: removed the probe + assume; FTS5 setup failure now throws loudly.
- **Swallowed `SQLiteException` in repositories.** Both `ftsSearch` implementations caught all Exceptions, logged, and returned `SearchResult(hits=emptyList(), ...)` — masking the parse error from callers. Fix: re-throw from the repository; `QueryItemsTool` and `QueryNotesTool` wrap with `errorResponse(ErrorCodes.INTERNAL_ERROR)`.

After all three fixes landed, the previously-skipped tests ran for the first time — and **two `scope.ancestorId` tests still failed** with a different SQLException: `Query returns results`. Root cause:

- **`WITH RECURSIVE` CTE + Exposed `exec()` routing.** When `scope.ancestorId != null` the SQL gains a `WITH RECURSIVE subtree(id) AS (...)` prefix, making it a SELECT-returning CTE. Exposed's `exec()` routes SQL starting with `WITH` through `executeUpdate()` on xerial sqlite-jdbc, which rejects it. **Same root cause** as PR #177 commit `031276e` already fixed for `findDescendants`, but that fix wasn't propagated to `ftsSearch`. Fix: replicate the `connection.prepareStatement + executeQuery` pattern. Note that Exposed v1's `JdbcResultSetApi` does not expose `getLong`/`getDouble` at all and only exposes `getString(Int)`, so numerics use `getObject(Int)` with a `Number` cast.

Also removed an empirically-false case-sensitivity caveat from `search-and-discovery.md` — lowercase queries match uppercase titles via trigram on the bundled SQLite (3.51.2).

### 3. Docker FTS5 smoke test in CI (the meta-fix)

The JUnit suite alone missed every P0 above. The smoke test that found them in #2 was manual. To close that gap, this PR adds **`.github/workflows/docker-smoke-test.yml`** which:

1. Builds the production `runtime-current` Docker image
2. Spawns it with stdio MCP transport
3. Runs `.github/scripts/docker-fts5-smoke-test.py` to send JSON-RPC over stdin, asserting three things end-to-end:
   - Create-then-search round-trip for a unique marker — guards against the alias-MATCH bug
   - `scope.ancestorId` CTE-scoped search returns hits — guards against the CTE+exec routing bug
   - `matchMode="substring"` with a 2-char query surfaces `isError=true` — guards against the exception-swallowing regression

Verified locally against the rebuilt `task-orchestrator:dev` image — all three assertions pass on the fixes in this PR.

### 4. Operational doc

Added a "Known Operational Quirks" section to `current/docs/fleet-deployment.md` documenting that `/mcp reconnect` in Claude Code retries the existing stdin pipe rather than recycling the docker container — so new image builds aren't picked up without an explicit `docker stop`. This cost ~30 minutes during the smoke test work today.

## Files changed

| File | Scope |
|---|---|
| `current/src/main/resources/db/migration/V7__*.sql` | (#1) Drop PRAGMA foreign_keys |
| `gradle/libs.versions.toml` | (#1) Ktor 3.4.2 → 3.3.3 |
| `current/src/main/kotlin/.../SQLiteWorkItemRepository.kt` | (#2) alias→table MATCH, re-throw, prepareStatement+executeQuery, getObject cast |
| `current/src/main/kotlin/.../SQLiteNoteRepository.kt` | (#2) Same |
| `current/src/main/kotlin/.../QueryItemsTool.kt` | (#2) try-catch → errorResponse |
| `current/src/main/kotlin/.../QueryNotesTool.kt` | (#2) Same |
| `current/src/test/kotlin/.../BaseFts5RepositoryTest.kt` | (#2) Removed skip-on-probe-failure |
| `current/src/test/kotlin/.../SQLiteWorkItemRepositoryFtsTest.kt` | (#2) Added regression test, doc updates |
| `current/src/test/kotlin/.../SQLiteNoteRepositoryFtsTest.kt` | (#2) Doc updates |
| `current/docs/search-and-discovery.md` | (#2) Removed case-sensitivity caveat |
| `.github/workflows/docker-smoke-test.yml` | (#3) New CI job |
| `.github/scripts/docker-fts5-smoke-test.py` | (#3) New smoke test |
| `current/docs/fleet-deployment.md` | (#4) `/mcp reconnect` operational note |

## Test plan

- [x] `:current:test` — 1904 tests, 0 failures, 0 skipped FTS5 (was 11 skipped pre-fix)
- [x] `:current:ktlintCheck` — passes
- [x] `docker build --target runtime-current` — passes
- [x] `python .github/scripts/docker-fts5-smoke-test.py` locally against the rebuilt image — all three assertions pass
- [ ] CI workflow `Docker FTS5 Smoke Test` runs green on this PR (verifies the same on Linux CI runners)
- [ ] After merge: `/mcp reconnect` (after `docker stop` per new doc) and confirm `query_items(operation="search")` returns hits in interactive use

🤖 Generated with [Claude Code](https://claude.com/claude-code)