### PR TITLE
fix(api): exempt /mcp from REST bearer auth so HTTP MCP works with API enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Stock deployment crashed on startup.** With `API_ENABLED` defaulting to `true`, the REST API
   config loaded in every mode and hard-required `API_AUTH_MODE` — so the default stdio container
   (no `API_*` vars) and naive MCP-over-HTTP both failed with `API_AUTH_MODE is required`.
+- **Enabling the REST API gated the `/mcp` endpoint behind bearer auth.** `ApiBearerAuth` is an
+  application-level plugin that intercepts every request, so with `API_ENABLED=true` the MCP
+  Streamable HTTP endpoint returned `401` to clients that send no REST token — breaking
+  MCP-over-HTTP whenever the REST API was also enabled (contradicting the documented "both on one
+  port" behavior). `/mcp` is now exempted via the auth plugin's public-path bypass.
 
 ### Changed
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
@@ -573,6 +573,12 @@ internal fun Application.installRestApiRoutes(
                 authConfig = apiConfig
                 // Use pre-loaded token entries (already loaded for event bus wiring at startup)
                 tokenEntries = apiTokenEntries
+                // ApiBearerAuth is an APPLICATION plugin — it intercepts every request, not just
+                // /api/v1. The MCP Streamable HTTP endpoint (/mcp) is a separate protocol with its
+                // own transport and must remain reachable WITHOUT a REST bearer token. Exempt it via
+                // the plugin's public-path bypass; otherwise enabling the REST API 401s /mcp and
+                // breaks MCP-over-HTTP clients (which send no REST token). See McpRestAuthBypassTest.
+                publicPaths = publicPaths + "/mcp"
             }
             serviceRoutes(
                 repositoryProvider = effectiveProvider,

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/McpRestAuthBypassTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/McpRestAuthBypassTest.kt
@@ -1,0 +1,142 @@
+package io.github.jpicklyk.mcptask.current.interfaces.mcp
+
+import io.github.jpicklyk.mcptask.current.application.service.IdempotencyCache
+import io.github.jpicklyk.mcptask.current.application.service.NoOpNoteSchemaService
+import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiAuthConfig
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiAuthMode
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiCapability
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiPrincipal
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiScope
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.BearerTokenStore
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.HashBytes
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.security.MessageDigest
+
+/**
+ * Regression guard: enabling the REST API must NOT gate the MCP transport endpoint.
+ *
+ * `ApiBearerAuth` is an application-level plugin, so it intercepts every request — not only
+ * `/api/v1`. The `/mcp` Streamable HTTP endpoint is a separate protocol that MCP clients reach
+ * without a REST bearer token; it must stay open while the `/api/v1` routes are gated. This was unreachable
+ * until the SSE-double-install startup crash was fixed (HTTP + API-enabled could never run before),
+ * so the leak shipped silently. This test wires the SAME production functions
+ * ([installMcpStreamableHttp] + [installRestApiRoutes]) with the REST API enabled in bearer mode.
+ */
+class McpRestAuthBypassTest {
+    private val token = "rest-bearer-token-for-test"
+
+    private fun sha256(s: String): ByteArray = MessageDigest.getInstance("SHA-256").digest(s.toByteArray(Charsets.UTF_8))
+
+    private fun bearerConfig(): Pair<ApiAuthConfig.Bearer, Map<HashBytes, BearerTokenStore.TokenEntry>> {
+        val principal =
+            ApiPrincipal(
+                tokenId = "test",
+                scope = ApiScope(rootIds = null, tagsInclude = emptySet()),
+                capabilities = setOf(ApiCapability.READ),
+                authMode = ApiAuthMode.BEARER,
+            )
+        val key = HashBytes(sha256(token))
+        return ApiAuthConfig.Bearer(tokens = mapOf(key to principal)) to
+            mapOf(key to BearerTokenStore.TokenEntry(principal, expiresAt = null))
+    }
+
+    private fun emptyServer(): Server =
+        Server(
+            serverInfo = Implementation(name = "auth-bypass-test", version = "1.0.0"),
+            options =
+                ServerOptions(
+                    capabilities = ServerCapabilities(tools = ServerCapabilities.Tools(listChanged = true)),
+                ),
+        )
+
+    private fun inMemoryProvider(): DefaultRepositoryProvider =
+        DefaultRepositoryProvider(
+            DatabaseManager(
+                Database.connect(
+                    "jdbc:h2:mem:authbypass_${System.nanoTime()};DB_CLOSE_DELAY=-1",
+                    driver = "org.h2.Driver",
+                ),
+            ).also { DirectDatabaseSchemaManager().updateSchema() },
+        )
+
+    @Test
+    fun `REST API enabled gates api routes but leaves the mcp endpoint open`() =
+        testApplication {
+            val (apiConfig, entries) = bearerConfig()
+            val provider = inMemoryProvider()
+            application {
+                // Same wiring CurrentMcpServer uses in HTTP mode with the API enabled.
+                installMcpStreamableHttp(emptyServer())
+                installRestApiRoutes(
+                    apiConfig = apiConfig,
+                    eventBus = null,
+                    effectiveProvider = provider,
+                    apiTokenEntries = entries,
+                    allowQueryToken = false,
+                    serverName = "auth-bypass-test",
+                    serverVersion = "1.0.0",
+                    actorAuthEnabled = false,
+                    noteSchemaService = NoOpNoteSchemaService,
+                    degradedModePolicy = DegradedModePolicy.ACCEPT_CACHED,
+                    idempotencyCache = IdempotencyCache(),
+                )
+            }
+
+            // /mcp must NOT require the REST bearer token — initialize succeeds with no Authorization.
+            val mcp =
+                client.post("/mcp") {
+                    header(HttpHeaders.Accept, "application/json, text/event-stream")
+                    contentType(ContentType.Application.Json)
+                    setBody(
+                        """{"jsonrpc":"2.0","id":1,"method":"initialize","params":""" +
+                            """{"protocolVersion":"2025-03-26","capabilities":{},""" +
+                            """"clientInfo":{"name":"t","version":"1.0"}}}""",
+                    )
+                }
+            assertEquals(
+                HttpStatusCode.OK,
+                mcp.status,
+                "/mcp must stay open when the REST API is enabled (no bearer token sent)",
+            )
+
+            // /api/v1 routes MUST be gated — no token → 401.
+            assertEquals(
+                HttpStatusCode.Unauthorized,
+                client.get("/api/v1/items").status,
+                "/api/v1/* must require a bearer token",
+            )
+
+            // /api/v1/health stays public (existing bypass) — no token → 200.
+            assertEquals(
+                HttpStatusCode.OK,
+                client.get("/api/v1/health").status,
+                "/api/v1/health must remain public",
+            )
+
+            // With a valid token, /api/v1 routes are reachable.
+            assertEquals(
+                HttpStatusCode.OK,
+                client.get("/api/v1/items") { header(HttpHeaders.Authorization, "Bearer $token") }.status,
+                "/api/v1/items must succeed with a valid bearer token",
+            )
+        }
+}


### PR DESCRIPTION
## Summary

Fixes a bug where **enabling the REST API gates the MCP Streamable HTTP endpoint (`/mcp`) behind bearer auth**, returning `401` to MCP-over-HTTP clients that send no REST token. This breaks the documented "MCP and REST on the same port" behavior whenever `API_ENABLED=true`.

`ApiBearerAuth` is created with `createApplicationPlugin`, so installing it inside `route("/api/v1")` still intercepts **every** request and 401s anything not in its public-path bypass — including `/mcp`. The combination was unreachable until the SSE startup-crash fix (#189), so the leak shipped silently.

## Changes

- Exempt `/mcp` via the auth plugin's existing public-path bypass (`publicPaths + "/mcp"`) in `installRestApiRoutes`. `/api/v1/*` stays gated; `/mcp` and `/api/v1/health` stay open.
- Add `McpRestAuthBypassTest` — wires the real `installMcpStreamableHttp` + `installRestApiRoutes` (bearer enabled) and asserts: `/mcp` no-token → 200, `/api/v1/items` no-token → 401, `/api/v1/health` no-token → 200, `/api/v1/items` with token → 200.
- CHANGELOG Unreleased entry.

## Testing

- [x] All existing tests pass (`./gradlew :current:test`) + `:current:ktlintCheck`
- [x] New tests added (`McpRestAuthBypassTest`)
- [x] Manual verification: rebuilt `:dev`, ran the HTTP container with `API_ENABLED=true API_AUTH_MODE=bearer`; `/mcp` initialize → 200 without a token, `/api/v1/items` → 401 without / 200 with the bearer token

## Checklist

- [x] Follows contribution guidelines
- [x] Commit messages follow conventional commit format
- [x] Database migrations (if any) handle SQLite table recreation correctly — N/A
- [x] API reference updated (if tool behavior changed) — N/A (no tool/param changes)
- [x] CHANGELOG.md updated

## Reviewer note

Follow-up worth considering (not in this PR): `ApiBearerAuth` being an application plugin means it enforces on *all* paths except an allowlist, so every future non-API endpoint must be allowlisted. Converting it to a route-scoped plugin (like `AuthorizationPlugin` already is) would be more robust, but is a larger change with health/well-known/events routing interactions that need dedicated testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
