### PR TITLE
docs(deploy): update deploy_to_docker skill for working HTTP transport

### DIFF
--- a/.claude/commands/deploy_to_docker.md
+++ b/.claude/commands/deploy_to_docker.md
@@ -134,9 +134,10 @@ docker run --rm -i -v <DATA_VOLUME>:/app/data <image-tag>
 
 #### If HTTP transport selected
 
-> **Note:** HTTP transport requires the MCP Kotlin SDK to support protocol version `2025-11-25`.
-> As of SDK 0.8.4, only `2025-06-18` is supported — Claude Code will show the server as failed.
-> Use HTTP mode for testing or when the SDK is updated.
+> **Note:** HTTP (Streamable HTTP) transport works with the bundled MCP Kotlin SDK (0.12.0). The
+> MCP endpoint is served at `/mcp`. The REST API is off by default (`API_ENABLED=false`); leave it
+> off for an MCP-only HTTP server, or set `API_ENABLED=true` + `API_AUTH_MODE` to enable it.
+> Origin validation is enforced (cross-origin requests get 403), so bind to loopback when local.
 
 Ask which run configuration to use:
 
@@ -173,15 +174,20 @@ docker rm mcp-task-orchestrator-http 2>/dev/null || true
 ```bash
 docker run -d \
   --name mcp-task-orchestrator-http \
+  --restart unless-stopped \
   -v <DATA_VOLUME>:/app/data \
   -v "$(pwd)"/.taskorchestrator:/project/.taskorchestrator:ro \
   -e AGENT_CONFIG_DIR=/project \
   -e MCP_TRANSPORT=http \
   -e MCP_HTTP_HOST=0.0.0.0 \
   -e MCP_HTTP_PORT=3001 \
-  -p 3001:3001 \
+  -e API_ENABLED=false \
+  -p 127.0.0.1:3001:3001 \
   <image-tag>
 ```
+> `MCP_HTTP_HOST=0.0.0.0` is the container's internal bind; `-p 127.0.0.1:3001:3001` publishes it to
+> the host on loopback only (per the Streamable HTTP localhost-binding recommendation). Use
+> `-p 3001:3001` only when you intentionally need access from other hosts.
 
 **"With Debug Logging"**
 ```bash
@@ -193,9 +199,10 @@ docker run -d \
   -e MCP_TRANSPORT=http \
   -e MCP_HTTP_HOST=0.0.0.0 \
   -e MCP_HTTP_PORT=3001 \
+  -e API_ENABLED=false \
   -e LOG_LEVEL=DEBUG \
   -e DATABASE_SHOW_SQL=true \
-  -p 3001:3001 \
+  -p 127.0.0.1:3001:3001 \
   <image-tag>
 ```
 
@@ -229,7 +236,7 @@ Report:
 - **Database persistence:** Volume `mcp-task-data` persists across container runs
 - **Config access:** Project mount modes mount the project for `.taskorchestrator/config.yaml` access
 - **STDIO transport:** Uses stdin/stdout, no port mapping needed; started with `-i` flag
-- **HTTP transport:** Runs detached (`-d`), exposes port 3001, named `mcp-task-orchestrator-http`; requires SDK protocol `2025-11-25` support (SDK 0.8.4 = `2025-06-18` only)
+- **HTTP transport:** Runs detached (`-d`), serves the MCP endpoint at `/mcp`, named `mcp-task-orchestrator-http`; publish on `127.0.0.1:3001` (loopback) by default. Works with the bundled SDK (0.12.0). The REST API stays off unless `API_ENABLED=true` + `API_AUTH_MODE` are set.
 
 ## Troubleshooting
 

--- a/.claude/commands/deploy_to_docker.md
+++ b/.claude/commands/deploy_to_docker.md
@@ -66,7 +66,7 @@ AskUserQuestion(
       },
       {
         label: "HTTP",
-        description: "Expose port 3001 — runs detached as a long-lived daemon; requires MCP SDK with 2025-11-25 protocol support"
+        description: "Serves the MCP endpoint at /mcp on port 3001 (loopback by default) — runs detached as a long-lived daemon"
       }
     ]
   }]


### PR DESCRIPTION
## Summary

Updates the `deploy_to_docker` skill, which had stale HTTP guidance that would mislead. HTTP (Streamable HTTP) transport now works with the bundled MCP Kotlin SDK 0.12.0 (fixed in #189), but the skill still warned it required SDK `2025-11-25` support and would "show the server as failed" on SDK 0.8.4.

## Changes

- Remove the obsolete SDK-version warning; document that HTTP works with SDK 0.12.0, serves `/mcp`, and that the REST API is off by default (`API_ENABLED=false`).
- Switch the HTTP run examples to publish on **loopback** (`-p 127.0.0.1:3001:3001`) per the Streamable HTTP localhost-binding recommendation, with a note on the container-bind vs host-publish distinction.
- Add `--restart unless-stopped` and an explicit `-e API_ENABLED=false` to the HTTP examples.
- Refresh the Notes section's HTTP bullet.

## Testing

- [x] All existing tests pass — N/A (docs/skill only, no code change)
- [x] New tests added for new functionality — N/A
- [x] Manual verification completed — followed the updated commands to build `task-orchestrator:dev` from `main` and run the HTTP container on `127.0.0.1:3001`; `/mcp` initialize returns 200

## Checklist

- [x] Follows contribution guidelines
- [x] Commit messages follow conventional commit format
- [x] Database migrations (if any) handle SQLite table recreation correctly — N/A
- [x] API reference updated (if tool behavior changed) — N/A
- [x] CHANGELOG.md updated — N/A (internal skill doc, no shipped behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
