### PR TITLE
docs: sync openapi enums, manage_items defaults, and workflow-guide examples

### DIFF
--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -50,6 +50,7 @@ is computed automatically from the parent; nesting depth is unbounded (cycle pro
 | `items` | array | Yes (create/update) | Array of item objects |
 | `ids` | array | Yes (delete) | Array of item UUIDs to delete |
 | `parentId` | string (UUID) | No | Shared default parent for all created items; per-item `parentId` overrides this |
+| `traits` | string | No | Comma-separated trait names applied as a shared default to all items in this batch (e.g., `"needs-migration-review,needs-security-review"`). Adds trait note requirements from the `traits:` config section. Merged into each item's `properties` JSON automatically. |
 | `recursive` | boolean | No | Delete all descendants before deleting the target items (default: false) |
 | `requiresVerification` | boolean | No | **Top-level `requiresVerification` is ignored.** Set it on individual items in the `items` array instead. |
 | `requestId` | string (UUID) | No | Client-generated UUID for idempotency. Repeated calls with the same `(actor.id, requestId)` within ~10 minutes return the cached response without re-executing. Cache is single-instance and in-memory (not persisted). |
@@ -88,9 +89,12 @@ Setting `parentId` to JSON null moves the item to root.
     { "id": "uuid", "modifiedAt": "2025-01-01T00:00:00Z", "requiresVerification": false }
   ],
   "updated": 1,
-  "failed": 0
+  "failed": 0,
+  "failures": [{ "id": "bad-uuid", "error": "Item 'bad-uuid' not found" }]
 }
 ```
+
+`failures` is only present when `failed > 0`; omitted entirely on a clean run.
 
 **Examples.**
 

--- a/current/docs/api/openapi.yaml
+++ b/current/docs/api/openapi.yaml
@@ -95,7 +95,7 @@ components:
           nullable: true
         priority:
           type: string
-          enum: [HIGH, MEDIUM, LOW, CRITICAL, BACKLOG]
+          enum: [high, medium, low]
         complexity:
           type: integer
           nullable: true
@@ -190,7 +190,7 @@ components:
       properties:
         status:
           type: string
-          enum: [unverified, verified, unavailable, unchecked]
+          enum: [absent, unchecked, verified, rejected, unavailable]
         verifier:
           type: string
           nullable: true
@@ -258,7 +258,7 @@ components:
           format: uuid
         type:
           type: string
-          enum: [blocks, relates_to]
+          enum: [blocks, is_blocked_by, relates_to]
         unblockAt:
           type: string
           nullable: true
@@ -278,7 +278,7 @@ components:
           type: string
         type:
           type: string
-          enum: [blocks, relates_to]
+          enum: [blocks, is_blocked_by, relates_to]
 
     ErrorDto:
       type: object
@@ -381,7 +381,7 @@ components:
           format: uuid
         type:
           type: string
-          enum: [blocks, relates_to]
+          enum: [blocks, is_blocked_by, relates_to]
         unblockAt:
           type: string
           nullable: true

--- a/current/docs/workflow-guide.md
+++ b/current/docs/workflow-guide.md
@@ -292,7 +292,7 @@ When `canAdvance: true`, calling `advance_item(trigger="start")` will succeed.
 ### Reading Existing Notes
 
 ```json
-manage_notes(operation="list", itemId="abc-123")
+query_notes(operation="list", itemId="abc-123")
 ```
 
 ---
@@ -685,7 +685,7 @@ The response echoes the actor claim and includes a verification record:
 ```json
 {
   "actor": { "id": "impl-agent", "kind": "subagent", "parent": "orchestrator-1" },
-  "verification": { "status": "unverified", "verifier": "noop" }
+  "verification": { "status": "unchecked", "verifier": "noop" }
 }
 ```
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsTool.kt
@@ -49,7 +49,7 @@ Unified write operations for WorkItems (create, update, delete).
   additional required notes.
 - Top-level `requiresVerification` is ignored — set it on individual items in the `items` array instead.
 - Depth auto-computed from parent (root=0, child=parent.depth+1, unbounded)
-- Defaults: role=queue, priority=medium, complexity=5
+- Defaults: role=queue, priority=medium; complexity has no default (null if not provided)
 - Response: `{ items: [{id, title, depth, role, priority, requiresVerification, tags, schemaMatch, expectedNotes}], created: N, failed: N, failures: [{index, error}] }`
 - `tags` is always included (null if not set). `expectedNotes` is always included (empty array when no schema matches). `schemaMatch` indicates whether the item's tags matched a configured note schema.
 
@@ -58,7 +58,7 @@ Unified write operations for WorkItems (create, update, delete).
 - Note: role changes are not allowed in update operations. Use advance_item with triggers (start, complete, block, hold, resume, cancel, reopen) instead.
 - Only provided fields are changed; omitted fields retain existing values
 - If parentId changes, depth is recomputed from new parent
-- Response: `{ items: [{id, modifiedAt}], updated: N, failed: N, failures: [{id, error}] }`
+- Response: `{ items: [{id, modifiedAt, requiresVerification}], updated: N, failed: N, failures: [{id, error}] }` (failures omitted when empty)
 
 **delete** - Delete by `ids` array (UUIDs or hex prefixes 4+ chars).
 - Response: `{ ids: [...], deleted: N, failed: N, failures: [{id, error}] }`


### PR DESCRIPTION
## Summary
Documentation / OpenAPI drift fixes, each verified against the Kotlin source of truth:
- `openapi.yaml`: `VerificationDto.status` enum → actual emitted values (`absent, unchecked, verified, rejected, unavailable`); `priority` enum → `high, medium, low` (removed nonexistent CRITICAL/BACKLOG); dependency-type enums → added the missing `is_blocked_by`
- `ManageItemsTool` description: `complexity` no longer claims a default of 5 (actual: null) — keeps `ToolDocumentationConsistencyTest` green
- `workflow-guide.md`: `manage_notes(operation="list")` → `query_notes(...)`; stale `"unverified"` example → `"unchecked"`
- `api-reference.md`: documented the top-level `traits` batch param; reconciled the manage_items update-response shape (added `failures`)

## Test Results
`:current:test` green (incl. `ToolDocumentationConsistencyTest`); `:current:ktlintCheck` clean. Docs-only plus one tool description string.

## Review
Lightweight (documentation) schema — no review gate; session-tracking filled.

## Note
Touches `api-reference.md`, which PR1 also edits — whichever merges second needs a trivial conflict resolution.

## MCP
Item `6153a265` — remediation tree `4ab3f9c8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
