### PR TITLE
fix(tools): extractTraits tolerates comma-string traits in properties bag

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/PropertiesHelper.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/PropertiesHelper.kt
@@ -11,13 +11,30 @@ object PropertiesHelper {
 
     /**
      * Extract the traits list from a properties JSON string.
-     * Returns empty list if properties is null, malformed, or has no "traits" key.
+     *
+     * Accepts the "traits" value as either a JSON array (`{"traits":["a","b"]}`) or a
+     * comma-separated JSON string (`{"traits":"a,b"}`) — the string form is split and
+     * trimmed identically to [mergeTraitsFromString], so hand-authored properties bags
+     * resolve the same as the `traits` convenience field. Any other value type (number,
+     * boolean, null), a missing key, malformed JSON, or null/blank input yields an empty list.
      */
     fun extractTraits(properties: String?): List<String> {
         if (properties.isNullOrBlank()) return emptyList()
         return try {
             val json = Json.parseToJsonElement(properties).jsonObject
-            json[TRAITS_KEY]?.jsonArray?.map { it.jsonPrimitive.content } ?: emptyList()
+            when (val traitsElement = json[TRAITS_KEY]) {
+                is JsonArray -> traitsElement.map { it.jsonPrimitive.content }
+                is JsonPrimitive ->
+                    if (traitsElement.isString) {
+                        traitsElement.content
+                            .split(",")
+                            .map { it.trim() }
+                            .filter { it.isNotEmpty() }
+                    } else {
+                        emptyList()
+                    }
+                else -> emptyList()
+            }
         } catch (_: Exception) {
             emptyList()
         }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/PropertiesHelperTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/PropertiesHelperTest.kt
@@ -52,9 +52,34 @@ class PropertiesHelperTest {
     }
 
     @Test
-    fun `extractTraits returns empty list when traits value is not an array`() {
-        // "traits" exists but is a string, not an array — jsonArray access throws
-        val properties = """{"traits": "not-an-array"}"""
+    fun `extractTraits parses single-trait comma-string in properties`() {
+        // "traits" as a JSON string (not an array) is tolerated and split on commas,
+        // mirroring the `traits` convenience field. A single value yields a one-element list.
+        val properties = """{"traits": "needs-security-review"}"""
+        assertEquals(listOf("needs-security-review"), PropertiesHelper.extractTraits(properties))
+    }
+
+    @Test
+    fun `extractTraits parses multi-trait comma-string in properties`() {
+        val properties = """{"traits": "a,b,c"}"""
+        assertEquals(listOf("a", "b", "c"), PropertiesHelper.extractTraits(properties))
+    }
+
+    @Test
+    fun `extractTraits trims whitespace and filters empty segments in comma-string`() {
+        val properties = """{"traits": " a , , b "}"""
+        assertEquals(listOf("a", "b"), PropertiesHelper.extractTraits(properties))
+    }
+
+    @Test
+    fun `extractTraits returns empty list when traits value is a number`() {
+        val properties = """{"traits": 42}"""
+        assertEquals(emptyList(), PropertiesHelper.extractTraits(properties))
+    }
+
+    @Test
+    fun `extractTraits returns empty list when traits value is null`() {
+        val properties = """{"traits": null}"""
         assertEquals(emptyList(), PropertiesHelper.extractTraits(properties))
     }
 


### PR DESCRIPTION
## Summary
`PropertiesHelper.extractTraits()` read `properties["traits"]` via `?.jsonArray`, which **throws** on a JSON string and was swallowed by the surrounding `catch`, so traits written as a comma-separated **string** (`{"traits":"a,b"}`) were silently dropped — the item got no trait notes and no error. Only the JSON-**array** form worked.

Now `extractTraits` accepts **both**:
- JSON array — `{"traits":["a","b"]}` (unchanged)
- comma-separated string — `{"traits":"a,b"}` (split/trim/filter, mirroring `mergeTraitsFromString`)

## Blast radius
Narrow: only **hand-authored `properties:`** bags were affected. The `traits` convenience field (create_work_tree / manage_items) and config `default_traits` were always safe — they pre-split to a JSON array. Confirmed via live MCP reproduction (array form merged the trait note; comma-string did not — in both `create` expectedNotes and `get_context`'s resolved schema).

## Tests
- Replaced `extractTraits returns empty list when traits value is not an array` — which **enshrined** the bug — with positive comma-string coverage.
- Added: single comma-string, multi comma-string, whitespace/empty-segment trimming, number→empty, null→empty.
- Full `:current:test` green; `:current:ktlintCheck` clean.

## Context
Corrects the 2026-05-20 `trait-not-merged-into-resolved-schema` retrospective suspicion — the array and field paths were never broken; only this comma-string edge case was. Addresses observation `dcce26c1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
