### PR TITLE
fix(security): wire JwksApiVerifier into REST auth; harden /mcp HTTP exposure

### DIFF
--- a/current/docs/fleet-deployment.md
+++ b/current/docs/fleet-deployment.md
@@ -12,6 +12,25 @@ For single-agent or local-dev setups, the defaults are appropriate and this guid
 
 ---
 
+## ⚠️ MCP HTTP Transport (`/mcp`) Is Unauthenticated — Read First
+
+When you run the server with `MCP_TRANSPORT=http`, the MCP endpoint is mounted at `/mcp` using the Streamable HTTP transport. **This endpoint has no authentication of any kind.** Any caller that can open a TCP connection to `MCP_HTTP_HOST:MCP_HTTP_PORT` (default `0.0.0.0:3001`) can invoke **every MCP tool** — full read, write, and delete of the entire work-item graph.
+
+This is **by design**: MCP-over-HTTP clients (Claude Code and other agents) connect without a REST bearer token, so gating `/mcp` would break them. The exemption is deliberate and load-bearing — do not attempt to bolt REST auth onto `/mcp`.
+
+**Critical consequences for fleet operators:**
+
+- **Enabling the REST API does NOT protect `/mcp`.** `API_ENABLED=true` + `API_AUTH_MODE=bearer|jwks` authenticates only the `/api/v1/*` routes. `/mcp` stays wide open regardless of REST auth mode. An operator who locks down the REST API can be lulled into thinking the whole HTTP surface is protected — it is not.
+- **The server logs a loud `SECURITY:` WARN at startup** whenever `MCP_TRANSPORT=http`, repeating this and noting the bind address. Check `docker logs` after first boot.
+- **You MUST fence `/mcp` at the network layer.** Choose one:
+  - Front it with an authenticating reverse proxy (e.g. nginx + mTLS, or an OAuth2 proxy) and never publish the raw port.
+  - Restrict it to a private network / VPC with no public ingress.
+  - For a single-host local run, bind loopback only: set `MCP_HTTP_HOST=127.0.0.1` (direct JAR run) or publish the Docker port as `127.0.0.1:3001:3001`.
+
+**Bind-default rationale.** The default bind is `0.0.0.0`, not `127.0.0.1`. Docker port-mapping (`-p host:container`) requires the server to bind all interfaces *inside* the container — a loopback default would make the published port unreachable and break the primary (containerized) deployment path. Control host exposure via the `-p` mapping for Docker, or set `MCP_HTTP_HOST=127.0.0.1` for a non-Docker local run. See [quick-start.md → HTTP transport security](quick-start.md) for the full matrix.
+
+---
+
 ## REST API Authentication
 
 The REST API layer (`API_ENABLED=true`) is a **separate authentication layer** from the MCP actor identity system. They are independent:

--- a/current/docs/quick-start.md
+++ b/current/docs/quick-start.md
@@ -452,11 +452,13 @@ The `docker compose --profile http up` service in `docker-compose.yml` is pre-co
 
 ### HTTP transport security
 
+> ⚠️ **SECURITY: `/mcp` over HTTP is UNAUTHENTICATED.** The Streamable HTTP transport has **no built-in authentication**. Anyone who can reach `MCP_HTTP_HOST:MCP_HTTP_PORT` gets **full read / write / delete** access to every MCP tool. Enabling the REST API (Step 10) does **not** protect `/mcp` — REST bearer/JWKS auth gates `/api/v1/*` only; `/mcp` stays open by design so MCP clients (which send no REST token) can still connect. The server logs a loud `SECURITY:` warning at startup whenever `MCP_TRANSPORT=http`. **Never expose this port to untrusted callers** — front it with an authenticating reverse proxy / mTLS, or keep it on a private network or loopback.
+
 The Streamable HTTP transport follows the [MCP transport security requirements](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning):
 
 - **Origin validation is enforced.** The server validates the `Origin` header and rejects cross-origin browser requests with `403 Forbidden` (DNS-rebinding protection). Non-browser MCP clients (Claude Code and other CLI agents) send no `Origin` and are unaffected.
