### PR TITLE
fix: add terminalRole param to complete_tree and fix cancel cascade gate

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt
@@ -22,6 +22,9 @@ import java.util.UUID
  * - rootId (optional UUID): complete all descendants of this item
  * - itemIds (optional array of UUID strings): explicit list of items to complete
  * - trigger (optional string, default "complete"): "complete" or "cancel"
+ * - terminalRole (optional string, default "done"): "done" or "cancelled". When "cancelled",
+ *   resolves the effective trigger to "cancel" (bypassing gate checks). Ignored when trigger
+ *   is explicitly provided.
  * - includeRoot (optional boolean, default true): when rootId is used, also include the root item itself
  *
  * One of rootId or itemIds must be provided.
@@ -41,6 +44,7 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
 - `rootId` (optional UUID string): complete all descendants of this item (exclusive with itemIds)
 - `itemIds` (optional array of UUID strings): explicit list of items to complete
 - `trigger` (optional string, default "complete"): "complete" or "cancel"
+- `terminalRole` (optional string, default "done"): "done" (default, enforces all required note gates) or "cancelled" (bypasses work-phase gate enforcement — use when cancelling items that were never in work role). When trigger is also provided, trigger takes precedence.
 - `includeRoot` (optional boolean, default true): when rootId is used, also include the root item itself in the completion scope. Ignored when itemIds is used.
 
 **Validation:** Exactly one of `rootId` or `itemIds` must be provided.
@@ -119,6 +123,27 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
                                 buildJsonArray {
                                     add(JsonPrimitive("complete"))
                                     add(JsonPrimitive("cancel"))
+                                }
+                            )
+                        }
+                    )
+                    put(
+                        "terminalRole",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "Terminal status label for completed items: 'done' (default, enforces all required note gates) " +
+                                        "or 'cancelled' (bypasses work-phase gate enforcement — use when cancelling items that were " +
+                                        "never in work role). When trigger is also provided, trigger takes precedence."
+                                )
+                            )
+                            put(
+                                "enum",
+                                buildJsonArray {
+                                    add(JsonPrimitive("done"))
+                                    add(JsonPrimitive("cancelled"))
                                 }
                             )
                         }
@@ -221,6 +246,17 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
                 throw ToolValidationException("trigger must be 'complete' or 'cancel', got: $trigger")
             }
         }
+
+        // Validate terminalRole if provided
+        val terminalRoleElem = paramsObj["terminalRole"]
+        if (terminalRoleElem != null && terminalRoleElem !is JsonNull) {
+            val prim =
+                terminalRoleElem as? JsonPrimitive
+                    ?: throw ToolValidationException("terminalRole must be a string")
+            if (prim.content.lowercase() !in setOf("done", "cancelled")) {
+                throw ToolValidationException("terminalRole must be 'done' or 'cancelled', got: ${prim.content}")
+            }
+        }
     }
 
     override suspend fun execute(
@@ -228,7 +264,13 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
         context: ToolExecutionContext
     ): JsonElement {
         val paramsObj = params as JsonObject
-        val trigger = (paramsObj["trigger"] as? JsonPrimitive)?.content?.lowercase() ?: "complete"
+        val explicitTrigger = (paramsObj["trigger"] as? JsonPrimitive)?.content?.lowercase()
+        val terminalRole = (paramsObj["terminalRole"] as? JsonPrimitive)?.content?.lowercase()
+        val trigger = when {
+            explicitTrigger != null -> explicitTrigger
+            terminalRole == "cancelled" -> "cancel"
+            else -> "complete"
+        }
         val includeRoot = (paramsObj["includeRoot"] as? JsonPrimitive)?.booleanOrNull ?: true
 
         val requestIdStr = optionalString(params, "requestId")

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt
@@ -266,11 +266,12 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
         val paramsObj = params as JsonObject
         val explicitTrigger = (paramsObj["trigger"] as? JsonPrimitive)?.content?.lowercase()
         val terminalRole = (paramsObj["terminalRole"] as? JsonPrimitive)?.content?.lowercase()
-        val trigger = when {
-            explicitTrigger != null -> explicitTrigger
-            terminalRole == "cancelled" -> "cancel"
-            else -> "complete"
-        }
+        val trigger =
+            when {
+                explicitTrigger != null -> explicitTrigger
+                terminalRole == "cancelled" -> "cancel"
+                else -> "complete"
+            }
         val includeRoot = (paramsObj["includeRoot"] as? JsonPrimitive)?.booleanOrNull ?: true
 
         val requestIdStr = optionalString(params, "requestId")

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -581,7 +581,9 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                         }
 
                     // Gate check: cascade-to-TERMINAL requires all required notes (like "complete" trigger)
