### PR TITLE
feat(query-items): overview excludeTerminal filter + lean work-summary dashboard

### DIFF
--- a/claude-plugins/task-orchestrator/skills/work-summary/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/work-summary/SKILL.md
@@ -1,241 +1,168 @@
 ---
 name: work-summary
-description: "Generates a hierarchical project dashboard showing all work items organized by container, with IDs, tags, status, and priority visible. Use when the user says: project status, what's active, show me the dashboard, work summary, what should I work on, project health, what's blocked, where did I leave off, show items, what's in the backlog, overview, or any request to see or review the current state of work items. Also use at session start when gathering current project context."
-argument-hint: "[optional: container UUID or title to scope the summary]"
+description: "Generates a project dashboard from MCP work items. Default is a lean, attention-first view: what's in flight, what's blocked, what to do next, what's queued. Use when the user says: project status, what's active, show me the dashboard, work summary, what should I work on, project health, what's blocked, where did I leave off, show items, what's in the backlog, overview, or any request to see or review the current state of work items. Also use at session start when gathering current project context."
+argument-hint: "[full | container UUID or title to scope the summary]"
 ---
 
 # Work Summary — Current (v3)
 
-Generate a PM-ready project dashboard. The goal is to show the full project state in one view — every container, every item, with enough detail (IDs, tags, priority, status) to make decisions and take action. Supplement the data with brief observations only when there is a genuine anomaly or actionable insight.
+Attention-first project dashboard. The default (lean) mode answers four questions — what's moving, what's stuck, what's next, what's queued — in a bounded view (~45 lines) regardless of workspace size. The exhaustive inventory is available as an explicit mode, not the default: mature workspaces accumulate hundreds of terminal items, and rendering them all buries the actionable content.
+
+Supplement the data with brief observations only when there is a genuine anomaly or actionable insight.
 
 ---
 
-## Step 0 — Scope Check
+## Step 0 — Mode Selection
 
-If `$ARGUMENTS` is provided:
-- If it looks like a UUID, use it directly as `parentId` for all queries below
-- If it's text, search: `query_items(operation="search", query="<text>")` — pick the best-matching root or container item and use its UUID as `parentId`
-- If multiple matches, pick the closest title match; if ambiguous, use `AskUserQuestion` to clarify
-
-When scoped to a `parentId`, modify the data collection calls:
-1. `query_items(operation="overview", itemId="<parentId>")` — scoped overview of that subtree
-2. `get_context()` — still global (filter to scope in analysis phase)
-3. `get_next_item(limit=5, parentId="<parentId>")` — scoped recommendations
-
-If no `$ARGUMENTS`, proceed with the global (unscoped) data collection as written below.
-
-## Data Collection (3 calls, run in parallel)
-
-1. `query_items(operation="overview", includeChildren=true)` — all root items with childCounts per role and direct children
-2. `get_context()` — active (work/review), blocked, and stalled items
-3. `get_next_item(limit=5)` — dependency-aware ranked recommendations
-
-**Why 3 calls:** Overview gives hierarchy structure, child counts, tags, priority, type, and traits for all items. get_context gives active/blocked/stalled signals. get_next_item gives dependency-aware recommendations.
+| `$ARGUMENTS` | Mode |
+|--------------|------|
+| empty | **Lean** (default) |
+| the literal word `full` | **Full Inventory** |
+| anything else | **Scoped** — resolve to a UUID via `query_items(operation="search", query=$ARGUMENTS, limit=5)`; prefer the best-matching root or container item; if ambiguous, present matches via `AskUserQuestion` |
 
 ---
 
-## Enrichment Phase
+## Lean Mode (default)
 
-Before rendering, cross-reference the data sources:
+### Data collection (all parallel)
 
-1. **Build lookup map from overview data:** Iterate overview root items and their children arrays. Each child in the overview includes `id, parentId, title, role, statusLabel, priority, depth, tags, type, childCounts, traits`. Build `overviewMap[id] = { priority, tags, type, traits, role, childCounts }`.
-2. **Build child count map:** Use the `childCounts` object directly from each child in the overview (no grouping needed). `childRoleCounts[id] = item.childCounts`.
-3. **Extract traits:** For items with `traits` arrays in the overview, note them for display in the Tags column.
-4. **Build active/blocked/stalled sets:** From get_context, create sets of item IDs that are active, blocked, or stalled
-5. **Classify root items:** Use the classification table below
-6. **Group standalone items by tag:** For root items classified as "Standalone item", group by their `tags` value (first tag if multiple). Items with no tag go into an "Uncategorized" group.
+1. `query_items(operation="overview", includeChildren=true, excludeTerminal=true)` — non-terminal roots with their children arrays and childCounts. **Fallback for older servers:** if `excludeTerminal` is rejected as an unknown parameter, call `query_items(operation="overview")` *without* `includeChildren`, then fetch children only where needed: for each non-terminal root whose `childCounts` show non-terminal children, `query_items(operation="search", parentId="<id>")` in parallel. Never fetch children of terminal roots.
+2. `get_context()` — health-check: active items, blocked items, stalled items, claim summary.
+3. `get_context(mode="session-resume", since="<now minus 48h, ISO 8601>")` — recent role transitions (the "where did I leave off" signal).
+4. `get_next_item(limit=5, includeDetails=true)` — ranked recommendations with parentId/tags.
+5. `query_items(operation="search", role="queue", limit=1)` — read `total` for the true queued count.
+6. `query_items(operation="search", role="terminal", limit=1)` — read `total` for the true done count.
 
-### Root Item Classification
+**Headline counts must come from these sources, never from eyeballing the overview payload** — overview covers roots + direct children only and may be truncated.
 
-| Pattern | Classification | Rendering |
-|---------|---------------|-----------|
-| Has non-terminal children | **Active container** | Full section with children table |
-| All children terminal | **Completed container** | Done footer |
-| No children, non-terminal role | **Standalone item** | Standalone Items table |
-| No children, terminal role | **Completed standalone** | Done footer |
+### Enrichment
 
