### PR TITLE
Add Dopemux transition proof envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added a `dopemux_proof_envelope` response field to `advance_item` and `complete_tree` so Dopemux can validate transition provenance, idempotency, actor, canonical writer, and receipt status without changing existing result payloads.
+
 ## [3.9.0] - 2026-06-01
 
 ### Added

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -485,9 +485,24 @@ Exactly one of `rootId` or `itemIds` must be provided.
     { "itemId": "uuid", "title": "Implement handler", "applied": false, "gateErrors": ["missing: done-criteria"] },
     { "itemId": "uuid", "title": "Write tests", "applied": false, "skipped": true, "skippedReason": "dependency gate failed" }
   ],
-  "summary": { "total": 3, "completed": 1, "skipped": 1, "gateFailures": 1 }
+  "summary": { "total": 3, "completed": 1, "skipped": 1, "gateFailures": 1 },
+  "dopemux_proof_envelope": {
+    "schema_version": "1",
+    "workflow_id": "uuid",
+    "transition": "queue->terminal",
+    "idempotency_key": "request-id-or-not-provided",
+    "actor": "operator-1",
+    "canonical_writer": "task-orchestrator",
+    "receipt": {
+      "proof_id": "task-orchestrator:complete_tree:uuid",
+      "operation": "complete_tree",
+      "status": "OK"
+    }
+  }
 }
 ```
+
+`dopemux_proof_envelope` is an additive response field for Dopemux consumers. It identifies the canonical writer (`task-orchestrator`), the first successfully applied transition in the call when one exists, the idempotency key value used by the caller or `"not-provided"`, and a compact receipt. `receipt.status` is `"OK"`, `"FAILED"`, or `"PARTIAL"` based on the aggregate result. Empty successful calls use `"none"` for `workflow_id` and `transition`.
 
 **`skippedReason` values:** Items can be skipped for two reasons:
 - `"dependency gate failed"` — a blocker item in the same target set failed its gate check or failed to apply, and this item is a downstream dependent.
@@ -988,11 +1003,26 @@ All cascade types are recorded in `cascadeEvents`.
     }
   ],
   "summary": { "total": 1, "succeeded": 1, "failed": 0 },
-  "allUnblockedItems": [{ "itemId": "uuid-next", "title": "Next task" }]
+  "allUnblockedItems": [{ "itemId": "uuid-next", "title": "Next task" }],
+  "dopemux_proof_envelope": {
+    "schema_version": "1",
+    "workflow_id": "uuid",
+    "transition": "queue->work",
+    "idempotency_key": "request-id-or-not-provided",
+    "actor": "operator-1",
+    "canonical_writer": "task-orchestrator",
+    "receipt": {
+      "proof_id": "task-orchestrator:advance_item:uuid",
+      "operation": "advance_item",
+      "status": "OK"
+    }
+  }
 }
 ```
 
 `unblockedItems` and `allUnblockedItems` are always present (as `[]` when empty). `cascadeEvents` is always present (as `[]` when no cascades occurred). `expectedNotes` is always present (as `[]` when no schema matches the item's tags). Each entry in `expectedNotes` includes: `key`, `role`, `required`, `description`, `exists`, and optionally `skill` (present only when a skill is configured for that note).
+
+`dopemux_proof_envelope` is an additive response field for Dopemux consumers. It identifies the canonical writer (`task-orchestrator`), the first successfully applied transition in the call when one exists, the request id value supplied by the caller or `"not-provided"`, the transition actor or `"anonymous"`, and a compact receipt. `receipt.status` is `"OK"`, `"FAILED"`, or `"PARTIAL"` based on the aggregate result.
 
 `guidancePointer` (string or null) is the guidance text for the first unfilled required note in the **new** role. It is null when no schema matches, no required notes exist for the new role, or all required notes are already filled. Omitted from the response when null.
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/DopemuxProofEnvelope.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/DopemuxProofEnvelope.kt
@@ -1,0 +1,33 @@
+package io.github.jpicklyk.mcptask.current.application.tools
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+private const val DOPEMUX_PROOF_SCHEMA_VERSION = "1"
+private const val DOPEMUX_CANONICAL_WRITER = "task-orchestrator"
+private const val NO_REQUEST_ID = "not-provided"
+private const val NO_ACTOR = "anonymous"
+
+internal fun buildDopemuxProofEnvelope(
+    operation: String,
+    workflowId: String,
+    transition: String,
+    requestId: String?,
+    actorId: String?,
+    status: String
+) = buildJsonObject {
+    put("schema_version", JsonPrimitive(DOPEMUX_PROOF_SCHEMA_VERSION))
+    put("workflow_id", JsonPrimitive(workflowId))
+    put("transition", JsonPrimitive(transition))
+    put("idempotency_key", JsonPrimitive(requestId?.takeIf { it.isNotBlank() } ?: NO_REQUEST_ID))
+    put("actor", JsonPrimitive(actorId?.takeIf { it.isNotBlank() } ?: NO_ACTOR))
+    put("canonical_writer", JsonPrimitive(DOPEMUX_CANONICAL_WRITER))
+    put(
+        "receipt",
+        buildJsonObject {
+            put("proof_id", JsonPrimitive("$DOPEMUX_CANONICAL_WRITER:$operation:$workflowId"))
+            put("operation", JsonPrimitive(operation))
+            put("status", JsonPrimitive(status))
+        }
+    )
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt
@@ -2,6 +2,7 @@ package io.github.jpicklyk.mcptask.current.application.tools.compound
 
 import io.github.jpicklyk.mcptask.current.application.service.RoleTransitionHandler
 import io.github.jpicklyk.mcptask.current.application.tools.*
+import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.modelcontextprotocol.kotlin.sdk.types.ToolAnnotations
@@ -279,18 +280,20 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
         // re-acquires the IdempotencyCache lock.
         if (requestId != null && trustedActorId != null) {
             return context.idempotencyCache.getOrCompute(trustedActorId, requestId) {
-                runBlocking { executeCompleteTree(paramsObj, trigger, includeRoot, context) }
+                runBlocking { executeCompleteTree(paramsObj, trigger, includeRoot, context, requestIdStr, trustedActorId) }
             }
         }
 
-        return executeCompleteTree(paramsObj, trigger, includeRoot, context)
+        return executeCompleteTree(paramsObj, trigger, includeRoot, context, requestIdStr, trustedActorId)
     }
 
     private suspend fun executeCompleteTree(
         paramsObj: JsonObject,
         trigger: String,
         includeRoot: Boolean,
-        context: ToolExecutionContext
+        context: ToolExecutionContext,
+        requestIdStr: String?,
+        trustedActorId: String?
     ): JsonElement {
         // Step 1: Collect target items (descendants only) and optionally the root item separately
         val (targetItems, rootItem) = collectTargetItemsWithRoot(paramsObj, context, includeRoot)
@@ -307,6 +310,17 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
                             put("skipped", JsonPrimitive(0))
                             put("gateFailures", JsonPrimitive(0))
                         }
+                    )
+                    put(
+                        "dopemux_proof_envelope",
+                        buildDopemuxProofEnvelope(
+                            operation = name,
+                            workflowId = "none",
+                            transition = "none",
+                            requestId = requestIdStr,
+                            actorId = trustedActorId,
+                            status = "OK"
+                        )
                     )
                 }
             )