-                    if (event.targetRole == Role.TERMINAL) {
+                    // Cancel cascades bypass work-phase gate enforcement (item was never in work role)
+                    val isCancelCascade = applyResult.item.statusLabel == "cancelled"
+                    if (event.targetRole == Role.TERMINAL && !isCancelCascade) {
                         val parentSchema = context.resolveSchema(parentItem)
                         if (parentSchema != null) {
                             val allRequired = parentSchema.notes.filter { it.required }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeToolTest.kt
@@ -1134,8 +1134,7 @@ class CompleteTreeToolTest {
                     )
                 )
             return object : NoteSchemaService {
-                override fun getSchemaForTags(tags: List<String>): List<NoteSchemaEntry>? =
-                    if (tags.isNotEmpty()) schemaEntries else null
+                override fun getSchemaForTags(tags: List<String>): List<NoteSchemaEntry>? = if (tags.isNotEmpty()) schemaEntries else null
             }
         }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeToolTest.kt
@@ -18,6 +18,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.*
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.util.UUID
 import kotlin.test.*
@@ -1114,5 +1115,162 @@ class CompleteTreeToolTest {
                 }
             )
         }
+    }
+
+    // ──────────────────────────────────────────────
+    // terminalRole parameter tests
+    // ──────────────────────────────────────────────
+
+    @Nested
+    inner class TerminalRoleTests {
+        private fun makeSchemaServiceWithWorkPhaseNote(): NoteSchemaService {
+            val schemaEntries =
+                listOf(
+                    NoteSchemaEntry(
+                        key = "session-tracking",
+                        role = Role.WORK,
+                        required = true,
+                        description = "Session tracking"
+                    )
+                )
+            return object : NoteSchemaService {
+                override fun getSchemaForTags(tags: List<String>): List<NoteSchemaEntry>? =
+                    if (tags.isNotEmpty()) schemaEntries else null
+            }
+        }
+
+        private fun contextWithNoteSchema(noteSchemaService: NoteSchemaService): ToolExecutionContext {
+            val provider = mockk<RepositoryProvider>()
+            every { provider.workItemRepository() } returns workItemRepo
+            every { provider.dependencyRepository() } returns depRepo
+            every { provider.noteRepository() } returns noteRepo
+            every { provider.roleTransitionRepository() } returns roleTransitionRepo
+            return ToolExecutionContext(provider, noteSchemaService)
+        }
+
+        @Test
+        fun `terminalRole=cancelled on queue item with unfilled notes succeeds`(): Unit =
+            runBlocking {
+                val itemId = UUID.randomUUID()
+                // Item has tags matching schema, so gate would normally enforce session-tracking
+                val item = makeItem(id = itemId, title = "Queue Item", role = Role.QUEUE, tags = "feature-task")
+
+                val gatedContext = contextWithNoteSchema(makeSchemaServiceWithWorkPhaseNote())
+
+                // No notes filled — normally gate would block "complete" trigger
+                coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+                coEvery { noteRepo.findByItemId(itemId) } returns Result.Success(emptyList())
+                coEvery { noteRepo.findByItemId(itemId, any()) } returns Result.Success(emptyList())
+                coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+                coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+                every { depRepo.findByToItemId(itemId) } returns emptyList()
+
+                val params =
+                    buildJsonObject {
+                        put(
+                            "itemIds",
+                            buildJsonArray { add(JsonPrimitive(itemId.toString())) }
+                        )
+                        put("terminalRole", JsonPrimitive("cancelled"))
+                    }
+                val result = tool.execute(params, gatedContext)
+
+                val results = extractResults(result)
+                assertEquals(1, results.size)
+                val r = results[0].jsonObject
+                assertTrue(r["applied"]!!.jsonPrimitive.boolean, "terminalRole=cancelled should bypass gate and succeed")
+                assertNull(r["gateErrors"], "No gate errors expected for terminalRole=cancelled")
+                assertEquals("cancel", r["trigger"]!!.jsonPrimitive.content)
+
+                val summary = extractSummary(result)
+                assertEquals(1, summary["completed"]!!.jsonPrimitive.int)
+                assertEquals(0, summary["gateFailures"]!!.jsonPrimitive.int)
+            }
+
+        @Test
+        fun `terminalRole=done explicit enforces gate same as default`(): Unit =
+            runBlocking {
+                val itemId = UUID.randomUUID()
+                val item = makeItem(id = itemId, title = "Queue Item", role = Role.QUEUE, tags = "feature-task")
+
+                val gatedContext = contextWithNoteSchema(makeSchemaServiceWithWorkPhaseNote())
+
+                // No notes filled — gate should block
+                coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+                coEvery { noteRepo.findByItemId(itemId) } returns Result.Success(emptyList())
+                coEvery { noteRepo.findByItemId(itemId, any()) } returns Result.Success(emptyList())
+                every { depRepo.findByToItemId(itemId) } returns emptyList()
+
+                val params =
+                    buildJsonObject {
+                        put(
+                            "itemIds",
+                            buildJsonArray { add(JsonPrimitive(itemId.toString())) }
+                        )
+                        put("terminalRole", JsonPrimitive("done"))
+                    }
+                val result = tool.execute(params, gatedContext)
+
+                val results = extractResults(result)
+                assertEquals(1, results.size)
+                val r = results[0].jsonObject
+                assertFalse(r["applied"]!!.jsonPrimitive.boolean, "terminalRole=done should enforce gate")
+                assertNotNull(r["gateErrors"], "Gate errors expected for terminalRole=done with unfilled notes")
+                val gateErrors = r["gateErrors"]!!.jsonArray
+                assertTrue(gateErrors.any { it.jsonPrimitive.content.contains("session-tracking") })
+
+                val summary = extractSummary(result)
+                assertEquals(0, summary["completed"]!!.jsonPrimitive.int)
+                assertEquals(1, summary["gateFailures"]!!.jsonPrimitive.int)
+            }
+
+        @Test
+        fun `terminalRole invalid value throws ToolValidationException`() {
+            assertFailsWith<ToolValidationException> {
+                tool.validateParams(
+                    buildJsonObject {
+                        put("rootId", JsonPrimitive(UUID.randomUUID().toString()))
+                        put("terminalRole", JsonPrimitive("invalid"))
+                    }
+                )
+            }
+        }
+
+        @Test
+        fun `terminalRole=cancelled with explicit trigger=complete - trigger wins and gate is enforced`(): Unit =
+            runBlocking {
+                val itemId = UUID.randomUUID()
+                val item = makeItem(id = itemId, title = "Queue Item", role = Role.QUEUE, tags = "feature-task")
+
+                val gatedContext = contextWithNoteSchema(makeSchemaServiceWithWorkPhaseNote())
+
+                // No notes filled
+                coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+                coEvery { noteRepo.findByItemId(itemId) } returns Result.Success(emptyList())
+                coEvery { noteRepo.findByItemId(itemId, any()) } returns Result.Success(emptyList())
+                every { depRepo.findByToItemId(itemId) } returns emptyList()
+
+                // Both terminalRole=cancelled AND trigger=complete: trigger wins
+                val params =
+                    buildJsonObject {
+                        put(
+                            "itemIds",
+                            buildJsonArray { add(JsonPrimitive(itemId.toString())) }
+                        )
+                        put("terminalRole", JsonPrimitive("cancelled"))
+                        put("trigger", JsonPrimitive("complete"))
+                    }
+                val result = tool.execute(params, gatedContext)
+
+                val results = extractResults(result)
+                assertEquals(1, results.size)
+                val r = results[0].jsonObject
+                // trigger=complete takes precedence → gate is enforced → should fail
+                assertFalse(r["applied"]!!.jsonPrimitive.boolean, "Explicit trigger=complete takes precedence over terminalRole=cancelled")
+                assertNotNull(r["gateErrors"], "Gate errors expected when trigger=complete wins")
+
+                val summary = extractSummary(result)
+                assertEquals(1, summary["gateFailures"]!!.jsonPrimitive.int)
+            }
     }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