-> **Note:** Overview `childCounts` reflects **direct children only**. Active grandchildren can exist under a terminal root. Cross-reference with `get_context` results.
+- **Containers are shelves, not work.** Items with tag or `type` = `container` never count as active; exclude them from the active/In Flight lists.
+- **Active** = health-check `activeItems` minus containers. **Blocked/stalled** = health-check lists as-is.
+- **Workstreams** = non-terminal roots with children. Progress fraction = `terminal / total` from `childCounts`; "next up" = the highest-priority queue-role child from the children array.
+- **Standalone queue roots** group by kind: the `type` field if set; else the first tag *not* in {`agent-observation`, `feature`, `container`}; else "Uncategorized".
+- **Rollup threshold:** any group with more than 5 items renders as a count line broken down by kind, listing individual items only when priority ≥ medium or tagged `action-item`.
+- **Hygiene candidates:** empty non-terminal containers; evident test artifacts (probe/smoke/depth-test titles, `mtest-*` tags).
 
----
+### Dashboard format
 
-## Dashboard Format
-
-Render the dashboard in this exact section order. Omit any section that has no data.
-
-### Section 1: Health Headline
+Render in this order; omit any section with no data.
 
 ```
 ## ◆ Work Summary
 
-[One sentence assessing project health and momentum.]
+[One sentence: health and momentum.]
 
-**X active · Y blocked · Z stalled · W queued · V done**
-```
+**N active · N blocked · N stalled · N queued · N done**
 
-Counts come from the search results grouped by role. "active" = work + review roles. "done" = terminal role.
+### ◉ In Flight
+| ID | Item | Container | Status | Pri |
+|----|------|-----------|--------|-----|
+| `xxxxxxxx` | <title> | <parent title or —> | ◉ work | high |
 
----
+↳ Recent: <up to 3 one-line transition summaries from session-resume, newest first — omit line if none in 48h>
 
-### Section 2: Attention Required
-
-Omit this entire section if there are no blocked or stalled items.
-
-```
 ### ⊘ Attention Required
-
 | ID | Item | Container | Issue |
 |----|------|-----------|-------|
-| `short-id` | <title> | <parent title or —> | Blocked by: `<blocker-id>` <blocker-title> |
-| `short-id` | <title> | <parent title or —> | Stalled: missing `<note-key>`, `<note-key>` |
-```
+| `xxxxxxxx` | <title> | <parent or —> | Blocked by: `<blocker-id>` <blocker-title> |
+| `yyyyyyyy` | <title> | <parent or —> | Stalled: missing `<note-key>` (trait: <trait-name> if applicable) |
 