@@ -368,6 +382,15 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
         var completedCount = 0
         var skippedCount = 0
         var gateFailureCount = 0
+        var envelopeWorkflowId: String? = null
+        var envelopeTransition: String? = null
+
+        fun rememberEnvelopeSource(item: WorkItem, targetRole: Role) {
+            if (envelopeWorkflowId == null) {
+                envelopeWorkflowId = item.id.toString()
+                envelopeTransition = "${item.role.toJsonString()}->${targetRole.toJsonString()}"
+            }
+        }
 
         for (itemId in sortedOrder) {
             val item = itemById[itemId] ?: continue
@@ -455,6 +478,7 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
             }
 
             completedCount++
+            rememberEnvelopeSource(item, resolution.targetRole)
             resultsList.add(
                 buildJsonObject {
                     put("itemId", JsonPrimitive(itemId.toString()))
@@ -487,7 +511,8 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
                     context,
                     resultsList,
                     onComplete = { completedCount++ },
-                    onSkip = { skippedCount++ }
+                    onSkip = { skippedCount++ },
+                    onApplied = { item, targetRole -> rememberEnvelopeSource(item, targetRole) }
                 )
             }
         }
@@ -505,6 +530,22 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
                         put("gateFailures", JsonPrimitive(gateFailureCount))
                     }
                 )
