### PR TITLE
refactor: migrate newSuspendedTransaction to suspendTransaction (Exposed 1.2)

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/DependencyRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/DependencyRepository.kt
@@ -12,7 +12,7 @@ import java.util.UUID
 interface DependencyRepository {
     fun create(dependency: Dependency): Dependency
 
-    /** Suspend variant for use within a [newSuspendedTransaction] context — joins the outer transaction. */
+    /** Suspend variant for use within a [suspendTransaction] context — joins the outer transaction. */
     suspend fun createSuspend(dependency: Dependency): Dependency
 
     fun findById(id: UUID): Dependency?

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteDependencyRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteDependencyRepository.kt
@@ -18,7 +18,7 @@ import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
-import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.UUID
 
@@ -33,7 +33,7 @@ class SQLiteDependencyRepository(
         transaction(databaseManager.getDatabase()) { insertDependencyInTransaction(dependency) }
 
     override suspend fun createSuspend(dependency: Dependency): Dependency =
-        newSuspendedTransaction(db = databaseManager.getDatabase()) {
+        suspendTransaction(db = databaseManager.getDatabase()) {
             insertDependencyInTransaction(dependency)
         }
 
@@ -294,7 +294,7 @@ class SQLiteDependencyRepository(
         itemId: UUID,
         type: DependencyType?,
     ): List<BacklinkRow> =
-        newSuspendedTransaction(db = databaseManager.getDatabase()) {
+        suspendTransaction(db = databaseManager.getDatabase()) {
             val uuidType = UUIDColumnType()
 
             // Build the query using Exposed DSL, joining to work_items for fromTitle.

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepository.kt
@@ -22,7 +22,7 @@ import org.jetbrains.exposed.v1.core.vendors.currentDialect
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
-import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 import org.jetbrains.exposed.v1.jdbc.update
 import org.slf4j.LoggerFactory
 import java.time.Instant
@@ -235,11 +235,11 @@ class SQLiteNoteRepository(
         val effectiveLimit = limit.coerceIn(1, 100)
 
         return try {
-            newSuspendedTransaction(db = databaseManager.getDatabase()) {
+            suspendTransaction(db = databaseManager.getDatabase()) {
                 // currentDialect is only accessible within an active transaction.
                 // FTS5 is SQLite-only — return empty for H2 (test environment).
                 if (currentDialect is H2Dialect) {
-                    return@newSuspendedTransaction SearchResult(hits = emptyList(), totalHits = 0, nextOffset = null)
+                    return@suspendTransaction SearchResult(hits = emptyList(), totalHits = 0, nextOffset = null)
                 }
                 val uuidType = UUIDColumnType()
                 val varcharType = VarCharColumnType(4000)
@@ -356,7 +356,7 @@ class SQLiteNoteRepository(
 
                 val allRowIds = (trigramHits.keys + textHits.keys).toSet()
                 if (allRowIds.isEmpty()) {
-                    return@newSuspendedTransaction SearchResult(
+                    return@suspendTransaction SearchResult(
                         hits = emptyList(),
                         totalHits = 0,
                         nextOffset = null,

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -40,7 +40,7 @@ import org.jetbrains.exposed.v1.jdbc.Query
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
-import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 import org.jetbrains.exposed.v1.jdbc.update
 import org.slf4j.LoggerFactory
 import java.time.Instant
@@ -153,7 +153,7 @@ class SQLiteWorkItemRepository(
             //   - H2's CURRENT_TIMESTAMP returns "YYYY-MM-DD HH:MM:SS.fffffff-HH" (with a non-
             //     standard offset like "-04" missing the minute portion); we normalize that and
             //     parse via OffsetDateTime.
-            newSuspendedTransaction(db = databaseManager.getDatabase()) {
+            suspendTransaction(db = databaseManager.getDatabase()) {
                 exec("SELECT CURRENT_TIMESTAMP") { rs ->
                     if (rs.next()) {
                         rs.getString(1)?.let { parseDbTimestamp(it) }
@@ -517,7 +517,7 @@ class SQLiteWorkItemRepository(
 
     override suspend fun findDescendants(id: UUID): Result<List<WorkItem>> =
         try {
-            newSuspendedTransaction(db = databaseManager.getDatabase()) {
+            suspendTransaction(db = databaseManager.getDatabase()) {
                 // currentDialect is only accessible within an active transaction.
                 // H2 (test environment): the recursive CTE exec() path uses parameterised
                 // UUID binding that is incompatible with H2's native UUID type, and H2
@@ -583,7 +583,7 @@ class SQLiteWorkItemRepository(
                     }
 
                     if (descendantIds.isEmpty()) {
-                        return@newSuspendedTransaction Result.Success(emptyList())
+                        return@suspendTransaction Result.Success(emptyList())
                     }
 
                     val entityIds = descendantIds.map { EntityID(it, WorkItemsTable) }
@@ -629,11 +629,11 @@ class SQLiteWorkItemRepository(
         val effectiveLimit = limit.coerceIn(1, 100)
 
         return try {
-            newSuspendedTransaction(db = databaseManager.getDatabase()) {
+            suspendTransaction(db = databaseManager.getDatabase()) {
                 // currentDialect is only accessible within an active transaction.
                 // FTS5 is SQLite-only — return empty for H2 (test environment).
                 if (currentDialect is H2Dialect) {
-                    return@newSuspendedTransaction SearchResult(hits = emptyList(), totalHits = 0, nextOffset = null)
+                    return@suspendTransaction SearchResult(hits = emptyList(), totalHits = 0, nextOffset = null)
                 }
                 val uuidType = UUIDColumnType()
 
@@ -766,7 +766,7 @@ class SQLiteWorkItemRepository(
                 // Collect all rowids (union of both maps).
                 val allRowIds = (trigramHits.keys + textHits.keys).toSet()
                 if (allRowIds.isEmpty()) {
-                    return@newSuspendedTransaction SearchResult(
+                    return@suspendTransaction SearchResult(
                         hits = emptyList(),
                         totalHits = 0,
                         nextOffset = null,
@@ -944,7 +944,7 @@ class SQLiteWorkItemRepository(
         ttlSeconds: Int
     ): ClaimResult =
         try {
-            newSuspendedTransaction(db = databaseManager.getDatabase()) {
+            suspendTransaction(db = databaseManager.getDatabase()) {
                 // Both agentId and itemId are bound as typed JDBC parameters — no string interpolation.
                 // itemId binds via UUIDColumnType so the WHERE id = ? predicate uses the primary-key
                 // index directly (the prior HEX(id) = ? form wrapped the column in a function call,
@@ -1049,7 +1049,7 @@ class SQLiteWorkItemRepository(
         agentId: String
     ): ReleaseResult =
         try {
-            newSuspendedTransaction(db = databaseManager.getDatabase()) {
+            suspendTransaction(db = databaseManager.getDatabase()) {
                 // Both agentId and itemId are bound as typed JDBC parameters — no string interpolation.
                 // itemId binds via UUIDColumnType so the WHERE id = ? predicate uses the primary-key
                 // index directly.
@@ -1059,11 +1059,11 @@ class SQLiteWorkItemRepository(
                 // Check existence and current claimant before attempting update.
                 val row =
                     WorkItemsTable.selectAll().where { WorkItemsTable.id eq itemId }.singleOrNull()
-                        ?: return@newSuspendedTransaction ReleaseResult.NotFound(itemId)
+                        ?: return@suspendTransaction ReleaseResult.NotFound(itemId)
 
                 val item = toWorkItem(row)
                 if (item.claimedBy != agentId) {
-                    return@newSuspendedTransaction ReleaseResult.NotClaimedByYou(itemId)
+                    return@suspendTransaction ReleaseResult.NotClaimedByYou(itemId)
                 }
 
                 // Release: clear all four claim fields atomically.
@@ -1088,7 +1088,7 @@ class SQLiteWorkItemRepository(
                 // Read back updated state.
                 val updatedRow =
                     WorkItemsTable.selectAll().where { WorkItemsTable.id eq itemId }.singleOrNull()
-                        ?: return@newSuspendedTransaction ReleaseResult.NotFound(itemId)
+                        ?: return@suspendTransaction ReleaseResult.NotFound(itemId)
 
                 ReleaseResult.Success(toWorkItem(updatedRow))
             }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/TransactionHelper.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/TransactionHelper.kt
@@ -3,12 +3,12 @@ package io.github.jpicklyk.mcptask.current.infrastructure.repository
 import io.github.jpicklyk.mcptask.current.domain.repository.RepositoryError
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
-import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 
 /**
  * Wraps a suspended database transaction with standardized error handling.
  *
- * The [block] executes inside [newSuspendedTransaction] and may return any [Result].
+ * The [block] executes inside [suspendTransaction] and may return any [Result].
  * Any exception thrown by [block] (including from domain validation) is caught and
  * converted to [Result.Error] with a [RepositoryError.DatabaseError].
  *
@@ -20,7 +20,7 @@ suspend fun <T> DatabaseManager.suspendedTransaction(
     block: suspend () -> Result<T>
 ): Result<T> =
     try {
-        newSuspendedTransaction(db = getDatabase()) {
+        suspendTransaction(db = getDatabase()) {
             block()
         }
     } catch (e: Exception) {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/service/SQLiteWorkTreeService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/service/SQLiteWorkTreeService.kt
@@ -14,13 +14,13 @@ import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.Depende
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteNoteRepository
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteWorkItemRepository
 import org.jetbrains.exposed.v1.jdbc.insert
-import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 import java.util.UUID
 
 /**
  * Infrastructure-layer implementation of [WorkTreeExecutor].
  *
- * Uses Exposed table objects directly inside a single [newSuspendedTransaction] so that
+ * Uses Exposed table objects directly inside a single [suspendTransaction] so that
  * all inserts (items, dependencies, notes) are committed atomically. Any exception thrown
  * during execution causes a full rollback — no orphaned rows.
  */
@@ -30,7 +30,7 @@ class SQLiteWorkTreeService(
     private val noteRepo: SQLiteNoteRepository
 ) : WorkTreeExecutor {
     override suspend fun execute(input: WorkTreeInput): WorkTreeResult =
-        newSuspendedTransaction(db = databaseManager.getDatabase()) {
+        suspendTransaction(db = databaseManager.getDatabase()) {
             val createdItems = mutableListOf<WorkItem>()
             val refToId = mutableMapOf<String, UUID>()
             val itemIdToRef = input.refToItem.entries.associate { (ref, item) -> item.id to ref }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/WorkTreeServiceIntegrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/WorkTreeServiceIntegrationTest.kt
@@ -28,7 +28,7 @@ import kotlin.test.assertTrue
  * Atomicity guarantee
  * -------------------
  * [SQLiteWorkTreeService] executes all inserts (items, dependencies, notes) inside a
- * single [newSuspendedTransaction] using Exposed table objects directly — no inner
+ * single [suspendTransaction] using Exposed table objects directly — no inner
  * repository transactions are opened.  This means a failure at any step rolls back
  * ALL prior inserts, providing true all-or-nothing semantics.
  *
@@ -129,7 +129,7 @@ class WorkTreeServiceIntegrationTest {
     //
     // "nonexistent_ref" is not present in refToItem. The executor throws
     // IllegalStateException during dep resolution. Because all operations run
-    // inside a single newSuspendedTransaction, the entire transaction is rolled
+    // inside a single suspendTransaction, the entire transaction is rolled
     // back — including the root item insert that occurred before the error.
     // ──────────────────────────────────────────────────────────────────────────
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryClaimTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryClaimTest.kt
@@ -271,7 +271,7 @@ class SQLiteWorkItemRepositoryClaimTest : SQLiteRepositoryTestBase() {
      * NICE-N5: Verifies that concurrent release operations on the same item do not corrupt data.
      *
      * Two real threads both call `repository.release(sameItemId, agentId)` concurrently.
-     * The release implementation uses a `newSuspendedTransaction` with a read-then-update pattern.
+     * The release implementation uses a `suspendTransaction` with a read-then-update pattern.
      *
      * Safety property: regardless of which thread wins the race (or whether both encounter lock
      * contention), the final DB state must be consistent — claim fields are either all null (released)


### PR DESCRIPTION
## Summary

- Replaces all `newSuspendedTransaction()` call sites with `suspendTransaction()` across 5 production files and 2 test files
- `newSuspendedTransaction` is deprecated in Exposed 1.2 and will be removed in a future release
- No behavior change — all call sites used `db=` parameter only; none required the coroutine context binding that would have needed `withContext()`

**Files changed:** `SQLiteDependencyRepository.kt`, `SQLiteNoteRepository.kt`, `SQLiteWorkItemRepository.kt`, `TransactionHelper.kt`, `SQLiteWorkTreeService.kt`, `DependencyRepository.kt` (comment), `WorkTreeServiceIntegrationTest.kt` (comment), `SQLiteWorkItemRepositoryClaimTest.kt` (comment)

Closes MCP item \`44229630\`.

## Test plan

- [x] Full test suite passes (1600+ tests)
- [x] ktlintCheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)