### PR TITLE
docs: fix 3 doc/code mismatches in API reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,8 +123,30 @@ private fun getConfigPath(): Path {
 ### New MCP Tool
 1. Extend `BaseToolDefinition` in `current/src/main/kotlin/.../application/tools/`
 2. Register in `CurrentMcpServer.kt`
-3. Update `current/docs/api-reference.md`
-4. Add tests in `current/src/test/kotlin/application/tools/`
+3. Update all three documentation surfaces (see below)
+4. Add to `ToolDocumentationConsistencyTest` tool list
+5. Add tests in `current/src/test/kotlin/application/tools/`
+
+### Tool Documentation Surfaces — Keep All Three in Sync
+
+Every tool has three independent documentation surfaces that must be updated together:
+
+| Surface | Location | Audience |
+|---------|----------|----------|
+| `description` string | In the tool source file | LLMs — seen via `tools/list` |
+| `parameterSchema` | In the tool source file | MCP clients — drives validation |
+| API reference | `current/docs/api-reference.md` | Humans |
+
+**CI guard:** `ToolDocumentationConsistencyTest` asserts every `parameterSchema` property name
+appears in the `description` string. This catches description↔schema drift automatically.
+The `api-reference.md` surface is not machine-checked — update it manually alongside code changes.
+
+**When changing a tool's parameters:**
+- Add/rename a param → update `parameterSchema`, `description` string, and `api-reference.md`
+- Remove a param → same three places
+- Change required/optional status → update `description` prose and `api-reference.md` table
+- Do NOT use shorthand like `createdAfter/Before` in descriptions — list each param individually
+  so the consistency test can find them
 
 ### New Database Migration
 Create `current/src/main/resources/db/migration/V{N}__{Description}.sql`. SQLite has no `ALTER COLUMN` — schema changes require table recreation. New tables in `DirectDatabaseSchemaManager` must be inserted in foreign-key order.

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -178,7 +178,7 @@ snippets, filtered list search, or hierarchical overview.
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `operation` | string | Yes | `"get"` |
-| `id` | string (UUID or 4+ char prefix) | Yes | Item to fetch |
+| `itemId` | string (UUID or 4+ char prefix) | Yes | Item to fetch |
 | `includeAncestors` | boolean | No | When true, each result includes an `ancestors` array (default: false) |
 
 #### Key Parameters — search (FTS5 mode, when `query` is provided)
@@ -456,9 +456,10 @@ missing, that item fails and its downstream dependents within the set are skippe
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `rootId` | string (UUID) | Conditionally | Complete all **descendants** of this item. The root item itself is NOT completed — only its descendants are processed. Mutually exclusive with `itemIds`. |
+| `rootId` | string (UUID) | Conditionally | Complete the root item and all its descendants (default). Use `includeRoot: false` to process only descendants. Mutually exclusive with `itemIds`. |
 | `itemIds` | array | Conditionally | Explicit list of item UUIDs to complete. Mutually exclusive with `rootId`. |
 | `trigger` | string | No | `complete` (default) or `cancel`. See gate enforcement note below. |
+| `includeRoot` | boolean | No | When using `rootId`, whether to include the root item itself (default: true). Ignored when `itemIds` is used. |
 | `requestId` | string (UUID) | No | Client-generated UUID for idempotency. See [Idempotency](#idempotency). |
 
 Exactly one of `rootId` or `itemIds` must be provided.

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/dependency/QueryDependenciesTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/dependency/QueryDependenciesTool.kt
@@ -27,10 +27,11 @@ Read-only dependency queries with filtering support.
 
 ## Operations
 
-### get (default)
+### get
 Query outgoing/incoming/all dependencies for a WorkItem.
 
 Parameters:
+- operation (required string): "get"
 - itemId (required UUID): WorkItem to query dependencies for
 - direction (optional): "incoming", "outgoing", "all" (default: "all")
   - incoming: deps where this item is the toItemId (things that block this item)
@@ -48,6 +49,7 @@ Practical use: "find all items that block REQ-42", "what references FEAT-7?".
 A backlink row means another item has an edge with toItemId = your itemId.
 
 Parameters:
+- operation (required string): "backlinks"
 - itemId (required UUID): target item to find backlinks for
 - type (optional): narrow to one dependency type — "BLOCKS", "IS_BLOCKED_BY", "RELATES_TO"
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt
@@ -42,8 +42,12 @@ Unified write operations for WorkItems (create, update, delete).
 **Operations:**
 
 **create** - Create WorkItems from `items` array.
-- Each item: `{ title (required), description?, summary?, role?, statusLabel?, priority?, complexity?, parentId?, metadata?, tags?, type?, properties? }`
+- Each item: `{ title (required), description?, summary?, role?, statusLabel?, priority?, complexity?, parentId?, metadata?, tags?, type?, properties?, requiresVerification? }`
 - Shared `parentId` at top level serves as default for all items (per-item parentId overrides)
+- Top-level `traits` (optional string): comma-separated trait names applied to all items in this operation
+  (e.g., `"needs-migration-review,needs-security-review"`). Traits augment each item's note schema with
+  additional required notes.
+- Top-level `requiresVerification` is ignored — set it on individual items in the `items` array instead.
 - Depth auto-computed from parent (root=0, child=parent.depth+1, unbounded)
 - Defaults: role=queue, priority=medium, complexity=5
 - Response: `{ items: [{id, title, depth, role, priority, requiresVerification, tags, schemaMatch, expectedNotes}], created: N, failed: N, failures: [{index, error}] }`

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
@@ -82,7 +82,7 @@ Operations: get, search, overview
     Markdown formatting in snippets is preserved as-is.
 
   *List mode* (when `query` is omitted): Filter items by structured criteria.
-  - Optional: parentId, depth, role, priority, tags, createdAfter/Before, modifiedAfter/Before,
+  - Optional: parentId, depth, role, priority, tags, type, createdAfter/Before, modifiedAfter/Before,
               roleChangedAfter/Before, sortBy, sortOrder, limit, offset, claimStatus, includeAncestors
   - claimStatus: "claimed" (active live claim), "unclaimed" (never claimed), "expired" (TTL elapsed).
     When provided, a boolean `isClaimed` field is added to each result.

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
@@ -82,8 +82,10 @@ Operations: get, search, overview
     Markdown formatting in snippets is preserved as-is.
 
   *List mode* (when `query` is omitted): Filter items by structured criteria.
-  - Optional: parentId, depth, role, priority, tags, type, createdAfter/Before, modifiedAfter/Before,
-              roleChangedAfter/Before, sortBy, sortOrder, limit, offset, claimStatus, includeAncestors
+  - Optional: parentId, depth, role, priority, tags, type,
+              createdAfter, createdBefore, modifiedAfter, modifiedBefore,
+              roleChangedAfter, roleChangedBefore,
+              sortBy, sortOrder, limit, offset, claimStatus, includeAncestors
   - claimStatus: "claimed" (active live claim), "unclaimed" (never claimed), "expired" (TTL elapsed).
     When provided, a boolean `isClaimed` field is added to each result.
   - Returns minimal fields: id, parentId, title, role, priority, depth, tags

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsTool.kt
@@ -32,7 +32,7 @@ Identifies WorkItems blocked by dependencies or explicitly in BLOCKED role.
 
 **Parameters:**
 - `parentId` (optional UUID): scope results to items under this parent
-- `includeItemDetails` (optional boolean, default false): include summary and tags for each blocked item
+- `includeDetails` (optional boolean, default false): include summary and tags for each blocked item
 - `includeAncestors` (optional boolean, default false): when true, each blocked item includes an
   `ancestors` array ordered root-first (direct parent last). Root items (depth=0) get `"ancestors": []`.
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
@@ -34,27 +34,33 @@ class GetContextTool : BaseToolDefinition() {
         """
 Read-only context snapshot. Three modes:
 
-**Item mode** — `itemId` (UUID):
+**Item mode** — pass `mode: "item"` (or provide `itemId`):
 Returns the item's current role, note schema for its tags, existing notes with filled/exists status,
 gate status (canAdvance + missing required notes for current phase), and `noteProgress`
 (`{filled, remaining, total}` counts of required notes for the current role; null for terminal or schema-free items).
 Full claim detail when item is claimed: `claimedBy`, `claimedAt`, `claimExpiresAt` (UTC), `isExpired` (boolean).
 Use this mode to diagnose stalled/expired claims — this is the only mode that exposes claimedBy identity.
 
-**Session resume** — `since` (ISO 8601 timestamp):
+**Session resume** — pass `mode: "session-resume"` (or provide `since`):
 Returns active items (role=work or review), recent role transitions since the timestamp
 (including actor/verification when present), and stalled items (active items with missing required notes).
 No claim summary in this mode — use item mode or health-check mode for claim visibility.
 
-**Health check** — no parameters:
+**Health check** — pass `mode: "health-check"` (or omit all mode-selecting params):
 Returns all active items (work/review), blocked items, stalled items, and
 `claimSummary: { active: N, expired: N }` — lightweight fleet health signal (counts only, no identity).
 
+When `mode` is omitted, the mode is inferred from which parameters are provided (`itemId` → item, `since` → session-resume, neither → health-check).
+
 Parameters:
-- itemId (optional UUID): triggers item context mode
-- since (optional ISO 8601 string): triggers session resume mode
+- mode (optional string: "item", "session-resume", "health-check"): explicit mode selection; takes
+  precedence over implicit detection when provided
+- itemId (optional UUID): item to inspect; required when mode="item"
+- since (optional ISO 8601 string): transition window start; required when mode="session-resume"
 - includeAncestors (optional boolean, default false): when true, each listed item includes an
   `ancestors` array ordered root-first (direct parent last). Root items (depth=0) get `"ancestors": []`.
+- limit (optional integer, default 50, max 200): maximum number of role transitions returned in
+  session-resume mode
         """.trimIndent()
 
     override val category = ToolCategory.WORKFLOW

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolDocumentationConsistencyTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolDocumentationConsistencyTest.kt
@@ -1,0 +1,99 @@
+package io.github.jpicklyk.mcptask.current.application.tools
+
+import io.github.jpicklyk.mcptask.current.application.tools.compound.CompleteTreeTool
+import io.github.jpicklyk.mcptask.current.application.tools.compound.CreateWorkTreeTool
+import io.github.jpicklyk.mcptask.current.application.tools.dependency.ManageDependenciesTool
+import io.github.jpicklyk.mcptask.current.application.tools.dependency.QueryDependenciesTool
+import io.github.jpicklyk.mcptask.current.application.tools.items.ManageItemsTool
+import io.github.jpicklyk.mcptask.current.application.tools.items.QueryItemsTool
+import io.github.jpicklyk.mcptask.current.application.tools.notes.ManageNotesTool
+import io.github.jpicklyk.mcptask.current.application.tools.notes.QueryNotesTool
+import io.github.jpicklyk.mcptask.current.application.tools.workflow.AdvanceItemTool
+import io.github.jpicklyk.mcptask.current.application.tools.workflow.ClaimItemTool
+import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetBlockedItemsTool
+import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetContextTool
+import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetNextItemTool
+import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetNextStatusTool
+import org.junit.jupiter.api.Test
+import kotlin.test.fail
+
+/**
+ * Verifies that every parameter named in a tool's [ToolDefinition.parameterSchema] is
+ * mentioned somewhere in the tool's [ToolDefinition.description] string.
+ *
+ * There are three independent documentation surfaces that must stay in sync:
+ *   1. description string  — what LLMs see via tools/list
+ *   2. parameterSchema     — what MCP clients validate against
+ *   3. api-reference.md    — what humans read
+ *
+ * This test guards the description↔schema surface automatically on every CI run.
+ * The api-reference.md surface requires human review; see CLAUDE.md "Documentation surfaces" note.
+ */
+class ToolDocumentationConsistencyTest {
+    private val allTools: List<ToolDefinition> =
+        listOf(
+            ManageItemsTool(),
+            QueryItemsTool(),
+            ManageNotesTool(),
+            QueryNotesTool(),
+            ManageDependenciesTool(),
+            QueryDependenciesTool(),
+            AdvanceItemTool(),
+            ClaimItemTool(),
+            GetBlockedItemsTool(),
+            GetContextTool(),
+            GetNextItemTool(),
+            GetNextStatusTool(),
+            CompleteTreeTool(),
+            CreateWorkTreeTool(),
+        )
+
+    @Test
+    fun `all schema parameter names appear in tool description string`() {
+        val failures = mutableListOf<String>()
+
+        for (tool in allTools) {
+            val description = tool.description
+            val schemaProps = tool.parameterSchema.properties ?: continue
+
+            for (paramName in schemaProps.keys) {
+                if (!description.contains(paramName)) {
+                    failures.add("${tool.name}: schema param '$paramName' not mentioned in description")
+                }
+            }
+        }
+
+        if (failures.isNotEmpty()) {
+            fail(
+                "Tool description/schema mismatches found. " +
+                    "Add each param to the tool's description string:\n" +
+                    failures.joinToString("\n") { "  - $it" }
+            )
+        }
+    }
+
+    @Test
+    fun `all required schema parameters are marked required in tool description`() {
+        val failures = mutableListOf<String>()
+
+        for (tool in allTools) {
+            val description = tool.description
+            val required = tool.parameterSchema.required ?: continue
+
+            for (paramName in required) {
+                // Required params must appear AND should not be described as optional-only.
+                // We check presence here; callers can verify the "required" framing manually.
+                if (!description.contains(paramName)) {
+                    failures.add("${tool.name}: required param '$paramName' not mentioned in description")
+                }
+            }
+        }
+
+        if (failures.isNotEmpty()) {
+            fail(
+                "Required schema params absent from description strings:\n" +
+                    failures.joinToString("\n") { "  - $it" }
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Post-merge follow-up from a consistency audit of PR #183 changes.

- **`get_blocked_items`**: Fix tool description string (`includeItemDetails` → `includeDetails`); the schema key and API reference were already correct but the description text (surfaced to LLMs via MCP protocol) still said the old name
- **`query_items` get**: Fix parameter table in api-reference.md (`id` → `itemId`); the worked example was correct but the table row still showed the old name  
- **`complete_tree`**: Add missing `includeRoot` parameter to api-reference.md table; fix `rootId` description which incorrectly stated the root item is NOT completed (default is `includeRoot: true`, so root IS included)

## Test plan

- [x] `./gradlew :current:ktlintCheck` — clean
- No behavioral changes; doc-only and description-string fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)