+                put(
+                    "dopemux_proof_envelope",
+                    buildDopemuxProofEnvelope(
+                        operation = name,
+                        workflowId = envelopeWorkflowId ?: "none",
+                        transition = envelopeTransition ?: "none",
+                        requestId = requestIdStr,
+                        actorId = trustedActorId,
+                        status =
+                            when {
+                                skippedCount == 0 && gateFailureCount == 0 -> "OK"
+                                completedCount == 0 -> "FAILED"
+                                else -> "PARTIAL"
+                            }
+                    )
+                )
             }
 
         return successResponse(data)
@@ -520,7 +561,8 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
         context: ToolExecutionContext,
         resultsList: MutableList<JsonObject>,
         onComplete: () -> Unit,
-        onSkip: () -> Unit
+        onSkip: () -> Unit,
+        onApplied: (WorkItem, Role) -> Unit
     ) {
         val hasReviewPhase = context.resolveHasReviewPhase(item)
         val resolution = handler.resolveTransition(item, trigger, hasReviewPhase)
@@ -566,6 +608,7 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
         }
 
         onComplete()
+        onApplied(item, resolution.targetRole)
         resultsList.add(
             buildJsonObject {
                 put("itemId", JsonPrimitive(item.id.toString()))

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -271,16 +271,17 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
         // repositories and never re-acquires the IdempotencyCache lock.
         if (requestId != null && trustedActorId != null) {
             return context.idempotencyCache.getOrCompute(trustedActorId, requestId) {
-                runBlocking { executeTransitions(transitions, context) }
+                runBlocking { executeTransitions(transitions, context, requestIdStr) }
             }
         }
 
-        return executeTransitions(transitions, context)
+        return executeTransitions(transitions, context, requestIdStr)
     }
 
     private suspend fun executeTransitions(
         transitions: JsonArray,
-        context: ToolExecutionContext
+        context: ToolExecutionContext,
+        requestIdStr: String?
     ): JsonElement {
         val handler = RoleTransitionHandler()
         val cascadeDetector = CascadeDetector()
@@ -289,6 +290,9 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
         val allUnblockedItems = mutableListOf<JsonObject>()
         var successCount = 0
         var failCount = 0
+        var envelopeWorkflowId: String? = null
+        var envelopeTransition: String? = null
+        var envelopeActorId: String? = null
 
         for (element in transitions) {
             val obj = element as JsonObject
@@ -556,6 +560,11 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
             }
 
             successCount++
+            if (envelopeWorkflowId == null) {
+                envelopeWorkflowId = itemId.toString()
+                envelopeTransition = "${previousRole.toJsonString()}->${targetRole.toJsonString()}"
+                envelopeActorId = actorClaim?.id
+            }
 
             // Phase 4: Cascade detection (only when reaching TERMINAL)
             // Uses iterative detect-apply pattern: after applying each cascade,
@@ -789,6 +798,22 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                     }
                 )
                 put("allUnblockedItems", JsonArray(allUnblockedItems))
