### PR TITLE
fix(api): true totals, real pagination, and skipped-row visibility on GET /items/roots

### DIFF
--- a/current/docs/api-rest.md
+++ b/current/docs/api-rest.md
@@ -216,13 +216,16 @@ List endpoints return a `PageDto<T>`:
   "page": 1,
   "pageSize": 20,
   "totalItems": 42,   // may be null when count is expensive
-  "hasMore": true
+  "hasMore": true,
+  "skipped": 1         // omitted when 0/null — see below
 }
 ```
 
 Query parameters: `?page=<int>` (default 1) and `?pageSize=<int>` (default 20, max typically 100).
 
 `totalItems` may be `null` for endpoints where computing an exact count is expensive; use `hasMore` for continuation.
+
+`skipped` counts rows in this page's underlying query window that were dropped because they failed domain validation (e.g. a corrupt/legacy row) — the row is excluded from `items` but still counted in `totalItems`. The field is omitted entirely when nothing was skipped. Invariant: `items.size == min(pageSize, totalItems - offset) - skipped` (clamped to the actual window), so truncation is always derivable from `totalItems`/`pageSize`/`page` without a separate `truncated` field. Currently populated on `GET /items` and `GET /items/roots`; other list endpoints report `skipped: null`.
 
 ---
 
@@ -481,16 +484,18 @@ Paginated list of work items with optional filters.
 | `orderBy` | string | Sort field |
 | `orderDir` | string | Sort direction: `asc`, `desc` |
 
-**Response:** `200 OK` → `PageDto<ItemDto>`
+**Response:** `200 OK` → `PageDto<ItemDto>` (see §7 for `skipped` semantics; populated on the unscoped branch)
 
 ### GET /items/roots
 
 Root-level items (depth=0) accessible to the caller.
 
-- Scoped tokens: returns only the specific root items within scope (efficient, not capped)
-- Unscoped/admin: scans up to 200 root items (documented cap)
+- Scoped tokens: returns only the specific root items within scope (efficient, not capped); `totalItems` is the exact scoped root count.
+- Unscoped/admin: fully paginated via standard `page`/`pageSize` params — `totalItems` comes from an exact `COUNT` query, unaffected by `pageSize` or by rows dropped for failing domain validation. There is no cap; page through all roots with repeated requests.
 
-**Response:** `200 OK` → `PageDto<ItemDto>`
+**Query parameters:** Standard pagination params (`page`, `pageSize`).
+
+**Response:** `200 OK` → `PageDto<ItemDto>` (see §7 for `skipped` semantics; populated on the unscoped branch)
 
 ### GET /items/{id}
 
@@ -1035,7 +1040,5 @@ The `"<previousRole>"` sentinel in `blocked.resume` is a literal string — reso
 **SSE dependency-event scoping depends on a warm ancestor cache.** Live root-filtering and `Last-Event-ID` replay are both correctly root-scoped — ring-buffer entries carry `affectedRoots` metadata and the replay path applies the same root-intersection filter as the live fan-out. One residual caveat remains for dependency events: `dependency.added` / `dependency.removed` resolve their affected roots from an in-memory ancestor cache populated by prior item create/update writes. On a cache miss (e.g., a dependency change with no preceding item write on that subtree during the connection's lifetime), the event falls back to an unscoped broadcast. This is a deliberate tradeoff; root-scoped subscribers that require exact dependency-event scoping should re-fetch state rather than relying solely on the event stream.
 
 **SSE is bearer-mode only.** The pre-flight auth plugin for the SSE route only supports bearer token authentication. JWKS JWT authentication for SSE is not implemented (the pre-flight plugin does not invoke the JWKS verifier).
-
-**`GET /items/roots` unscoped cap.** Unscoped/admin callers on `GET /items/roots` receive at most 200 root items. Scoped callers are not subject to this cap.
 
 **FTS5 requires SQLite.** Search endpoints (`GET /search`, `GET /notes/search`) return empty results when the repository is H2-backed (test/embedded environments). FTS5 is only available against the production SQLite database.

--- a/current/docs/api/openapi.yaml
+++ b/current/docs/api/openapi.yaml
@@ -309,8 +309,18 @@ components:
           type: integer
           format: int64
           nullable: true
+          description: May be null when computing an exact count is expensive.
         hasMore:
           type: boolean
+        skipped:
+          type: integer
+          nullable: true
+          description: >
+            Count of rows in this page's query window dropped for failing domain validation
+            (e.g. a corrupt/legacy row). Omitted when nothing was skipped. The row is still
+            counted in totalItems. Invariant: items.size == min(pageSize, totalItems - offset)
+            - skipped (clamped to the actual window). Currently populated on GET /items and
+            GET /items/roots.
 
     ItemCreateDto:
       type: object
@@ -827,6 +837,11 @@ paths:
   /items/roots:
     get:
       summary: List root items (depth=0)
+      description: >
+        Scoped tokens return only the specific root items within scope (totalItems is the exact
+        scoped root count). Unscoped/admin callers get standard page/pageSize pagination with
+        totalItems from an exact COUNT query — no cap; page through all roots with repeated
+        requests.
       operationId: listRootItems
       tags: [items]
       parameters:

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
@@ -198,9 +198,15 @@ interface WorkItemRepository {
      *
      * Returns an [ItemFetchResult]: rows that fail domain validation are dropped rather than
      * failing the whole query — [ItemFetchResult.skipped] reports how many were dropped. Use
-     * [countRootItems] (unaffected by [limit] or validation) for the true root count.
+     * [countRootItems] (unaffected by [limit]/[offset] or validation) for the true root count.
+     *
+     * @param offset Zero-based row offset applied at the SQL level, for paging through roots
+     *   beyond the first [limit] rows.
      */
-    suspend fun findRootItems(limit: Int = 50): Result<ItemFetchResult>
+    suspend fun findRootItems(
+        limit: Int = 50,
+        offset: Int = 0,
+    ): Result<ItemFetchResult>
 
     /**
      * True count of root items (items with `parentId IS NULL`), unaffected by any `limit` and

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -527,7 +527,10 @@ class SQLiteWorkItemRepository(
             Result.Success(counts)
         }
 
-    override suspend fun findRootItems(limit: Int): Result<ItemFetchResult> =
+    override suspend fun findRootItems(
+        limit: Int,
+        offset: Int,
+    ): Result<ItemFetchResult> =
         databaseManager.suspendedTransaction("Failed to find root items") {
             // Ordered newest-first for deterministic, dashboard-relevant pagination — previously
             // relied on SQLite's unordered natural (oldest-first) row order, which meant the
@@ -538,6 +541,7 @@ class SQLiteWorkItemRepository(
                     .where { WorkItemsTable.parentId.isNull() }
                     .orderBy(WorkItemsTable.createdAt, SortOrder.DESC)
                     .limit(limit)
+                    .offset(offset.coerceAtLeast(0).toLong())
                     .toList()
             val items = rows.mapNotNull { toWorkItemOrNull(it) }
             Result.Success(ItemFetchResult(items, skipped = rows.size - items.size))

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/dto/Dtos.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/dto/Dtos.kt
@@ -124,6 +124,12 @@ data class DependencyEdgeDto(
  *
  * `totalItems` may be null when computing the exact count is expensive — callers should
  * use `hasMore` for pagination control in that case.
+ *
+ * `skipped` counts rows in this page's underlying query window that were dropped because they
+ * failed domain validation (see `ItemFetchResult.skipped`). Null/omitted when no rows were
+ * skipped. Invariant: `items.size == min(pageSize, totalItems - offset) - skipped` (clamped to
+ * the actual window), so a caller can derive whether the window itself was short without a
+ * separate `truncated` field.
  */
 @Serializable
 data class PageDto<T>(
@@ -132,6 +138,7 @@ data class PageDto<T>(
     val pageSize: Int,
     val totalItems: Long?,
     val hasMore: Boolean,
+    val skipped: Int? = null,
 )
 
 /**

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/pagination/PageParams.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/pagination/PageParams.kt
@@ -55,11 +55,15 @@ fun ApplicationCall.pageParams(): PageParams {
  * @param items The items on this page (already limited to [PageParams.pageSize] rows).
  * @param pageParams The parsed page/pageSize pair.
  * @param totalItems Optional exact total count; null when too expensive to compute.
+ * @param skipped Optional count of rows dropped from this page's window due to failed domain
+ *   validation (see [io.github.jpicklyk.mcptask.current.domain.repository.ItemFetchResult]).
+ *   Pass null or 0 when nothing was skipped — either way it is omitted from the serialized DTO.
  */
 fun <T> buildPageDto(
     items: List<T>,
     pageParams: PageParams,
     totalItems: Long?,
+    skipped: Int? = null,
 ): PageDto<T> {
     val hasMore =
         if (totalItems != null) {
@@ -73,5 +77,6 @@ fun <T> buildPageDto(
         pageSize = pageParams.pageSize,
         totalItems = totalItems,
         hasMore = hasMore,
+        skipped = skipped?.takeIf { it > 0 },
     )
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemRoutes.kt
@@ -90,6 +90,10 @@ fun Route.itemRoutes(repositoryProvider: RepositoryProvider) {
                     else -> null
                 }
 
+            // Populated only by the unscoped findByFilters branch below — findInScope has no
+            // ItemFetchResult/skipped-row tracking, so scoped requests always report null.
+            var skippedCount: Int? = null
+
             val items =
                 if (effectiveScopeRootIds != null) {
                     if (effectiveScopeRootIds.isEmpty()) {
@@ -116,8 +120,8 @@ fun Route.itemRoutes(repositoryProvider: RepositoryProvider) {
                     )
                 } else {
                     // Unwrap ItemFetchResult to List<WorkItem> here so both branches of this
-                    // if/else agree on Result<List<WorkItem>> — skipped-row visibility for this
-                    // endpoint is future work (see query_items list mode for the tool-layer version).
+                    // if/else agree on Result<List<WorkItem>>; skippedCount above carries the
+                    // dropped-row count forward for the response DTO.
                     when (
                         val r =
                             workItemRepo.findByFilters(
@@ -137,7 +141,10 @@ fun Route.itemRoutes(repositoryProvider: RepositoryProvider) {
                                 claimStatus = claimStatus,
                             )
                     ) {
-                        is Result.Success -> Result.Success(r.data.items)
+                        is Result.Success -> {
+                            skippedCount = r.data.skipped
+                            Result.Success(r.data.items)
+                        }
                         is Result.Error -> r
                     }
                 }
@@ -180,7 +187,7 @@ fun Route.itemRoutes(repositoryProvider: RepositoryProvider) {
                                 ).let { r -> if (r is Result.Success) r.data.toLong() else null }
                         }
                     val dtos = items.data.map { it.toDto() }
-                    call.respond(HttpStatusCode.OK, buildPageDto(dtos, pp, total))
+                    call.respond(HttpStatusCode.OK, buildPageDto(dtos, pp, total, skippedCount))
                 }
             }
         }
@@ -192,8 +199,10 @@ fun Route.itemRoutes(repositoryProvider: RepositoryProvider) {
             val scopeRootIds = principal?.scope?.rootIds
 
             if (scopeRootIds != null) {
-                // Scoped token: fetch only the specific root items the principal can see.
-                // This avoids the 200-cap correctness issue for tokens with many roots.
+                // Scoped token: fetch only the specific root items the principal can see. The
+                // token's scope set is the authoritative bound on visible roots, so `roots.size`
+                // here is already the TRUE total for this principal — no separate count call or
+                // 200-style cap applies to this branch.
                 val roots =
                     scopeRootIds
                         .mapNotNull { rid ->
@@ -204,18 +213,29 @@ fun Route.itemRoutes(repositoryProvider: RepositoryProvider) {
                 val dtos = page.map { it.toDto() }
                 call.respond(HttpStatusCode.OK, buildPageDto(dtos, pp, roots.size.toLong()))
             } else {
-                // Unscoped/admin: global scan (cap documented — full count may exceed 200).
-                val result = workItemRepo.findRootItems(limit = 200)
+                // Unscoped/admin: true total from countRootItems() (unaffected by limit/offset or
+                // validation drops) and real limit/offset pagination — replaces the old silent
+                // 200-row cap so callers can page through every root.
+                val totalResult = workItemRepo.countRootItems()
+                val total =
+                    when (totalResult) {
+                        is Result.Error -> {
+                            logger.warn("GET /items/roots DB error (count): {}", totalResult.error.message)
+                            call.respond(HttpStatusCode.InternalServerError, ErrorDto("db_error", "Database query failed"))
+                            return@get
+                        }
+                        is Result.Success -> totalResult.data
+                    }
+
+                val result = workItemRepo.findRootItems(limit = pp.pageSize, offset = pp.offset)
                 when (result) {
                     is Result.Error -> {
                         logger.warn("GET /items/roots DB error: {}", result.error.message)
                         call.respond(HttpStatusCode.InternalServerError, ErrorDto("db_error", "Database query failed"))
                     }
                     is Result.Success -> {
-                        val allRoots = result.data.items
-                        val page = allRoots.drop(pp.offset).take(pp.pageSize)
-                        val dtos = page.map { it.toDto() }
-                        call.respond(HttpStatusCode.OK, buildPageDto(dtos, pp, allRoots.size.toLong()))
+                        val dtos = result.data.items.map { it.toDto() }
+                        call.respond(HttpStatusCode.OK, buildPageDto(dtos, pp, total, result.data.skipped))
                     }
                 }
             }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ApiTestHelper.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ApiTestHelper.kt
@@ -64,6 +64,19 @@ fun buildH2RepositoryProvider(): DefaultRepositoryProvider {
 fun buildH2RepositoryProviderScoped(): DefaultRepositoryProvider = buildH2RepositoryProvider()
 
 /**
+ * Like [buildH2RepositoryProvider] but also returns the raw [Database] handle, for tests that
+ * need to bypass the repository layer (e.g. writing a corrupt/invalid-domain row directly via
+ * Exposed to simulate validation-drop scenarios — see [WorkItemsTable] usage in repository tests).
+ */
+fun buildH2RepositoryProviderWithDatabase(): Pair<DefaultRepositoryProvider, Database> {
+    val dbName = "api_test_${System.nanoTime()}"
+    val database = Database.connect("jdbc:h2:mem:$dbName;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+    val databaseManager = DatabaseManager(database)
+    DirectDatabaseSchemaManager().updateSchema()
+    return DefaultRepositoryProvider(databaseManager) to database
+}
+
+/**
  * Returns a [ApiAuthConfig.Bearer] with two principals:
  * - [TEST_TOKEN] → `read` capability, unrestricted scope (optionally scoped by [scopeRootIds] and/or [tagsInclude])
  * - [ADMIN_TOKEN] → `admin` + `read` capabilities, unrestricted scope

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemRoutesTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemRoutesTest.kt
@@ -3,16 +3,29 @@ package io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes
 import io.github.jpicklyk.mcptask.current.domain.model.Priority
 import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.WorkItemsTable
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
 import org.junit.jupiter.api.Test
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -605,5 +618,128 @@ class ItemRoutesTest {
             val body = response.bodyAsText()
             assertTrue(body.contains("InScopeRoot"), "Expected in-scope root: $body")
             assertFalse(body.contains("OutOfScopeRoot"), "Out-of-scope root must be excluded: $body")
+        }
+
+    // ─── /items/roots accuracy: true total, real pagination, skipped visibility ─
+
+    /**
+     * Directly blanks a row's title via Exposed, bypassing [WorkItem.validate]. Simulates a
+     * corrupt/legacy row that the repository's row mapper must drop rather than fail the whole
+     * query. Same technique as `SQLiteWorkItemRepositoryFilterTest.forceBlankTitle`.
+     */
+    private fun forceBlankTitle(
+        database: Database,
+        itemId: UUID,
+    ) {
+        transaction(db = database) {
+            WorkItemsTable.update({ WorkItemsTable.id eq itemId }) {
+                it[WorkItemsTable.title] = ""
+            }
+        }
+    }
+
+    @Test
+    fun `GET items roots unscoped reports true total and pages through all roots`() =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            runBlocking {
+                repeat(5) { i -> repo.workItemRepository().create(WorkItem(title = "Root $i", depth = 0)) }
+            }
+            application {
+                configureTestApp { itemRoutes(repo) }
+            }
+
+            val page1 =
+                client.get("/api/v1/items/roots?page=1&pageSize=2") {
+                    header("Authorization", "Bearer $TEST_TOKEN")
+                }
+            assertEquals(HttpStatusCode.OK, page1.status)
+            val page1Json = Json.parseToJsonElement(page1.bodyAsText()).jsonObject
+            assertEquals(5L, page1Json["totalItems"]!!.jsonPrimitive.long, "totalItems must be the true root count")
+            assertEquals(2, page1Json["items"]!!.jsonArray.size, "page 1 of pageSize=2 must return exactly 2 items")
+            assertTrue(page1Json["hasMore"]!!.jsonPrimitive.boolean, "5 roots over pageSize=2 must have more pages")
+
+            val page3 =
+                client.get("/api/v1/items/roots?page=3&pageSize=2") {
+                    header("Authorization", "Bearer $TEST_TOKEN")
+                }
+            assertEquals(HttpStatusCode.OK, page3.status)
+            val page3Json = Json.parseToJsonElement(page3.bodyAsText()).jsonObject
+            assertEquals(5L, page3Json["totalItems"]!!.jsonPrimitive.long)
+            assertFalse(page3Json["hasMore"]!!.jsonPrimitive.boolean, "last page (5 roots, offset 4) has no more")
+        }
+
+    @Test
+    fun `GET items roots unscoped surfaces skipped for a row that fails domain validation`() =
+        testApplication {
+            val (repo, database) = buildH2RepositoryProviderWithDatabase()
+            val good1 =
+                runBlocking {
+                    repo.workItemRepository().create(WorkItem(title = "Good root 1", depth = 0)).getOrNull()!!
+                }
+            runBlocking { repo.workItemRepository().create(WorkItem(title = "Good root 2", depth = 0)) }
+            val corrupt =
+                runBlocking {
+                    repo.workItemRepository().create(WorkItem(title = "Will be corrupted", depth = 0)).getOrNull()!!
+                }
+            forceBlankTitle(database, corrupt.id)
+
+            application {
+                configureTestApp { itemRoutes(repo) }
+            }
+            val response =
+                client.get("/api/v1/items/roots") {
+                    header("Authorization", "Bearer $TEST_TOKEN")
+                }
+            assertEquals(HttpStatusCode.OK, response.status)
+            val json = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+            assertEquals(3L, json["totalItems"]!!.jsonPrimitive.long, "corrupt row still counted in totalItems")
+            assertEquals(1, json["skipped"]!!.jsonPrimitive.int)
+            val body = response.bodyAsText()
+            assertTrue(body.contains(good1.title), "Expected good root present: $body")
+            assertFalse(body.contains("Will be corrupted"), "Corrupt root must be dropped from items: $body")
+        }
+
+    @Test
+    fun `GET items roots omits skipped field when nothing was dropped`() =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            runBlocking {
+                repo.workItemRepository().create(WorkItem(title = "Clean root", depth = 0))
+            }
+            application {
+                configureTestApp { itemRoutes(repo) }
+            }
+            val response =
+                client.get("/api/v1/items/roots") {
+                    header("Authorization", "Bearer $TEST_TOKEN")
+                }
+            assertEquals(HttpStatusCode.OK, response.status)
+            val json = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+            assertNull(json["skipped"], "skipped must be omitted when nothing was dropped")
+        }
+
+    @Test
+    fun `GET items surfaces skipped for a row that fails domain validation`() =
+        testApplication {
+            val (repo, database) = buildH2RepositoryProviderWithDatabase()
+            runBlocking { repo.workItemRepository().create(WorkItem(title = "Good item", depth = 0)) }
+            val corrupt =
+                runBlocking {
+                    repo.workItemRepository().create(WorkItem(title = "Will be corrupted", depth = 0)).getOrNull()!!
+                }
+            forceBlankTitle(database, corrupt.id)
+
+            application {
+                configureTestApp { itemRoutes(repo) }
+            }
+            val response =
+                client.get("/api/v1/items") {
+                    header("Authorization", "Bearer $TEST_TOKEN")
+                }
+            assertEquals(HttpStatusCode.OK, response.status)
+            val json = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+            assertEquals(2L, json["totalItems"]!!.jsonPrimitive.long, "corrupt row still counted in totalItems")
+            assertEquals(1, json["skipped"]!!.jsonPrimitive.int)
         }
 }


### PR DESCRIPTION
## Summary
- `GET /items/roots` (unscoped/admin): page `total` now comes from `countRootItems()` (true DB count) instead of the returned-count; the silent 200-row cap is replaced with standard `page`/`pageSize` pagination (default 50, max 200) backed by SQL LIMIT/OFFSET via a new backward-compatible `offset` param on `findRootItems`.
- Additive optional `skipped` field on `PageDto` (omitted when 0), populated on `GET /items` and `GET /items/roots` from `ItemFetchResult.skipped` — REST clients now see validation-dropped rows, completing the REST side of PR #213.
- Scoped-token roots branch intentionally untouched: independently verified its total is already exact by construction.
- Docs: `api-rest.md` pagination/roots/known-limitations sections + `openapi.yaml` (`skipped` schema, roots description).

## Test Results
2342 tests, 0 failures (independent `--rerun` verification) + ktlint clean. 4 new tests: true-total pagination (off-by-one checked at page boundaries), skipped-row visibility on roots and /items, skipped-omitted-when-zero.

## Review
Independent review verdict: PASS WITH OBSERVATIONS. Scoped-branch no-defect claim confirmed by tracing the Result-conversion path. Follow-up logged: scoped roots branch silently drops corrupt rows without a `skipped` signal (pre-existing asymmetry).

## MCP
Item: 21127bf7-bf34-4176-b704-bffd3aed496c

🤖 Generated with [Claude Code](https://claude.com/claude-code)