### PR TITLE
feat(create_work_tree): attach mode via root.id (root.title optional)

### DIFF
--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -364,14 +364,19 @@ Nullable fields (`parentId`, `statusLabel`, `tags`, `type`) are omitted when nul
 between them, and optional blank notes — all in a single call. Eliminates the round-trips required
 when calling `manage_items`, `manage_dependencies`, and `manage_notes` separately.
 
+**Attach mode.** Pass `root.id` (UUID or hex prefix of an existing item) instead of `root.title` to
+attach children, deps, and notes directly to an existing item. When `root.id` is provided, `root.title`
+is optional (ignored if both are given). The existing item is NOT re-inserted; children are created
+under it at `existing.depth + 1`. Providing both `root.id` and `parentId` is rejected with `VALIDATION_ERROR`.
+
 **Operations.** Single operation (no `operation` parameter).
 
 #### Key Parameters
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `root` | object | Yes | Root item spec: `{ title, priority?, tags?, type?, traits?, summary?, description?, requiresVerification? }` |
-| `parentId` | string (UUID) | No | Existing parent; root depth = parent.depth + 1 |
+| `root` | object | Yes | Create mode: `{ title (required), priority?, tags?, type?, traits?, summary?, description?, requiresVerification? }`. Attach mode: `{ id? (UUID or hex prefix of existing item), title? (optional when id provided), priority?, tags?, type?, traits?, summary?, description?, requiresVerification? }`. When `id` is present, `title` is optional and ignored. |
+| `parentId` | string (UUID) | No | Existing parent; root depth = parent.depth + 1. Cannot be combined with `root.id`. |
 | `children` | array | No | Child item specs: `[{ ref, title, priority?, tags?, type?, traits?, summary?, description?, requiresVerification? }]`. `ref` is a local name used in `deps`. |
 | `deps` | array | No | Dependency specs: `[{ from: ref, to: ref, type?: BLOCKS\|IS_BLOCKED_BY\|RELATES_TO, unblockAt?: queue\|work\|review\|terminal }]`. Use `"root"` to reference the root item. |
 | `createNotes` | boolean | No | Auto-create blank notes for each item from its resolved schema (looked up by `type` first, then by `tags`). Default: false. |