+                put(
+                    "dopemux_proof_envelope",
+                    buildDopemuxProofEnvelope(
+                        operation = name,
+                        workflowId = envelopeWorkflowId ?: "none",
+                        transition = envelopeTransition ?: "none",
+                        requestId = requestIdStr,
+                        actorId = envelopeActorId,
+                        status =
+                            when {
+                                failCount == 0 -> "OK"
+                                successCount == 0 -> "FAILED"
+                                else -> "PARTIAL"
+                            }
+                    )
+                )
             }
 
         return successResponse(data)

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeToolTest.kt
@@ -134,6 +134,10 @@ class CompleteTreeToolTest {
             assertEquals(0, summary["completed"]!!.jsonPrimitive.int)
             assertEquals(0, summary["skipped"]!!.jsonPrimitive.int)
             assertEquals(0, summary["gateFailures"]!!.jsonPrimitive.int)
+
+            val envelope = data["dopemux_proof_envelope"]!!.jsonObject
+            assertEquals("complete_tree", envelope["receipt"]!!.jsonObject["operation"]!!.jsonPrimitive.content)
+            assertEquals("OK", envelope["receipt"]!!.jsonObject["status"]!!.jsonPrimitive.content)
         }
 
     // ──────────────────────────────────────────────
@@ -169,6 +173,54 @@ class CompleteTreeToolTest {
             assertEquals(1, summary["completed"]!!.jsonPrimitive.int)
             assertEquals(0, summary["skipped"]!!.jsonPrimitive.int)
             assertEquals(0, summary["gateFailures"]!!.jsonPrimitive.int)
+        }
+
+    @Test
+    fun `single item completion response includes dopemux proof envelope`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            val requestId = UUID.randomUUID().toString()
+            val item = makeItem(id = itemId, title = "Simple Item", role = Role.QUEUE)
+
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+            coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+            coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+            every { depRepo.findByToItemId(itemId) } returns emptyList()
+            every { depRepo.findByFromItemId(itemId) } returns emptyList()
+
+            val params =
+                buildJsonObject {
+                    put("requestId", JsonPrimitive(requestId))
+                    put(
+                        "actor",
+                        buildJsonObject {
+                            put("id", JsonPrimitive("operator-1"))
+                            put("kind", JsonPrimitive("orchestrator"))
+                        }
+                    )
+                    put(
+                        "itemIds",
+                        buildJsonArray {
+                            add(JsonPrimitive(itemId.toString()))
+                        }
+                    )
+                    put("trigger", JsonPrimitive("complete"))
+                }
+
+            val result = tool.execute(params, context)
+
+            val envelope = extractData(result)["dopemux_proof_envelope"]!!.jsonObject
+            assertEquals("1", envelope["schema_version"]!!.jsonPrimitive.content)
+            assertEquals(itemId.toString(), envelope["workflow_id"]!!.jsonPrimitive.content)
+            assertEquals("queue->terminal", envelope["transition"]!!.jsonPrimitive.content)
+            assertEquals(requestId, envelope["idempotency_key"]!!.jsonPrimitive.content)
+            assertEquals("operator-1", envelope["actor"]!!.jsonPrimitive.content)
+            assertEquals("task-orchestrator", envelope["canonical_writer"]!!.jsonPrimitive.content)
+
+            val receipt = envelope["receipt"]!!.jsonObject
+            assertEquals("complete_tree", receipt["operation"]!!.jsonPrimitive.content)
+            assertEquals("OK", receipt["status"]!!.jsonPrimitive.content)
+            assertTrue(receipt["proof_id"]!!.jsonPrimitive.content.isNotBlank())
         }
 
     // ──────────────────────────────────────────────
@@ -940,6 +992,10 @@ class CompleteTreeToolTest {
 
             val summary = extractSummary(result)
             assertEquals(1, summary["completed"]!!.jsonPrimitive.int)
+
+            val envelope = extractData(result)["dopemux_proof_envelope"]!!.jsonObject
+            assertEquals(rootId.toString(), envelope["workflow_id"]!!.jsonPrimitive.content)
+            assertEquals("queue->terminal", envelope["transition"]!!.jsonPrimitive.content)
         }
 
     // ──────────────────────────────────────────────

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
@@ -145,6 +145,58 @@ class AdvanceItemToolTest {
             assertEquals(0, summary["failed"]!!.jsonPrimitive.int)
         }
 