-For blocked items, show what is blocking them. For stalled items, show which required notes are missing. When a stalled item's missing note key matches a trait's note key (e.g., `migration-assessment` from trait `needs-migration-review`), mention the trait in the Issue column: `Stalled: missing \`migration-assessment\` (trait: needs-migration-review)`
-
-If there is actionable context (e.g., blocker is not in active work, or a stalled item has a `guidancePointer`), add a brief observation line below the table — one sentence max.
-
-Include the short ID so the user can reference items in follow-up commands.
-
----
-
-### Section 3: Project Inventory
-
-This is the core of the dashboard. Show every active container with its children.
-
-For each active container (has non-terminal children), render:
-
-```
-#### <Container Title> `<8-char-id>`
-<role-symbol> <role> · <N open> · <N done>
-
-| ID | Title | Status | Pri | Tags | Children |
-|----|-------|--------|-----|------|----------|
-| `xxxxxxxx` | <child title> | ◉ work | high | feature-task ▸migration | — |
-| `yyyyyyyy` | <child title> | ○ queue | med | — | 2○ 1◉ |
-| `zzzzzzzz` | <child title> | ⊘ blocked | high | bug-fix ▸security | — |
-
-✓ N completed: <comma-separated titles of terminal children>
-```
-
-**Rendering rules for container sections:**
-- Sort children: ◉ active (work/review) first, then ⊘ blocked, then ○ queue, then ✓ terminal
-- Non-terminal children get full table rows with all columns
-- Terminal children are collapsed into the `✓ N completed` line below the table. If 0 completed, omit the line. If more than 5 completed, show first 3 titles then `(+N more)`.
-- The container header shows the short ID for user reference
-- `<N open>` = queue + work + review + blocked children count
-- **Children column:** If an item itself has children (detected from search results where other items have this item's ID as `parentId`), show a compact role summary using the format `N○ N◉ N⊘ N✓` (omit roles with zero count). If the item has no children, show `—`.
-- Tags column: show tag value or `—` if none. When an item has traits, append them after the tag using a `▸` prefix with shortened trait names (strip `needs-` prefix). Example: `feature-task ▸migration-review` or `bug-fix ▸security`. If no tag but has traits, show `▸<trait-name>` only.
-- Priority column: show `high`, `med`, `low`, or `—` if default/unset
-
-**If a container itself is in work/review role**, prefix its header with the role symbol: `#### ◉ Tech Debt \`89d02e32\``
-
----
-
-### Section 4: Standalone Items
-
-Root items (depth 0) that have no children and are non-terminal. Omit section if none.
-
-**Grouping strategy — adaptive, hierarchy-first:**
-
-Items with a `parentId` are always shown under their container in Section 3 — hierarchy wins over tags. Standalone items (no parent) are grouped by tag in this section. This adapts to how the user organizes work:
-
-- **Hierarchy users** (containers with children): most items appear in Section 3, few standalones here
-- **Tag users** (flat items with schema tags, no containers): Section 3 is empty, this section becomes the primary view with tag-based groupings
-- **Mixed users**: containers in Section 3, orphaned tagged items grouped here by tag
-
-**Rendering rules:**
-
-1. Collect all non-terminal root items with no children
-2. Group them by tag value. Items with multiple tags: use the first tag. Items with no tag: group under "Uncategorized"
-3. If only one tag group exists (or all items are uncategorized), render as a flat table without tag subheadings
-4. If multiple tag groups exist, render each as a subheading with its own table
-
-**Multi-group format:**
-```
-### Standalone Items
-
-#### feature-implementation
-
-| ID | Title | Status | Pri | Children |
-|----|-------|--------|-----|----------|
-| `xxxxxxxx` | <title> | ○ queue | med | — |
-
-#### bug-fix
-
-| ID | Title | Status | Pri | Children |
-|----|-------|--------|-----|----------|
-| `yyyyyyyy` | <title> | ○ queue | high | — |
-
-#### Uncategorized
-
-| ID | Title | Status | Pri | Children |
-|----|-------|--------|-----|----------|
-| `zzzzzzzz` | <title> | ○ queue | med | — |
-```
-
-**Single-group format** (all same tag or all uncategorized):
-```
-### Standalone Items
-
-| ID | Title | Status | Pri | Tags | Children |
-|----|-------|--------|-----|------|----------|
-| `xxxxxxxx` | <title> | ○ queue | med | — | — |
-```
-
-Note: when items are grouped by tag, the Tags column is omitted from the table (the tag subheading already conveys it). When rendered as a flat table, include the Tags column.
-
----
-
-### Section 5: Recommended Next
-
-From `get_next_item` results. Omit if no recommendations.
-
-```
 ### ▸ Recommended Next
-
 | ID | Title | Container | Pri |
 |----|-------|-----------|-----|
-| `xxxxxxxx` | <title> | <parent title or —> | high |
+
+### ○ Backlog
+**Workstreams**
+| ID | Workstream | Progress | Next up | Pri |
+|----|-----------|----------|---------|-----|
+| `xxxxxxxx` | <root title> | 2/5 done | <queue child title> | high |
+
+**<Kind>** (N): `id` <title> (pri) · `id` <title> (pri) · ...        ← groups of ≤5
+**<Kind>** (N): X bug · Y optimization · Z friction — highest: `id` <title> (pri)   ← groups of >5
+
+### ✓ Done — N terminal items
+
+↳ Hygiene: <N> test artifacts, <N> empty containers — candidates for /batch-complete
 ```
 
-These items are queue-role, not blocked by dependencies, ranked by priority then complexity. Brief observation (one sentence) only if there's a parallelization opportunity or if all recommendations come from the same container.
+**Lean-mode rules:**
+- Total output target is ~45 lines; rollups are how you hold that budget.
+- The Done section is a single line (count from the role-total query). No titles, no done/cancelled split in lean mode — the terminal statusLabels aren't fetched. Use `full` mode for the breakdown.
+- The Hygiene line appears only when candidates exist.
+- If all of In Flight / Attention / Recommended Next are empty, say so in the health sentence ("Quiet board — nothing in flight...") rather than rendering empty sections.
 
 ---
 
-### Section 6: Done
+## Full Inventory Mode (`$ARGUMENTS` = `full`)
 
-Compact footer for completed work. Omit if nothing is terminal.
+Everything lean mode shows, plus the complete per-container inventory.
 
-```
-### ✓ Done (N total)
+### Data collection (all parallel)
 
-**Completed containers:** <title> (N children) · <title> (N children)
-**Completed standalone:** <title> · <title> · (+N more if >5)
-```
+1. `query_items(operation="overview", includeChildren=true)` — all roots. **If the response has `truncated: true`, re-issue with `limit=<total>`** so nothing is silently missing.
+2. `get_context()` — health-check.
+3. `get_next_item(limit=5, includeDetails=true)`.
+4. Role-total queries as in lean mode (queue + terminal, `limit=1`).
 
-N total = count of all terminal root items (containers + standalone).
+### Sections, in order
+
+1. **Health Headline** — same as lean mode; counts from health-check + role-total queries, containers excluded from active.
+2. **Attention Required** — same as lean mode.
+3. **Recommended Next** — same as lean mode (deliberately above the inventory).
+4. **Project Inventory** — for each **active container** (root with non-terminal children):
+
+   ```
+   #### <Container Title> `<8-char-id>`
+   <role-symbol> <role> · <N open> · <N done>
+
+   | ID | Title | Status | Pri | Tags | Children |
+   |----|-------|--------|-----|------|----------|
+
+   ✓ N completed: <first 3 titles> (+N more)
+   ```
+
+   - Sort children: ◉ active first, then ⊘ blocked, then ○ queue; terminal children collapse into the `✓ N completed` footer line (omit if 0; if >5, first 3 titles then `(+N more)`).
+   - `<N open>` = queue + work + review + blocked children.
+   - **Children column** = compact role summary `N○ N◉ N⊘ N✓` built from the child's own `childCounts` in the overview payload (omit zero roles; `—` if childless).
+   - **Tags column** = tag value or `—`; traits append with `▸` prefix, `needs-` stripped (`feature-task ▸migration-review`).
+   - If the container itself is work/review role, prefix its header with the role symbol.
+5. **Standalone Items** — non-terminal childless roots, grouped by the shared grouping key (below). One tag group → flat table with Tags column; multiple groups → subheading per group, Tags column omitted.
+6. **Done** — `### ✓ Done (N done · N cancelled)` with `**Completed containers:** <title> (N children) · ...` and `**Completed standalone:** <title> · ... (+N more if >5)`. **Cancelled items are counted and listed separately — never presented as completed work.**
+7. **Empty containers** — `**Empty (no items):** <title>, <title>` at the end of the inventory if any exist.
 
 ---
 
-### Internal: Short ID → Full UUID Mapping
+## Scoped Mode (`$ARGUMENTS` = UUID or title)
 
-Do NOT render a UUID reference table in the dashboard output. The user references items by short ID only.
+Use the resolved UUID as the scope for full-inventory-style rendering of one subtree:
 
-Instead, retain the short→full UUID mapping as internal agent context. When the user references a short ID in a follow-up command (e.g., "start `0499a6aa`"), resolve it to the full UUID silently for the MCP tool call. The search results from data collection provide all the full UUIDs needed.
+1. `query_items(operation="overview", itemId="<parentId>")` — scoped overview.
+2. `get_context()` — global; filter to the scope during enrichment.
+3. `get_next_item(limit=5, parentId="<parentId>", includeDetails=true)` — scoped recommendations.
+
+Render the Full Inventory sections for that subtree only. All shared rules apply.
 
 ---
 
-## Formatting Conventions
+## Shared Rendering Rules
 
 **Status symbols:** `✓` terminal · `◉` work/review · `⊘` blocked/stalled · `○` queue
 
-**Short IDs:** First 8 characters of the UUID, rendered in backticks: `` `af21ed9a` ``
+**Short IDs:** first 8 chars of the UUID in backticks: `` `af21ed9a` ``. Use `—` for empty values, not `0` or blank. Priority renders as `high` / `med` / `low`.
 
-**Use `—`** for empty/null values, not `0` or blank.
+**Grouping key** (standalone items, all modes): `type` field if set; else first tag not in {`agent-observation`, `feature`, `container`}; else "Uncategorized". The generic tag is never the group — the specific one is.
 
-**Priority abbreviations:** `high`, `med`, `low` in tables.
+**Containers** (tag or type `container`) are never counted as active work in any headline or In Flight list, regardless of their role.
 
-**Observations:** Write them sparingly — only when there is a genuine anomaly, bottleneck, or actionable insight. A healthy project needs zero observations. Do not fill space with "work is progressing normally" — the data speaks for itself.
+**statusLabel:** the item's *role* drives the status symbol. Print the statusLabel text only when the item is non-terminal AND the label differs from the role's default. Never print statusLabels on terminal items — stale `in-progress` labels on terminal items are a known artifact (bug `100da214`).
 
-**Empty containers:** Root items where ALL childCounts are zero and role is non-terminal. If any exist, note them at the end of the inventory section: `**Empty (no items):** <title>, <title>`
+**Cancelled ≠ done:** wherever terminal items are broken down, count `statusLabel: "cancelled"` separately.
 
-**Trait abbreviations:** Strip `needs-` prefix for display: `needs-migration-review` → `▸migration-review`
+**Truncation:** if any data-collection response had `truncated: true` that you could not resolve by re-fetching, end the dashboard with `⚠ showing X of Y root items` — never silently drop data.
+
+**Observations:** write them sparingly — only for a genuine anomaly, bottleneck, or actionable insight. A healthy project needs zero observations.
+
+### Internal: Short ID → Full UUID Mapping
+
+Do NOT render a UUID reference table. Retain the short→full UUID mapping as internal context; when the user references a short ID in a follow-up (e.g., "start `0499a6aa`"), resolve it silently for the MCP call from the data already collected.

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -229,7 +229,9 @@ snippets, filtered list search, or hierarchical overview.
 | `operation` | string | Yes | `"overview"` |
 | `itemId` | string (UUID) | No | Scope overview to a specific item; omit for global root overview |
 | `includeChildren` | boolean | No | Include direct children on each root item (global mode only, default: false) |
-| `limit` | integer | No | Max root items (default: 20) |
+| `limit` | integer | No | Max root items (default: 50; global mode only) |
+| `offset` | integer | No | Skip N root items for pagination (default: 0; global mode only — scoped overview always returns all direct children, unpaginated) |
+| `excludeTerminal` | boolean | No | Default false. Global mode: drop terminal-role roots from `items` before their children/counts are even fetched, and `total`/`truncated` reflect the filtered set. Scoped mode: drop terminal-role items from `children` only — the parent is always returned regardless of its own role, and `childCounts` stays unfiltered. |
 
 **Examples.**
 
@@ -327,11 +329,13 @@ When `claimStatus` filter is provided, each result item includes an additional `
 }
 ```
 
-Scoped overview returns the full item JSON in `item`, a count per role in `childCounts`, and a minimal JSON list of direct children in `children` (using `toMinimalJson` fields). Note: scoped overview children do not include `childCounts` or `traits`.
+Scoped overview returns the full item JSON in `item`, a count per role in `childCounts`, and a minimal JSON list of direct children in `children` (using `toMinimalJson` fields, each also enriched with its own `childCounts` and optional `traits` — same enrichment as global-mode `includeChildren`). `childCounts` on the parent is always the full, unfiltered role breakdown, even when `excludeTerminal` hides some of those children from the `children` array below it.
 
 **Response (overview — global mode, no `itemId`).**
 
-Global overview returns root items with the same minimal fields as search, plus `childCounts`, optional `traits`, and `claimSummary` per root item. When `includeChildren` is true, each root includes a `children` array where each child has the minimal fields plus its own `childCounts` and optional `traits`. Root items are ordered newest-`createdAt`-first. `limit` defaults to 50 (same default as list-mode search).
+Global overview returns root items with the same minimal fields as search, plus `childCounts`, optional `traits`, and `claimSummary` per root item. When `includeChildren` is true, each root includes a `children` array where each child has the minimal fields plus its own `childCounts` and optional `traits`. Root items are ordered newest-`createdAt`-first (ties broken by `id` for stable pagination). `limit` defaults to 50 (same default as list-mode search); `offset` pages through roots beyond the first page, same convention as list-mode search.
+
+When `excludeTerminal` is true, terminal-role roots are filtered at the SQL level before pagination — they never appear in `items`, their `children`/`childCounts`/`claimSummary` are never fetched, and `total`/`truncated` are computed against the filtered (non-terminal) set rather than the unconditional root count.
 
 ```json
 {
@@ -353,13 +357,14 @@ Global overview returns root items with the same minimal fields as search, plus 
   ],
   "total": 55,
   "truncated": true,
+  "offset": 0,
   "skipped": 1
 }
 ```
 
 Nullable fields (`parentId`, `statusLabel`, `tags`, `type`) are omitted when null. `traits` is omitted when the item has no traits (never an empty array). `children` is only present when `includeChildren` is true.
 
-`total` is the **true count of all root items** in the database (via a dedicated `COUNT` query), independent of `limit` and of any validation drops — **not** the size of the `items` array. `truncated` is `true` when `items.length < total` for **any** reason — pagination (`total > limit`) or validation drops — which is broader than FTS search's `truncated` (that flag fires only at the FTS hit cap); use `skipped` to disambiguate the cause. `skipped` is present only when > 0: it counts root rows within this page's window that failed domain validation and were dropped rather than returned; a WARN log identifies the row so it can be repaired.
+`total` is the **true count of matching root items** (via a dedicated `COUNT` query) — the unconditional root count when `excludeTerminal` is false/omitted, or the count of non-terminal roots when `excludeTerminal` is true. Either way it is independent of `limit`/`offset` and of any validation drops, and is **not** the size of the `items` array. `offset` echoes the request's `offset` (0 if omitted). `truncated` is `true` when `offset + items.length < total` for **any** reason — more pages remain, or validation drops shrank this page — which is broader than FTS search's `truncated` (that flag fires only at the FTS hit cap); use `skipped` to disambiguate the cause. `skipped` is present only when > 0: it counts root rows within this page's window that failed domain validation and were dropped rather than returned; a WARN log identifies the row so it can be repaired.
 
 `claimSummary` counts are scoped to the direct children of each root item. `active` = live non-expired claims; `expired` = claims past TTL; `unclaimed` = items with no claim record. `claimedBy` identity is never included at this level.
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
@@ -97,8 +97,15 @@ Operations: get, search, overview
 - With itemId: Item metadata + child counts by role + direct children list
 - Without itemId: Global overview of all root items with per-root child counts and claimSummary { active, expired, unclaimed }
 - claimSummary counts are per root-item's subtree (or global when no itemId)
-- Default limit: 20 root items
+- Default limit: 50 root items; offset paginates through roots beyond the first page
+  (global overview only — limit/offset are not applied to scoped overview, which always returns
+  all direct children of the given item)
+- truncated (global overview only) = offset + returned root count < total
 - includeChildren (boolean, default false): When true (global overview only), each root item includes a `children` array of its direct child items
+- excludeTerminal (boolean, default false): global overview drops terminal-role roots from `items`
+  before fetching their children/counts, and total/truncated reflect the filtered set; scoped
+  overview drops terminal-role items from `children` only (the parent itself and childCounts are
+  unaffected)
         """.trimIndent()
 
     override val category = ToolCategory.ITEM_MANAGEMENT
@@ -382,6 +389,24 @@ Operations: get, search, overview
                                 "description",
                                 JsonPrimitive(
                                     "When true, each root item in global overview includes a `children` array of direct child items (overview operation, global mode only)"
+                                )
+                            )
+                        }
+                    )
+                    put(
+                        "excludeTerminal",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("boolean"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "Overview operation only, default false. Global overview (no itemId): excludes " +
+                                        "terminal-role roots from `items` — they are filtered at the SQL level before " +
+                                        "child counts/claim summaries are fetched, and `total`/`truncated` reflect the " +
+                                        "filtered (non-terminal) root count. Scoped overview (itemId set): excludes " +
+                                        "terminal-role items from the `children` array only — the parent item is always " +
+                                        "returned regardless of its own role, and `childCounts` still reflects the full, " +
+                                        "unfiltered role breakdown."
                                 )
                             )
                         }
@@ -948,7 +973,7 @@ Operations: get, search, overview
         if (itemIdError != null) return itemIdError
 
         return if (itemId != null) {
-            executeScopedOverview(itemId, context)
+            executeScopedOverview(itemId, params, context)
         } else {
             executeGlobalOverview(params, context)
         }
@@ -956,8 +981,11 @@ Operations: get, search, overview
 
     private suspend fun executeScopedOverview(
         itemId: java.util.UUID,
+        params: JsonElement,
         context: ToolExecutionContext
     ): JsonElement {
+        val excludeTerminal = optionalBoolean(params, "excludeTerminal", false)
+
         // Fetch the item itself
         val item =
             when (val result = context.workItemRepository().getById(itemId)) {
@@ -968,7 +996,7 @@ Operations: get, search, overview
                 )
             }
 
-        // Count children by role
+        // Count children by role — always the full breakdown, unaffected by excludeTerminal.
         val childCounts =
             when (val result = context.workItemRepository().countChildrenByRole(itemId)) {
                 is Result.Success -> result.data
@@ -987,12 +1015,15 @@ Operations: get, search, overview
                     ErrorCodes.DATABASE_ERROR
                 )
             }
+        // excludeTerminal filters the emitted list only — childCounts above stays unfiltered so
+        // callers can still see how many terminal children exist even when they're hidden here.
+        val visibleChildren = if (excludeTerminal) children.filterNot { it.role == Role.TERMINAL } else children
 
         val data =
             buildJsonObject {
                 put("item", item.toFullJson())
                 put("childCounts", roleCountToJson(childCounts))
-                put("children", JsonArray(children.map { enrichChildJson(it, context) }))
+                put("children", JsonArray(visibleChildren.map { enrichChildJson(it, context) }))
             }
 
         return successResponse(data)
@@ -1005,11 +1036,16 @@ Operations: get, search, overview
         // Default aligned with the shared `limit` parameterSchema description ("default: 50") —
         // this operation previously hardcoded 20, silently truncating dashboards with 21-50 roots.
         val limit = optionalInt(params, "limit") ?: 50
+        val offset = (optionalInt(params, "offset") ?: 0).coerceAtLeast(0)
         val includeChildren = params.jsonObject["includeChildren"]?.jsonPrimitive?.booleanOrNull ?: false
+        val excludeTerminal = optionalBoolean(params, "excludeTerminal", false)
 
-        // Fetch root items (newest-createdAt-first; validation-failed rows dropped and counted)
+        // Fetch root items (newest-createdAt-first; validation-failed rows dropped and counted).
+        // When excludeTerminal is set, terminal-role roots are filtered at the SQL level — they
+        // are never fetched, so the enrichment loop below never pays for their child counts,
+        // claim summaries, or children payload.
         val fetchResult =
-            when (val result = context.workItemRepository().findRootItems(limit)) {
+            when (val result = context.workItemRepository().findRootItems(limit, offset, excludeTerminal)) {
                 is Result.Success -> result.data
                 is Result.Error -> return errorResponse(
                     result.error.message,
@@ -1019,9 +1055,12 @@ Operations: get, search, overview
         val rootItems = fetchResult.items
         val skipped = fetchResult.skipped
 
-        // True root count — unaffected by `limit` or validation drops (see countRootItems KDoc).
+        // True (filtered, when excludeTerminal) root count — unaffected by `limit`/`offset` or
+        // validation drops (see countRootItems KDoc). `total` reflects the same excludeTerminal
+        // value passed to findRootItems above, so it is the count of the set being paged through,
+        // not the unconditional root count.
         val totalRoots =
-            when (val result = context.workItemRepository().countRootItems()) {
+            when (val result = context.workItemRepository().countRootItems(excludeTerminal)) {
                 is Result.Success -> result.data
                 is Result.Error -> return errorResponse(
                     result.error.message,
@@ -1070,7 +1109,10 @@ Operations: get, search, overview
                                 is Result.Success -> result.data
                                 is Result.Error -> emptyList()
                             }
-                        put("children", JsonArray(children.map { enrichChildJson(it, context) }))
+                        // Same excludeTerminal semantics as the scoped-overview `children` array.
+                        val visibleChildren =
+                            if (excludeTerminal) children.filterNot { it.role == Role.TERMINAL } else children
+                        put("children", JsonArray(visibleChildren.map { enrichChildJson(it, context) }))
                     }
                 }
             }
@@ -1078,10 +1120,12 @@ Operations: get, search, overview
         val data =
             buildJsonObject {
                 put("items", JsonArray(itemsWithCounts))
-                // total = true root count (countRootItems), not the returned-page size — matches
-                // the totalHits/truncated convention used by FTS search (executeFtsSearch).
+                // total = root count for the queried set (countRootItems, same excludeTerminal
+                // value as findRootItems above) — not the returned-page size. Matches the
+                // totalHits/truncated convention used by FTS search (executeFtsSearch).
                 put("total", JsonPrimitive(totalRoots))
-                put("truncated", JsonPrimitive(rootItems.size < totalRoots))
+                put("truncated", JsonPrimitive(offset + rootItems.size < totalRoots))
+                put("offset", JsonPrimitive(offset))
                 if (skipped > 0) put("skipped", JsonPrimitive(skipped))
             }
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
@@ -102,10 +102,7 @@ Operations: get, search, overview
   all direct children of the given item)
 - truncated (global overview only) = offset + returned root count < total
 - includeChildren (boolean, default false): When true (global overview only), each root item includes a `children` array of its direct child items
-- excludeTerminal (boolean, default false): global overview drops terminal-role roots from `items`
-  before fetching their children/counts, and total/truncated reflect the filtered set; scoped
-  overview drops terminal-role items from `children` only (the parent itself and childCounts are
-  unaffected)
+- excludeTerminal (boolean, default false): hide terminal-role items from overview results (global vs scoped semantics in the parameter schema)
         """.trimIndent()
 
     override val category = ToolCategory.ITEM_MANAGEMENT

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
@@ -198,23 +198,32 @@ interface WorkItemRepository {
      *
      * Returns an [ItemFetchResult]: rows that fail domain validation are dropped rather than
      * failing the whole query — [ItemFetchResult.skipped] reports how many were dropped. Use
-     * [countRootItems] (unaffected by [limit]/[offset] or validation) for the true root count.
+     * [countRootItems] (unaffected by [limit]/[offset] or validation, with the same
+     * [excludeTerminal] value) for the true root count.
      *
      * @param offset Zero-based row offset applied at the SQL level, for paging through roots
      *   beyond the first [limit] rows.
+     * @param excludeTerminal When true, roots whose `role` is `terminal` are filtered out at the
+     *   SQL level (applied before `limit`/`offset`), so a terminal root is never fetched and
+     *   never counts against the page.
      */
     suspend fun findRootItems(
         limit: Int = 50,
         offset: Int = 0,
+        excludeTerminal: Boolean = false,
     ): Result<ItemFetchResult>
 
     /**
      * True count of root items (items with `parentId IS NULL`), unaffected by any `limit` and
      * computed at the raw-SQL level (not subject to the domain-validation drops that
-     * [findRootItems] applies). Pair with [findRootItems] to detect truncation:
-     * `truncated = returned < total` where `returned = findRootItems(limit).items.size`.
+     * [findRootItems] applies). Pair with [findRootItems] (same [excludeTerminal] value) to
+     * detect truncation: `truncated = offset + returned < total` where
+     * `returned = findRootItems(limit, offset).items.size`.
+     *
+     * @param excludeTerminal When true, counts only roots whose `role` is not `terminal` —
+     *   i.e. the count matches the filtered set [findRootItems] returns with the same flag.
      */
-    suspend fun countRootItems(): Result<Long>
+    suspend fun countRootItems(excludeTerminal: Boolean = false): Result<Long>
 
     /**
      * Find all descendants of the given item (children, grandchildren, etc.) recursively.

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -34,6 +34,7 @@ import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.core.java.UUIDColumnType
 import org.jetbrains.exposed.v1.core.lessEq
 import org.jetbrains.exposed.v1.core.like
+import org.jetbrains.exposed.v1.core.neq
 import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.core.vendors.H2Dialect
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
@@ -530,16 +531,20 @@ class SQLiteWorkItemRepository(
     override suspend fun findRootItems(
         limit: Int,
         offset: Int,
+        excludeTerminal: Boolean,
     ): Result<ItemFetchResult> =
         databaseManager.suspendedTransaction("Failed to find root items") {
             // Ordered newest-first for deterministic, dashboard-relevant pagination — previously
             // relied on SQLite's unordered natural (oldest-first) row order, which meant the
-            // oldest `limit` roots were always returned regardless of how many existed.
+            // oldest `limit` roots were always returned regardless of how many existed. `id` is a
+            // secondary sort key so rows sharing a `createdAt` millisecond still get a stable,
+            // total order — required for offset-based paging to return disjoint pages.
             val rows =
                 WorkItemsTable
                     .selectAll()
-                    .where { WorkItemsTable.parentId.isNull() }
+                    .where { rootItemsCondition(excludeTerminal) }
                     .orderBy(WorkItemsTable.createdAt, SortOrder.DESC)
+                    .orderBy(WorkItemsTable.id, SortOrder.ASC)
                     .limit(limit)
                     .offset(offset.coerceAtLeast(0).toLong())
                     .toList()
@@ -547,10 +552,16 @@ class SQLiteWorkItemRepository(
             Result.Success(ItemFetchResult(items, skipped = rows.size - items.size))
         }
 
-    override suspend fun countRootItems(): Result<Long> =
+    override suspend fun countRootItems(excludeTerminal: Boolean): Result<Long> =
         databaseManager.suspendedTransaction("Failed to count root items") {
-            Result.Success(WorkItemsTable.selectAll().where { WorkItemsTable.parentId.isNull() }.count())
+            Result.Success(WorkItemsTable.selectAll().where { rootItemsCondition(excludeTerminal) }.count())
         }
+
+    /** Shared WHERE condition for root-item queries: `parentId IS NULL`, optionally excluding terminal-role rows. */
+    private fun rootItemsCondition(excludeTerminal: Boolean): Op<Boolean> {
+        val isRoot = WorkItemsTable.parentId.isNull()
+        return if (excludeTerminal) isRoot and (WorkItemsTable.role neq Role.TERMINAL.name.lowercase()) else isRoot
+    }
 
     override suspend fun findDescendants(id: UUID): Result<List<WorkItem>> =
         try {

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolTest.kt
@@ -913,6 +913,221 @@ class QueryItemsToolTest {
         }
 
     // ──────────────────────────────────────────────
+    // excludeTerminal — overview operation
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `global overview excludeTerminal true hides terminal roots and keeps non-terminal roots intact`(): Unit =
+        runBlocking {
+            val activeRootId = createItem("Active Root")
+            createItem("Active Child", parentId = activeRootId, role = "queue")
+            createItem("Done Root", role = "terminal")
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("overview"),
+                        "excludeTerminal" to JsonPrimitive(true)
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            val items = data["items"]!!.jsonArray
+
+            val titles = items.map { it.jsonObject["title"]!!.jsonPrimitive.content }
+            assertTrue(titles.contains("Active Root"), "Non-terminal root should still be present")
+            assertFalse(titles.contains("Done Root"), "Terminal root should be excluded from items")
+
+            // total reflects the filtered (non-terminal) root count, not the unconditional count.
+            assertEquals(1, data["total"]!!.jsonPrimitive.int)
+            assertEquals(false, data["truncated"]!!.jsonPrimitive.boolean)
+
+            // childCounts/children on the surviving root are unaffected by the filter.
+            val activeRoot = items.first { it.jsonObject["title"]!!.jsonPrimitive.content == "Active Root" }.jsonObject
+            val childCounts = activeRoot["childCounts"] as JsonObject
+            assertEquals(1, childCounts["queue"]!!.jsonPrimitive.int)
+        }
+
+    @Test
+    fun `global overview excludeTerminal true with includeChildren also hides terminal children under surviving roots`(): Unit =
+        runBlocking {
+            val rootId = createItem("Root With Mixed Children")
+            createItem("Live Child", parentId = rootId, role = "work")
+            createItem("Done Child", parentId = rootId, role = "terminal")
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("overview"),
+                        "excludeTerminal" to JsonPrimitive(true),
+                        "includeChildren" to JsonPrimitive(true)
+                    ),
+                    context
+                ) as JsonObject
+
+            val data = result["data"] as JsonObject
+            val rootItem =
+                data["items"]!!
+                    .jsonArray
+                    .first { it.jsonObject["title"]!!.jsonPrimitive.content == "Root With Mixed Children" }
+                    .jsonObject
+            val children = rootItem["children"]!!.jsonArray
+            assertEquals(1, children.size)
+            assertEquals("Live Child", children[0].jsonObject["title"]!!.jsonPrimitive.content)
+        }
+
+    @Test
+    fun `scoped overview excludeTerminal true filters terminal children but always returns the parent`(): Unit =
+        runBlocking {
+            val parentId = createItem("Parent In Progress")
+            createItem("Live Child", parentId = parentId, role = "work")
+            createItem("Done Child", parentId = parentId, role = "terminal")
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("overview"),
+                        "itemId" to JsonPrimitive(parentId),
+                        "excludeTerminal" to JsonPrimitive(true)
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+
+            // Parent is always returned regardless of its own role.
+            val item = data["item"] as JsonObject
+            assertEquals("Parent In Progress", item["title"]!!.jsonPrimitive.content)
+
+            val children = data["children"]!!.jsonArray
+            assertEquals(1, children.size)
+            assertEquals("Live Child", children[0].jsonObject["title"]!!.jsonPrimitive.content)
+
+            // childCounts still reflects the full, unfiltered role breakdown.
+            val childCounts = data["childCounts"] as JsonObject
+            assertEquals(1, childCounts["work"]!!.jsonPrimitive.int)
+            assertEquals(1, childCounts["terminal"]!!.jsonPrimitive.int)
+        }
+
+    @Test
+    fun `scoped overview excludeTerminal true still returns a terminal parent itself`(): Unit =
+        runBlocking {
+            val parentId = createItem("Finished Parent", role = "terminal")
+            createItem("Leftover Child", parentId = parentId, role = "terminal")
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("overview"),
+                        "itemId" to JsonPrimitive(parentId),
+                        "excludeTerminal" to JsonPrimitive(true)
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            val item = data["item"] as JsonObject
+            assertEquals("Finished Parent", item["title"]!!.jsonPrimitive.content)
+            assertEquals(0, data["children"]!!.jsonArray.size)
+        }
+
+    @Test
+    fun `overview excludeTerminal omitted defaults to false and preserves current behavior`(): Unit =
+        runBlocking {
+            val parentId = createItem("Parent")
+            createItem("Live Child", parentId = parentId, role = "work")
+            createItem("Done Child", parentId = parentId, role = "terminal")
+            createItem("Done Root", role = "terminal")
+
+            // Global overview: no excludeTerminal param at all.
+            val globalResult =
+                tool.execute(
+                    params("operation" to JsonPrimitive("overview")),
+                    context
+                ) as JsonObject
+            val globalData = globalResult["data"] as JsonObject
+            val globalTitles = globalData["items"]!!.jsonArray.map { it.jsonObject["title"]!!.jsonPrimitive.content }
+            assertTrue(globalTitles.contains("Done Root"), "Terminal root should still appear when excludeTerminal is omitted")
+            assertEquals(2, globalData["total"]!!.jsonPrimitive.int)
+
+            // Scoped overview: no excludeTerminal param at all.
+            val scopedResult =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("overview"),
+                        "itemId" to JsonPrimitive(parentId)
+                    ),
+                    context
+                ) as JsonObject
+            val scopedData = scopedResult["data"] as JsonObject
+            assertEquals(2, scopedData["children"]!!.jsonArray.size)
+        }
+
+    // ──────────────────────────────────────────────
+    // limit/offset pagination — global overview operation
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `global overview offset pages through roots beyond the first page`(): Unit =
+        runBlocking {
+            // Created oldest-first; overview orders newest-createdAt-first, so item 0 is last.
+            val ids = (0 until 5).map { i -> createItem("Root $i") }
+
+            val firstPage =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("overview"),
+                        "limit" to JsonPrimitive(2),
+                        "offset" to JsonPrimitive(0)
+                    ),
+                    context
+                ) as JsonObject
+            val firstData = firstPage["data"] as JsonObject
+            assertEquals(2, firstData["items"]!!.jsonArray.size)
+            assertEquals(5, firstData["total"]!!.jsonPrimitive.int)
+            assertEquals(true, firstData["truncated"]!!.jsonPrimitive.boolean)
+            assertEquals(0, firstData["offset"]!!.jsonPrimitive.int)
+
+            val secondPage =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("overview"),
+                        "limit" to JsonPrimitive(2),
+                        "offset" to JsonPrimitive(2)
+                    ),
+                    context
+                ) as JsonObject
+            val secondData = secondPage["data"] as JsonObject
+            assertEquals(2, secondData["items"]!!.jsonArray.size)
+            assertEquals(true, secondData["truncated"]!!.jsonPrimitive.boolean)
+
+            val thirdPage =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("overview"),
+                        "limit" to JsonPrimitive(2),
+                        "offset" to JsonPrimitive(4)
+                    ),
+                    context
+                ) as JsonObject
+            val thirdData = thirdPage["data"] as JsonObject
+            assertEquals(1, thirdData["items"]!!.jsonArray.size)
+            assertEquals(false, thirdData["truncated"]!!.jsonPrimitive.boolean, "Last page should not be truncated")
+
+            // No overlap between pages.
+            val firstTitles = firstData["items"]!!.jsonArray.map { it.jsonObject["title"]!!.jsonPrimitive.content }.toSet()
+            val secondTitles = secondData["items"]!!.jsonArray.map { it.jsonObject["title"]!!.jsonPrimitive.content }.toSet()
+            val thirdTitles = thirdData["items"]!!.jsonArray.map { it.jsonObject["title"]!!.jsonPrimitive.content }.toSet()
+            assertEquals(emptySet(), firstTitles intersect secondTitles)
+            assertEquals(emptySet(), secondTitles intersect thirdTitles)
+            assertEquals(ids.size, (firstTitles + secondTitles + thirdTitles).size)
+        }
+
+    // ──────────────────────────────────────────────
     // statusLabel coverage
     // ──────────────────────────────────────────────
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryFilterTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryFilterTest.kt
@@ -407,6 +407,44 @@ class SQLiteWorkItemRepositoryFilterTest {
             assertEquals(listOf("Newest", "Middle", "Oldest"), titles)
         }
 