@@ -3235,4 +3235,83 @@ class AdvanceItemToolTest {
             // Should not throw
             tool.validateParams(params)
         }
+
+    // ──────────────────────────────────────────────
+    // Cancel cascade gate bypass tests
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `cancel child cascade to parent bypasses work-phase gate on parent with unfilled notes`(): Unit =
+        runBlocking {
+            val parentId = UUID.randomUUID()
+            val childId = UUID.randomUUID()
+            // Parent in WORK role with tags matching a schema that has required work-phase notes
+            // Use WorkItem directly to set tags (makeItem helper doesn't support tags param)
+            val parentItem = WorkItem(id = parentId, title = "Gated Parent", role = Role.WORK, tags = "feature-task")
+            // Child in WORK role under this parent
+            val childItem = makeItem(id = childId, role = Role.WORK, title = "Child", parentId = parentId)
+
+            // Schema with required work-phase note on parent — matches "feature-task" tag
+            val schemaEntries =
+                listOf(
+                    NoteSchemaEntry(
+                        key = "session-tracking",
+                        role = Role.WORK,
+                        required = true,
+                        description = "Session tracking"
+                    )
+                )
+            val noteSchemaService =
+                object : NoteSchemaService {
+                    override fun getSchemaForTags(tags: List<String>): List<NoteSchemaEntry>? =
+                        if (tags.isNotEmpty()) schemaEntries else null
+                }
+
+            val noteRepo = mockk<NoteRepository>()
+            // Parent has no notes filled — gate would block if trigger were "complete"
+            coEvery { noteRepo.findByItemId(parentId) } returns Result.Success(emptyList())
+            coEvery { noteRepo.findByItemId(parentId, any()) } returns Result.Success(emptyList())
+            // Child notes (not relevant for cascade gate, but needed for the child's own gate check)
+            coEvery { noteRepo.findByItemId(childId) } returns Result.Success(emptyList())
+            coEvery { noteRepo.findByItemId(childId, any()) } returns Result.Success(emptyList())
+
+            val gatedContext =
+                run {
+                    val provider = mockk<RepositoryProvider>()
+                    every { provider.workItemRepository() } returns workItemRepo
+                    every { provider.dependencyRepository() } returns depRepo
+                    every { provider.noteRepository() } returns noteRepo
+                    every { provider.roleTransitionRepository() } returns roleTransitionRepo
+                    ToolExecutionContext(provider, noteSchemaService)
+                }
+
+            coEvery { workItemRepo.getById(childId) } returns Result.Success(childItem)
+            coEvery { workItemRepo.getById(parentId) } returns Result.Success(parentItem)
+            coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+            coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+            every { depRepo.findByToItemId(any()) } returns emptyList()
+            every { depRepo.findByFromItemId(any()) } returns emptyList()
+            // After child cancels, all remaining children of parent are terminal
+            coEvery { workItemRepo.countChildrenByRole(parentId) } returns
+                Result.Success(mapOf(Role.TERMINAL to 1))
+
+            // Cancel the child — this should cascade the parent to TERMINAL without gate check
+            val params = buildParams(transitionObj(childId, "cancel"))
+            val result = tool.execute(params, gatedContext)
+
+            val results = extractResults(result)
+            val r = results[0].jsonObject
+            assertTrue(r["applied"]!!.jsonPrimitive.boolean, "Child cancel should succeed")
+            assertEquals("terminal", r["newRole"]!!.jsonPrimitive.content)
+            assertEquals("cancelled", r["statusLabel"]!!.jsonPrimitive.content)
+
+            // Cascade event for parent should be applied — NOT gate-blocked
+            val cascadeEvents = r["cascadeEvents"]!!.jsonArray
+            assertEquals(1, cascadeEvents.size, "Expected one cascade event for parent")
+            val cascade = cascadeEvents[0].jsonObject
+            assertEquals(parentId.toString(), cascade["itemId"]!!.jsonPrimitive.content)
+            assertEquals("terminal", cascade["targetRole"]!!.jsonPrimitive.content)
+            assertTrue(cascade["applied"]!!.jsonPrimitive.boolean, "Parent cascade should be applied (not gate-blocked)")
+            assertNull(cascade["gateBlocked"], "gateBlocked must not be present on cancel cascade")
+        }
 }