+    @Test
+    fun `start transition response includes dopemux proof envelope`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            val requestId = UUID.randomUUID().toString()
+            val item = makeItem(id = itemId, role = Role.QUEUE)
+
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+            coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+            coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+            every { depRepo.findByToItemId(itemId) } returns emptyList()
+            every { depRepo.findByFromItemId(itemId) } returns emptyList()
+
+            val params =
+                buildJsonObject {
+                    put("requestId", JsonPrimitive(requestId))
+                    put(
+                        "transitions",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("itemId", JsonPrimitive(itemId.toString()))
+                                    put("trigger", JsonPrimitive("start"))
+                                    put(
+                                        "actor",
+                                        buildJsonObject {
+                                            put("id", JsonPrimitive("operator-1"))
+                                            put("kind", JsonPrimitive("orchestrator"))
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
+
+            val result = tool.execute(params, context)
+
+            val envelope = extractData(result)["dopemux_proof_envelope"]!!.jsonObject
+            assertEquals("1", envelope["schema_version"]!!.jsonPrimitive.content)
+            assertEquals(itemId.toString(), envelope["workflow_id"]!!.jsonPrimitive.content)
+            assertEquals("queue->work", envelope["transition"]!!.jsonPrimitive.content)
+            assertEquals(requestId, envelope["idempotency_key"]!!.jsonPrimitive.content)
+            assertEquals("operator-1", envelope["actor"]!!.jsonPrimitive.content)
+            assertEquals("task-orchestrator", envelope["canonical_writer"]!!.jsonPrimitive.content)
+
+            val receipt = envelope["receipt"]!!.jsonObject
+            assertEquals("advance_item", receipt["operation"]!!.jsonPrimitive.content)
+            assertEquals("OK", receipt["status"]!!.jsonPrimitive.content)
+            assertTrue(receipt["proof_id"]!!.jsonPrimitive.content.isNotBlank())
+        }
+
     // ──────────────────────────────────────────────
     // 2. Single complete transition QUEUE -> TERMINAL
     // ──────────────────────────────────────────────

--- a/proof/TP-DMX-ORCH-014A-UPSTREAM/PROOF.json
+++ b/proof/TP-DMX-ORCH-014A-UPSTREAM/PROOF.json
@@ -1,0 +1,75 @@
+{
+  "packet_id": "TP-DMX-ORCH-014A-UPSTREAM",
+  "project": "task-orchestrator",
+  "repo": "https://github.com/jpicklyk/task-orchestrator.git",
+  "branch": "feat/dopemux-transition-proof-envelope",
+  "base": "origin/main@20f2a9a9207b63e4ff1d70272377c589f954c50f",
+  "status": "READY_FOR_REVIEW_WITH_DETEKT_BLOCKED",
+  "authority_conflicts": [
+    {
+      "observed": "Live upstream source root is current/src/main/kotlin/io/github/jpicklyk/mcptask/current/...",
+      "packet": "Task packet allowlist references current/src/main/kotlin/com/jpicklyk/taskorchestrator/...",
+      "resolution": "Implemented against live runtime paths after inspecting upstream AGENTS.md, CLAUDE.md, source, and tests."
+    },
+    {
+      "observed": "No artifacts/ directory exists in the upstream checkout.",
+      "packet": "Task packet references artifacts/repo-truth-pack/MCP_TOOL_SCHEMAS/task-orchestrator-tools.json.",
+      "resolution": "Did not invent a generated artifact path; documented validation result here instead."
+    }
+  ],
+  "changes": [
+    "Added dopemux_proof_envelope to advance_item responses.",
+    "Added dopemux_proof_envelope to complete_tree responses, including empty successful calls and root-only completions.",
+    "Added focused unit coverage for advance_item, complete_tree, empty complete_tree, and root-only complete_tree envelope paths.",
+    "Documented the additive response field in current/docs/api-reference.md and CHANGELOG.md."
+  ],
+  "validations": [
+    {
+      "command": "sh ./gradlew :current:test --tests \"io.github.jpicklyk.mcptask.current.application.tools.workflow.AdvanceItemToolTest.start transition response includes dopemux proof envelope\" --tests \"io.github.jpicklyk.mcptask.current.application.tools.compound.CompleteTreeToolTest.single item completion response includes dopemux proof envelope\"",
+      "exit_code": 1,
+      "result": "PASS_AS_RED",
+      "evidence": "Tests failed before implementation because dopemux_proof_envelope was absent."
+    },
+    {
+      "command": "sh ./gradlew :current:test --tests \"io.github.jpicklyk.mcptask.current.application.tools.workflow.AdvanceItemToolTest.start transition response includes dopemux proof envelope\" --tests \"io.github.jpicklyk.mcptask.current.application.tools.compound.CompleteTreeToolTest.single item completion response includes dopemux proof envelope\" --tests \"io.github.jpicklyk.mcptask.current.application.tools.compound.CompleteTreeToolTest.empty item list returns empty results\" --tests \"io.github.jpicklyk.mcptask.current.application.tools.compound.CompleteTreeToolTest.rootId with no descendants still processes root when includeRoot=true\"",
+      "exit_code": 0,
+      "result": "PASS",
+      "evidence": "Focused envelope tests passed."
+    },
+    {
+      "command": "sh ./gradlew :current:compileKotlin",
+      "exit_code": 0,
+      "result": "PASS",
+      "evidence": "BUILD SUCCESSFUL."
+    },
+    {
+      "command": "sh ./gradlew :current:test",
+      "exit_code": 0,
+      "result": "PASS",
+      "evidence": "BUILD SUCCESSFUL; 2281 tests completed."
+    },
+    {
+      "command": "sh ./gradlew detekt",
+      "exit_code": 1,
+      "result": "NOT_RUN",
+      "evidence": "Gradle reported: Task 'detekt' not found in root project 'task-orchestrator' and its subprojects."
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "result": "PASS",
+      "evidence": "No whitespace errors."
+    },
+    {
+      "command": "rg --files -g '.pre-commit-config.yaml' -g '.pre-commit-config.yml' -g 'pre-commit-config.yaml' -g 'pre-commit-config.yml'",
+      "exit_code": 1,
+      "result": "NOT_RUN",
+      "evidence": "No pre-commit config found in this checkout."
+    }
+  ],
+  "residual_risks": [
+    "No detekt task is wired in the live Gradle project, so the packet detekt validation could not execute.",
+    "The proof envelope is additive and unit-tested, but not exercised through an end-to-end MCP client in this run.",
+    "The packet allowlist and schema artifact paths appear stale relative to upstream runtime truth."
+  ]
+}


### PR DESCRIPTION
## Summary
- Add additive `dopemux_proof_envelope` metadata to `advance_item` and `complete_tree` responses.
- Cover `advance_item`, `complete_tree`, empty `complete_tree`, and root-only `complete_tree` envelope paths.
- Document the response field in the API reference, changelog, and packet proof bundle.

## Validation
- PASS: `sh ./gradlew :current:compileKotlin`
- PASS: `sh ./gradlew :current:test` (2,281 tests)
- PASS: `git diff --check`
- PASS: `jq . proof/TP-DMX-ORCH-014A-UPSTREAM/PROOF.json >/dev/null`
- NOT_RUN: `sh ./gradlew detekt` because Gradle reports `Task 'detekt' not found in root project 'task-orchestrator' and its subprojects.`
- NOT_RUN: pre-commit hook execution because no `.pre-commit-config.yaml` or `.pre-commit-config.yml` exists in this checkout.

## Authority Notes
- The Dopemux task packet referenced stale `com/jpicklyk/taskorchestrator/...` paths; live upstream source uses `io/github/jpicklyk/mcptask/current/...`, so this implementation follows live runtime source and tests.
- The packet referenced an `artifacts/` schema path that does not exist in this checkout; no generated artifact path was invented.