+    @Test
+    fun `findRootItems with excludeTerminal true omits terminal roots`() =
+        runBlocking {
+            repository.create(WorkItem(title = "Active Root", depth = 0, role = Role.QUEUE))
+            repository.create(WorkItem(title = "Done Root", depth = 0, role = Role.TERMINAL))
+
+            val result = repository.findRootItems(excludeTerminal = true)
+            assertIs<Result.Success<ItemFetchResult>>(result)
+            assertEquals(listOf("Active Root"), result.data.items.map { it.title })
+        }
+
+    @Test
+    fun `findRootItems with excludeTerminal false preserves current behavior`() =
+        runBlocking {
+            repository.create(WorkItem(title = "Active Root", depth = 0, role = Role.QUEUE))
+            repository.create(WorkItem(title = "Done Root", depth = 0, role = Role.TERMINAL))
+
+            val result = repository.findRootItems()
+            assertIs<Result.Success<ItemFetchResult>>(result)
+            assertEquals(2, result.data.items.size)
+        }
+
+    @Test
+    fun `countRootItems with excludeTerminal true counts only non-terminal roots`() =
+        runBlocking {
+            repository.create(WorkItem(title = "Active Root 1", depth = 0, role = Role.QUEUE))
+            repository.create(WorkItem(title = "Active Root 2", depth = 0, role = Role.WORK))
+            repository.create(WorkItem(title = "Done Root", depth = 0, role = Role.TERMINAL))
+
+            val filteredCount = repository.countRootItems(excludeTerminal = true)
+            assertIs<Result.Success<Long>>(filteredCount)
+            assertEquals(2L, filteredCount.data)
+
+            val unfilteredCount = repository.countRootItems()
+            assertIs<Result.Success<Long>>(unfilteredCount)
+            assertEquals(3L, unfilteredCount.data)
+        }
+
     /**
      * Directly blanks a row's title via Exposed, bypassing [WorkItem.validate]. Simulates a
      * corrupt/legacy row that [SQLiteWorkItemRepository]'s `toWorkItemOrNull` must drop rather


### PR DESCRIPTION
## Summary
- Adds `excludeTerminal` (boolean, default false) to `query_items` overview: global mode filters terminal-role roots at the SQL level before child-count/claim/children enrichment (`total`/`truncated` reflect the filtered set); scoped mode filters terminal children only, leaving the parent and its full `childCounts` breakdown intact.
- Wires `offset` through global overview (repository already supported it; the tool never passed it), adds an `id` secondary sort key for stable pagination, echoes `offset` in the response, and aligns the default limit with the documented 50 (was hardcoded 20).
- Rewrites the `work-summary` plugin skill around progressive disclosure: lean attention-first default (~45-line budget, true role counts, session-resume recency, backlog rollups), exhaustive inventory behind an explicit `full` argument, scoped mode unchanged. Fixes phantom data references, silent truncation, first-tag grouping collapse, container-as-active miscounts, and cancelled/done conflation.
- api-reference.md updated, including a stale-claim fix (scoped overview children DO carry `childCounts`/`traits` enrichment).

## Test Results
2351 tests completed, 0 failed; ktlintCheck clean (both verified at EXIT=0). New coverage: excludeTerminal global/scoped/regression semantics at the tool layer (+215 lines) and SQL-level root filtering at the repository layer (new SQLiteWorkItemRepositoryFilterTest).

## Review
Pass with observations. Independent implementation (subagent) with orchestrator review of the Kotlin change; simplify pass applied one fix (condensed duplicated excludeTerminal prose to a one-line pointer, keeping the parameterSchema as the detailed source). Skill-level validation (live /work-summary run comparing counts to role-query totals) is deferred to post-merge after marketplace re-add.

## MCP
- 71851001-91be-4248-b319-b1730a351e45 (overview excludeTerminal filtering)
- 01d17bfa-b924-4695-8524-03105e8a1f9e (work-summary skill overhaul)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cjv1qfXhHWVipTfAQ6DasP