### PR TITLE
fix: HTTP (Streamable HTTP) transport startup crashes + default-off REST API; add transport tests & docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **HTTP transport (`MCP_TRANSPORT=http`) crashed on startup.** MCP SDK 0.12.0 made
+  `mcpStreamableHttp` install the Ktor `SSE` plugin itself, colliding with an explicit
+  `install(SSE)` (`DuplicatePluginException`). The server never started in HTTP mode, regardless of
+  API config. Removed the redundant `install(SSE)`.
+- **Stock deployment crashed on startup.** With `API_ENABLED` defaulting to `true`, the REST API
+  config loaded in every mode and hard-required `API_AUTH_MODE` — so the default stdio container
+  (no `API_*` vars) and naive MCP-over-HTTP both failed with `API_AUTH_MODE is required`.
+
+### Changed
+
+- **`API_ENABLED` now defaults to `false` (default-off).** The REST API is opt-in: set
+  `API_ENABLED=true` (plus `API_AUTH_MODE`) to enable it. An unset `API_ENABLED` resolves to
+  `ApiAuthConfig.Disabled`, so the stock container boots cleanly with no API configuration. (Refines
+  the still-unreleased REST API layer; not a breaking change.)
+- **`docker-compose.yml` `http` profile** now publishes on `127.0.0.1:3001` (loopback) and sets
+  `API_ENABLED=false`, per the Streamable HTTP transport's localhost-binding recommendation.
+
+### Added
+
+- **MCP-over-HTTP setup documentation.** `quick-start.md` documents the MCP-only HTTP path
+  (`MCP_TRANSPORT=http`, `/mcp` endpoint), client registration (`claude mcp add --transport http`
+  and `.mcp.json`), an HTTP env-var reference, and HTTP transport security guidance (Origin
+  validation, loopback binding, unauthenticated `/mcp`).
+- **HTTP transport tests.** `McpStreamableHttpTransportTest` drives the real `mcpStreamableHttp`
+  module over Ktor — initialize → tools/list → tools/call across all 14 tools — and asserts
+  cross-origin requests are rejected with `403` (DNS-rebinding protection). The HTTP module wiring
+  is extracted into `installMcpStreamableHttp`/`installRestApiRoutes` so the production path is
+  directly testable.
+
 ## [3.8.0] - 2026-05-22 (Plugin v3.2.2)
 
 ### Breaking Changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ Add to `gradle/libs.versions.toml` (`[versions]` + `[libraries]`), then referenc
 - `DEGRADED_MODE_POLICY` — overrides `actor_authentication.degraded_mode_policy` in config; values: `accept-cached` (default) | `accept-self-reported` | `reject`; invalid value = startup failure
 
 **REST API environment variables** (see also `current/docs/fleet-deployment.md`):
-- `API_ENABLED` — master API switch (default: `true`; requires `API_AUTH_MODE` when enabled)
+- `API_ENABLED` — master API switch (default: `false`; set `true` to opt into the REST API, which then requires `API_AUTH_MODE`)
 - `API_AUTH_MODE` — `bearer` or `jwks`; required when API enabled; no `none` mode
 - `API_TOKENS_PATH` — bearer token YAML file path (default: `/run/secrets/api-tokens.yaml`)
 - `API_JWKS_URL` — JWKS endpoint URL (jwks mode, required)

--- a/current/docs/fleet-deployment.md
+++ b/current/docs/fleet-deployment.md
@@ -25,7 +25,7 @@ A REST API caller with `write-items` capability can create and patch items; it d
 
 ### Enabling the REST API
 