### PR DESCRIPTION
## Summary

- Adds `terminalRole` parameter to `complete_tree` (values: `done` / `cancelled`). When `terminalRole="cancelled"` and no explicit `trigger` is set, the effective trigger resolves to `"cancel"` — bypassing work-phase note gate enforcement. Explicit `trigger` always takes precedence.
- Fixes `advance_item` cancel cascades: when a child is cancelled (statusLabel="cancelled"), the parent's cascade-to-TERMINAL gate check is now skipped entirely, matching cancel semantics.

**Root cause of the observed bug:** Calling `complete_tree(terminalRole="cancelled")` silently ignored the unrecognized parameter, fell back to `trigger="complete"`, and gate-checked all required notes including work-phase notes that were never applicable for unstarted queue items.

Closes MCP item `7ae1169b-adaf-4328-8ac9-53286534fad4`.

## Test plan

- [x] `terminalRole="cancelled"` on queue items with unfilled schema notes → all applied, no gate failures
- [x] `terminalRole="done"` explicit → same gate enforcement as default
- [x] `trigger="complete"` + `terminalRole="cancelled"` → trigger wins, gate enforced
- [x] Invalid `terminalRole` value → `ToolValidationException`
- [x] Cancel child cascade to parent with unfilled work-phase notes → cascade applied=true, no gateBlocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)