### PR TITLE
docs(quick-start): surface stdio vs HTTP transport choice before registration

### DIFF
--- a/current/docs/quick-start.md
+++ b/current/docs/quick-start.md
@@ -23,6 +23,8 @@ The image is published to GitHub Container Registry. The `latest` tag always poi
 
 ## Step 2: Add to Claude Code
 
+> **Choosing a transport — read this before registering.** This guide sets up the **stdio** transport (Steps 2–3), which is the right choice for most local Claude Code users: the server runs on demand, one process per project, with no ports to manage. If you instead need **HTTP** — for remote clients, container-to-container access, or a single shared long-running server — the registration is different. Skip ahead to [Step 9: Running MCP over HTTP](#step-9-running-mcp-over-http-optional) and register that endpoint *instead of* the stdio one below; Steps 4–8 (plugin, workflow, schemas) then apply unchanged. Step 1 (pulling the image) is shared by both transports. You can switch later by re-registering.
+
 ### Option A: CLI (recommended)
 
 Run this once in your terminal:


### PR DESCRIPTION
## What

Adds a transport-choice callout at the top of **Step 2** of `current/docs/quick-start.md`, where stdio and HTTP setups first diverge.

## Why

The quick-start read as a linear stdio walkthrough: it set up the stdio transport in Steps 2–3 and only revealed HTTP as an option at **Step 9**. A user who actually wanted HTTP would discover the divergence only *after* completing the stdio registration that doesn't apply to them.

## The fix

A blockquote callout placed at the start of Step 2 (the point where registration diverges, not Step 1 which is the shared image pull):

- Most users continue with **stdio** (Steps 2–3).
- HTTP users (remote clients, container-to-container, shared long-running server) jump to [Step 9](current/docs/quick-start.md) and register that endpoint *instead of* the stdio one.
- Clarifies that Step 1 (image pull) is shared, and Steps 4–8 (plugin, workflow, schemas) apply unchanged regardless of transport — so HTTP users don't think they're abandoning the rest of the guide.
- Links forward via the in-page anchor `#step-9-running-mcp-over-http-optional`.

## Reviewer notes

- Single-file, docs-only change (2 insertions).
- Kept the existing stdio-first linear flow intentionally — the callout fixes late discovery without restructuring HTTP into a top-level fork. Open to a more symmetric "pick your transport" rework if preferred.
- The reciprocal Step 9 framing ("By default the server speaks stdio (Step 2)… to serve over HTTP instead") already reads coherently with the new forward pointer; no Step 9 edit was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)