-Set `API_ENABLED=true` (default `true` — but the API requires `API_AUTH_MODE` to be set; startup fails without it). Choose a mode:
+The REST API is off by default (`API_ENABLED` defaults to `false`). Set `API_ENABLED=true` to opt in — the API then requires `API_AUTH_MODE` to be set, and startup fails without it. Choose a mode:
 
 ```bash
 # Bearer mode — static tokens from a YAML secret file
@@ -49,7 +49,7 @@ API_JWKS_CACHE_TTL_SECONDS=300   # optional, default 300
 
 | Variable | Required when | Default | Description |
 |----------|--------------|---------|-------------|
-| `API_ENABLED` | always | `true` | Master API switch. `false` skips all `/api/v1/*` route registration. |
+| `API_ENABLED` | optional | `false` | Master API switch. Unset or `false` skips all `/api/v1/*` route registration; set `true` to opt in. |
 | `API_AUTH_MODE` | API enabled | — | `bearer` or `jwks`. Required; no `none` mode. |
 | `API_TOKENS_PATH` | bearer mode | `/run/secrets/api-tokens.yaml` | Path to bearer token YAML secret file. |
 | `API_JWKS_URL` | jwks mode | — | JWKS endpoint URL (fully-qualified HTTP/HTTPS). |

--- a/current/docs/quick-start.md
+++ b/current/docs/quick-start.md
@@ -396,7 +396,32 @@ After adding or editing this file, reconnect the MCP server:
 
 ---
 
-## Step 9: Enabling the REST API (optional)
+## Step 9: Running MCP over HTTP (optional)
+
+By default the server speaks the **stdio** transport (Step 2). To serve MCP over **HTTP** instead — for remote clients, container-to-container access, or a shared long-running server — set `MCP_TRANSPORT=http`. The MCP endpoint is mounted at `/mcp` using the Streamable HTTP transport.
+
+```bash
+docker run --rm -p 3001:3001 \
+  -v mcp-task-data:/app/data \
+  -v "$(pwd)/.taskorchestrator:/project/.taskorchestrator:ro" \
+  -e MCP_TRANSPORT=http \
+  -e MCP_HTTP_PORT=3001 \
+  -e AGENT_CONFIG_DIR=/project \
+  -e API_ENABLED=false \
+  ghcr.io/jpicklyk/task-orchestrator:latest
+```
+
+Point your MCP client at `http://localhost:3001/mcp`.
+
+> **`API_ENABLED=false` is required for MCP-only HTTP.** The REST API (Step 10) is a separate opt-in layer that *hard-requires* an auth mode — leaving the API enabled without `API_AUTH_MODE` is a fatal startup error. Set `API_ENABLED=false` when you want the MCP transport over HTTP without the REST surface.
+
+> **Schema config works identically over HTTP.** `.taskorchestrator/config.yaml` is loaded via `AGENT_CONFIG_DIR` regardless of transport — the `-v ...:/project/.taskorchestrator:ro` mount above gives the HTTP server the same schemas it would have over stdio. (An HTTP server resolves a single project's config; run one server per project.)
+
+The `docker compose --profile http up` service in `docker-compose.yml` is pre-configured this way.
+
+---
+
+## Step 10: Enabling the REST API (optional)
 
 The REST API layer provides HTTP endpoints for dashboards, CI systems, and operators who want to read or write work items without an MCP client.
 

--- a/current/docs/quick-start.md
+++ b/current/docs/quick-start.md
@@ -439,10 +439,10 @@ Restart Claude Code and run `/mcp` to confirm the connection and all 14 tools. O
 | `MCP_TRANSPORT` | `stdio` | Set to `http` to serve the Streamable HTTP transport instead of stdio. |
 | `MCP_HTTP_PORT` | `3001` | Port the server listens on (inside the container for Docker). |
 | `MCP_HTTP_HOST` | `0.0.0.0` | Interface the server binds. Leave at `0.0.0.0` for Docker — the container is network-isolated, so control host exposure via the `-p` mapping (publish to `127.0.0.1` as shown above). For a direct, non-Docker JAR run, set `127.0.0.1` to bind loopback only. |
-| `API_ENABLED` | `true` | Set `false` for MCP-only HTTP; `true` opts into the REST API (Step 10) and then requires `API_AUTH_MODE`. |
+| `API_ENABLED` | `false` | REST API off by default (MCP-only). Set `true` to opt into the REST API (Step 10), which then requires `API_AUTH_MODE`. |
 | `AGENT_CONFIG_DIR` | working dir | Directory containing `.taskorchestrator/config.yaml` (schema config). Set to the mounted project path. |
 
-> **`API_ENABLED=false` is required for MCP-only HTTP.** The REST API (Step 10) is a separate opt-in layer that *hard-requires* an auth mode — leaving the API enabled without `API_AUTH_MODE` is a fatal startup error. Set `API_ENABLED=false` when you want the MCP transport over HTTP without the REST surface.
+> **The REST API is off by default.** `API_ENABLED` defaults to `false`, so MCP-over-HTTP needs no API configuration — the example sets it explicitly only for clarity. Opt into the REST API (Step 10) with `API_ENABLED=true`, which then *hard-requires* `API_AUTH_MODE` (omitting it is a fatal startup error).
 
 > **Schema config works identically over HTTP.** `.taskorchestrator/config.yaml` is loaded via `AGENT_CONFIG_DIR` regardless of transport — the `-v ...:/project/.taskorchestrator:ro` mount above gives the HTTP server the same schemas it would have over stdio. (An HTTP server resolves a single project's config; run one server per project.)
 

--- a/current/docs/quick-start.md
+++ b/current/docs/quick-start.md
@@ -411,7 +411,36 @@ docker run --rm -p 127.0.0.1:3001:3001 \
   ghcr.io/jpicklyk/task-orchestrator:latest
 ```
 
-Point your MCP client at `http://localhost:3001/mcp`.
+**Register the HTTP endpoint with Claude Code:**
+
+```bash
+claude mcp add --transport http mcp-task-orchestrator-http http://localhost:3001/mcp
+```
+
+Or add it to a project `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "mcp-task-orchestrator-http": {
+      "type": "http",
+      "url": "http://localhost:3001/mcp"
+    }
+  }
+}
+```
+
+Restart Claude Code and run `/mcp` to confirm the connection and all 14 tools. Other MCP clients should target the same `http://localhost:3001/mcp` URL using the Streamable HTTP transport.
+
+**HTTP transport environment variables:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MCP_TRANSPORT` | `stdio` | Set to `http` to serve the Streamable HTTP transport instead of stdio. |
+| `MCP_HTTP_PORT` | `3001` | Port the server listens on (inside the container for Docker). |
+| `MCP_HTTP_HOST` | `0.0.0.0` | Interface the server binds. Leave at `0.0.0.0` for Docker — the container is network-isolated, so control host exposure via the `-p` mapping (publish to `127.0.0.1` as shown above). For a direct, non-Docker JAR run, set `127.0.0.1` to bind loopback only. |
+| `API_ENABLED` | `true` | Set `false` for MCP-only HTTP; `true` opts into the REST API (Step 10) and then requires `API_AUTH_MODE`. |
+| `AGENT_CONFIG_DIR` | working dir | Directory containing `.taskorchestrator/config.yaml` (schema config). Set to the mounted project path. |
 
 > **`API_ENABLED=false` is required for MCP-only HTTP.** The REST API (Step 10) is a separate opt-in layer that *hard-requires* an auth mode — leaving the API enabled without `API_AUTH_MODE` is a fatal startup error. Set `API_ENABLED=false` when you want the MCP transport over HTTP without the REST surface.
 

--- a/current/docs/quick-start.md
+++ b/current/docs/quick-start.md
@@ -401,7 +401,7 @@ After adding or editing this file, reconnect the MCP server:
 By default the server speaks the **stdio** transport (Step 2). To serve MCP over **HTTP** instead — for remote clients, container-to-container access, or a shared long-running server — set `MCP_TRANSPORT=http`. The MCP endpoint is mounted at `/mcp` using the Streamable HTTP transport.
 
 ```bash
-docker run --rm -p 3001:3001 \
+docker run --rm -p 127.0.0.1:3001:3001 \
   -v mcp-task-data:/app/data \
   -v "$(pwd)/.taskorchestrator:/project/.taskorchestrator:ro" \
   -e MCP_TRANSPORT=http \
@@ -418,6 +418,14 @@ Point your MCP client at `http://localhost:3001/mcp`.
 > **Schema config works identically over HTTP.** `.taskorchestrator/config.yaml` is loaded via `AGENT_CONFIG_DIR` regardless of transport — the `-v ...:/project/.taskorchestrator:ro` mount above gives the HTTP server the same schemas it would have over stdio. (An HTTP server resolves a single project's config; run one server per project.)
 
 The `docker compose --profile http up` service in `docker-compose.yml` is pre-configured this way.
+
+### HTTP transport security
+
+The Streamable HTTP transport follows the [MCP transport security requirements](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning):
+
+- **Origin validation is enforced.** The server validates the `Origin` header and rejects cross-origin browser requests with `403 Forbidden` (DNS-rebinding protection). Non-browser MCP clients (Claude Code and other CLI agents) send no `Origin` and are unaffected.
+- **Bind to loopback when running locally.** The examples above publish the port as `127.0.0.1:3001:3001` so it is reachable only from the local host. Use `-p 3001:3001` (or set `MCP_HTTP_HOST`) only when you intentionally need access from other hosts.
+- **The `/mcp` endpoint is unauthenticated.** Unlike the REST API (Step 10, which requires bearer/JWKS auth), the MCP transport has no built-in authentication. Keep it on a trusted network boundary, or front it with an authenticating reverse proxy, before exposing it to untrusted callers.
 
 ---
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/ApiAuthConfigLoader.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/ApiAuthConfigLoader.kt
@@ -13,7 +13,7 @@ import java.net.URL
  *
  * | Variable | Required when | Default | Description |
  * |----------|--------------|---------|-------------|
- * | `API_ENABLED` | always | `true` | Master API switch. `false` → [ApiAuthConfig.Disabled]. |
+ * | `API_ENABLED` | optional | `false` | Master API switch. Unset or `false` → [ApiAuthConfig.Disabled]. `true` opts in (then `API_AUTH_MODE` is required). |
  * | `API_AUTH_MODE` | `API_ENABLED=true` | — | `bearer` or `jwks`. Unset / `none` / invalid → startup failure. |
  * | `API_TOKENS_PATH` | bearer mode | `/run/secrets/api-tokens.yaml` | Path to the bearer token secret file. |
  * | `API_JWKS_URL` | jwks mode | — | JWKS endpoint URL. Required; startup fails if absent. |
@@ -44,7 +44,7 @@ class ApiAuthConfigLoader(
         val apiEnabled = resolveApiEnabled()
 
         if (!apiEnabled) {
-            logger.info("API is disabled (API_ENABLED=false)")
+            logger.info("API is disabled (API_ENABLED unset or false)")
             return ApiAuthConfig.Disabled
         }
 
@@ -63,7 +63,11 @@ class ApiAuthConfigLoader(
     // -------------------------------------------------------------------------
 
     private fun resolveApiEnabled(): Boolean {
-        val raw = envResolver("API_ENABLED") ?: return true
+        // Default-OFF: when API_ENABLED is unset, the REST API is disabled. This keeps the stock
+        // container (stdio, no API_* vars) booting cleanly — an enabled API hard-requires
+        // API_AUTH_MODE and would otherwise crash a default deployment at startup. The API is an
+        // opt-in layer the operator turns on with API_ENABLED=true + API_AUTH_MODE.
+        val raw = envResolver("API_ENABLED") ?: return false
         return when (raw.lowercase().trim()) {
             "true", "1", "yes" -> true
             "false", "0", "no" -> false

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
@@ -60,7 +60,6 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.plugins.cors.routing.CORS
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
-import io.ktor.server.sse.SSE
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.StdioServerTransport
@@ -442,16 +441,18 @@ class CurrentMcpServer(
                     configureCors()
                 }
 
-                // 3. SSE plugin — required by mcpStreamableHttp and future Phase 6 /events endpoint
-                install(SSE)
-
-                // 4. Mount /mcp — mcpStreamableHttp sees ContentNegotiation already installed
-                //    (logs warning "already installed" and skips its own CN install)
+                // 3. Mount /mcp — mcpStreamableHttp installs the Ktor SSE plugin ITSELF (SDK 0.12.0).
+                //    Do NOT install(SSE) before this call: a second install throws
+                //    DuplicatePluginException ("already installed with the same key as SSE") at
+                //    startup and the HTTP server never comes up. The SSE plugin installed here also
+                //    serves the Phase 6 /api/v1/events route registered in the routing block below.
+                //    mcpStreamableHttp also sees ContentNegotiation already installed (logs a
+                //    warning "already installed" and skips its own CN install).
                 mcpStreamableHttp {
                     server
                 }
 
-                // 5. Register REST routes when API is enabled
+                // 4. Register REST routes when API is enabled
                 if (apiConfig !is ApiAuthConfig.Disabled) {
                     routing {
                         // Authenticated routes under /api/v1 — auth plugin enforces bearer/JWKS

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
@@ -5,6 +5,7 @@ import io.github.jpicklyk.mcptask.current.application.service.IdempotencyCache
 import io.github.jpicklyk.mcptask.current.application.service.NextItemRecommender
 import io.github.jpicklyk.mcptask.current.application.service.NoOpActorVerifier
 import io.github.jpicklyk.mcptask.current.application.service.WorkItemSchemaService
+import io.github.jpicklyk.mcptask.current.application.tools.ToolDefinition
 import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
 import io.github.jpicklyk.mcptask.current.application.tools.compound.CompleteTreeTool
 import io.github.jpicklyk.mcptask.current.application.tools.compound.CreateWorkTreeTool
@@ -53,6 +54,7 @@ import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.serviceRoutes
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.transitionRoutes
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.wellKnownRoutes
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.embeddedServer
@@ -158,29 +160,8 @@ class CurrentMcpServer(
                 if (apiWiring.eventBus != null) "enabled — writes publish to SSE bus" else "disabled — raw provider"
             )
 
-            // Build tool list
-            val tools =
-                listOf(
-                    // Phase 1: CRUD
-                    ManageItemsTool(),
-                    QueryItemsTool(),
-                    ManageNotesTool(),
-                    QueryNotesTool(),
-                    // Phase 2: Dependencies
-                    ManageDependenciesTool(),
-                    QueryDependenciesTool(),
-                    // Phase 2: Workflow
-                    AdvanceItemTool(),
-                    ClaimItemTool(),
-                    GetNextStatusTool(),
-                    GetNextItemTool(),
-                    GetBlockedItemsTool(),
-                    // Phase 3: Compound operations
-                    CompleteTreeTool(),
-                    CreateWorkTreeTool(),
-                    // Phase 3: Context
-                    GetContextTool()
-                )
+            // Build tool list (shared with tests via buildMcpTools())
+            val tools = buildMcpTools()
 
             // Configure MCP server
             val serverName = System.getenv("MCP_SERVER_NAME") ?: "mcp-task-orchestrator-current"
@@ -427,78 +408,24 @@ class CurrentMcpServer(
         val done = Job()
         val ktorServer =
             embeddedServer(CIO, host = host, port = port) {
-                // 1. Install ContentNegotiation FIRST with McpJson.
-                //    The MCP SDK's installMcpContentNegotiation() is idempotent — when it finds CN
-                //    already installed it logs a warning and skips. By installing McpJson here, REST
-                //    routes benefit from the same JSON configuration (explicitNulls=false,
-                //    encodeDefaults=true). Both /mcp and /api/v1/* use the same Json instance.
-                install(ContentNegotiation) {
-                    json(McpJson)
-                }
-
-                // 2. CORS plugin — env-driven allowlist, locked-down default (empty = no cross-origin)
-                install(CORS) {
-                    configureCors()
-                }
-
-                // 3. Mount /mcp — mcpStreamableHttp installs the Ktor SSE plugin ITSELF (SDK 0.12.0).
-                //    Do NOT install(SSE) before this call: a second install throws
-                //    DuplicatePluginException ("already installed with the same key as SSE") at
-                //    startup and the HTTP server never comes up. The SSE plugin installed here also
-                //    serves the Phase 6 /api/v1/events route registered in the routing block below.
-                //    mcpStreamableHttp also sees ContentNegotiation already installed (logs a
-                //    warning "already installed" and skips its own CN install).
-                mcpStreamableHttp {
-                    server
-                }
-
-                // 4. Register REST routes when API is enabled
-                if (apiConfig !is ApiAuthConfig.Disabled) {
-                    routing {
-                        // Authenticated routes under /api/v1 — auth plugin enforces bearer/JWKS
-                        route("/api/v1") {
-                            install(ApiBearerAuth) {
-                                authConfig = apiConfig
-                                // Use pre-loaded token entries (already loaded for event bus wiring above)
-                                tokenEntries = apiTokenEntries
-                            }
-                            serviceRoutes(
-                                repositoryProvider = effectiveProvider,
-                                serverName = serverName,
-                                serverVersion = version,
-                                actorAuthEnabled = actorAuthEnabled,
-                            )
-                            // Phase 3: read API — items, notes, dependencies, transitions, search
-                            itemRoutes(effectiveProvider)
-                            noteRoutes(effectiveProvider)
-                            dependencyRoutes(effectiveProvider)
-                            transitionRoutes(effectiveProvider)
-                            searchRoutes(effectiveProvider)
-                            // Phase 4: config/schema-discovery + status-graph
-                            configRoutes(noteSchemaService)
-                            // Phase 5: write API — items, notes, dependencies, advance
-                            itemWriteRoutes(effectiveProvider, degradedModePolicy, idempotencyCache, noteSchemaService)
-                            noteWriteRoutes(effectiveProvider, degradedModePolicy, idempotencyCache)
-                            dependencyWriteRoutes(effectiveProvider, degradedModePolicy)
-                        }
-                        // Phase 6: real-time SSE event stream — registered OUTSIDE the ApiBearerAuth
-                        // block (as a sibling `route("/api/v1/events")`) so the ApiBearerAuth plugin
-                        // does NOT intercept it. The SSE route does its own inline pre-flight auth,
-                        // which additionally supports the opt-in `?token=` query-param path that
-                        // ApiBearerAuth (header-only) would reject before our handler runs.
-                        if (eventBus != null) {
-                            route("/api/v1") {
-                                eventRoutes(
-                                    eventBus = eventBus,
-                                    tokenEntries = apiTokenEntries,
-                                    allowQueryToken = allowQueryToken,
-                                )
-                            }
-                        }
-                        // Discovery endpoint — no auth, mounted at root
-                        wellKnownRoutes(serverName = serverName, serverVersion = version)
-                    }
-                }
+                // MCP transport (/mcp) + optional REST API (/api/v1) wiring is extracted into
+                // installMcpStreamableHttp() and installRestApiRoutes() so the SAME production code
+                // path is exercised by tests (see McpStreamableHttpTransportTest). The MCP mount must
+                // come first: mcpStreamableHttp installs the SSE plugin that the events route reuses.
+                installMcpStreamableHttp(server)
+                installRestApiRoutes(
+                    apiConfig = apiConfig,
+                    eventBus = eventBus,
+                    effectiveProvider = effectiveProvider,
+                    apiTokenEntries = apiTokenEntries,
+                    allowQueryToken = allowQueryToken,
+                    serverName = serverName,
+                    serverVersion = version,
+                    actorAuthEnabled = actorAuthEnabled,
+                    noteSchemaService = noteSchemaService,
+                    degradedModePolicy = degradedModePolicy,
+                    idempotencyCache = idempotencyCache,
+                )
             }
 
         shutdownCoordinator?.addCleanupAction("Stop HTTP Server") {
@@ -557,4 +484,129 @@ class CurrentMcpServer(
                 ),
             instructions = "Current (v3) MCP Task Orchestrator — $toolCount tools: $toolNames"
         )
+}
+
+/**
+ * Builds the canonical list of MCP tools registered with the server.
+ *
+ * Extracted from [CurrentMcpServer.run] so tests can register the exact same tool set the
+ * production server exposes (see McpStreamableHttpTransportTest), avoiding a hard-coded tool
+ * count or a drifting parallel list.
+ */
+internal fun buildMcpTools(): List<ToolDefinition> =
+    listOf(
+        // Phase 1: CRUD
+        ManageItemsTool(),
+        QueryItemsTool(),
+        ManageNotesTool(),
+        QueryNotesTool(),
+        // Phase 2: Dependencies
+        ManageDependenciesTool(),
+        QueryDependenciesTool(),
+        // Phase 2: Workflow
+        AdvanceItemTool(),
+        ClaimItemTool(),
+        GetNextStatusTool(),
+        GetNextItemTool(),
+        GetBlockedItemsTool(),
+        // Phase 3: Compound operations
+        CompleteTreeTool(),
+        CreateWorkTreeTool(),
+        // Phase 3: Context
+        GetContextTool(),
+    )
+
+/**
+ * Installs the MCP Streamable HTTP transport at `/mcp` plus the JSON + CORS plugins it shares with
+ * the REST API.
+ *
+ * **Plugin-ordering contract (do not reorder):**
+ * 1. [ContentNegotiation] with `McpJson` is installed first so both `/mcp` and the `/api/v1` routes
+ *    use the same JSON config (`explicitNulls=false`, `encodeDefaults=true`). `mcpStreamableHttp` detects CN
+ *    is already installed and skips its own (logging a benign "already installed" warning).
+ * 2. [CORS] — env-driven allowlist, locked-down default (empty = no cross-origin).
+ * 3. [mcpStreamableHttp] mounts `/mcp` and **installs the Ktor `SSE` plugin itself** (SDK 0.12.0).
+ *    Therefore callers MUST NOT `install(SSE)` separately: a second install throws
+ *    `DuplicatePluginException` at startup and the HTTP server never comes up. The SSE plugin
+ *    installed here is reused by the `/api/v1/events` route in [installRestApiRoutes].
+ *
+ * Extracted from [CurrentMcpServer.runHttpTransport] so the exact production wiring is testable.
+ */
+internal fun Application.installMcpStreamableHttp(server: Server) {
+    install(ContentNegotiation) {
+        json(McpJson)
+    }
+    install(CORS) {
+        configureCors()
+    }
+    mcpStreamableHttp {
+        server
+    }
+}
+
+/**
+ * Registers the REST API routes under `/api/v1` when the API is enabled. No-op when
+ * [apiConfig] is [ApiAuthConfig.Disabled] (default-off) — `/mcp` still works without these routes.
+ *
+ * Must be called AFTER [installMcpStreamableHttp]: the SSE-backed `/api/v1/events` stream relies on
+ * the SSE plugin that `mcpStreamableHttp` installed.
+ */
+internal fun Application.installRestApiRoutes(
+    apiConfig: ApiAuthConfig,
+    eventBus: ApiEventBus?,
+    effectiveProvider: RepositoryProvider,
+    apiTokenEntries: Map<HashBytes, BearerTokenStore.TokenEntry>,
+    allowQueryToken: Boolean,
+    serverName: String,
+    serverVersion: String,
+    actorAuthEnabled: Boolean,
+    noteSchemaService: WorkItemSchemaService,
+    degradedModePolicy: DegradedModePolicy,
+    idempotencyCache: IdempotencyCache,
+) {
+    if (apiConfig is ApiAuthConfig.Disabled) return
+
+    routing {
+        // Authenticated routes under /api/v1 — auth plugin enforces bearer/JWKS
+        route("/api/v1") {
+            install(ApiBearerAuth) {
+                authConfig = apiConfig
+                // Use pre-loaded token entries (already loaded for event bus wiring at startup)
+                tokenEntries = apiTokenEntries
+            }
+            serviceRoutes(
+                repositoryProvider = effectiveProvider,
+                serverName = serverName,
+                serverVersion = serverVersion,
+                actorAuthEnabled = actorAuthEnabled,
+            )
+            // Phase 3: read API — items, notes, dependencies, transitions, search
+            itemRoutes(effectiveProvider)
+            noteRoutes(effectiveProvider)
+            dependencyRoutes(effectiveProvider)
+            transitionRoutes(effectiveProvider)
+            searchRoutes(effectiveProvider)
+            // Phase 4: config/schema-discovery + status-graph
+            configRoutes(noteSchemaService)
+            // Phase 5: write API — items, notes, dependencies, advance
+            itemWriteRoutes(effectiveProvider, degradedModePolicy, idempotencyCache, noteSchemaService)
+            noteWriteRoutes(effectiveProvider, degradedModePolicy, idempotencyCache)
+            dependencyWriteRoutes(effectiveProvider, degradedModePolicy)
+        }
+        // Phase 6: real-time SSE event stream — registered OUTSIDE the ApiBearerAuth block (as a
+        // sibling `route("/api/v1/events")`) so the ApiBearerAuth plugin does NOT intercept it. The
+        // SSE route does its own inline pre-flight auth, which additionally supports the opt-in
+        // `?token=` query-param path that ApiBearerAuth (header-only) would reject before our handler.
+        if (eventBus != null) {
+            route("/api/v1") {
+                eventRoutes(
+                    eventBus = eventBus,
+                    tokenEntries = apiTokenEntries,
+                    allowQueryToken = allowQueryToken,
+                )
+            }
+        }
+        // Discovery endpoint — no auth, mounted at root
+        wellKnownRoutes(serverName = serverName, serverVersion = serverVersion)
+    }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/ApiAuthConfigLoaderTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/ApiAuthConfigLoaderTest.kt
@@ -58,10 +58,12 @@ class ApiAuthConfigLoaderTest {
     }
 
     @Test
-    fun `API_ENABLED not set defaults to enabled — requires AUTH_MODE`() {
+    fun `API_ENABLED not set defaults to disabled (default-off)`() {
+        // Default-OFF: an unset API_ENABLED must NOT enable the API. Enabling it hard-requires
+        // API_AUTH_MODE, so a true default would crash the stock stdio container at startup.
         val loader = ApiAuthConfigLoader(envResolver = env())
-        val ex = assertThrows<IllegalArgumentException> { loader.load() }
-        assertTrue(ex.message!!.contains("API_AUTH_MODE"), "Error: ${ex.message}")
+        val config = loader.load()
+        assertInstanceOf(ApiAuthConfig.Disabled::class.java, config)
     }
 
     // -------------------------------------------------------------------------

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/ContentNegotiationOrderSpikeTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/ContentNegotiationOrderSpikeTest.kt
@@ -37,7 +37,12 @@ import org.junit.jupiter.api.Test
  * 1. When CN is installed with McpJson first, subsequent JSON routes work correctly.
  * 2. McpJson uses explicitNulls=false and encodeDefaults=true — the REST /info endpoint
  *    serializes correctly under the same config.
- * 3. install(SSE) is idempotent with mcpStreamableHttp's SSE install path.
+ *
+ * NOTE: an earlier version of this comment claimed "install(SSE) is idempotent with
+ * mcpStreamableHttp's SSE install path." That is FALSE for MCP SDK 0.12.0 — mcpStreamableHttp
+ * installs the SSE plugin itself, so an explicit install(SSE) throws DuplicatePluginException at
+ * startup. This spike never actually called mcpStreamableHttp, which is why it never caught the
+ * bug; the real /mcp transport is now exercised by McpStreamableHttpTransportTest.
  */
 class ContentNegotiationOrderSpikeTest {
     @Serializable

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/McpStreamableHttpTransportTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/McpStreamableHttpTransportTest.kt
@@ -118,6 +118,31 @@ class McpStreamableHttpTransportTest {
         }
 
     @Test
+    fun `rejects cross-origin requests with 403 to guard against DNS rebinding`() =
+        testApplication {
+            val server = serverWithAllTools()
+            application { installMcpStreamableHttp(server) }
+
+            // Streamable HTTP spec security requirement: servers MUST validate the Origin header and
+            // respond 403 to an invalid origin (DNS-rebinding protection). This is enforced by the
+            // SDK's mcpStreamableHttp; the test locks the behavior in for our wiring so a future SDK
+            // bump or misconfiguration that drops it is caught.
+            val response =
+                client.post("/mcp") {
+                    header(HttpHeaders.Accept, acceptBoth)
+                    header(HttpHeaders.Origin, "http://evil.example.com")
+                    contentType(ContentType.Application.Json)
+                    setBody(initializeBody)
+                }
+
+            assertEquals(
+                HttpStatusCode.Forbidden,
+                response.status,
+                "a cross-origin Origin header must be rejected with 403",
+            )
+        }
+
+    @Test
     fun `tools list and a tool call work over the HTTP transport`() =
         testApplication {
             val server = serverWithAllTools()

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/McpStreamableHttpTransportTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/McpStreamableHttpTransportTest.kt
@@ -1,0 +1,181 @@
+package io.github.jpicklyk.mcptask.current.interfaces.mcp
+
+import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * End-to-end tests for the MCP **Streamable HTTP** transport mounted at `/mcp`.
+ *
+ * These tests are the regression guard for the SDK-0.12.0 startup crash where an explicit
+ * `install(SSE)` collided with the SSE plugin that `mcpStreamableHttp` installs itself
+ * (`DuplicatePluginException` → HTTP server never started). They exercise the SAME production
+ * wiring function ([installMcpStreamableHttp]) and the SAME tool set ([buildMcpTools]) the real
+ * server uses — so re-introducing a duplicate plugin install, or otherwise breaking the `/mcp`
+ * module, fails the application at first request and trips these tests.
+ *
+ * Unlike [McpToolAdapterIntegrationTest] (in-process ChannelTransport), this drives the protocol
+ * over real HTTP through Ktor's test engine, covering the transport layer the integration test
+ * cannot reach.
+ */
+class McpStreamableHttpTransportTest {
+    private val rpc = Json { ignoreUnknownKeys = true }
+
+    /** Builds a real MCP [Server] with all production tools registered against an in-memory DB. */
+    private fun serverWithAllTools(): Server {
+        val provider =
+            DefaultRepositoryProvider(
+                DatabaseManager(
+                    Database.connect(
+                        "jdbc:h2:mem:httptransport_${System.nanoTime()};DB_CLOSE_DELAY=-1",
+                        driver = "org.h2.Driver",
+                    ),
+                ).also { DirectDatabaseSchemaManager().updateSchema() },
+            )
+        val server =
+            Server(
+                serverInfo = Implementation(name = "http-transport-test", version = "1.0.0"),
+                options =
+                    ServerOptions(
+                        capabilities =
+                            ServerCapabilities(tools = ServerCapabilities.Tools(listChanged = true)),
+                    ),
+            )
+        McpToolAdapter().registerToolsWithServer(server, buildMcpTools(), ToolExecutionContext(provider))
+        return server
+    }
+
+    /**
+     * Extracts the JSON-RPC envelope from a Streamable-HTTP response body. The transport may reply
+     * with raw `application/json` or an SSE frame (`event: message\ndata: {...}`); handle both.
+     */
+    private fun parseRpc(body: String): JsonObject {
+        val payload =
+            body
+                .lineSequence()
+                .firstOrNull { it.startsWith("data:") }
+                ?.removePrefix("data:")
+                ?.trim()
+                ?: body.trim()
+        return rpc.parseToJsonElement(payload).jsonObject
+    }
+
+    private val initializeBody =
+        """{"jsonrpc":"2.0","id":1,"method":"initialize","params":""" +
+            """{"protocolVersion":"2025-03-26","capabilities":{},""" +
+            """"clientInfo":{"name":"transport-test","version":"1.0"}}}"""
+
+    private val acceptBoth = "application/json, text/event-stream"
+
+    @Test
+    fun `mcpStreamableHttp module wires without SSE conflict and serves initialize`() =
+        testApplication {
+            val server = serverWithAllTools()
+            application { installMcpStreamableHttp(server) }
+
+            val response =
+                client.post("/mcp") {
+                    header(HttpHeaders.Accept, acceptBoth)
+                    contentType(ContentType.Application.Json)
+                    setBody(initializeBody)
+                }
+
+            // If a duplicate SSE plugin were installed, the app would fail to start and this would
+            // not be 200 OK — this assertion is the core regression guard.
+            assertEquals(HttpStatusCode.OK, response.status, "initialize should return 200")
+
+            val sessionId = response.headers["mcp-session-id"]
+            assertNotNull(sessionId, "server must assign an Mcp-Session-Id on initialize")
+
+            val result = parseRpc(response.bodyAsText())["result"]?.jsonObject
+            assertNotNull(result, "initialize must return a result")
+            assertNotNull(result!!["protocolVersion"], "result must carry protocolVersion")
+            assertNotNull(result["serverInfo"], "result must carry serverInfo")
+        }
+
+    @Test
+    fun `tools list and a tool call work over the HTTP transport`() =
+        testApplication {
+            val server = serverWithAllTools()
+            application { installMcpStreamableHttp(server) }
+
+            // 1) initialize → capture the session id
+            val init =
+                client.post("/mcp") {
+                    header(HttpHeaders.Accept, acceptBoth)
+                    contentType(ContentType.Application.Json)
+                    setBody(initializeBody)
+                }
+            assertEquals(HttpStatusCode.OK, init.status)
+            val sessionId = init.headers["mcp-session-id"]
+            assertNotNull(sessionId, "expected Mcp-Session-Id header")
+
+            // 2) notifications/initialized — completes the handshake
+            client.post("/mcp") {
+                header(HttpHeaders.Accept, acceptBoth)
+                header("mcp-session-id", sessionId!!)
+                contentType(ContentType.Application.Json)
+                setBody("""{"jsonrpc":"2.0","method":"notifications/initialized"}""")
+            }
+
+            // 3) tools/list — every production tool must be served over HTTP
+            val listResp =
+                client.post("/mcp") {
+                    header(HttpHeaders.Accept, acceptBoth)
+                    header("mcp-session-id", sessionId!!)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"jsonrpc":"2.0","id":2,"method":"tools/list"}""")
+                }
+            assertEquals(HttpStatusCode.OK, listResp.status)
+            val servedNames =
+                parseRpc(listResp.bodyAsText())["result"]!!
+                    .jsonObject["tools"]!!
+                    .jsonArray
+                    .map { it.jsonObject["name"]!!.jsonPrimitive.content }
+                    .toSet()
+            val expectedNames = buildMcpTools().map { it.name }.toSet()
+            assertEquals(expectedNames, servedNames, "tools/list must expose exactly the production tool set")
+
+            // 4) tools/call query_items overview — proves the full stack executes over HTTP
+            val callResp =
+                client.post("/mcp") {
+                    header(HttpHeaders.Accept, acceptBoth)
+                    header("mcp-session-id", sessionId!!)
+                    contentType(ContentType.Application.Json)
+                    setBody(
+                        """{"jsonrpc":"2.0","id":3,"method":"tools/call",""" +
+                            """"params":{"name":"query_items","arguments":{"operation":"overview"}}}""",
+                    )
+                }
+            assertEquals(HttpStatusCode.OK, callResp.status)
+            val callResult = parseRpc(callResp.bodyAsText())["result"]!!.jsonObject
+            assertTrue(
+                callResult["isError"]?.jsonPrimitive?.content != "true",
+                "query_items overview should not be an error over HTTP: $callResult",
+            )
+        }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,11 @@ services:
       USE_FLYWAY: "true"
       AGENT_CONFIG_DIR: /project
       MCP_SERVER_NAME: mcp-task-orchestrator
+      # MCP-over-HTTP only. The REST API is an opt-in layer that hard-requires an auth mode
+      # (API_AUTH_MODE=bearer|jwks); leaving it enabled with no auth mode is a fatal startup error.
+      # To enable the REST API, set API_ENABLED: "true" and add API_AUTH_MODE + token/JWKS config
+      # (see current/docs/quick-start.md "Enabling the REST API").
+      API_ENABLED: "false"
     ports:
       - "3001:3001"
     logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,10 @@ services:
       # (see current/docs/quick-start.md "Enabling the REST API").
       API_ENABLED: "false"
     ports:
-      - "3001:3001"
+      # Bind to loopback only (Streamable HTTP spec: prefer localhost when running locally).
+      # The /mcp endpoint is unauthenticated; do not expose it on all interfaces. To reach it
+      # from other hosts, front it with an authenticated reverse proxy or change to "3001:3001".
+      - "127.0.0.1:3001:3001"
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
## Summary

Fixes the MCP **Streamable HTTP** transport, which crashed on startup under MCP SDK 0.12.0, and fixes a related crash in the stock deployment caused by the REST API defaulting on. Adds end-to-end HTTP transport tests, hardens the transport per the MCP Streamable HTTP spec, and documents HTTP setup. Verified live against a running container.

Two startup crashes are fixed:

1. **HTTP mode never started.** SDK 0.12.0 made `mcpStreamableHttp` install the Ktor `SSE` plugin itself, colliding with our explicit `install(SSE)` → `DuplicatePluginException`. The HTTP server crashed regardless of API config.
2. **Stock deployment never started.** `API_ENABLED` defaulted to `true`, and an enabled API hard-requires `API_AUTH_MODE`. Because the API config loads in `run()` before the transport branch, the default stdio container (`claude mcp add-json`, no API vars) *and* naive MCP-over-HTTP both crashed with `API_AUTH_MODE is required`.

CI never caught either: the only HTTP wiring test installed SSE but never called `mcpStreamableHttp`, and a spike test documented a (false) assumption that the explicit `install(SSE)` was idempotent with it.

## Changes

- **fix(transport):** remove the redundant `install(SSE)` — the SDK installs it; the `/api/v1/events` route reuses it.
- **fix(api):** default `API_ENABLED` to `false` (default-off). The REST API is opt-in via `API_ENABLED=true` + `API_AUTH_MODE`; an unset value resolves to `Disabled`. Supersedes the uncommitted default-off WIP on `main`'s working tree.
- **refactor:** extract the HTTP module into `installMcpStreamableHttp()` / `installRestApiRoutes()` and the tool list into `buildMcpTools()` so the production wiring is directly testable.
- **test:** add `McpStreamableHttpTransportTest` — drives the real `mcpStreamableHttp` module over Ktor (initialize → tools/list → tools/call across all 14 tools) and asserts cross-origin requests → `403` (DNS-rebinding). Correct the stale spike-test comment.
- **security:** publish the compose `http` profile and quick-start examples on `127.0.0.1` (loopback) per the spec; document HTTP transport security (Origin validation enforced by the SDK, loopback binding, `/mcp` is unauthenticated).
- **docs:** self-contained MCP-over-HTTP quick-start step (client registration, env-var table); correct the documented `API_ENABLED` default in `CLAUDE.md` / `fleet-deployment.md` / `quick-start.md`; add a CHANGELOG Unreleased entry.

## Spec audit (Streamable HTTP, 2025-11-25)

Audited `/mcp` against the spec. The SDK satisfies every protocol-level **MUST**, verified live: invalid `Origin` → 403, GET → SSE, POST notification → 202, invalid `MCP-Protocol-Version` → 400, DELETE session → 200, non-streaming `Accept` → 406. The deployment-level **SHOULDs** we own (loopback binding, documenting the unauthenticated `/mcp`) are addressed here.

## Testing

- [x] All existing tests pass (`./gradlew :current:test`) + `:current:ktlintCheck`
- [x] New tests added for new functionality (`McpStreamableHttpTransportTest`: 3 tests incl. Origin/403; updated `ApiAuthConfigLoaderTest` for default-off)
- [x] Manual verification completed — built the image and confirmed live: HTTP `/mcp` initialize/tools/list/tools/call all 200; config.yaml schemas resolve over HTTP identically to stdio; naive stdio + naive HTTP (no `API_ENABLED`) both boot cleanly

## Checklist

- [x] Follows contribution guidelines
- [x] Commit messages follow conventional commit format
- [x] Database migrations (if any) handle SQLite table recreation correctly — N/A (no migrations)
- [x] API reference updated (if tool behavior changed) — N/A (no tool/parameter changes; transport + docs only)
- [x] CHANGELOG.md updated

## Reviewer notes

- The `API_ENABLED` default-off change refines the still-**unreleased** REST API (#188), so it is **not** a breaking change.
- This supersedes the uncommitted default-off WIP on `main`'s working tree (`ApiAuthConfigLoader.kt` + test, `CLAUDE.md`, `fleet-deployment.md`) — that local WIP can be discarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