@@ -379,7 +384,7 @@ when calling `manage_items`, `manage_dependencies`, and `manage_notes` separatel
 | `actor` | object | No | Actor claim `{ id, kind: orchestrator\|subagent\|user\|external, parent?, proof? }`. Used for idempotency keying AND propagated as the actor attribution on every persisted note (both explicit and `createNotes=true` blanks). |
 | `requestId` | string (UUID) | No | Client-generated UUID for idempotency. See [Idempotency](#idempotency). Requires `actor` to function. |
 
-Nesting depth is unbounded. The root item can be at any depth; children are always root.depth + 1. Cycle protection is enforced at the database level.
+Nesting depth is unbounded. The root item can be at any depth; children are always root.depth + 1. In attach mode, children derive depth from the existing root's depth. Cycle protection is enforced at the database level.
 
 **Example.**
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
@@ -36,13 +36,15 @@ class CreateWorkTreeTool :
         """
 Atomically create a hierarchical work tree: root item, child items, dependencies, and optional notes.
 
+**Attach mode:** Pass `root.id` (UUID or hex prefix of an existing item) to attach children/deps/notes directly to an existing item instead of creating a new root. When `root.id` is provided, `root.title` is optional (ignored if both are given). Providing both `root.id` and `parentId` is rejected (contradictory). The existing item is NOT re-inserted; children are created under it at existing.depth+1.
+
 **Idempotency:** Pass `requestId` (client-generated UUID) together with a top-level `actor.id` to enable idempotent retries. Repeated calls with the same (actor, requestId) within ~10 minutes return the cached response without re-executing.
 
 **Actor attribution:** A single top-level `actor` is applied to **every** persisted note in the tree (both explicit `notes` entries and `createNotes=true` schema blanks). This differs from `manage_notes`, which accepts a per-note `actor` block. If the top-level `actor` is malformed (e.g., missing `kind`), idempotency is disabled and attribution is dropped to `null` on each note — the call still proceeds and items/notes are created without an audit identity.
 
 **Parameters:**
-- `root` (required): Root item spec `{ title (required), priority?, tags?, traits?, summary?, description?, requiresVerification?, type? }`. `traits` is a comma-separated string of trait keys merged into properties.
-- `parentId` (optional): UUID of existing parent item. If provided, root depth = parent.depth + 1; otherwise depth = 0.
+- `root` (required): Root item spec. In create mode: `{ title (required), priority?, tags?, traits?, summary?, description?, requiresVerification?, type? }`. In attach mode: `{ id? (UUID or hex prefix of existing item), title? (optional, ignored when id is provided), priority?, tags?, traits?, summary?, description?, requiresVerification?, type? }`. `traits` is a comma-separated string of trait keys merged into properties.
+- `parentId` (optional): UUID of existing parent item. If provided, root depth = parent.depth + 1; otherwise depth = 0. Cannot be combined with `root.id`.
 - `children` (optional): Array of child item specs `[{ ref (required), title (required), parentRef (optional, defaults to "root"), priority?, tags?, traits?, summary?, description?, requiresVerification?, type? }]`. `ref` is a local name used in `deps` to wire dependencies. `parentRef` specifies this child's parent: either `"root"` or another child's `ref`. Children can be provided in any order; a topological sort ensures parents are created before children. Item specs must NOT embed their own nested `children` array — express nesting via this flat array plus `parentRef`; a nested `children` key is rejected with a validation error rather than silently dropped.
 - `deps` (optional): Array of dependency specs `[{ from: ref, to: ref, type?: BLOCKS|IS_BLOCKED_BY|RELATES_TO, unblockAt?: queue|work|review|terminal }]`. Use `"root"` to reference the root item.
 - `createNotes` (optional, default false): Auto-create blank notes for each item based on its resolved schema (looked up by `type` first, then by `tags`).
@@ -50,7 +52,7 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
 - `actor` (optional): Actor claim `{ id (required), kind (required: orchestrator|subagent|user|external), parent?, proof? }`. See **Idempotency** and **Actor attribution** above for the two effects.
 - `requestId` (optional): Client-generated UUID. With `actor`, enables idempotent retries (see Idempotency above).
 
-**Depth:** Root depth = parent.depth + 1 when parentId is provided, otherwise 0. Children's depth = their parent's depth + 1 (root or sibling via parentRef). No application-layer depth cap; cycle protection is enforced by the database.
+**Depth:** Root depth = parent.depth + 1 when parentId is provided, otherwise 0. In attach mode, children's depth derives from the existing root item's depth. Children's depth = their parent's depth + 1 (root or sibling via parentRef). No application-layer depth cap; cycle protection is enforced by the database.
 
 **Response:**
 ```json
@@ -92,8 +94,11 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                             put(
                                 "description",
                                 JsonPrimitive(
-                                    "Root item spec: { title (required), priority?, tags?, traits?, summary?, " +
+                                    "Root item spec. Create mode: { title (required), priority?, tags?, traits?, summary?, " +
                                         "description?, requiresVerification?, type? }. " +
+                                        "Attach mode: { id? (UUID or hex prefix of existing item), title? (optional when id provided), " +
+                                        "priority?, tags?, traits?, summary?, description?, requiresVerification?, type? }. " +
+                                        "When id is present, title is optional and ignored if both are given. " +
                                         "traits is a comma-separated string of trait keys merged into properties."
                                 )
                             )
@@ -223,10 +228,30 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
         val rootObj =
             rootElement as? JsonObject
                 ?: throw ToolValidationException("'root' must be a JSON object")
+
+        val rootId = (rootObj["id"] as? JsonPrimitive)?.takeIf { it.isString }?.content
         val rootTitle = (rootObj["title"] as? JsonPrimitive)?.takeIf { it.isString }?.content
-        if (rootTitle.isNullOrBlank()) {
-            throw ToolValidationException("'root.title' is required and must be a non-blank string")
+
+        if (rootId != null && !rootId.isBlank()) {
+            // Attach mode: root.id provided — root.title is optional.
+            // Reject root.id combined with parentId (contradictory: attach vs new-root-under-parent).
+            val parentIdElement = paramsObj["parentId"]
+            if (parentIdElement != null && parentIdElement !is JsonNull) {
+                val parentIdStr = (parentIdElement as? JsonPrimitive)?.takeIf { it.isString }?.content
+                if (!parentIdStr.isNullOrBlank()) {
+                    throw ToolValidationException(
+                        "'root.id' and 'parentId' cannot both be provided: 'root.id' attaches to an existing " +
+                            "item (which already has its own parent), while 'parentId' creates a new root under a parent."
+                    )
+                }
+            }
+        } else {
+            // Create mode: root.title is required.
+            if (rootTitle.isNullOrBlank()) {
+                throw ToolValidationException("'root.title' is required and must be a non-blank string")
+            }
         }
+
         rejectNestedChildren(rootObj, "root")
 
         // Validate children if provided
@@ -409,34 +434,60 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
         noteActorClaim: ActorClaim?,
         noteVerification: VerificationResult?
     ): JsonElement {
-        // ── 1. Parse parentId (optional) ──────────────────────────────────────
+        // ── 1. Detect mode: attach (root.id present) vs create ────────────────
+        val rootObj = paramsObj["root"] as JsonObject
+        val rootIdStr = (rootObj["id"] as? JsonPrimitive)?.takeIf { it.isString }?.content?.takeIf { it.isNotBlank() }
+        val isAttachMode = rootIdStr != null
+
+        // ── 2. Parse parentId (only valid in create mode) ────────────────────
+        //   validateParams already rejects root.id + parentId together, so if we
+        //   reach here in attach mode, parentId is absent.
         val (parentId, parentIdError) = resolveItemId(params, "parentId", context, required = false)
         if (parentIdError != null) return parentIdError
 
-        // ── 2. Compute root depth from parent ──────────────────────────────────
-        val rootDepth =
-            if (parentId != null) {
-                val parentResult = context.workItemRepository().getById(parentId)
-                when (parentResult) {
-                    is Result.Success -> parentResult.data.depth + 1
-                    is Result.Error -> return errorResponse(
-                        "Parent item '$parentId' not found: ${parentResult.error.message}",
-                        ErrorCodes.RESOURCE_NOT_FOUND
-                    )
-                }
-            } else {
-                0
-            }
+        // ── 3. Resolve root (attach mode: fetch existing; create mode: build new) ──
+        val rootItem: WorkItem
+        val isExistingRoot: Boolean
 
-        // ── 3. Parse root ──────────────────────────────────────────────────────
-        val rootObj = paramsObj["root"] as JsonObject
-        val rootItem =
-            buildWorkItem(
-                obj = rootObj,
-                parentId = parentId,
-                depth = rootDepth,
-                contextLabel = "root"
-            ) ?: return errorResponse("Failed to build root item", ErrorCodes.VALIDATION_ERROR)
+        if (isAttachMode) {
+            // Resolve the existing item via id (supports hex prefix like parentId)
+            val (resolvedRootId, rootIdError) = resolveIdString(rootIdStr!!, context)
+            if (rootIdError != null) return rootIdError
+            val fetchResult = context.workItemRepository().getById(resolvedRootId!!)
+            when (fetchResult) {
+                is Result.Success -> {
+                    rootItem = fetchResult.data
+                    isExistingRoot = true
+                }
+                is Result.Error -> return errorResponse(
+                    "Root item '$rootIdStr' not found: ${fetchResult.error.message}",
+                    ErrorCodes.RESOURCE_NOT_FOUND
+                )
+            }
+        } else {
+            // Create mode: compute root depth from parent, then build a new WorkItem.
+            val rootDepth =
+                if (parentId != null) {
+                    val parentResult = context.workItemRepository().getById(parentId)
+                    when (parentResult) {
+                        is Result.Success -> parentResult.data.depth + 1
+                        is Result.Error -> return errorResponse(
+                            "Parent item '$parentId' not found: ${parentResult.error.message}",
+                            ErrorCodes.RESOURCE_NOT_FOUND
+                        )
+                    }
+                } else {
+                    0
+                }
+            rootItem =
+                buildWorkItem(
+                    obj = rootObj,
+                    parentId = parentId,
+                    depth = rootDepth,
+                    contextLabel = "root"
+                ) ?: return errorResponse("Failed to build root item", ErrorCodes.VALIDATION_ERROR)
+            isExistingRoot = false
+        }
 
         // ── 4. Parse children ──────────────────────────────────────────────────
         val childrenArray = paramsObj["children"] as? JsonArray ?: JsonArray(emptyList())
@@ -629,8 +680,13 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
             }
         }
 
-        // ── 7. Build ordered item list (root first, children in topological order) ─
-        val orderedItems = mutableListOf(rootItem)
+        // ── 7. Build ordered item list ────────────────────────────────────────
+        // In attach mode the existing root is NOT inserted (it already exists in the DB).
+        // In create mode the root leads the list (root first, children in topological order).
+        val orderedItems = mutableListOf<WorkItem>()
+        if (!isExistingRoot) {
+            orderedItems.add(rootItem)
+        }
         for (ref in sortedChildRefs) {
             orderedItems.add(refToItem[ref]!!)
         }
@@ -658,7 +714,9 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
         // Build ref-to-result-item map for note lookup
         val idToRef = treeResult.refToId.entries.associate { (ref, id) -> id to ref }
 
-        val rootResultItem = treeResult.items.first()
+        // In attach mode the root was not inserted — use the fetched existing item for the response.
+        // In create mode the root is treeResult.items.first().
+        val rootResultItem = if (isExistingRoot) rootItem else treeResult.items.first()
         val rootSchemaFields = buildSchemaResponseFields(context.resolveSchema(rootResultItem))
         val rootJson =
             buildJsonObject {
@@ -671,9 +729,12 @@ Atomically create a hierarchical work tree: root item, child items, dependencies
                 put("expectedNotes", rootSchemaFields.expectedNotes)
             }
 
+        // In attach mode treeResult.items contains only children.
+        // In create mode children start at index 1 (after the root).
+        val childItems = if (isExistingRoot) treeResult.items else treeResult.items.drop(1)
         val childrenJson =
             JsonArray(
-                treeResult.items.drop(1).map { item ->
+                childItems.map { item ->
                     val ref = idToRef[item.id] ?: "unknown"
                     val childSchemaFields = buildSchemaResponseFields(context.resolveSchema(item))
                     buildJsonObject {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/service/SQLiteWorkTreeService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/service/SQLiteWorkTreeService.kt
@@ -15,7 +15,6 @@ import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteNoteRe
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteWorkItemRepository
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
-import java.util.UUID
 
 /**
  * Infrastructure-layer implementation of [WorkTreeExecutor].
@@ -32,10 +31,15 @@ class SQLiteWorkTreeService(
     override suspend fun execute(input: WorkTreeInput): WorkTreeResult =
         suspendTransaction(db = databaseManager.getDatabase()) {
             val createdItems = mutableListOf<WorkItem>()
-            val refToId = mutableMapOf<String, UUID>()
             val itemIdToRef = input.refToItem.entries.associate { (ref, item) -> item.id to ref }
 
-            // 1. Insert all WorkItems via shared helper (no inner transaction)
+            // Seed refToId from ALL refs in refToItem (existing + to-be-created) so that
+            // dependency resolution can reference a pre-existing root (attach mode) before
+            // any inserts happen. In normal create mode this is a no-op superset of the
+            // per-insert population below — all refToItem entries are also in items.
+            val refToId = input.refToItem.mapValuesTo(mutableMapOf()) { (_, item) -> item.id }
+
+            // 1. Insert WorkItems that are in input.items (children in attach mode; all in create mode)
             for (item in input.items) {
                 val insertResult = workItemRepo.insertRow(item)
                 if (insertResult is Result.Error) {

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolIntegrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolIntegrationTest.kt
@@ -250,6 +250,153 @@ class CreateWorkTreeToolIntegrationTest {
         }
 
     // ──────────────────────────────────────────────────────────────────────────
+    // Attach mode: children created under existing item, root not re-inserted,
+    // dep root→child resolves to existing id, note on root binds to existing id
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `attach mode - children created under existing item at correct depth`(): Unit =
+        runBlocking {
+            // 1. Create an existing item at depth 0 that will become the attach root
+            val existingItemParams =
+                buildJsonObject {
+                    put(
+                        "root",
+                        buildJsonObject {
+                            put("title", JsonPrimitive("Existing Feature Root"))
+                        }
+                    )
+                }
+            val createResult = tool.execute(existingItemParams, context) as JsonObject
+            assertTrue(createResult["success"]!!.jsonPrimitive.boolean, "Pre-create should succeed: $createResult")
+            val existingRootId =
+                UUID.fromString(
+                    (createResult["data"] as JsonObject)["root"]!!.jsonObject["id"]!!.jsonPrimitive.content
+                )
+            val existingRoot = (workItemRepository.getById(existingRootId) as Result.Success).data
+            assertEquals(0, existingRoot.depth, "Pre-created root should be at depth 0")
+
+            // 2. Attach two children + a dep (root→c1) + a note on root
+            val attachParams =
+                buildJsonObject {
+                    put("root", buildJsonObject { put("id", JsonPrimitive(existingRootId.toString())) })
+                    put(
+                        "children",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("ref", JsonPrimitive("c1"))
+                                    put("title", JsonPrimitive("Attach Child One"))
+                                }
+                            )
+                            add(
+                                buildJsonObject {
+                                    put("ref", JsonPrimitive("c2"))
+                                    put("title", JsonPrimitive("Attach Child Two"))
+                                }
+                            )
+                        }
+                    )
+                    put(
+                        "deps",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("from", JsonPrimitive("root"))
+                                    put("to", JsonPrimitive("c1"))
+                                    put("type", JsonPrimitive("BLOCKS"))
+                                }
+                            )
+                        }
+                    )
+                    put(
+                        "notes",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("itemRef", JsonPrimitive("root"))
+                                    put("key", JsonPrimitive("attach-note"))
+                                    put("role", JsonPrimitive("queue"))
+                                    put("body", JsonPrimitive("note on existing root"))
+                                }
+                            )
+                        }
+                    )
+                }
+            val attachResult = tool.execute(attachParams, context) as JsonObject
+            assertTrue(attachResult["success"]!!.jsonPrimitive.boolean, "Attach should succeed: $attachResult")
+
+            val data = attachResult["data"] as JsonObject
+
+            // Response root reflects the existing item
+            val rootJson = data["root"] as JsonObject
+            assertEquals(existingRootId.toString(), rootJson["id"]!!.jsonPrimitive.content)
+            assertEquals("Existing Feature Root", rootJson["title"]!!.jsonPrimitive.content)
+            assertEquals(0, rootJson["depth"]!!.jsonPrimitive.int)
+
+            // Children are at depth 1 (existing.depth 0 + 1)
+            val childrenArr = data["children"] as JsonArray
+            assertEquals(2, childrenArr.size)
+            val c1Id = UUID.fromString(childrenArr[0].jsonObject["id"]!!.jsonPrimitive.content)
+            val c2Id = UUID.fromString(childrenArr[1].jsonObject["id"]!!.jsonPrimitive.content)
+
+            val c1 = (workItemRepository.getById(c1Id) as Result.Success).data
+            val c2 = (workItemRepository.getById(c2Id) as Result.Success).data
+            assertEquals(1, c1.depth, "c1 should be at depth 1")
+            assertEquals(1, c2.depth, "c2 should be at depth 1")
+            assertEquals(existingRootId, c1.parentId, "c1 parent should be the existing root")
+            assertEquals(existingRootId, c2.parentId, "c2 parent should be the existing root")
+
+            // Existing root is NOT duplicated in DB (still exactly 1 item with that id)
+            val rootRefetch = workItemRepository.getById(existingRootId)
+            assertTrue(rootRefetch is Result.Success, "Existing root should still be fetchable after attach")
+
+            // Dep root→c1 resolves to existingRootId
+            val depsArr = data["dependencies"] as JsonArray
+            assertEquals(1, depsArr.size)
+            // The dep was created — verify via response
+            val depJson = depsArr[0].jsonObject
+            assertEquals("root", depJson["fromRef"]!!.jsonPrimitive.content)
+            assertEquals("c1", depJson["toRef"]!!.jsonPrimitive.content)
+
+            // Note on root binds to existingRootId
+            val noteResult = noteRepository.findByItemIdAndKey(existingRootId, "attach-note")
+            assertTrue(noteResult is Result.Success, "Note lookup should succeed")
+            val note = (noteResult as Result.Success).data
+            assertNotNull(note, "Note on root should be in DB")
+            assertEquals(existingRootId, note.itemId, "Note must be bound to the existing root")
+            assertEquals("note on existing root", note.body)
+        }
+
+    @Test
+    fun `attach mode - root id not found returns RESOURCE_NOT_FOUND error`(): Unit =
+        runBlocking {
+            val missingId = UUID.randomUUID()
+            val params =
+                buildJsonObject {
+                    put("root", buildJsonObject { put("id", JsonPrimitive(missingId.toString())) })
+                    put(
+                        "children",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("ref", JsonPrimitive("c1"))
+                                    put("title", JsonPrimitive("Should Not Create"))
+                                }
+                            )
+                        }
+                    )
+                }
+            val result = tool.execute(params, context) as JsonObject
+            assertEquals(false, result["success"]!!.jsonPrimitive.boolean, "Expected failure for missing root.id: $result")
+            val errorMsg = result["error"]!!.jsonObject["message"]!!.jsonPrimitive.content
+            assertTrue(
+                errorMsg.contains("not found") || errorMsg.contains(missingId.toString()),
+                "Error should mention the missing id: $errorMsg"
+            )
+        }
+
+    // ──────────────────────────────────────────────────────────────────────────
     // Top-level actor attribution persists on the DB row for every note
     //
     // Verifies the audit trail is intact end-to-end: actor.id, actor.kind, and

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolTest.kt
@@ -2499,4 +2499,203 @@ class CreateWorkTreeToolTest {
             }
         }
     }
+
+    // ──────────────────────────────────────────────
+    // Attach mode: validateParams tests
+    // ──────────────────────────────────────────────
+
+    @Nested
+    inner class AttachModeValidateParamsTests {
+        @Test
+        fun `root with id and no title does NOT throw (attach mode)`() {
+            // Should not throw — root.id present makes root.title optional
+            tool.validateParams(
+                buildJsonObject {
+                    put(
+                        "root",
+                        buildJsonObject {
+                            put("id", JsonPrimitive("8409074f-aca8-45be-b258-3550a4d069c4"))
+                            // title intentionally absent
+                        }
+                    )
+                }
+            )
+        }
+
+        @Test
+        fun `root with id and title does NOT throw (id wins, title ignored)`() {
+            // Both present is allowed — id takes precedence, title is ignored
+            tool.validateParams(
+                buildJsonObject {
+                    put(
+                        "root",
+                        buildJsonObject {
+                            put("id", JsonPrimitive("8409074f-aca8-45be-b258-3550a4d069c4"))
+                            put("title", JsonPrimitive("This title will be ignored"))
+                        }
+                    )
+                }
+            )
+        }
+
+        @Test
+        fun `root with neither id nor title throws ToolValidationException`() {
+            val ex =
+                assertFailsWith<ToolValidationException> {
+                    tool.validateParams(
+                        buildJsonObject {
+                            put(
+                                "root",
+                                buildJsonObject {
+                                    put("description", JsonPrimitive("no id and no title"))
+                                }
+                            )
+                        }
+                    )
+                }
+            assertTrue(
+                ex.message?.contains("root.title") == true || ex.message?.contains("required") == true,
+                "Exception should mention that title is required: ${ex.message}"
+            )
+        }
+
+        @Test
+        fun `root id with blank string falls through to title-required path`() {
+            // A blank id string is treated the same as absent id
+            val ex =
+                assertFailsWith<ToolValidationException> {
+                    tool.validateParams(
+                        buildJsonObject {
+                            put(
+                                "root",
+                                buildJsonObject {
+                                    put("id", JsonPrimitive("   ")) // blank
+                                    // title absent
+                                }
+                            )
+                        }
+                    )
+                }
+            assertTrue(
+                ex.message?.contains("root.title") == true || ex.message?.contains("required") == true,
+                "Blank id should fall through to title-required path: ${ex.message}"
+            )
+        }
+
+        @Test
+        fun `root id combined with parentId throws ToolValidationException`() {
+            val ex =
+                assertFailsWith<ToolValidationException> {
+                    tool.validateParams(
+                        buildJsonObject {
+                            put(
+                                "root",
+                                buildJsonObject {
+                                    put("id", JsonPrimitive("8409074f-aca8-45be-b258-3550a4d069c4"))
+                                }
+                            )
+                            put("parentId", JsonPrimitive(UUID.randomUUID().toString()))
+                        }
+                    )
+                }
+            assertTrue(
+                ex.message?.contains("root.id") == true && ex.message?.contains("parentId") == true,
+                "Exception should mention both root.id and parentId: ${ex.message}"
+            )
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // Attach mode: execute tests (unit / MockK)
+    // ──────────────────────────────────────────────
+
+    @Nested
+    inner class AttachModeExecuteTests {
+        @Test
+        fun `attach mode - existing root resolved and children depth derives from it`(): Unit =
+            runBlocking {
+                val existingRootId = UUID.randomUUID()
+                val existingRoot =
+                    WorkItem(
+                        id = existingRootId,
+                        title = "Existing Root at Depth 2",
+                        depth = 2,
+                        parentId = UUID.randomUUID()
+                    )
+                coEvery { workItemRepo.getById(existingRootId) } returns Result.Success(existingRoot)
+
+                var capturedInput: WorkTreeInput? = null
+                coEvery { mockExecutor.execute(any()) } answers {
+                    val input = firstArg<WorkTreeInput>()
+                    capturedInput = input
+                    // In attach mode items only contains children — reflect them back
+                    val refToId = input.refToItem.mapValues { (_, item) -> item.id }
+                    WorkTreeResult(
+                        items = input.items,
+                        refToId = refToId,
+                        deps = emptyList(),
+                        notes = emptyList()
+                    )
+                }
+
+                val params =
+                    buildJsonObject {
+                        put("root", buildJsonObject { put("id", JsonPrimitive(existingRootId.toString())) })
+                        put(
+                            "children",
+                            buildJsonArray {
+                                add(makeChildSpec("c1", "Child One"))
+                                add(makeChildSpec("c2", "Child Two"))
+                            }
+                        )
+                    }
+                val result = tool.execute(params, context)
+                val data = extractData(result)
+
+                // Response root reflects the existing item
+                val rootJson = data["root"]!!.jsonObject
+                assertEquals(existingRootId.toString(), rootJson["id"]!!.jsonPrimitive.content)
+                assertEquals("Existing Root at Depth 2", rootJson["title"]!!.jsonPrimitive.content)
+                assertEquals(2, rootJson["depth"]!!.jsonPrimitive.int)
+
+                // Children are at depth 3 (existingRoot.depth + 1 = 3)
+                val childrenArr = data["children"]!!.jsonArray
+                assertEquals(2, childrenArr.size)
+                assertEquals(3, childrenArr[0].jsonObject["depth"]!!.jsonPrimitive.int)
+                assertEquals(3, childrenArr[1].jsonObject["depth"]!!.jsonPrimitive.int)
+
+                // The existing root is NOT in input.items (only children)
+                val input = capturedInput!!
+                assertEquals(2, input.items.size, "Only children should be in items-to-insert in attach mode")
+                assertTrue(
+                    input.items.none { it.id == existingRootId },
+                    "Existing root must NOT be in the items-to-insert list"
+                )
+
+                // refToItem contains the existing root so deps can reference it
+                assertEquals(existingRoot, input.refToItem[CreateWorkTreeTool.ROOT_REF])
+            }
+
+        @Test
+        fun `attach mode - missing root id returns RESOURCE_NOT_FOUND error`(): Unit =
+            runBlocking {
+                val missingId = UUID.randomUUID()
+                coEvery { workItemRepo.getById(missingId) } returns
+                    Result.Error(RepositoryError.NotFound(missingId, "WorkItem not found"))
+
+                val params =
+                    buildJsonObject {
+                        put("root", buildJsonObject { put("id", JsonPrimitive(missingId.toString())) })
+                    }
+                val result = tool.execute(params, context)
+
+                val obj = result as JsonObject
+                assertFalse(obj["success"]!!.jsonPrimitive.boolean)
+                val errorMsg = obj["error"]!!.jsonObject["message"]!!.jsonPrimitive.content
+                assertTrue(
+                    errorMsg.contains("not found") || errorMsg.contains(missingId.toString()),
+                    "Expected not-found error for missing root.id, got: $errorMsg"
+                )
+            }
+    }
 }


### PR DESCRIPTION
## Summary
Fixes `8409074f` — adds **attach mode** to `create_work_tree` via an optional `root.id`.

> ⚠️ **Stacked on #207** (reject nested children). Base is `fix/create-work-tree-reject-nested-children` — merge #207 first; GitHub retargets this to `main` once #207 lands.

Previously `create_work_tree` always created a NEW root and unconditionally required `root.title`. There was no way to add children/deps/notes directly to an existing item (`parentId` only creates a new root *under* the parent).

## What changed
- **`root.id` (optional)** on the root spec = attach mode: an existing item becomes the root; children/deps/notes attach directly to it. `root.title` is optional when `root.id` is given.
- `CreateWorkTreeTool`: conditional title validation; reject `root.id` + `parentId`; resolve the existing item (hex-prefix supported), **exclude it from items-to-create**, children depth = existing depth + 1; `RESOURCE_NOT_FOUND` when the id doesn't resolve.
- `SQLiteWorkTreeService`: seed `refToId` from `refToItem` before the insert loop (backward-compatible superset) so deps referencing the pre-existing root resolve.
- Docs: `api-reference.md` + `parameterSchema`/`description` document `root.id`.

## Tests
- Unit (validateParams): id-without-title OK, id+title OK, neither throws, id+parentId throws.
- Integration (H2): attach creates children at `existing.depth+1`, existing root **not duplicated**, dep root→child resolves to the existing id, note on root binds to the existing id, not-found errors.
- Independent review confirmed the `refToId` pre-seed is backward-compatible (bad-ref regression test still fails correctly). `:current:test` + `:current:ktlintCheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)