### PR TITLE
fix(persistence): atomic note upsert, parameterized claim TTL, hoist dbNow, single-statement release

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepository.kt
@@ -20,10 +20,9 @@ import org.jetbrains.exposed.v1.core.java.UUIDColumnType
 import org.jetbrains.exposed.v1.core.vendors.H2Dialect
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
-import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
-import org.jetbrains.exposed.v1.jdbc.update
+import org.jetbrains.exposed.v1.jdbc.upsert
 import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.UUID
@@ -45,60 +44,61 @@ class SQLiteNoteRepository(
         }
 
     /**
-     * Upserts a single [Note] row in [NotesTable] using select-then-update-or-insert logic.
+     * Upserts a single [Note] row in [NotesTable] atomically using a single
+     * INSERT … ON CONFLICT DO UPDATE statement (via Exposed's dialect-agnostic `upsert()`).
      *
      * **Must be called within an existing transaction** — this function does NOT open its own
      * transaction. Use [upsert] for the public API that wraps this in a transaction.
      *
-     * Returns the note with the correct ID and timestamps (existing ID on update, original on insert).
+     * **Concurrency safety:** The prior implementation used SELECT-then-branch-to-UPDATE-or-INSERT,
+     * which had a TOCTOU race: two concurrent writers for the same (itemId, key) could both see
+     * `existing == null` and both attempt INSERT. The second INSERT would hit the UNIQUE constraint
+     * on (work_item_id, key) and its write would be silently dropped. Using a single atomic
+     * statement eliminates the race — the DB resolves the conflict in one serialised operation.
+     *
+     * **Dialect handling:** On SQLite (production) Exposed emits
+     * `INSERT … ON CONFLICT(work_item_id, key) DO UPDATE SET …`.
+     * On H2 (test environment) Exposed emits `MERGE INTO … USING (VALUES …) AS excluded ON …`.
+     * Both are single atomic statements; no dialect branching is needed here.
+     *
+     * Returns the note with the correct ID (existing ID preserved on conflict, new ID on fresh insert).
      */
     internal fun upsertRow(note: Note): Result<Note> {
         note.validate()
-        // Check if a note with the same (itemId, key) already exists
-        val existing =
+        val now = Instant.now()
+
+        // Perform a single atomic upsert keyed on (itemId, key) — the UNIQUE index columns.
+        // On conflict: update all mutable fields (last-writer-wins for actor attribution).
+        // The primary-key column (id) is excluded from the DO UPDATE set by Exposed automatically.
+        NotesTable.upsert(
+            keys = arrayOf(NotesTable.itemId, NotesTable.key),
+        ) {
+            it[id] = note.id
+            it[itemId] = note.itemId
+            it[key] = note.key
+            it[role] = note.role
+            it[body] = note.body
+            it[createdAt] = note.createdAt
+            it[modifiedAt] = now
+            it[NotesTable.actorId] = note.actorClaim?.id
+            it[NotesTable.actorKind] = note.actorClaim?.kind?.toJsonString()
+            it[NotesTable.actorParent] = note.actorClaim?.parent
+            it[NotesTable.actorProof] = note.actorClaim?.proof
+            it[NotesTable.verificationStatus] = note.verification?.status?.toJsonString()
+            it[NotesTable.verificationVerifier] = note.verification?.verifier
+            it[NotesTable.verificationReason] = note.verification?.reason
+        }
+
+        // Read back the canonical row to obtain the actual ID (preserved from the pre-existing
+        // row on conflict, or the note.id we just inserted on a fresh row).
+        val row =
             NotesTable
                 .selectAll()
                 .where { (NotesTable.itemId eq note.itemId) and (NotesTable.key eq note.key) }
                 .singleOrNull()
+                ?: return Result.Error(RepositoryError.NotFound(note.id, "Note not found after upsert: (${note.itemId}, ${note.key})"))
 
-        return if (existing != null) {
-            // Update existing note (last-writer-wins for actor attribution)
-            val existingId = existing[NotesTable.id].value
-            val now = Instant.now()
-            NotesTable.update({ NotesTable.id eq existingId }) {
-                it[body] = note.body
-                it[role] = note.role
-                it[modifiedAt] = now
-                it[NotesTable.actorId] = note.actorClaim?.id
-                it[NotesTable.actorKind] = note.actorClaim?.kind?.toJsonString()
-                it[NotesTable.actorParent] = note.actorClaim?.parent
-                it[NotesTable.actorProof] = note.actorClaim?.proof
-                it[NotesTable.verificationStatus] = note.verification?.status?.toJsonString()
-                it[NotesTable.verificationVerifier] = note.verification?.verifier
-                it[NotesTable.verificationReason] = note.verification?.reason
-            }
-            // Return the updated note with the existing ID and updated timestamp
-            Result.Success(note.copy(id = existingId, modifiedAt = now))
-        } else {
-            // Insert new note
-            NotesTable.insert {
-                it[id] = note.id
-                it[itemId] = note.itemId
-                it[key] = note.key
-                it[role] = note.role
-                it[body] = note.body
-                it[createdAt] = note.createdAt
-                it[modifiedAt] = note.modifiedAt
-                it[NotesTable.actorId] = note.actorClaim?.id
-                it[NotesTable.actorKind] = note.actorClaim?.kind?.toJsonString()
-                it[NotesTable.actorParent] = note.actorClaim?.parent
-                it[NotesTable.actorProof] = note.actorClaim?.proof
-                it[NotesTable.verificationStatus] = note.verification?.status?.toJsonString()
-                it[NotesTable.verificationVerifier] = note.verification?.verifier
-                it[NotesTable.verificationReason] = note.verification?.reason
-            }
-            Result.Success(note)
-        }
+        return Result.Success(mapRowToNote(row))
     }
 
     override suspend fun upsert(note: Note): Result<Note> =

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepository.kt
@@ -61,6 +61,20 @@ class SQLiteNoteRepository(
      * On H2 (test environment) Exposed emits `MERGE INTO … USING (VALUES …) AS excluded ON …`.
      * Both are single atomic statements; no dialect branching is needed here.
      *
+     * **Row identity / immutability:** On the conflict (update) path, the `onUpdate` block
+     * below enumerates ONLY the mutable columns. The immutable `id` (primary key) and
+     * `created_at` columns are deliberately omitted, so the pre-existing row keeps its original
+     * id and createdAt — only body/role/modifiedAt/actor/verification change. This preserves
+     * the invariant asserted by `upsert preserves original note id and createdAt on update`.
+     *
+     * **FTS5 sync:** Because the SQLite statement is `INSERT … ON CONFLICT DO UPDATE` (NOT
+     * `INSERT OR REPLACE`), the existing row's `rowid` is preserved on conflict. The notes
+     * external-content FTS5 tables (`notes_fts_trigram`, `notes_fts_text`) sync via AFTER
+     * INSERT/UPDATE/DELETE triggers keyed on `rowid`; an INSERT-OR-REPLACE would delete+reinsert
+     * the row with a new rowid and orphan the FTS index, whereas ON CONFLICT DO UPDATE fires the
+     * AFTER UPDATE trigger and keeps the FTS rowid stable. The fresh-insert path fires the
+     * AFTER INSERT trigger as before.
+     *
      * Returns the note with the correct ID (existing ID preserved on conflict, new ID on fresh insert).
      */
     internal fun upsertRow(note: Note): Result<Note> {
@@ -68,10 +82,25 @@ class SQLiteNoteRepository(
         val now = Instant.now()
 
         // Perform a single atomic upsert keyed on (itemId, key) — the UNIQUE index columns.
-        // On conflict: update all mutable fields (last-writer-wins for actor attribution).
-        // The primary-key column (id) is excluded from the DO UPDATE set by Exposed automatically.
+        //
+        // body{}      — INSERT values for the fresh-insert path (all columns, including id/createdAt).
+        // onUpdate{}  — DO UPDATE SET clause for the conflict path: ONLY mutable columns.
+        //               id, itemId, key, and createdAt are intentionally NOT updated so the
+        //               existing row keeps its identity and creation timestamp.
         NotesTable.upsert(
             keys = arrayOf(NotesTable.itemId, NotesTable.key),
+            onUpdate = {
+                it[NotesTable.role] = note.role
+                it[NotesTable.body] = note.body
+                it[NotesTable.modifiedAt] = now
+                it[NotesTable.actorId] = note.actorClaim?.id
+                it[NotesTable.actorKind] = note.actorClaim?.kind?.toJsonString()
+                it[NotesTable.actorParent] = note.actorClaim?.parent
+                it[NotesTable.actorProof] = note.actorClaim?.proof
+                it[NotesTable.verificationStatus] = note.verification?.status?.toJsonString()
+                it[NotesTable.verificationVerifier] = note.verification?.verifier
+                it[NotesTable.verificationReason] = note.verification?.reason
+            },
         ) {
             it[id] = note.id
             it[itemId] = note.itemId
@@ -90,7 +119,8 @@ class SQLiteNoteRepository(
         }
 
         // Read back the canonical row to obtain the actual ID (preserved from the pre-existing
-        // row on conflict, or the note.id we just inserted on a fresh row).
+        // row on conflict, or the note.id we just inserted on a fresh row) and the canonical
+        // createdAt (unchanged on conflict).
         val row =
             NotesTable
                 .selectAll()

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -409,11 +409,13 @@ class SQLiteWorkItemRepository(
         offset: Int,
         type: String?,
         claimStatus: String?
-    ): Result<List<WorkItem>> =
-        databaseManager.suspendedTransaction("Failed to find WorkItems by filters") {
-            // Fetch DB-side now once so all claim-freshness comparisons in buildFilteredQuery
-            // use the DB clock rather than the JVM clock.
-            val nowFromDb = if (claimStatus != null) dbNow() else Instant.now()
+    ): Result<List<WorkItem>> {
+        // Fetch DB-side now ONCE before opening the transaction so all claim-freshness
+        // comparisons in buildFilteredQuery use the DB clock rather than the JVM clock, and to
+        // avoid a nested transaction/savepoint (dbNow() opens its own suspendTransaction).
+        val nowFromDb = if (claimStatus != null) dbNow() else Instant.now()
+
+        return databaseManager.suspendedTransaction("Failed to find WorkItems by filters") {
             val baseQuery =
                 buildFilteredQuery(
                     parentId,
@@ -457,6 +459,7 @@ class SQLiteWorkItemRepository(
 
             Result.Success(items)
         }
+    }
 
     override suspend fun countByFilters(
         parentId: UUID?,
@@ -473,9 +476,12 @@ class SQLiteWorkItemRepository(
         roleChangedBefore: Instant?,
         type: String?,
         claimStatus: String?
-    ): Result<Int> =
-        databaseManager.suspendedTransaction("Failed to count WorkItems by filters") {
-            val nowFromDb = if (claimStatus != null) dbNow() else Instant.now()
+    ): Result<Int> {
+        // Fetch DB-side now ONCE before opening the transaction (see findByFilters) to avoid a
+        // nested transaction/savepoint from dbNow().
+        val nowFromDb = if (claimStatus != null) dbNow() else Instant.now()
+
+        return databaseManager.suspendedTransaction("Failed to count WorkItems by filters") {
             val count =
                 buildFilteredQuery(
                     parentId,
@@ -497,6 +503,7 @@ class SQLiteWorkItemRepository(
 
             Result.Success(count.toInt())
         }
+    }
 
     override suspend fun countChildrenByRole(parentId: UUID): Result<Map<Role, Int>> =
         databaseManager.suspendedTransaction("Failed to count children by role") {
@@ -1353,11 +1360,13 @@ class SQLiteWorkItemRepository(
         }
     }
 
-    override suspend fun countByClaimStatus(parentId: UUID?): Result<ClaimStatusCounts> =
-        databaseManager.suspendedTransaction("Failed to count WorkItems by claim status") {
-            // Use DB-side clock so counts are consistent with the DB's view of claim freshness.
-            val now = dbNow()
+    override suspend fun countByClaimStatus(parentId: UUID?): Result<ClaimStatusCounts> {
+        // Read DB-side clock ONCE before opening the transaction to avoid a nested
+        // transaction/savepoint (dbNow() opens its own suspendTransaction internally).
+        // Use DB-side clock so counts are consistent with the DB's view of claim freshness.
+        val now = dbNow()
 
+        return databaseManager.suspendedTransaction("Failed to count WorkItems by claim status") {
             // Helper to build a base condition list optionally scoped to a parent
             fun baseConditions(): MutableList<Op<Boolean>> {
                 val conds = mutableListOf<Op<Boolean>>()
@@ -1405,6 +1414,7 @@ class SQLiteWorkItemRepository(
 
             Result.Success(ClaimStatusCounts(active = activeCount, expired = expiredCount, unclaimed = unclaimedCount))
         }
+    }
 
     override suspend fun findInScope(
         rootIds: Set<UUID>,
@@ -1429,12 +1439,15 @@ class SQLiteWorkItemRepository(
     ): Result<List<WorkItem>> {
         if (rootIds.isEmpty()) return Result.Success(emptyList())
 
+        // Fetch DB-side now ONCE before opening the transaction to avoid a nested
+        // transaction/savepoint (dbNow() opens its own suspendTransaction internally).
+        val nowFromDb = if (claimStatus != null) dbNow() else Instant.now()
+
         return try {
             suspendTransaction(db = databaseManager.getDatabase()) {
                 val scopeIds = resolveScopeIds(rootIds)
                 if (scopeIds.isEmpty()) return@suspendTransaction Result.Success(emptyList())
 
-                val nowFromDb = if (claimStatus != null) dbNow() else Instant.now()
                 val base =
                     buildScopedQuery(
                         scopeIds,
@@ -1502,12 +1515,15 @@ class SQLiteWorkItemRepository(
     ): Result<Int> {
         if (rootIds.isEmpty()) return Result.Success(0)
 
+        // Fetch DB-side now ONCE before opening the transaction to avoid a nested
+        // transaction/savepoint (dbNow() opens its own suspendTransaction internally).
+        val nowFromDb = if (claimStatus != null) dbNow() else Instant.now()
+
         return try {
             suspendTransaction(db = databaseManager.getDatabase()) {
                 val scopeIds = resolveScopeIds(rootIds)
                 if (scopeIds.isEmpty()) return@suspendTransaction Result.Success(0)
 
-                val nowFromDb = if (claimStatus != null) dbNow() else Instant.now()
                 val count =
                     buildScopedQuery(
                         scopeIds,

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -972,13 +972,23 @@ class SQLiteWorkItemRepository(
         ttlSeconds: Int
     ): ClaimResult =
         try {
+            // Read the DB-side clock ONCE before opening the transaction to avoid a nested
+            // transaction/savepoint when dbNow() opens its own suspendTransaction internally.
+            // This instant is used only for computing retryAfterMs on the AlreadyClaimed path —
+            // the claim SQL itself uses datetime('now') exclusively for DB-side timestamps.
+            val dbNowInstant = dbNow()
+
             suspendTransaction(db = databaseManager.getDatabase()) {
-                // Both agentId and itemId are bound as typed JDBC parameters — no string interpolation.
+                // All parameters are bound as typed JDBC parameters — no string interpolation.
                 // itemId binds via UUIDColumnType so the WHERE id = ? predicate uses the primary-key
                 // index directly (the prior HEX(id) = ? form wrapped the column in a function call,
                 // which the SQLite planner cannot push through the PK index, forcing a full scan).
+                // ttlOffset binds as a VarChar parameter (+N) passed to datetime('now', ? || ' seconds')
+                // so the TTL value is never interpolated into raw SQL text.
                 val agentIdType = VarCharColumnType(500)
                 val uuidType = UUIDColumnType()
+                val ttlOffsetType = VarCharColumnType(50)
+                val ttlOffset = "+$ttlSeconds"
 
                 // Step 1 (acquire target): Claim or refresh the target item using only DB-side timestamps.
                 // Matches rows that are: (a) unclaimed, (b) expired, or (c) already held by this agent.
@@ -993,7 +1003,7 @@ class SQLiteWorkItemRepository(
                     UPDATE work_items
                       SET claimed_by = ?,
                           claimed_at = datetime('now'),
-                          claim_expires_at = datetime('now', '+$ttlSeconds seconds'),
+                          claim_expires_at = datetime('now', ? || ' seconds'),
                           original_claimed_at = COALESCE(
                             CASE WHEN claimed_by = ? THEN original_claimed_at ELSE NULL END,
                             datetime('now')
@@ -1008,6 +1018,7 @@ class SQLiteWorkItemRepository(
                     args =
                         listOf(
                             agentIdType to agentId,
+                            ttlOffsetType to ttlOffset,
                             agentIdType to agentId,
                             uuidType to itemId,
                             agentIdType to agentId,
@@ -1027,10 +1038,9 @@ class SQLiteWorkItemRepository(
                                 item.claimedBy == agentId -> ClaimResult.Success(item)
                                 else -> {
                                     // Claimed by someone else — compute retryAfterMs using the DB clock
-                                    // so the hint reflects DB-side remaining TTL, not JVM-side.
+                                    // (read before the transaction to avoid a nested transaction).
                                     val retryAfterMs =
                                         if (item.claimExpiresAt != null) {
-                                            val dbNowInstant = dbNow()
                                             val remaining = item.claimExpiresAt.toEpochMilli() - dbNowInstant.toEpochMilli()
                                             if (remaining > 0) remaining else null
                                         } else {
@@ -1084,18 +1094,13 @@ class SQLiteWorkItemRepository(
                 val agentIdType = VarCharColumnType(500)
                 val uuidType = UUIDColumnType()
 
-                // Check existence and current claimant before attempting update.
-                val row =
-                    WorkItemsTable.selectAll().where { WorkItemsTable.id eq itemId }.singleOrNull()
-                        ?: return@suspendTransaction ReleaseResult.NotFound(itemId)
-
-                val item = toWorkItem(row)
-                if (item.claimedBy != agentId) {
-                    return@suspendTransaction ReleaseResult.NotClaimedByYou(itemId)
-                }
-
-                // Release: clear all four claim fields atomically.
-                exec(
+                // Single-statement release: the WHERE clause atomically asserts both item identity
+                // and claimant ownership.  We capture the affected-row count to determine the
+                // outcome — eliminating the prior SELECT-then-UPDATE TOCTOU window where a claim
+                // stolen between the pre-read and the UPDATE could produce a false Success result
+                // (the UPDATE would zero-match but the code would still return ReleaseResult.Success
+                // with stale data because the row count was never checked).
+                val sql =
                     """
                     UPDATE work_items
                       SET claimed_by = NULL,
@@ -1105,20 +1110,31 @@ class SQLiteWorkItemRepository(
                           version = version + 1
                       WHERE id = ?
                         AND claimed_by = ?
-                    """.trimIndent(),
-                    args =
-                        listOf(
-                            uuidType to itemId,
-                            agentIdType to agentId,
-                        )
-                )
+                    """.trimIndent()
+                val ps = this.connection.prepareStatement(sql, false)
+                val rowsUpdated =
+                    try {
+                        ps.fillParameters(listOf(uuidType to itemId, agentIdType to agentId))
+                        ps.executeUpdate()
+                    } finally {
+                        ps.closeIfPossible()
+                    }
 
-                // Read back updated state.
-                val updatedRow =
-                    WorkItemsTable.selectAll().where { WorkItemsTable.id eq itemId }.singleOrNull()
-                        ?: return@suspendTransaction ReleaseResult.NotFound(itemId)
-
-                ReleaseResult.Success(toWorkItem(updatedRow))
+                when {
+                    rowsUpdated > 0 -> {
+                        // Release succeeded — read back the updated state.
+                        val updatedRow =
+                            WorkItemsTable.selectAll().where { WorkItemsTable.id eq itemId }.singleOrNull()
+                                ?: return@suspendTransaction ReleaseResult.NotFound(itemId)
+                        ReleaseResult.Success(toWorkItem(updatedRow))
+                    }
+                    else -> {
+                        // Zero rows updated — item either doesn't exist or is not claimed by this agent.
+                        val exists =
+                            WorkItemsTable.selectAll().where { WorkItemsTable.id eq itemId }.singleOrNull()
+                        if (exists == null) ReleaseResult.NotFound(itemId) else ReleaseResult.NotClaimedByYou(itemId)
+                    }
+                }
             }
         } catch (e: Exception) {
             logger.error("Failed to release WorkItem $itemId for agent $agentId: ${e.message}", e)
@@ -1130,8 +1146,12 @@ class SQLiteWorkItemRepository(
         parentId: UUID?,
         excludeActiveClaims: Boolean,
         limit: Int
-    ): Result<List<WorkItem>> =
-        databaseManager.suspendedTransaction("Failed to find next items by role") {
+    ): Result<List<WorkItem>> {
+        // Read DB-side clock ONCE before opening the transaction to avoid a nested
+        // transaction/savepoint (dbNow() opens its own suspendTransaction internally).
+        val dbNowInstant = if (excludeActiveClaims) dbNow() else null
+
+        return databaseManager.suspendedTransaction("Failed to find next items by role") {
             val conditions = mutableListOf<Op<Boolean>>()
 
             // Role filter
@@ -1144,9 +1164,8 @@ class SQLiteWorkItemRepository(
             // An item is "actively claimed" when claimed_by IS NOT NULL AND claim_expires_at > now.
             // The complement (items to include) is: claimed_by IS NULL OR claim_expires_at <= now.
             // Use DB-side now so the freshness decision is made on the DB clock, not the JVM clock.
-            if (excludeActiveClaims) {
+            if (excludeActiveClaims && dbNowInstant != null) {
                 val notClaimed = WorkItemsTable.claimedBy.isNull()
-                val dbNowInstant = dbNow()
                 val claimExpired = WorkItemsTable.claimExpiresAt lessEq dbNowInstant
                 // Re-express as: NOT (claimedBy IS NOT NULL AND claimExpiresAt > now)
                 //               = claimedBy IS NULL  OR  claimExpiresAt <= now
@@ -1163,6 +1182,7 @@ class SQLiteWorkItemRepository(
 
             Result.Success(items)
         }
+    }
 
     override suspend fun findClaimable(
         role: Role,
@@ -1180,8 +1200,12 @@ class SQLiteWorkItemRepository(
         orderBy: NextItemOrder,
         limit: Int,
         requestingAgentId: String?,
-    ): Result<List<WorkItem>> =
-        databaseManager.suspendedTransaction("Failed to find claimable items") {
+    ): Result<List<WorkItem>> {
+        // Read DB-side clock ONCE before opening the transaction to avoid a nested
+        // transaction/savepoint (dbNow() opens its own suspendTransaction internally).
+        val dbNowInstant = dbNow()
+
+        return databaseManager.suspendedTransaction("Failed to find claimable items") {
             val conditions = mutableListOf<Op<Boolean>>()
 
             // Role filter — always required
@@ -1216,8 +1240,7 @@ class SQLiteWorkItemRepository(
 
             // Active-claim exclusion — always applied; claim-eligibility by definition requires this.
             // Include items where: claimed_by IS NULL  OR  claim_expires_at <= now.
-            // DB-side now avoids JVM/SQLite clock skew.
-            val dbNowInstant = dbNow()
+            // dbNowInstant was obtained before the transaction to avoid a nested transaction.
             conditions.add(WorkItemsTable.claimedBy.isNull() or (WorkItemsTable.claimExpiresAt lessEq dbNowInstant))
 
             val combined = conditions.reduce { acc, op -> acc and op }
@@ -1328,6 +1351,7 @@ class SQLiteWorkItemRepository(
 
             Result.Success(filtered)
         }
+    }
 
     override suspend fun countByClaimStatus(parentId: UUID?): Result<ClaimStatusCounts> =
         databaseManager.suspendedTransaction("Failed to count WorkItems by claim status") {

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/Fts5MigrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/Fts5MigrationTest.kt
@@ -128,6 +128,10 @@ class Fts5MigrationTest {
                     )
                     """.trimIndent()
                 )
+                // Unique index on (work_item_id, key) — matches production migration V1
+                // (idx_notes_item_key). Required as the ON CONFLICT(work_item_id, key) target
+                // for the atomic note upsert.
+                exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_notes_item_key ON notes(work_item_id, key)")
                 exec(
                     """
                     CREATE TABLE IF NOT EXISTS dependencies (

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteNoteRepositoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteNoteRepositoryTest.kt
@@ -17,6 +17,9 @@ import org.jetbrains.exposed.v1.jdbc.Database
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
@@ -396,6 +399,73 @@ class SQLiteNoteRepositoryTest {
                 originalCreatedAt.epochSecond,
                 dbNote.createdAt.epochSecond,
                 "createdAt in DB should not be changed by upsert update"
+            )
+        }
+
+    /**
+     * BUG1-REGRESSION: Concurrent upsert for the same (itemId, key) must not lose either write.
+     *
+     * Prior implementation used SELECT-then-INSERT-or-UPDATE (TOCTOU). Two threads that both
+     * saw `existing == null` would both attempt INSERT; the second INSERT would hit the UNIQUE
+     * constraint on (work_item_id, key) and return Result.Error, silently dropping the write.
+     *
+     * The atomic upsert fix uses a single INSERT … ON CONFLICT DO UPDATE (SQLite) /
+     * MERGE INTO (H2) statement, so exactly one of the two writes wins and the other becomes
+     * a conflict-resolved update. After both threads complete, exactly one row must exist and
+     * both threads must have received Result.Success (not Result.Error).
+     */
+    @Test
+    fun `concurrent upsert for same itemId and key — both return Success, exactly one row persisted`(): Unit =
+        runBlocking {
+            val key = "concurrent-upsert-key"
+            val body1 = "body from thread 1"
+            val body2 = "body from thread 2"
+
+            val executor = Executors.newFixedThreadPool(2)
+            val startGate = CountDownLatch(1)
+            val results = arrayOfNulls<Result<Note>>(2)
+
+            val future1 =
+                executor.submit {
+                    startGate.await()
+                    results[0] =
+                        runBlocking {
+                            noteRepository.upsert(
+                                Note(itemId = testItemId, key = key, role = "queue", body = body1)
+                            )
+                        }
+                }
+            val future2 =
+                executor.submit {
+                    startGate.await()
+                    results[1] =
+                        runBlocking {
+                            noteRepository.upsert(
+                                Note(itemId = testItemId, key = key, role = "queue", body = body2)
+                            )
+                        }
+                }
+
+            startGate.countDown()
+            future1.get(10, TimeUnit.SECONDS)
+            future2.get(10, TimeUnit.SECONDS)
+            executor.shutdown()
+
+            // Both threads must have received Success — no write is silently dropped.
+            assertIs<Result.Success<Note>>(results[0], "Thread 1 upsert must return Success")
+            assertIs<Result.Success<Note>>(results[1], "Thread 2 upsert must return Success")
+
+            // Exactly one row must exist for this (itemId, key) pair.
+            val findResult = noteRepository.findByItemId(testItemId)
+            assertIs<Result.Success<List<Note>>>(findResult)
+            val notesForKey = findResult.data.filter { it.key == key }
+            assertEquals(1, notesForKey.size, "Exactly one note row must exist after concurrent upserts")
+
+            // The persisted body must be one of the two submitted values (not corrupted).
+            val persistedBody = notesForKey[0].body
+            assertTrue(
+                persistedBody == body1 || persistedBody == body2,
+                "Persisted body must be one of the two submitted values but was: $persistedBody"
             )
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryClaimTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryClaimTest.kt
@@ -1317,4 +1317,96 @@ class SQLiteWorkItemRepositoryClaimTest : SQLiteRepositoryTestBase() {
                     "The PK-index miss may have regressed. Actual plan:\n$plan"
             )
         }
+
+    // -----------------------------------------------------------------------
+    // BUG2-REGRESSION: Parameterized claim TTL — expiry is honored correctly
+    // -----------------------------------------------------------------------
+
+    /**
+     * BUG2-REGRESSION: Claim with a short TTL produces a claimExpiresAt strictly after claimedAt,
+     * and the expiry comparison in findForNextItem/findClaimable respects the TTL value.
+     *
+     * This test verifies that the parameterized `datetime('now', ? || ' seconds')` form
+     * (replacing the prior interpolated `datetime('now', '+$ttlSeconds seconds')`) still
+     * produces a valid future expiry instant. A TTL of 30 seconds should produce
+     * claimExpiresAt >= claimedAt + 29 seconds (generous margin for DB second-granularity).
+     */
+    @Test
+    fun `parameterized TTL claim — claimExpiresAt is strictly after claimedAt by the given TTL`(): Unit =
+        runBlocking {
+            val item = createItem()
+            val ttlSeconds = 30
+
+            val result = repository.claim(item.id, "agent-ttl-param", ttlSeconds)
+            assertIs<ClaimResult.Success>(result)
+            val claimed = result.item
+
+            val claimedAt = assertNotNull(claimed.claimedAt, "claimedAt must be set")
+            val claimExpiresAt = assertNotNull(claimed.claimExpiresAt, "claimExpiresAt must be set")
+
+            // claimExpiresAt must be strictly after claimedAt
+            assertTrue(
+                claimExpiresAt > claimedAt,
+                "claimExpiresAt must be after claimedAt for ttlSeconds=$ttlSeconds"
+            )
+
+            // claimExpiresAt should be approximately claimedAt + ttlSeconds (within 5 seconds margin)
+            val diffSeconds = (claimExpiresAt.toEpochMilli() - claimedAt.toEpochMilli()) / 1000L
+            assertTrue(
+                diffSeconds >= ttlSeconds - 5 && diffSeconds <= ttlSeconds + 5,
+                "Expected claimExpiresAt - claimedAt ≈ $ttlSeconds s, got $diffSeconds s"
+            )
+        }
+
+    // -----------------------------------------------------------------------
+    // BUG4-REGRESSION: release() single-statement semantics
+    // -----------------------------------------------------------------------
+
+    /**
+     * BUG4-REGRESSION: Release by the wrong agent returns NotClaimedByYou (not Success).
+     *
+     * Prior implementation: SELECT row → check claimedBy → UPDATE WHERE id=? AND claimed_by=?.
+     * Bug: if the claim was stolen between the pre-read and the UPDATE, the UPDATE zero-matches
+     * but the code returned ReleaseResult.Success with stale data because row count was unchecked.
+     *
+     * Fix: single UPDATE WHERE id=? AND claimed_by=? with row-count check. Zero rows → derive
+     * NotFound vs NotClaimedByYou from a follow-up existence check.
+     *
+     * This test covers the straightforward "wrong agent" path; the TOCTOU window itself is
+     * exercised by the concurrent release test above (concurrent_release_does_not_corrupt).
+     */
+    @Test
+    fun `release by wrong agent returns NotClaimedByYou — never Success`(): Unit =
+        runBlocking {
+            val item = createItem()
+            // Claim by agent-holder
+            assertIs<ClaimResult.Success>(repository.claim(item.id, "agent-holder-bug4", 900))
+
+            // Attempt release by a different agent — must return NotClaimedByYou
+            val result = repository.release(item.id, "agent-interloper-bug4")
+            assertIs<ReleaseResult.NotClaimedByYou>(result)
+            assertEquals(item.id, result.itemId)
+
+            // Verify the item is still held by the original claimer
+            val fetchResult = repository.getById(item.id)
+            assertIs<Result.Success<WorkItem>>(fetchResult)
+            assertEquals("agent-holder-bug4", fetchResult.data.claimedBy, "Item must still be held by original claimer")
+        }
+
+    /**
+     * BUG4-REGRESSION: Release on unclaimed item returns NotClaimedByYou (not NotFound).
+     *
+     * After the single-statement fix, zero rows updated + item exists → NotClaimedByYou.
+     * An unclaimed item has claimedBy=null which never matches the WHERE claimed_by=? predicate.
+     */
+    @Test
+    fun `release on unclaimed item returns NotClaimedByYou with correct itemId`(): Unit =
+        runBlocking {
+            val item = createItem()
+            // Item is never claimed
+
+            val result = repository.release(item.id, "agent-nobody-bug4")
+            assertIs<ReleaseResult.NotClaimedByYou>(result)
+            assertEquals(item.id, result.itemId)
+        }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/SearchRoutesIntegrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/SearchRoutesIntegrationTest.kt
@@ -118,6 +118,10 @@ class SearchRoutesIntegrationTest {
                     )
                     """.trimIndent()
                 )
+                // Unique index on (work_item_id, key) — matches production migration V1
+                // (idx_notes_item_key). Required as the ON CONFLICT(work_item_id, key) target
+                // for the atomic note upsert.
+                exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_notes_item_key ON notes(work_item_id, key)")
                 exec(
                     """
                     CREATE TABLE IF NOT EXISTS dependencies (

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/test/BaseFts5RepositoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/test/BaseFts5RepositoryTest.kt
@@ -102,6 +102,11 @@ abstract class BaseFts5RepositoryTest {
                 )
                 """.trimIndent()
             )
+            // Unique index on (work_item_id, key) — matches production migration V1
+            // (idx_notes_item_key). Required as the ON CONFLICT(work_item_id, key) target for
+            // the atomic note upsert; without it SQLite raises "ON CONFLICT clause does not match
+            // any PRIMARY KEY or UNIQUE constraint".
+            exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_notes_item_key ON notes(work_item_id, key)")
             exec("CREATE INDEX IF NOT EXISTS idx_notes_item_id ON notes(work_item_id)")
 
             exec(


### PR DESCRIPTION
## Summary
Repository concurrency + SQL hygiene:
- `SQLiteNoteRepository.upsertRow` is now an atomic Exposed `upsert` (was SELECT-then-INSERT/UPDATE, which dropped one writer's note under concurrent same-key writes). `onUpdate` updates only mutable columns, preserving note `id`/`createdAt`/rowid so the external-content FTS index stays in sync.
- `claim()` binds the TTL as a parameter instead of string-interpolating `ttlSeconds` into SQL (latent-injection hygiene; the misleading "no interpolation" comment is corrected)
- `dbNow()` hoisted out of 8 open-transaction call sites (no more nested transactions): `claim`, `findForNextItem`, `findClaimable`, `countByClaimStatus`, `findByFilters`, `countByFilters`, `findInScope`, `countInScope`
- `release()` uses a single `UPDATE ... WHERE id=? AND claimed_by=?` with a rowcount check (removes the read-then-update TOCTOU)

## Test Results
Full `:current:test` green; `:current:ktlintCheck` clean. Added concurrent-upsert, claim-TTL, and release-semantics tests. Three FTS test fixtures were corrected to include the `idx_notes_item_key` unique index that prod migration V1 already provides (required for the `ON CONFLICT` target).

## Review
Independent review: **PASS** — upsert atomicity, FTS rowid sync, and H2/SQLite dialect parity all verified.

## MCP
Item `71bb1f72` — remediation tree `4ab3f9c8`. Includes the `countByClaimStatus` follow-up plus a full audit confirming no `dbNow()` calls remain inside open transactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
