### PR TITLE
perf(tools): omit no-op verification blocks from attributed note and transition output

### DIFF
--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -540,7 +540,7 @@ Each upsert note element may include an optional `actor` object:
 - `parent` (optional string): ID of the dispatching agent (forms delegation chain)
 - `proof` (optional string): Opaque credential blob (persisted, unused by Stage 1)
 
-When provided, the upsert response includes `actor` and `verification` objects on each successfully upserted note, and the note is persisted with actor claim data that appears in subsequent `query_notes` responses.
+When provided, the upsert response includes an `actor` object on each successfully upserted note, and the note is persisted with actor claim data that appears in subsequent `query_notes` responses. A `verification` object is also included, *except* when no actor verifier is configured (the default `noop` verifier) — in that case `verification` is omitted entirely, since a no-op result carries no information beyond "no verifier is configured." See [Verification Record](#verification-record).
 
 The `(itemId, key)` pair is unique — upserting with an existing pair updates the note in place
 (preserving its UUID).
@@ -920,7 +920,7 @@ Each transition element may include an optional `actor` object:
 - `parent` (optional string): ID of the dispatching agent (forms delegation chain)
 - `proof` (optional string): Opaque credential blob (persisted, unused by Stage 1)
 
-When provided, the response includes `actor` and `verification` objects on each successful transition.
+When provided, the response includes an `actor` object on each successful transition. A `verification` object is also included, *except* when no actor verifier is configured (the default `noop` verifier) — in that case `verification` is omitted entirely. See [Verification Record](#verification-record).
 
 **Ownership enforcement.** When an item has an active (non-expired) claim, `advance_item` enforces ownership on **every** trigger value. The actor (resolved via `degradedModePolicy`) must match the `claimedBy` value on the item. If the item is unclaimed or the claim has expired, any actor can transition it. Cascade transitions (system-generated, parent promotions) are always allowed and bypass ownership checks — they are not reachable via this tool.
 
@@ -1678,7 +1678,16 @@ Actor attribution tracks *who* made changes to work items. Every `advance_item` 
 
 ### Verification Record
 
-Every persisted actor claim includes a verification record:
+Every persisted actor claim includes a verification record.
+
+**Output omission.** MCP tool responses (`manage_notes` upsert, `advance_item` transitions,
+`query_notes` get/list, `get_context` recent transitions) omit the `verification` object
+whenever `verifier == "noop"` — the default when no `actor_authentication.verifier` is
+configured. A no-op result carries no information beyond "no verifier is configured," which is
+a deployment-wide fact repeated on every attributed note and transition, so it is dropped from
+output rather than serialized. The record is still persisted in the database; only the MCP
+response representation omits it. Any other verifier result — including a future verifier that
+legitimately returns `unchecked` with a `reason` — serializes in full.
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/current/docs/workflow-guide.md
+++ b/current/docs/workflow-guide.md
@@ -680,12 +680,12 @@ advance_item(transitions=[{
 }])
 ```
 
-The response echoes the actor claim and includes a verification record:
+The response echoes the actor claim. A `verification` record appears only when a real actor verifier (e.g. JWKS) is configured — with the default no-op verifier the field is omitted entirely:
 
 ```json
 {
   "actor": { "id": "impl-agent", "kind": "subagent", "parent": "orchestrator-1" },
-  "verification": { "status": "unchecked", "verifier": "noop" }
+  "verification": { "status": "verified", "verifier": "jwks" }
 }
 ```
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/EntityJsonSerializers.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/EntityJsonSerializers.kt
@@ -97,7 +97,7 @@ fun Note.toJson(includeBody: Boolean = true): JsonObject =
         put("createdAt", JsonPrimitive(createdAt.toString()))
         put("modifiedAt", JsonPrimitive(modifiedAt.toString()))
         actorClaim?.let { put("actor", it.toJson()) }
-        verification?.let { put("verification", it.toJson()) }
+        verification?.toJsonOrOmit()?.let { put("verification", it) }
     }
 
 // ──────────────────────────────────────────────
@@ -141,3 +141,13 @@ fun VerificationResult.toJson(): JsonObject =
             )
         }
     }
+
+/**
+ * JSON representation of a [VerificationResult] for attributed note/transition output, or
+ * `null` when the result came from a no-op verifier (`verifier == "noop"`). A no-op result
+ * carries no information beyond "no verifier is configured" — a deployment-wide fact repeated
+ * on every attributed note and transition — so it is omitted rather than serialized. Meaningful
+ * results (any other verifier, including a future one that legitimately returns UNCHECKED with
+ * a reason) still serialize in full via [toJson].
+ */
+fun VerificationResult.toJsonOrOmit(): JsonObject? = if (verifier == "noop") null else toJson()

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesTool.kt
@@ -348,7 +348,7 @@ Unified write operations for Notes (upsert, delete).
                                 put("key", JsonPrimitive(result.data.key))
                                 put("role", JsonPrimitive(result.data.role))
                                 actorClaim?.let { put("actor", it.toJson()) }
-                                verification?.let { put("verification", it.toJson()) }
+                                verification?.toJsonOrOmit()?.let { put("verification", it) }
                             }
                         )
                     }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -69,7 +69,7 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
       "trigger": "start",
       "applied": true,
       "actor": { "id": "agent-1", "kind": "subagent", "parent": "orch-1" },
-      "verification": { "status": "unverified", "verifier": "noop" },
+      "verification": { "status": "verified", "verifier": "jwks" },
       "cascadeEvents": [
         { "itemId": "uuid", "title": "Parent Item Title", "previousRole": "work", "targetRole": "terminal", "applied": true }
       ],
@@ -482,7 +482,7 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                     put("applied", JsonPrimitive(true))
                     if (summary != null) put("summary", JsonPrimitive(summary))
                     actorClaim?.let { put("actor", it.toJson()) }
-                    verification?.let { put("verification", it.toJson()) }
+                    verification?.toJsonOrOmit()?.let { put("verification", it) }
                     put("cascadeEvents", JsonArray(cascadeJsonList))
                     put("unblockedItems", JsonArray(unblockedJsonList))
                     put("expectedNotes", expectedNotesJson)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
@@ -378,7 +378,7 @@ Parameters:
                                 put("trigger", JsonPrimitive(t.trigger))
                                 put("at", JsonPrimitive(t.transitionedAt.toString()))
                                 t.actorClaim?.let { put("actor", it.toJson()) }
-                                t.verification?.let { put("verification", it.toJson()) }
+                                t.verification?.toJsonOrOmit()?.let { put("verification", it) }
                             }
                         }
                     )

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/EntityJsonSerializersTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/EntityJsonSerializersTest.kt
@@ -1,0 +1,100 @@
+package io.github.jpicklyk.mcptask.current.application.tools
+
+import io.github.jpicklyk.mcptask.current.domain.model.VerificationResult
+import io.github.jpicklyk.mcptask.current.domain.model.VerificationStatus
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Exhaustive coverage of [VerificationResult.toJsonOrOmit], the shared helper used by all four
+ * emission sites (Note.toJson, ManageNotesTool upsert response, AdvanceItemTool transition
+ * results, GetContextTool recentTransitions) to decide whether a verification block is included.
+ */
+class EntityJsonSerializersTest {
+    @Test
+    fun `toJsonOrOmit returns null for a no-op verifier regardless of status`() {
+        val result = VerificationResult(status = VerificationStatus.UNCHECKED, verifier = "noop")
+        assertNull(result.toJsonOrOmit())
+    }
+
+    @Test
+    fun `toJsonOrOmit returns null for a no-op verifier even with reason and metadata`() {
+        // Guards against a future noop variant that starts attaching a reason/metadata —
+        // omission is keyed on verifier identity, not on payload richness.
+        val result =
+            VerificationResult(
+                status = VerificationStatus.UNCHECKED,
+                verifier = "noop",
+                reason = "should still be omitted",
+                metadata = mapOf("k" to "v")
+            )
+        assertNull(result.toJsonOrOmit())
+    }
+
+    @Test
+    fun `toJsonOrOmit serializes a non-noop verified result in full`() {
+        val result =
+            VerificationResult(
+                status = VerificationStatus.VERIFIED,
+                verifier = "jwks",
+                reason = "signature and claims valid",
+                metadata = mapOf("verifiedFromCache" to "true", "cacheAgeSeconds" to "12")
+            )
+
+        val json = result.toJsonOrOmit()
+        assertEquals(result.toJson(), json)
+        requireNotNull(json)
+        assertEquals("verified", json["status"]!!.jsonPrimitive.content)
+        assertEquals("jwks", json["verifier"]!!.jsonPrimitive.content)
+        assertEquals("signature and claims valid", json["reason"]!!.jsonPrimitive.content)
+        val metadata = json["metadata"]!!.jsonObject
+        assertEquals("true", metadata["verifiedFromCache"]!!.jsonPrimitive.content)
+        assertEquals("12", metadata["cacheAgeSeconds"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `toJsonOrOmit serializes a non-noop rejected result in full`() {
+        val result =
+            VerificationResult(
+                status = VerificationStatus.REJECTED,
+                verifier = "jwks",
+                reason = "signature invalid",
+                metadata = mapOf("failureKind" to "crypto")
+            )
+
+        val json = result.toJsonOrOmit()
+        assertEquals(result.toJson(), json)
+        requireNotNull(json)
+        assertEquals("rejected", json["status"]!!.jsonPrimitive.content)
+        assertEquals("crypto", json["metadata"]!!.jsonObject["failureKind"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `toJsonOrOmit serializes an UNCHECKED status from a non-noop verifier`() {
+        // Decision rule: omission is keyed on verifier == "noop", not on status == UNCHECKED —
+        // a future verifier could legitimately return UNCHECKED with a meaningful reason.
+        val result =
+            VerificationResult(
+                status = VerificationStatus.UNCHECKED,
+                verifier = "jwks-degraded",
+                reason = "JWKS endpoint unreachable; degraded mode accepted claim"
+            )
+
+        val json = result.toJsonOrOmit()
+        requireNotNull(json)
+        assertEquals("unchecked", json["status"]!!.jsonPrimitive.content)
+        assertEquals("jwks-degraded", json["verifier"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `toJsonOrOmit serializes a result with null verifier`() {
+        val result = VerificationResult(status = VerificationStatus.ABSENT, verifier = null)
+        val json = result.toJsonOrOmit()
+        requireNotNull(json)
+        assertEquals("absent", json["status"]!!.jsonPrimitive.content)
+        assertNull(json["verifier"])
+    }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesToolTest.kt
@@ -955,7 +955,7 @@ class ManageNotesToolTest {
     // ──────────────────────────────────────────────
 
     @Test
-    fun `upsert with actor claim includes actor and verification in response`(): Unit =
+    fun `upsert with actor claim includes actor but omits noop verification in response`(): Unit =
         runBlocking {
             val itemId = createTestItem()
 
@@ -996,9 +996,7 @@ class ManageNotesToolTest {
             assertEquals("agent-001", actor["id"]!!.jsonPrimitive.content)
             assertEquals("subagent", actor["kind"]!!.jsonPrimitive.content)
 
-            assertNotNull(note["verification"], "verification field should be present in response")
-            val verification = note["verification"] as JsonObject
-            assertNotNull(verification["status"]!!.jsonPrimitive.content)
+            assertFalse(note.containsKey("verification"), "verification field should be omitted for a no-op verifier")
         }
 
     @Test
@@ -1142,7 +1140,7 @@ class ManageNotesToolTest {
         }
 
     @Test
-    fun `batch upsert with mixed actor presence both succeed with correct actor presence`(): Unit =
+    fun `batch upsert with mixed actor presence both succeed with correct actor presence and omit noop verification`(): Unit =
         runBlocking {
             val itemId = createTestItem()
 
@@ -1191,7 +1189,7 @@ class ManageNotesToolTest {
 
             assertTrue(noteWithActor.containsKey("actor"), "note with actor should have actor in response")
             assertEquals("agent-batch", (noteWithActor["actor"] as JsonObject)["id"]!!.jsonPrimitive.content)
-            assertTrue(noteWithActor.containsKey("verification"), "note with actor should have verification in response")
+            assertFalse(noteWithActor.containsKey("verification"), "verification should be omitted for a no-op verifier")
 
             assertFalse(noteWithoutActor.containsKey("actor"), "note without actor should not have actor key")
             assertFalse(noteWithoutActor.containsKey("verification"), "note without actor should not have verification key")

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/QueryNotesToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/QueryNotesToolTest.kt
@@ -324,7 +324,7 @@ class QueryNotesToolTest {
     }
 
     @Test
-    fun `get note with actor includes actor and verification in response`(): Unit =
+    fun `get note with actor includes actor but omits noop verification in response`(): Unit =
         runBlocking {
             val itemId = createTestItem()
             val noteId =
@@ -358,15 +358,13 @@ class QueryNotesToolTest {
             assertEquals("orch-1", actor["parent"]!!.jsonPrimitive.content)
             assertFalse(actor.containsKey("proof"), "proof should be absent when not provided")
 
-            // Verification should be present (NoOpActorVerifier marks as unchecked)
-            assertTrue(data.containsKey("verification"), "verification field should be present")
-            val verification = data["verification"]!!.jsonObject
-            assertEquals("unchecked", verification["status"]!!.jsonPrimitive.content)
-            assertEquals("noop", verification["verifier"]!!.jsonPrimitive.content)
+            // Verification is omitted for a no-op verifier (NoOpActorVerifier) — it carries no
+            // information beyond "no verifier is configured", which is a deployment-wide fact.
+            assertFalse(data.containsKey("verification"), "verification field should be omitted for a no-op verifier")
         }
 
     @Test
-    fun `list notes includes actor and verification on notes that have actor claim`(): Unit =
+    fun `list notes includes actor but omits noop verification on notes that have actor claim`(): Unit =
         runBlocking {
             val itemId = createTestItem()
             // Create two notes — one with actor, one without
@@ -399,7 +397,7 @@ class QueryNotesToolTest {
             assertTrue(planNote.containsKey("actor"), "plan note should have actor field")
             assertEquals("orch-1", planNote["actor"]!!.jsonObject["id"]!!.jsonPrimitive.content)
             assertEquals("orchestrator", planNote["actor"]!!.jsonObject["kind"]!!.jsonPrimitive.content)
-            assertTrue(planNote.containsKey("verification"), "plan note should have verification field")
+            assertFalse(planNote.containsKey("verification"), "verification should be omitted for a no-op verifier")
 
             // The note without actor should NOT have actor field
             val approachNote = notes.first { it.jsonObject["key"]!!.jsonPrimitive.content == "approach" }.jsonObject

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
@@ -1,5 +1,6 @@
 package io.github.jpicklyk.mcptask.current.application.tools.workflow
 
+import io.github.jpicklyk.mcptask.current.application.service.ActorVerifier
 import io.github.jpicklyk.mcptask.current.application.service.NoteSchemaService
 import io.github.jpicklyk.mcptask.current.application.service.StatusLabelService
 import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
@@ -62,6 +63,10 @@ class AdvanceItemToolTest {
     /** Build a custom context with a specific StatusLabelService, reusing existing mocked repos. */
     private fun contextWithLabels(labelService: StatusLabelService): ToolExecutionContext =
         ToolExecutionContext(repoProvider, statusLabelService = labelService)
+
+    /** Build a custom context with a specific ActorVerifier, reusing existing mocked repos. */
+    private fun contextWithVerifier(verifier: ActorVerifier): ToolExecutionContext =
+        ToolExecutionContext(repoProvider, actorVerifier = verifier)
 
     private fun makeItem(
         id: UUID = UUID.randomUUID(),
@@ -2109,7 +2114,7 @@ class AdvanceItemToolTest {
     // ──────────────────────────────────────────────
 
     @Test
-    fun `transition with actor claim includes actor and verification in response`(): Unit =
+    fun `transition with actor claim includes actor but omits noop verification in response`(): Unit =
         runBlocking {
             val itemId = UUID.randomUUID()
             val item = makeItem(id = itemId, role = Role.QUEUE)
@@ -2149,10 +2154,57 @@ class AdvanceItemToolTest {
             assertEquals("session-abc", actor["parent"]!!.jsonPrimitive.content)
             assertFalse(actor.containsKey("proof"), "proof should be absent when not provided")
 
-            // Verification should be present (NoOpActorVerifier returns UNCHECKED)
+            // Verification is omitted for a no-op verifier (NoOpActorVerifier) — it carries no
+            // information beyond "no verifier is configured".
+            assertFalse(r.containsKey("verification"), "verification field should be omitted for a no-op verifier")
+        }
+
+    @Test
+    fun `transition with actor claim includes full verification when a non-noop verifier is configured`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            val item = makeItem(id = itemId, role = Role.QUEUE)
+
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+            coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+            coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+            every { depRepo.findByToItemId(itemId) } returns emptyList()
+            every { depRepo.findByFromItemId(itemId) } returns emptyList()
+
+            val jwksVerifier =
+                object : ActorVerifier {
+                    override suspend fun verify(actor: ActorClaim): VerificationResult =
+                        VerificationResult(
+                            status = VerificationStatus.VERIFIED,
+                            verifier = "jwks",
+                            reason = "signature and claims valid",
+                            metadata = mapOf("verifiedFromCache" to "false")
+                        )
+                }
+
+            val actorJson =
+                buildJsonObject {
+                    put("id", "orchestrator-001")
+                    put("kind", "orchestrator")
+                }
+            val params =
+                buildParams(
+                    buildJsonObject {
+                        put("itemId", itemId.toString())
+                        put("trigger", "start")
+                        put("actor", actorJson)
+                    }
+                )
+            val result = tool.execute(params, contextWithVerifier(jwksVerifier))
+
+            val results = extractResults(result)
+            val r = results[0].jsonObject
+            assertTrue(r.containsKey("verification"), "verification should be present for a non-noop verifier")
             val verification = r["verification"]!!.jsonObject
-            assertEquals("unchecked", verification["status"]!!.jsonPrimitive.content)
-            assertEquals("noop", verification["verifier"]!!.jsonPrimitive.content)
+            assertEquals("verified", verification["status"]!!.jsonPrimitive.content)
+            assertEquals("jwks", verification["verifier"]!!.jsonPrimitive.content)
+            assertEquals("signature and claims valid", verification["reason"]!!.jsonPrimitive.content)
+            assertEquals("false", verification["metadata"]!!.jsonObject["verifiedFromCache"]!!.jsonPrimitive.content)
         }
 
     @Test
@@ -2233,7 +2285,7 @@ class AdvanceItemToolTest {
             assertTrue(r1.containsKey("actor"), "First transition should have actor")
             assertEquals("agent-xyz", r1["actor"]!!.jsonObject["id"]!!.jsonPrimitive.content)
             assertEquals("subagent", r1["actor"]!!.jsonObject["kind"]!!.jsonPrimitive.content)
-            assertTrue(r1.containsKey("verification"))
+            assertFalse(r1.containsKey("verification"), "First transition should omit noop verification")
 
             assertTrue(r2["applied"]!!.jsonPrimitive.boolean)
             assertFalse(r2.containsKey("actor"), "Second transition should not have actor")

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolTest.kt
@@ -1819,7 +1819,7 @@ class GetContextToolTest {
     // ──────────────────────────────────────────────
 
     @Test
-    fun `session resume includes actor on recent transitions when actorClaim is set`(): Unit =
+    fun `session resume includes actor but omits noop verification on recent transitions`(): Unit =
         runBlocking {
             val since = Instant.now().minusSeconds(3600)
             val itemId = UUID.randomUUID()
@@ -1865,11 +1865,53 @@ class GetContextToolTest {
             assertFalse(actorObj.containsKey("parent"), "parent should be absent when null")
             assertFalse(actorObj.containsKey("proof"), "proof should be absent when null")
 
-            // Verification should be present
-            assertTrue(t.containsKey("verification"), "verification field should be present")
+            // Verification is omitted for a no-op verifier — it carries no information beyond
+            // "no verifier is configured".
+            assertFalse(t.containsKey("verification"), "verification field should be omitted for a no-op verifier")
+        }
+
+    @Test
+    fun `session resume includes full verification on recent transitions for a non-noop verifier`(): Unit =
+        runBlocking {
+            val since = Instant.now().minusSeconds(3600)
+            val itemId = UUID.randomUUID()
+
+            val actor = ActorClaim(id = "orch-1", kind = ActorKind.ORCHESTRATOR, parent = null)
+            val verification =
+                VerificationResult(
+                    status = VerificationStatus.VERIFIED,
+                    verifier = "jwks",
+                    reason = "signature and claims valid"
+                )
+            val transition =
+                RoleTransition(
+                    itemId = itemId,
+                    fromRole = "queue",
+                    toRole = "work",
+                    trigger = "start",
+                    actorClaim = actor,
+                    verification = verification
+                )
+
+            coEvery { workItemRepo.findByRole(Role.WORK, any()) } returns Result.Success(emptyList())
+            coEvery { workItemRepo.findByRole(Role.REVIEW, any()) } returns Result.Success(emptyList())
+            coEvery { roleTransitionRepo.findSince(any(), any()) } returns Result.Success(listOf(transition))
+
+            val result =
+                tool.execute(
+                    params("since" to JsonPrimitive(since.toString())),
+                    context
+                )
+
+            val data = extractData(result)
+            val recentTransitions = data["recentTransitions"]!!.jsonArray
+            val t = recentTransitions[0].jsonObject
+
+            assertTrue(t.containsKey("verification"), "verification should be present for a non-noop verifier")
             val verObj = t["verification"]!!.jsonObject
-            assertEquals("unchecked", verObj["status"]!!.jsonPrimitive.content)
-            assertEquals("noop", verObj["verifier"]!!.jsonPrimitive.content)
+            assertEquals("verified", verObj["status"]!!.jsonPrimitive.content)
+            assertEquals("jwks", verObj["verifier"]!!.jsonPrimitive.content)
+            assertEquals("signature and claims valid", verObj["reason"]!!.jsonPrimitive.content)
         }
 
     @Test


### PR DESCRIPTION
## Summary
- `VerificationResult.toJsonOrOmit()` (new shared helper) suppresses the `verification` block when `verifier == "noop"` — the default no-verifier-configured case where the block carries zero information. Measured: the block is ~61% of the attribution payload on a note; attributed note lists shrink accordingly.
- Applied at all 4 emission sites (`Note.toJson()`, `manage_notes` upsert response, `advance_item` transition results, `get_context` recentTransitions), replacing 3 hand-rolled inline duplicates.
- Real verifier results (JWKS etc.) serialize unchanged — the rule keys on `verifier`, not status, so a future verifier returning UNCHECKED with a reason still serializes. Persistence and REST untouched (output-only change).
- Docs: `api-reference.md` (3 places), `workflow-guide.md` example, and a stale noop example in `advance_item`'s tool description.

## Test Results
2332 tests, 0 failures (forced `--rerun-tasks` clean run) + ktlintCheck clean. Flipped assertions verify `verification` is absent (not merely unasserted); non-noop counter-tests exercise real tools through the `ToolExecutionContext` verifier seam; exhaustive standalone helper coverage incl. null-verifier edge case.

## Review
Independent review verdict: PASS WITH OBSERVATIONS. Emission-site sweep clean (16 `VerificationResult` / 11 `.verification` references audited — no 5th site). Doc nit fixed in follow-up commit. Noted nitpick: notes-tool tests lack the non-noop counter-test the workflow-tool tests have (shared helper is exhaustively covered standalone).

## MCP
Item: c8aac664-dd03-4fd3-b55a-9a6a47f56d45

🤖 Generated with [Claude Code](https://claude.com/claude-code)