-- **Bind to loopback when running locally.** The examples above publish the port as `127.0.0.1:3001:3001` so it is reachable only from the local host. Use `-p 3001:3001` (or set `MCP_HTTP_HOST`) only when you intentionally need access from other hosts.
-- **The `/mcp` endpoint is unauthenticated.** Unlike the REST API (Step 10, which requires bearer/JWKS auth), the MCP transport has no built-in authentication. Keep it on a trusted network boundary, or front it with an authenticating reverse proxy, before exposing it to untrusted callers.
+- **Bind to loopback when running locally.** For a direct (non-Docker) JAR run, set `MCP_HTTP_HOST=127.0.0.1` so the server binds loopback only. The default is `0.0.0.0` because Docker port-mapping requires the server to bind all interfaces *inside* the container — control host exposure via the `-p` mapping instead (the examples above publish as `127.0.0.1:3001:3001` so the port is reachable only from the local host). Use `-p 3001:3001` only when you intentionally need access from other hosts, and only behind a reverse proxy / mTLS.
+- **The `/mcp` endpoint is unauthenticated** (see the warning above). Keep it on a trusted network boundary, or front it with an authenticating reverse proxy, before exposing it to untrusted callers.
 
 ---
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/EventRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/EventRoutes.kt
@@ -4,6 +4,7 @@ import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiCapability
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiPrincipal
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.BearerTokenStore
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.HashBytes
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.JwksApiVerifier
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.events.ApiEvent
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.events.ApiEventBus
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.events.ApiEventType
@@ -53,6 +54,13 @@ private val SseTokenExpiryKey: AttributeKey<Instant> = AttributeKey("SseTokenExp
 private class SseInlineAuthConfig {
     var tokenEntries: Map<HashBytes, BearerTokenStore.TokenEntry> = emptyMap()
     var allowQueryToken: Boolean = false
+
+    /**
+     * REST JWT verifier for jwks mode. When set, a presented token that is not found among
+     * [tokenEntries] (bearer mode is empty in jwks mode) is validated as a JWT. Null in bearer
+     * and disabled modes.
+     */
+    var jwksVerifier: JwksApiVerifier? = null
 }
 
 /**
@@ -74,6 +82,7 @@ private val sseInlineAuthPlugin =
     ) {
         val tokenEntries = pluginConfig.tokenEntries
         val allowQueryToken = pluginConfig.allowQueryToken
+        val jwksVerifier = pluginConfig.jwksVerifier
 
         onCall { call ->
             // Resolution order: Authorization header → (opt-in) ?token= query param → 401.
@@ -100,9 +109,38 @@ private val sseInlineAuthPlugin =
                 return@onCall
             }
 
+            // Resolve the principal. Bearer mode: SHA-256 lookup against pre-loaded token entries
+            // (carries an explicit expiry → drives the periodic expiry watchdog). JWKS mode:
+            // tokenEntries is empty, so the lookup misses and we fall through to the JWT verifier.
+            // The verifier enforces `exp` at verify time, so no separate expiry watchdog is needed
+            // (expiry stays null and the periodic check is skipped).
             val digest = sha256Bytes(rawToken)
             val entry = tokenEntries[HashBytes(digest)]
-            if (entry == null) {
+
+            val principal: ApiPrincipal?
+            val expiry: Instant?
+            if (entry != null) {
+                principal = entry.principal
+                expiry = entry.expiresAt
+                if (expiry != null && Instant.now().isAfter(expiry)) {
+                    call.response.header("WWW-Authenticate", "Bearer error=\"invalid_token\"")
+                    call.respond(
+                        HttpStatusCode.Unauthorized,
+                        mapOf("error" to "invalid_token", "error_description" to "Token has expired"),
+                    )
+                    return@onCall
+                }
+            } else if (jwksVerifier != null) {
+                // JWKS mode — validate the token as a JWT. verify() enforces exp/nbf/iss/aud and
+                // returns null on any failure. Expiry is enforced inside verify(), so no watchdog.
+                principal = jwksVerifier.verify(rawToken)
+                expiry = null
+            } else {
+                principal = null
+                expiry = null
+            }
+
+            if (principal == null) {
                 call.response.header("WWW-Authenticate", "Bearer error=\"invalid_token\"")
                 call.respond(
                     HttpStatusCode.Unauthorized,
@@ -111,7 +149,6 @@ private val sseInlineAuthPlugin =
                 return@onCall
             }
 
-            val principal = entry.principal
             if (!principal.capabilities.contains(ApiCapability.READ) &&
                 !principal.capabilities.contains(ApiCapability.ADMIN)
             ) {
@@ -121,16 +158,6 @@ private val sseInlineAuthPlugin =
                         "error" to "insufficient_scope",
                         "error_description" to "Token does not have read capability",
                     ),
-                )
-                return@onCall
-            }
-
-            val expiry = entry.expiresAt
-            if (expiry != null && Instant.now().isAfter(expiry)) {
-                call.response.header("WWW-Authenticate", "Bearer error=\"invalid_token\"")
-                call.respond(
-                    HttpStatusCode.Unauthorized,
-                    mapOf("error" to "invalid_token", "error_description" to "Token has expired"),
                 )
                 return@onCall
             }
@@ -169,12 +196,15 @@ private val sseInlineAuthPlugin =
  * @param eventBus The shared [ApiEventBus] instance.
  * @param tokenEntries Pre-loaded bearer token entries with expiry metadata.
  * @param allowQueryToken Whether `?token=` query param is accepted.
+ * @param jwksVerifier REST JWT verifier for jwks mode; null in bearer/disabled modes. When set,
+ *   a token not found among [tokenEntries] is validated as a JWT.
  * @param authCheckIntervalSeconds Interval between token-expiry checks.
  */
 fun Route.eventRoutes(
     eventBus: ApiEventBus,
     tokenEntries: Map<HashBytes, BearerTokenStore.TokenEntry> = emptyMap(),
     allowQueryToken: Boolean = System.getenv("API_ALLOW_QUERY_TOKEN_FOR_SSE")?.lowercase() == "true",
+    jwksVerifier: JwksApiVerifier? = null,
     authCheckIntervalSeconds: Int =
         System.getenv("API_SSE_AUTH_CHECK_INTERVAL_SECONDS")?.toIntOrNull() ?: 30,
 ) {
@@ -184,6 +214,7 @@ fun Route.eventRoutes(
         install(sseInlineAuthPlugin) {
             this.tokenEntries = tokenEntries
             this.allowQueryToken = allowQueryToken
+            this.jwksVerifier = jwksVerifier
         }
 
         sse {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemWriteRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemWriteRoutes.kt
@@ -318,7 +318,10 @@ fun Route.itemWriteRoutes(
                         Json.parseToJsonElement(bodyText) as? JsonObject
                             ?: return errorCaptured(HttpStatusCode.BadRequest, "validation_error", "PATCH body must be a JSON object")
                     } catch (e: Exception) {
-                        return errorCaptured(HttpStatusCode.BadRequest, "validation_error", "Invalid JSON: ${e.message}")
+                        // Log the parse detail server-side; do not echo the raw exception message back
+                        // to the client (avoids leaking parser internals / input fragments).
+                        writeLogger.debug("PATCH body JSON parse failed: {}", e.message)
+                        return errorCaptured(HttpStatusCode.BadRequest, "validation_error", "Invalid JSON in request body")
                     }
 
                 // Security: reject any attempt to patch server-owned fields
@@ -355,7 +358,9 @@ fun Route.itemWriteRoutes(
                     try {
                         Json.decodeFromJsonElement<ItemPatchDto>(normalizedMerged)
                     } catch (e: Exception) {
-                        return errorCaptured(HttpStatusCode.BadRequest, "validation_error", "Invalid patch values: ${e.message}")
+                        // Log the decode detail server-side; return a generic message to the client.
+                        writeLogger.debug("PATCH patch-value decode failed: {}", e.message)
+                        return errorCaptured(HttpStatusCode.BadRequest, "validation_error", "Invalid patch values")
                     }
 
                 // The projection (WorkItemPatchProjection) includes EVERY patchable field in `base`,

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
@@ -24,6 +24,7 @@ import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetNextStat
 import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
 import io.github.jpicklyk.mcptask.current.domain.model.VerifierConfig
 import io.github.jpicklyk.mcptask.current.infrastructure.config.ApiAuthConfigLoader
+import io.github.jpicklyk.mcptask.current.infrastructure.config.DefaultJwksKeySetProvider
 import io.github.jpicklyk.mcptask.current.infrastructure.config.JwksActorVerifier
 import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlActorAuthenticationConfigService
 import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlNoteSchemaService
@@ -38,6 +39,7 @@ import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiAuthConfig
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiBearerAuth
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.BearerTokenStore
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.HashBytes
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.JwksApiVerifier
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.cors.configureCors
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.events.ApiEventBus
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.events.EventPublishingRepositoryProvider
@@ -235,6 +237,10 @@ class CurrentMcpServer(
      *   when the API is enabled, or the raw provider (passed in) when disabled.
      * @param tokenEntries Pre-loaded bearer token entries with expiry metadata (empty unless bearer mode).
      * @param allowQueryToken Whether `?token=` query-param auth is enabled for the SSE route.
+     * @param jwksVerifier REST JWT verifier built from [ApiAuthConfig.Jwks] settings, or null unless
+     *   the API is enabled in jwks mode. This is the REST-API verifier
+     *   ([io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.JwksApiVerifier]) — NOT the
+     *   unrelated actor-authentication [JwksActorVerifier].
      */
     private data class ApiWiring(
         val apiConfig: ApiAuthConfig,
@@ -242,6 +248,7 @@ class CurrentMcpServer(
         val effectiveProvider: RepositoryProvider,
         val tokenEntries: Map<HashBytes, BearerTokenStore.TokenEntry>,
         val allowQueryToken: Boolean,
+        val jwksVerifier: JwksApiVerifier?,
     )
 
     /**
@@ -281,6 +288,7 @@ class CurrentMcpServer(
                 effectiveProvider = rawProvider,
                 tokenEntries = emptyMap(),
                 allowQueryToken = allowQueryToken,
+                jwksVerifier = null,
             )
         }
 
@@ -296,12 +304,39 @@ class CurrentMcpServer(
                 emptyMap()
             }
 
+        // In jwks mode, build the REST JWT verifier from the resolved ApiAuthConfig.Jwks settings.
+        // Without this, the ApiBearerAuth plugin's Jwks branch finds a null verifier and 401s every
+        // request (the original bug). The key provider is a DefaultJwksKeySetProvider configured with
+        // a direct JWKS URL (config.url → VerifierConfig.Jwks.jwksUri) — REST jwks uses no OIDC
+        // discovery or DID trust, so only jwksUri/issuer/audience/algorithms/cacheTtl are set.
+        // NOTE: this is the REST verifier (JwksApiVerifier), NOT the actor-auth JwksActorVerifier.
+        val jwksVerifier: JwksApiVerifier? =
+            if (apiConfig is ApiAuthConfig.Jwks) {
+                val keyProvider =
+                    DefaultJwksKeySetProvider(
+                        VerifierConfig.Jwks(
+                            jwksUri = apiConfig.url,
+                            issuer = apiConfig.issuer,
+                            audience = apiConfig.audience,
+                            algorithms = apiConfig.algorithms,
+                            cacheTtlSeconds = apiConfig.cacheTtlSeconds,
+                        ),
+                    )
+                shutdownCoordinator?.addCleanupAction("Close REST JWKS key provider") {
+                    keyProvider.close()
+                }
+                JwksApiVerifier(apiConfig, keyProvider)
+            } else {
+                null
+            }
+
         return ApiWiring(
             apiConfig = apiConfig,
             eventBus = bus,
             effectiveProvider = decorated,
             tokenEntries = tokenEntries,
             allowQueryToken = allowQueryToken,
+            jwksVerifier = jwksVerifier,
         )
     }
 
@@ -390,6 +425,35 @@ class CurrentMcpServer(
         val port = System.getenv("MCP_HTTP_PORT")?.toIntOrNull() ?: 3001
         logger.info("Starting MCP server with HTTP transport on $host:$port/mcp ...")
 
+        // SECURITY WARNING: the /mcp Streamable HTTP endpoint is UNAUTHENTICATED by design — MCP
+        // clients reach it with no REST bearer token, so the ApiBearerAuth plugin exempts /mcp even
+        // when the REST API is enabled (see installRestApiRoutes / McpRestAuthBypassTest). Anyone who
+        // can reach $host:$port gets full read/write/delete via every MCP tool. This MUST be fronted
+        // by a reverse proxy / mTLS / network fencing before exposing the port. Bind is controlled by
+        // MCP_HTTP_HOST (default 0.0.0.0 so Docker port-mapping works; set 127.0.0.1 for loopback-only
+        // local runs). Logged loudly at startup so operators cannot miss it.
+        logger.warn(
+            "SECURITY: /mcp over HTTP is UNAUTHENTICATED. Anyone who can reach {}:{} has full " +
+                "read/write/delete access to all MCP tools. Front it with a reverse proxy, mTLS, or a " +
+                "private network — do NOT expose this port to untrusted callers. Bind address is set " +
+                "via MCP_HTTP_HOST (currently '{}'); use 127.0.0.1 for loopback-only local runs.",
+            host,
+            port,
+            host,
+        )
+        if (apiWiring.apiConfig !is ApiAuthConfig.Disabled) {
+            logger.warn(
+                "SECURITY: API_ENABLED=true authenticates /api/v1 routes but does NOT protect /mcp. " +
+                    "The /mcp endpoint remains unauthenticated regardless of the REST API auth mode.",
+            )
+        }
+        if (host == "0.0.0.0") {
+            logger.warn(
+                "SECURITY: MCP HTTP transport is bound to 0.0.0.0 (all interfaces). If this is not a " +
+                    "container behind a reverse proxy / private network, set MCP_HTTP_HOST=127.0.0.1.",
+            )
+        }
+
         // Phase 6: reuse the API wiring resolved ONCE in run() — the SAME bus and decorated
         // provider already feeding the MCP tool context. Do NOT re-resolve here, or the SSE route
         // would subscribe to a different bus than the one MCP-tool writes publish to.
@@ -398,6 +462,7 @@ class CurrentMcpServer(
         val effectiveProvider = apiWiring.effectiveProvider
         val apiTokenEntries = apiWiring.tokenEntries
         val allowQueryToken = apiWiring.allowQueryToken
+        val jwksVerifier = apiWiring.jwksVerifier
 
         // Determine actor_authentication status for /info endpoint
         val actorAuthEnabled =
@@ -425,6 +490,7 @@ class CurrentMcpServer(
                     noteSchemaService = noteSchemaService,
                     degradedModePolicy = degradedModePolicy,
                     idempotencyCache = idempotencyCache,
+                    jwksVerifier = jwksVerifier,
                 )
             }
 
@@ -563,6 +629,7 @@ internal fun Application.installRestApiRoutes(
     noteSchemaService: WorkItemSchemaService,
     degradedModePolicy: DegradedModePolicy,
     idempotencyCache: IdempotencyCache,
+    jwksVerifier: JwksApiVerifier? = null,
 ) {
     if (apiConfig is ApiAuthConfig.Disabled) return
 
@@ -573,6 +640,10 @@ internal fun Application.installRestApiRoutes(
                 authConfig = apiConfig
                 // Use pre-loaded token entries (already loaded for event bus wiring at startup)
                 tokenEntries = apiTokenEntries
+                // Wire the REST JWT verifier so jwks mode actually authenticates. Without this the
+                // plugin's Jwks branch finds a null verifier and 401s every request (the bug being
+                // fixed). Null in bearer/disabled modes — the plugin never reads it there.
+                this.jwksVerifier = jwksVerifier
                 // ApiBearerAuth is an APPLICATION plugin — it intercepts every request, not just
                 // /api/v1. The MCP Streamable HTTP endpoint (/mcp) is a separate protocol with its
                 // own transport and must remain reachable WITHOUT a REST bearer token. Exempt it via
@@ -609,6 +680,7 @@ internal fun Application.installRestApiRoutes(
                     eventBus = eventBus,
                     tokenEntries = apiTokenEntries,
                     allowQueryToken = allowQueryToken,
+                    jwksVerifier = jwksVerifier,
                 )
             }
         }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/McpJwksRestAuthTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/McpJwksRestAuthTest.kt
@@ -1,0 +1,309 @@
+package io.github.jpicklyk.mcptask.current.interfaces.mcp
+
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.RSASSASigner
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import io.github.jpicklyk.mcptask.current.application.service.IdempotencyCache
+import io.github.jpicklyk.mcptask.current.application.service.NoOpNoteSchemaService
+import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
+import io.github.jpicklyk.mcptask.current.infrastructure.config.CacheState
+import io.github.jpicklyk.mcptask.current.infrastructure.config.JwksKeySetProvider
+import io.github.jpicklyk.mcptask.current.infrastructure.config.JwksResult
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiAuthConfig
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.JwksApiVerifier
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.events.ApiEvent
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.events.ApiEventBus
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.events.ApiEventType
+import io.ktor.client.plugins.sse.sse
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.withTimeout
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.security.Security
+import java.time.Instant
+import java.util.Date
+import java.util.UUID
+import kotlin.time.Duration.Companion.seconds
+import io.ktor.client.plugins.sse.SSE as ClientSSE
+
+/**
+ * Integration coverage for the REST API in **jwks mode** — the path that shipped broken because
+ * `install(ApiBearerAuth)` never set `jwksVerifier`, so the plugin's `ApiAuthConfig.Jwks` branch
+ * found a null verifier and 401'd every request (and SSE).
+ *
+ * This wires the SAME production functions ([installMcpStreamableHttp] + [installRestApiRoutes])
+ * with the API enabled in jwks mode, passing a [JwksApiVerifier] backed by an in-test RSA keypair
+ * (served via a mocked [JwksKeySetProvider]). The valid-JWT cases are regression tests that would
+ * have caught the original bug; the bad-alg / expired cases prove the verifier's checks are not
+ * weakened by the wiring.
+ */
+class McpJwksRestAuthTest {
+    companion object {
+        init {
+            // RSA signing/verification needs no BouncyCastle, but match the sibling test's setup.
+            if (Security.getProvider("BC") == null) {
+                Security.addProvider(org.bouncycastle.jce.provider.BouncyCastleProvider())
+            }
+        }
+
+        private val rsaKey = RSAKeyGenerator(2048).keyID("rest-jwks-key").generate()
+    }
+
+    private val testIssuer = "https://idp.test.example"
+    private val testAudience = "task-orchestrator-api"
+
+    private fun jwksConfig(algorithms: List<String> = listOf("RS256")): ApiAuthConfig.Jwks =
+        ApiAuthConfig.Jwks(
+            url = "https://idp.test.example/.well-known/jwks.json",
+            issuer = testIssuer,
+            audience = testAudience,
+            algorithms = algorithms,
+            cacheTtlSeconds = 300,
+        )
+
+    /** Mock key provider that always serves the in-test RSA public key. */
+    private fun rsaKeyProvider(): JwksKeySetProvider {
+        val provider = mockk<JwksKeySetProvider>()
+        val result = JwksResult(JWKSet(listOf(rsaKey.toPublicJWK())), CacheState(fromStaleCache = false, ageSeconds = null))
+        coEvery { provider.getKeySet() } returns result
+        coEvery { provider.getKeySetForIssuer(any()) } returns result
+        every { provider.getResolvedIssuer() } returns null
+        every { provider.close() } just Runs
+        return provider
+    }
+
+    private fun verifier(algorithms: List<String> = listOf("RS256")): JwksApiVerifier =
+        JwksApiVerifier(jwksConfig(algorithms), rsaKeyProvider())
+
+    private fun buildClaims(
+        subject: String = "jwks-api-caller",
+        issuer: String = testIssuer,
+        audience: String = testAudience,
+        expiry: Instant = Instant.now().plusSeconds(300),
+    ): JWTClaimsSet =
+        JWTClaimsSet
+            .Builder()
+            .subject(subject)
+            .issuer(issuer)
+            .audience(audience)
+            .expirationTime(Date.from(expiry))
+            .build()
+
+    private fun signRs256(claims: JWTClaimsSet = buildClaims()): String {
+        val jwt = SignedJWT(JWSHeader.Builder(JWSAlgorithm.RS256).keyID("rest-jwks-key").build(), claims)
+        jwt.sign(RSASSASigner(rsaKey))
+        return jwt.serialize()
+    }
+
+    private fun emptyServer(): Server =
+        Server(
+            serverInfo = Implementation(name = "jwks-rest-test", version = "1.0.0"),
+            options =
+                ServerOptions(
+                    capabilities = ServerCapabilities(tools = ServerCapabilities.Tools(listChanged = true)),
+                ),
+        )
+
+    private fun inMemoryProvider(): DefaultRepositoryProvider =
+        DefaultRepositoryProvider(
+            DatabaseManager(
+                Database.connect(
+                    "jdbc:h2:mem:jwksrest_${System.nanoTime()};DB_CLOSE_DELAY=-1",
+                    driver = "org.h2.Driver",
+                ),
+            ).also { DirectDatabaseSchemaManager().updateSchema() },
+        )
+
+    /**
+     * Installs the production wiring with the API enabled in jwks mode. The [eventBus] is wired so
+     * the SSE route is also registered (and given the jwks verifier).
+     */
+    private fun io.ktor.server.application.Application.installJwksApp(
+        verifier: JwksApiVerifier,
+        eventBus: ApiEventBus? = null,
+    ) {
+        installMcpStreamableHttp(emptyServer())
+        installRestApiRoutes(
+            apiConfig = jwksConfig(),
+            eventBus = eventBus,
+            effectiveProvider = inMemoryProvider(),
+            apiTokenEntries = emptyMap(), // jwks mode loads no bearer entries
+            allowQueryToken = false,
+            serverName = "jwks-rest-test",
+            serverVersion = "1.0.0",
+            actorAuthEnabled = false,
+            noteSchemaService = NoOpNoteSchemaService,
+            degradedModePolicy = DegradedModePolicy.ACCEPT_CACHED,
+            idempotencyCache = IdempotencyCache(),
+            jwksVerifier = verifier,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // REST routes — jwks mode
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `valid JWT authorizes a REST request`() =
+        testApplication {
+            application { installJwksApp(verifier()) }
+
+            val response =
+                client.get("/api/v1/items") {
+                    header(HttpHeaders.Authorization, "Bearer ${signRs256()}")
+                }
+            assertEquals(
+                HttpStatusCode.OK,
+                response.status,
+                "A valid JWT must authorize /api/v1 in jwks mode (regression for the missing jwksVerifier wiring)",
+            )
+        }
+
+    @Test
+    fun `missing token returns 401 in jwks mode`() =
+        testApplication {
+            application { installJwksApp(verifier()) }
+            assertEquals(HttpStatusCode.Unauthorized, client.get("/api/v1/items").status)
+        }
+
+    @Test
+    fun `JWT signed with disallowed algorithm returns 401`() =
+        testApplication {
+            // Verifier only allows RS512; the token is RS256 → rejected by the allowlist check.
+            application { installJwksApp(verifier(algorithms = listOf("RS512"))) }
+
+            val response =
+                client.get("/api/v1/items") {
+                    header(HttpHeaders.Authorization, "Bearer ${signRs256()}")
+                }
+            assertEquals(
+                HttpStatusCode.Unauthorized,
+                response.status,
+                "A JWT whose alg is not in the allowlist must 401 (verifier checks must not be weakened)",
+            )
+        }
+
+    @Test
+    fun `expired JWT returns 401`() =
+        testApplication {
+            application { installJwksApp(verifier()) }
+
+            val expired = signRs256(buildClaims(expiry = Instant.now().minusSeconds(3600)))
+            val response =
+                client.get("/api/v1/items") {
+                    header(HttpHeaders.Authorization, "Bearer $expired")
+                }
+            assertEquals(HttpStatusCode.Unauthorized, response.status, "An expired JWT must 401")
+        }
+
+    @Test
+    fun `mcp endpoint stays open in jwks mode`() =
+        testApplication {
+            application { installJwksApp(verifier()) }
+            // /mcp must remain reachable without any REST credential, even in jwks mode (the public-path
+            // bypass is auth-mode independent). Initialize succeeds with no Authorization header.
+            val mcp =
+                client.post("/mcp") {
+                    header(HttpHeaders.Accept, "application/json, text/event-stream")
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(
+                        """{"jsonrpc":"2.0","id":1,"method":"initialize","params":""" +
+                            """{"protocolVersion":"2025-03-26","capabilities":{},""" +
+                            """"clientInfo":{"name":"t","version":"1.0"}}}""",
+                    )
+                }
+            assertEquals(
+                HttpStatusCode.OK,
+                mcp.status,
+                "/mcp must stay open in jwks mode (no bearer token sent)",
+            )
+        }
+
+    // -------------------------------------------------------------------------
+    // SSE — jwks mode
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `SSE missing token returns 401 in jwks mode`() =
+        testApplication {
+            val bus = ApiEventBus()
+            application { installJwksApp(verifier(), eventBus = bus) }
+            assertEquals(HttpStatusCode.Unauthorized, client.get("/api/v1/events").status)
+        }
+
+    @Test
+    fun `SSE invalid JWT returns 401 in jwks mode`() =
+        testApplication {
+            val bus = ApiEventBus()
+            application { installJwksApp(verifier(), eventBus = bus) }
+            val response =
+                client.get("/api/v1/events") {
+                    header(HttpHeaders.Authorization, "Bearer not-a-valid-jwt")
+                }
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+    @Test
+    fun `SSE streams a replayed event to a JWT-authenticated client in jwks mode`(): Unit =
+        testApplication {
+            val bus = ApiEventBus()
+
+            // Publish an event to the ring buffer BEFORE subscribing so replay can deliver it.
+            val itemId = UUID.randomUUID()
+            val prePublished = bus.buildEvent(ApiEventType.ITEM_CREATED, itemId = itemId, modifiedAt = Instant.now())
+            bus.publish(prePublished, emptySet())
+
+            application { installJwksApp(verifier(), eventBus = bus) }
+
+            val sseClient = createClient { install(ClientSSE) }
+            val testJson = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
+
+            val collected = mutableListOf<ApiEvent>()
+            withTimeout(10.seconds) {
+                sseClient.sse(
+                    urlString = "/api/v1/events",
+                    request = {
+                        header(HttpHeaders.Authorization, "Bearer ${signRs256()}")
+                        header("Last-Event-ID", "0")
+                    },
+                ) {
+                    incoming.take(1).toList().forEach { sse ->
+                        collected.add(testJson.decodeFromString(ApiEvent.serializer(), sse.data.orEmpty()))
+                    }
+                }
+            }
+
+            assertEquals(1, collected.size, "Expected exactly one replayed event over the JWT-authed SSE stream")
+            assertEquals(ApiEventType.ITEM_CREATED, collected[0].event)
+            assertTrue(
+                collected[0].itemId == itemId.toString(),
+                "Replayed event should carry the published item id. Got: ${collected[0].itemId}",
+            )
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/McpJwksRestAuthTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/McpJwksRestAuthTest.kt
@@ -68,7 +68,10 @@ class McpJwksRestAuthTest {
         init {
             // RSA signing/verification needs no BouncyCastle, but match the sibling test's setup.
             if (Security.getProvider("BC") == null) {
-                Security.addProvider(org.bouncycastle.jce.provider.BouncyCastleProvider())
+                Security.addProvider(
+                    org.bouncycastle.jce.provider
+                        .BouncyCastleProvider()
+                )
             }
         }
 


### PR DESCRIPTION
## Summary
Two security fixes combined (both touch `CurrentMcpServer.kt`):

**JWKS REST auth was non-functional.** The `ApiBearerAuth` plugin install never set `jwksVerifier`, so `API_AUTH_MODE=jwks` returned 401 for every `/api/v1` request and SSE connection. Now constructs and wires the REST `JwksApiVerifier` (distinct from the actor-auth `JwksActorVerifier`) for both REST routes and SSE. Adds integration tests: valid JWT, disallowed alg, expired token, SSE auth.

**/mcp HTTP exposure hardening.** Loud `SECURITY:` startup WARN when `MCP_TRANSPORT=http` (escalated when API enabled / bound to `0.0.0.0`); security callouts added to `fleet-deployment.md` and `quick-start.md`; kept the `0.0.0.0` default (Docker requires it) and documented `MCP_HTTP_HOST` for loopback. The intentional `/mcp` auth exemption is unchanged. Ride-along: 400 error bodies no longer echo raw exception messages (logged server-side instead).

## Test Results
`:current:test` green; `:current:ktlintCheck` clean. New JWKS integration tests use a real RSA keypair with real signing/verification.

## Review
Independent security review: **PASS**. Confirmed jwks mode now authenticates without weakening the verifier's alg-allowlist/iss/aud/exp checks; correct verifier used; no secrets logged. Non-blocking: SSE jwks validated at connect only (documented v1 limit); the `0.0.0.0` WARN is an exact-string match (won't fire for IPv6 `::`, though the always-on bind WARN still names the host).

## MCP
Items `542f3786` (JWKS wiring) + `5e2db58c` (/mcp exposure) — remediation tree `4ab3f9c8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
