### PR TITLE
feat(server): project-root subtree scoping primitives

### DIFF
--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -229,11 +229,12 @@ snippets, filtered list search, or hierarchical overview.
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `operation` | string | Yes | `"overview"` |
-| `itemId` | string (UUID) | No | Scope overview to a specific item; omit for global root overview |
+| `itemId` | string (UUID) | No | Scope overview to a specific item (scoped mode); omit for global root overview. Mutually exclusive with `ancestorId`. |
+| `ancestorId` | string (UUID or 4+ char prefix) | No | Anchored mode: renders this item's DIRECT CHILDREN as the roots set, each with a full-subtree role-count roll-up. Mutually exclusive with `itemId` — supplying both is a validation error. |
 | `includeChildren` | boolean | No | Include direct children on each root item (global mode only, default: false) |
-| `limit` | integer | No | Max root items (default: 50; global mode only) |
-| `offset` | integer | No | Skip N root items for pagination (default: 0; global mode only — scoped overview always returns all direct children, unpaginated) |
-| `excludeTerminal` | boolean | No | Default false. Global mode: drop terminal-role roots from `items` before their children/counts are even fetched, and `total`/`truncated` reflect the filtered set. Scoped mode: drop terminal-role items from `children` only — the parent is always returned regardless of its own role, and `childCounts` stays unfiltered. |
+| `limit` | integer | No | Max root items (default: 50; global and anchored modes only) |
+| `offset` | integer | No | Skip N root items for pagination (default: 0; global and anchored modes only — scoped overview always returns all direct children, unpaginated) |
+| `excludeTerminal` | boolean | No | Default false. Global and anchored modes: drop terminal-role roots from `items` before their children/counts are even fetched, and `total`/`truncated` reflect the filtered set. Scoped mode: drop terminal-role items from `children` only — the parent is always returned regardless of its own role, and `childCounts` stays unfiltered. |
 
 #### Key Parameters — schema
 
@@ -395,6 +396,35 @@ Nullable fields (`parentId`, `statusLabel`, `tags`, `type`) are omitted when nul
 `total` is the **true count of matching root items** (via a dedicated `COUNT` query) — the unconditional root count when `excludeTerminal` is false/omitted, or the count of non-terminal roots when `excludeTerminal` is true. Either way it is independent of `limit`/`offset` and of any validation drops, and is **not** the size of the `items` array. `offset` echoes the request's `offset` (0 if omitted). `truncated` is `true` when `offset + items.length < total` for **any** reason — more pages remain, or validation drops shrank this page — which is broader than FTS search's `truncated` (that flag fires only at the FTS hit cap); use `skipped` to disambiguate the cause. `skipped` is present only when > 0: it counts root rows within this page's window that failed domain validation and were dropped rather than returned; a WARN log identifies the row so it can be repaired.
 
 `claimSummary` counts are scoped to the direct children of each root item. `active` = live non-expired claims; `expired` = claims past TTL; `unclaimed` = items with no claim record. `claimedBy` identity is never included at this level.
+
+**Response (overview — anchored mode, with `ancestorId`).**
+
+```json
+{
+  "anchor": { "id": "uuid", "title": "Q3 Platform Project" },
+  "items": [
+    {
+      "id": "uuid", "parentId": "uuid", "title": "Auth Feature", "role": "work",
+      "priority": "high", "depth": 1, "tags": "backend", "type": "feature-implementation",
+      "traits": ["needs-migration-review"],
+      "childCounts": { "queue": 2, "work": 1, "review": 0, "blocked": 0, "terminal": 1 }
+    }
+  ],
+  "total": 6,
+  "truncated": false,
+  "offset": 0
+}
+```
+
+Anchored overview renders `ancestorId`'s **direct children** as the roots set (instead of true
+depth-0 items) — the project-dashboard entry point when `ancestorId` is a project/feature anchor.
+The `anchor` envelope names the item whose children are being rendered. Each item uses the same
+minimal fields as global overview, but its `childCounts` is a **full-subtree** role roll-up
+(descendants at any depth), not the direct-children-only breakdown that global/scoped overview use
+— this is the key semantic difference from scoped overview (`itemId`), which returns direct
+childCounts. `claimSummary` and `includeChildren` are not supported in anchored mode (kept to one
+repository call per child). `total`/`truncated`/`offset`/`excludeTerminal` follow the same
+conventions as global mode, applied to the anchor's direct-children set rather than true roots.
 
 ---
 

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -205,6 +205,7 @@ snippets, filtered list search, or hierarchical overview.
 |---|---|---|---|
 | `operation` | string | Yes | `"search"` |
 | `parentId` | string (UUID) | No | Filter by parent |
+| `ancestorId` | string (UUID or 4+ char prefix) | No | List mode only: limit to items in this item's subtree (any depth, inclusive). Mirrors `scope.ancestorId`'s semantics but for list-mode filtering; omitted = unscoped, byte-identical to prior behavior. Not used in FTS mode — use `scope.ancestorId` there. |
 | `depth` | integer | No | Filter by depth level |
 | `role` | string | No | Filter by role: `queue`, `work`, `review`, `blocked`, `terminal` |
 | `priority` | string | No | Filter: `high`, `medium`, `low` |
@@ -1196,6 +1197,7 @@ When `mode` is omitted, the mode is inferred from which parameters are present (
 | `mode` | string | No | Explicit mode: `"item"`, `"session-resume"`, or `"health-check"`. When provided, takes precedence over implicit detection. |
 | `itemId` | string (UUID) | No | Item UUID for item mode. Required when `mode="item"`. |
 | `since` | string (ISO 8601) | No | Timestamp for session-resume mode. Required when `mode="session-resume"`. |
+| `ancestorId` | string (UUID or 4+ char prefix) | No | Limit health-check and session-resume results (active/blocked/stalled items, claim summary) to this item's subtree (any depth, inclusive). Ignored in item mode. Omitted = unscoped. Does NOT scope `recentTransitions` in session-resume mode — see note below. |
 | `includeAncestors` | boolean | No | Include `ancestors` array on each listed item (default: false) |
 | `limit` | integer (1–200) | No | Max role transitions in session-resume mode (default: 10) |
 
@@ -1273,6 +1275,8 @@ Each entry in the `schema` array is keys-only: `key`, `role`, `required`, `exist
 
 `limit` caps `recentTransitions` (default 10, max 200). Each transition entry is `{ itemId, title, fromRole, toRole, at, actorId? }` — `actorId` is omitted when the transition had no actor claim. There is no claim summary in this mode — use item mode or health-check mode for claim visibility. `stalledItems` entries may include `guidanceKey`/`skillPointer` for the first missing note, same semantics as item mode.
 
+**Known limitation:** when `ancestorId` is set, `activeItems` and `stalledItems` are scoped to the subtree, but `recentTransitions` is NOT — it always reflects transitions across the whole tree. Scoping transitions would require resolving the subtree set and filtering the transition-item lookup by it, which was flagged as invasive for the initial implementation.
+
 **Response (health-check mode).**
 
 ```json
@@ -1311,6 +1315,7 @@ and is intentionally inclusive.
 |---|---|---|---|
 | `role` | string | No | Role to query: `queue`, `work`, `review`, or `blocked` (default: `queue`) |
 | `parentId` | string (UUID) | No | Scope recommendations to items under this parent |
+| `ancestorId` | string (UUID or 4+ char prefix) | No | Limit recommendations to this item's subtree (any depth, inclusive). Composes with `parentId` (both applied). Omitted = unscoped, byte-identical to prior behavior. |
 | `limit` | integer (1–20) | No | Number of recommendations (default: 1) |
 | `includeDetails` | boolean | No | Include `summary`, `tags`, and `parentId` in each recommendation (default: false) |
 | `includeAncestors` | boolean | No | Include `ancestors` array on each recommendation (default: false) |
@@ -1640,6 +1645,7 @@ dependency edges). Terminal items are never included.
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `parentId` | string (UUID) | No | Scope results to items under this parent |
+| `ancestorId` | string (UUID or 4+ char prefix) | No | Limit candidate items to this item's subtree (any depth, inclusive). Composes with `parentId` (both applied). Omitted = unscoped, byte-identical to prior behavior. |
 | `includeDetails` | boolean | No | Include `summary` and `tags` for each blocked item (default: false) |
 | `includeAncestors` | boolean | No | Include `ancestors` array on each blocked item (default: false) |
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ItemHierarchyValidator.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ItemHierarchyValidator.kt
@@ -72,32 +72,34 @@ class ItemHierarchyValidator {
     }
 
     /**
-     * Recomputes the stored `depth` for every descendant of [itemId] after the item's own depth
-     * changed by [delta] (`newDepth - oldDepth`).
+     * Recomputes the stored `depth` and `rootId` for every descendant of [itemId] after the
+     * item's own depth changed by [delta] (`newDepth - oldDepth`) and its own root ancestor
+     * changed to [newRootId].
      *
-     * No-op when [delta] is zero — callers may invoke this unconditionally. Fetches the full
+     * Unlike the depth-only cascade this replaced, this is NOT a no-op when [delta] is zero:
+     * reparenting an item to a different root subtree at the *same* depth (e.g. moving a
+     * depth-1 leaf from one root's children to another root's children) leaves depth
+     * unchanged but must still restamp `rootId` on every descendant. Fetches the full
      * descendant set via [WorkItemRepository.findDescendants] and applies [delta] to each
-     * descendant's depth, persisting through [WorkItemRepository.update] (the update builder keeps
-     * `modifiedAt` monotonic, and `update` enforces the same optimistic-version check used for any
-     * other item write).
+     * descendant's depth while overwriting `rootId` with [newRootId], persisting through
+     * [WorkItemRepository.update] (the update builder keeps `modifiedAt` monotonic, and
+     * `update` enforces the same optimistic-version check used for any other item write).
      *
      * This issues one `update` per descendant — there is no bulk-update primitive on
      * [WorkItemRepository] to batch these into a single statement. Callers that need the parent's
-     * own depth write and this cascade to be atomic (all-or-nothing) MUST invoke both inside a
-     * shared [WorkItemRepository.inTransaction] block.
+     * own depth/rootId write and this cascade to be atomic (all-or-nothing) MUST invoke both
+     * inside a shared [WorkItemRepository.inTransaction] block.
      *
      * @return [Result.Success] once every descendant has been updated (including the trivial case
-     *   of zero descendants or a zero [delta]); [Result.Error] on the first failure encountered —
-     *   either the descendant fetch or a single descendant's update (e.g. a version-mismatch
-     *   conflict).
+     *   of zero descendants); [Result.Error] on the first failure encountered — either the
+     *   descendant fetch or a single descendant's update (e.g. a version-mismatch conflict).
      */
     suspend fun recomputeDescendantDepths(
         itemId: UUID,
         delta: Int,
+        newRootId: UUID,
         repo: WorkItemRepository
     ): Result<Unit> {
-        if (delta == 0) return Result.Success(Unit)
-
         val descendants =
             when (val descendantsResult = repo.findDescendants(itemId)) {
                 is Result.Success -> descendantsResult.data
@@ -105,7 +107,7 @@ class ItemHierarchyValidator {
             }
 
         for (descendant in descendants) {
-            val updatedDescendant = descendant.update { d -> d.copy(depth = d.depth + delta) }
+            val updatedDescendant = descendant.update { d -> d.copy(depth = d.depth + delta, rootId = newRootId) }
             when (val updateResult = repo.update(updatedDescendant)) {
                 is Result.Success -> {}
                 is Result.Error -> return updateResult

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommender.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommender.kt
@@ -50,6 +50,12 @@ class NextItemRecommender(
          * exclusion for callers without actor context, such as [GetNextItemTool]).
          */
         val requestingAgentId: String? = null,
+        /**
+         * Optional subtree scope forwarded to [WorkItemRepository.findClaimable]. When null
+         * (default), unscoped. When non-null, candidates are restricted to the subtree(s)
+         * rooted at these UUIDs (roots included) — same resolution as [WorkItemRepository.findInScope].
+         */
+        val ancestorIds: Set<UUID>? = null,
     )
 
     /**
@@ -83,6 +89,7 @@ class NextItemRecommender(
                 orderBy = criteria.orderBy,
                 limit = OVER_FETCH_LIMIT,
                 requestingAgentId = criteria.requestingAgentId,
+                rootIds = criteria.ancestorIds,
             )
 
         if (candidatesResult is Result.Error) {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
@@ -427,26 +427,38 @@ depth in attach mode). No depth cap.
                 )
             }
         } else {
-            // Create mode: compute root depth from parent, then build a new WorkItem.
-            val rootDepth =
-                if (parentId != null) {
-                    val parentResult = context.workItemRepository().getById(parentId)
-                    when (parentResult) {
-                        is Result.Success -> parentResult.data.depth + 1
-                        is Result.Error -> return errorResponse(
-                            "Parent item '$parentId' not found: ${parentResult.error.message}",
-                            ErrorCodes.RESOURCE_NOT_FOUND
-                        )
+            // Create mode: compute root depth + rootId from parent, then build a new WorkItem.
+            // rootId: a new root with no parentId is its own root; a new root created under
+            // parentId inherits that parent's root (or the parent's own id, if the parent
+            // predates the root_id backfill and has no rootId yet) — same idiom as
+            // CreateItemHandler.
+            val rootItemId = UUID.randomUUID()
+            val rootDepth: Int
+            val rootRootId: UUID
+            if (parentId != null) {
+                val parentResult = context.workItemRepository().getById(parentId)
+                when (parentResult) {
+                    is Result.Success -> {
+                        rootDepth = parentResult.data.depth + 1
+                        rootRootId = parentResult.data.rootId ?: parentResult.data.id
                     }
-                } else {
-                    0
+                    is Result.Error -> return errorResponse(
+                        "Parent item '$parentId' not found: ${parentResult.error.message}",
+                        ErrorCodes.RESOURCE_NOT_FOUND
+                    )
                 }
+            } else {
+                rootDepth = 0
+                rootRootId = rootItemId
+            }
             rootItem =
                 buildWorkItem(
                     obj = rootObj,
                     parentId = parentId,
                     depth = rootDepth,
-                    contextLabel = "root"
+                    rootId = rootRootId,
+                    contextLabel = "root",
+                    id = rootItemId
                 ) ?: return errorResponse("Failed to build root item", ErrorCodes.VALIDATION_ERROR)
             isExistingRoot = false
         }
@@ -504,11 +516,18 @@ depth in attach mode). No depth cap.
             val parentRef = refToParentRef[ref]!!
             val parentItem = refToItem[parentRef]!! // root or already-built sibling
             val depth = parentItem.depth + 1
+            // rootId: inherit the parent's root (or the parent's own id, if the parent predates
+            // the root_id backfill and has no rootId yet). Works uniformly in both modes — in
+            // attach mode, refToItem[ROOT_REF] is the fetched *existing* root item, so its
+            // direct children correctly inherit its rootId ?: its id; deeper descendants inherit
+            // through their already-built parent, which by then carries the resolved rootId.
+            val childRootId = parentItem.rootId ?: parentItem.id
             val childItem =
                 buildWorkItem(
                     obj = childObj,
                     parentId = parentItem.id,
                     depth = depth,
+                    rootId = childRootId,
                     contextLabel = "child '$ref'"
                 ) ?: return errorResponse("Failed to build child item '$ref'", ErrorCodes.VALIDATION_ERROR)
             refToItem[ref] = childItem
@@ -812,7 +831,9 @@ depth in attach mode). No depth cap.
         obj: JsonObject,
         parentId: UUID?,
         depth: Int,
-        contextLabel: String
+        rootId: UUID,
+        contextLabel: String,
+        id: UUID = UUID.randomUUID()
     ): WorkItem? {
         val title =
             (obj["title"] as? JsonPrimitive)?.takeIf { it.isString }?.content
@@ -836,8 +857,9 @@ depth in attach mode). No depth cap.
 
         return try {
             WorkItem(
-                id = UUID.randomUUID(),
+                id = id,
                 parentId = parentId,
+                rootId = rootId,
                 title = title,
                 description = description,
                 summary = summary,

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/CreateItemHandler.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/CreateItemHandler.kt
@@ -88,6 +88,20 @@ class CreateItemHandler(
                         errorPrefix = "Item at index $index"
                     )
 
+                // rootId: inherit the parent's root (or the parent's own id, if the parent
+                // predates the root_id backfill and has no rootId yet); own id at depth 0.
+                val rootId =
+                    if (parentId == null) {
+                        itemId
+                    } else {
+                        when (val parentResult = repo.getById(parentId)) {
+                            is Result.Success -> parentResult.data.rootId ?: parentResult.data.id
+                            is Result.Error -> throw ToolValidationException(
+                                "Item at index $index: parent '$parentId' not found"
+                            )
+                        }
+                    }
+
                 // Parse role with default
                 val role =
                     if (roleStr != null) {
@@ -119,6 +133,7 @@ class CreateItemHandler(
                     WorkItem(
                         id = itemId,
                         parentId = parentId,
+                        rootId = rootId,
                         title = title,
                         description = description,
                         summary = summary,

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
@@ -57,8 +57,11 @@ description for the available filters. `claimedBy` identity is NEVER included in
 (list mode's `claimStatus` filter only adds a boolean `isClaimed`) — use `get_context(itemId)` for
 full claim details.
 
-**overview** without `itemId` returns a global summary of all root items; with `itemId` it returns
-that item's metadata, child counts by role, and direct children.
+**overview** without `itemId`/`ancestorId` returns a global summary of all root items; with `itemId`
+it returns that item's metadata, child counts by role, and direct children (scoped overview). With
+`ancestorId` instead, that item's direct children become the roots set (each enriched with
+full-subtree role-count roll-ups) — the anchored/project-dashboard entry point. `itemId` and
+`ancestorId` are mutually exclusive for this operation; supplying both is a validation error.
 
 **schema** requires exactly one of `type` or `itemId`. Returns the full note schema (description +
 guidance + skill + maxLength per entry) — the reference target for keys-only `expectedNotes` /
@@ -119,10 +122,15 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
                             put(
                                 "description",
                                 JsonPrimitive(
-                                    "List mode only (search without `query`): UUID or hex prefix (4+ chars) of an " +
-                                        "item whose subtree (any depth, inclusive) results are limited to. Mirrors " +
-                                        "scope.ancestorId's semantics but for list-mode filtering; omitted = " +
-                                        "unscoped, byte-identical to current behavior. Not used in FTS mode — use " +
+                                    "UUID or hex prefix (4+ chars) of an item whose subtree scopes the operation. " +
+                                        "In list mode (search without `query`): results are limited to this item's " +
+                                        "subtree (any depth, inclusive) — mirrors scope.ancestorId's semantics as a " +
+                                        "top-level list-mode param; omitted = unscoped, byte-identical to current " +
+                                        "behavior. In the overview operation: this item's direct children become " +
+                                        "the roots set (instead of true depth-0 items), each enriched with " +
+                                        "full-subtree role-count roll-ups — overview's counterpart of list-mode " +
+                                        "ancestorId, for anchoring a dashboard on a project/feature container; " +
+                                        "mutually exclusive with itemId there. Not used in FTS mode — use " +
                                         "scope.ancestorId there instead."
                                 )
                             )
@@ -434,7 +442,17 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
                     throw ToolValidationException("offset must be non-negative")
                 }
             }
-            "overview" -> { /* all parameters are optional */ }
+            "overview" -> {
+                validateIdOrPrefix(params, "ancestorId", required = false)
+                val itemIdStr = optionalString(params, "itemId")
+                val ancestorIdStr = optionalString(params, "ancestorId")
+                if (itemIdStr != null && ancestorIdStr != null) {
+                    throw ToolValidationException(
+                        "operation=overview accepts at most one of: itemId, ancestorId — they select " +
+                            "mutually exclusive overview modes (scoped vs. anchored)"
+                    )
+                }
+            }
             "schema" -> {
                 val type = optionalString(params, "type")
                 val itemIdStr = optionalString(params, "itemId")
@@ -528,18 +546,23 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
                             if (it is JsonPrimitive && it.isString) it.content else null
                         }
                     }
-                if (title != null) {
-                    val children =
-                        data?.get("children")?.let {
-                            (it as? JsonArray)?.size
-                        } ?: 0
-                    "Overview: $title -- $children children"
-                } else {
-                    val total =
-                        data?.get("total")?.let {
-                            if (it is JsonPrimitive) it.intOrNull else null
-                        } ?: 0
-                    "Overview: root items -- $total items"
+                val anchorTitle =
+                    data?.get("anchor")?.let { anchorObj ->
+                        (anchorObj as? JsonObject)?.get("title")?.let {
+                            if (it is JsonPrimitive && it.isString) it.content else null
+                        }
+                    }
+                val total =
+                    data?.get("total")?.let {
+                        if (it is JsonPrimitive) it.intOrNull else null
+                    } ?: 0
+                when {
+                    title != null -> {
+                        val children = data?.get("children")?.let { (it as? JsonArray)?.size } ?: 0
+                        "Overview: $title -- $children children"
+                    }
+                    anchorTitle != null -> "Overview: $anchorTitle -- $total root(s)"
+                    else -> "Overview: root items -- $total items"
                 }
             }
             "schema" -> {
@@ -1077,11 +1100,15 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
     ): JsonElement {
         val (itemId, itemIdError) = resolveItemId(params, "itemId", context, required = false)
         if (itemIdError != null) return itemIdError
+        val (ancestorId, ancestorIdError) = resolveItemId(params, "ancestorId", context, required = false)
+        if (ancestorIdError != null) return ancestorIdError
 
-        return if (itemId != null) {
-            executeScopedOverview(itemId, params, context)
-        } else {
-            executeGlobalOverview(params, context)
+        // validateParams rejects itemId+ancestorId together for real callers (McpToolAdapter);
+        // itemId takes priority here as a defensive fallback for direct execute() calls.
+        return when {
+            itemId != null -> executeScopedOverview(itemId, params, context)
+            ancestorId != null -> executeAnchoredOverview(ancestorId, params, context)
+            else -> executeGlobalOverview(params, context)
         }
     }
 
@@ -1130,6 +1157,103 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
                 put("item", item.toFullJson())
                 put("childCounts", roleCountToJson(childCounts))
                 put("children", JsonArray(visibleChildren.map { enrichChildJson(it, context) }))
+            }
+
+        return successResponse(data)
+    }
+
+    /**
+     * Anchored overview: [ancestorId]'s DIRECT CHILDREN act as the roots set (instead of true
+     * depth-0 items) — the project-dashboard entry point when [ancestorId] is a project/feature
+     * anchor. Distinct from [executeScopedOverview] (`itemId`), which returns the item itself plus
+     * its children with DIRECT childCounts: here each child is enriched with a FULL-SUBTREE
+     * role-count roll-up via [WorkItemRepository.countInScopeByRole], one call per child.
+     *
+     * `countInScopeByRole` is roots-inclusive (mirrors the `InScope` family's contract), so the
+     * child's own role is subtracted from its roll-up here — `childCounts` stays "descendants
+     * only", consistent with every other `childCounts` field this tool emits (never self-inclusive).
+     *
+     * `excludeTerminal` is applied at the same layer the global path applies it: filtered children
+     * are excluded from both `items` and the `total`/`truncated` basis (unlike scoped overview,
+     * where `excludeTerminal` only trims the `children` array and `childCounts` stays unfiltered).
+     */
+    private suspend fun executeAnchoredOverview(
+        ancestorId: java.util.UUID,
+        params: JsonElement,
+        context: ToolExecutionContext
+    ): JsonElement {
+        val limit = optionalInt(params, "limit") ?: 50
+        val offset = (optionalInt(params, "offset") ?: 0).coerceAtLeast(0)
+        val excludeTerminal = optionalBoolean(params, "excludeTerminal", false)
+
+        val anchorItem =
+            when (val result = context.workItemRepository().getById(ancestorId)) {
+                is Result.Success -> result.data
+                is Result.Error -> return errorResponse(
+                    result.error.message,
+                    ErrorCodes.RESOURCE_NOT_FOUND
+                )
+            }
+
+        // Direct children of the anchor act as the roots set for this view.
+        val allChildren =
+            when (val result = context.workItemRepository().findChildren(ancestorId)) {
+                is Result.Success -> result.data
+                is Result.Error -> return errorResponse(
+                    result.error.message,
+                    ErrorCodes.DATABASE_ERROR
+                )
+            }
+        // findChildren has no SQL-level excludeTerminal or ordering — filter and sort in memory.
+        // excludeTerminal narrows the roots set itself (same layer as the global path), so
+        // total/truncated below reflect the filtered count, not the raw direct-children count.
+        val visibleChildren =
+            (if (excludeTerminal) allChildren.filterNot { it.role == Role.TERMINAL } else allChildren)
+                .sortedByDescending { it.createdAt }
+        val totalChildren = visibleChildren.size
+        val pagedChildren = visibleChildren.drop(offset).take(limit)
+
+        val itemsWithCounts =
+            pagedChildren.map { child ->
+                val subtreeCounts =
+                    when (
+                        val result =
+                            context.workItemRepository().countInScopeByRole(rootIds = setOf(child.id))
+                    ) {
+                        is Result.Success -> result.data
+                        is Result.Error -> emptyMap()
+                    }
+                // Subtract the child's own role — countInScopeByRole is roots-inclusive, but
+                // childCounts here should represent descendants only (see KDoc above).
+                val descendantCounts =
+                    subtreeCounts.toMutableMap().apply {
+                        val withoutSelf = (this[child.role] ?: 0) - 1
+                        if (withoutSelf > 0) this[child.role] = withoutSelf else remove(child.role)
+                    }
+
+                buildJsonObject {
+                    child.toMinimalJson().forEach { (k, v) -> put(k, v) }
+                    val childTraits = PropertiesHelper.extractTraits(child.properties)
+                    if (childTraits.isNotEmpty()) {
+                        put("traits", JsonArray(childTraits.map { JsonPrimitive(it) }))
+                    }
+                    put("childCounts", roleCountToJson(descendantCounts))
+                }
+            }
+
+        val data =
+            buildJsonObject {
+                put(
+                    "anchor",
+                    buildJsonObject {
+                        put("id", JsonPrimitive(anchorItem.id.toString()))
+                        put("title", JsonPrimitive(anchorItem.title))
+                    }
+                )
+                put("items", JsonArray(itemsWithCounts))
+                put("total", JsonPrimitive(totalChildren))
+                put("truncated", JsonPrimitive(offset + pagedChildren.size < totalChildren))
+                put("offset", JsonPrimitive(offset))
             }
 
         return successResponse(data)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
@@ -113,6 +113,22 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
                         }
                     )
                     put(
+                        "ancestorId",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "List mode only (search without `query`): UUID or hex prefix (4+ chars) of an " +
+                                        "item whose subtree (any depth, inclusive) results are limited to. Mirrors " +
+                                        "scope.ancestorId's semantics but for list-mode filtering; omitted = " +
+                                        "unscoped, byte-identical to current behavior. Not used in FTS mode — use " +
+                                        "scope.ancestorId there instead."
+                                )
+                            )
+                        }
+                    )
+                    put(
                         "role",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
@@ -396,6 +412,7 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
         when (operation) {
             "get" -> validateIdOrPrefix(params, "itemId")
             "search" -> {
+                validateIdOrPrefix(params, "ancestorId", required = false)
                 val claimStatus = optionalString(params, "claimStatus")
                 if (claimStatus != null && claimStatus !in VALID_CLAIM_STATUSES) {
                     throw ToolValidationException(
@@ -819,6 +836,8 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
     ): JsonElement {
         val (parentId, parentIdError) = resolveItemId(params, "parentId", context, required = false)
         if (parentIdError != null) return parentIdError
+        val (ancestorId, ancestorIdError) = resolveItemId(params, "ancestorId", context, required = false)
+        if (ancestorIdError != null) return ancestorIdError
         val depth = optionalInt(params, "depth")
         val roleStr = optionalString(params, "role")
         val priorityStr = optionalString(params, "priority")
@@ -871,92 +890,149 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
         // Parse tags
         val tags = tagsStr?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }
 
-        // Get full match count (no limit/offset) for accurate pagination metadata
+        // Get full match count (no limit/offset) for accurate pagination metadata.
+        // When ancestorId is set, route through countInScope/findInScope (T2.2 scoped variants)
+        // instead of countByFilters/findByFilters — same filter set, additionally restricted to
+        // the ancestor's subtree (inclusive). Omitted ancestorId preserves whole-DB behavior.
         val totalCount =
-            when (
-                val countResult =
-                    context.workItemRepository().countByFilters(
-                        parentId = parentId,
-                        depth = depth,
-                        role = role,
-                        priority = priority,
-                        tags = tags,
-                        query = null, // LIKE-based query removed; FTS goes through executeFtsSearch
-                        createdAfter = createdAfter,
-                        createdBefore = createdBefore,
-                        modifiedAfter = modifiedAfter,
-                        modifiedBefore = modifiedBefore,
-                        roleChangedAfter = roleChangedAfter,
-                        roleChangedBefore = roleChangedBefore,
-                        type = typeFilter,
-                        claimStatus = claimStatusFilter
-                    )
-            ) {
-                is Result.Success -> countResult.data
-                is Result.Error -> return errorResponse(countResult.error.message, ErrorCodes.DATABASE_ERROR)
-            }
-
-        return when (
-            val result =
-                context.workItemRepository().findByFilters(
-                    parentId = parentId,
-                    depth = depth,
-                    role = role,
-                    priority = priority,
-                    tags = tags,
-                    query = null, // LIKE-based query removed; FTS goes through executeFtsSearch
-                    createdAfter = createdAfter,
-                    createdBefore = createdBefore,
-                    modifiedAfter = modifiedAfter,
-                    modifiedBefore = modifiedBefore,
-                    roleChangedAfter = roleChangedAfter,
-                    roleChangedBefore = roleChangedBefore,
-                    sortBy = sortBy,
-                    sortOrder = sortOrder,
-                    limit = limit,
-                    offset = offset,
-                    type = typeFilter,
-                    claimStatus = claimStatusFilter
-                )
-        ) {
-            is Result.Success -> {
-                val items = result.data.items
-                val skipped = result.data.skipped
-
-                val chains: Map<java.util.UUID, List<WorkItem>> =
-                    if (includeAncestors && items.isNotEmpty()) {
-                        val chainResult = context.workItemRepository().findAncestorChains(items.map { it.id }.toSet())
-                        (chainResult as? Result.Success)?.data ?: emptyMap()
-                    } else {
-                        emptyMap()
-                    }
-
-                val data =
-                    buildJsonObject {
-                        put(
-                            "items",
-                            JsonArray(
-                                items.map { item ->
-                                    buildSearchResultItem(item, claimStatusFilter, includeAncestors, chains)
-                                }
-                            )
+            if (ancestorId != null) {
+                when (
+                    val countResult =
+                        context.workItemRepository().countInScope(
+                            rootIds = setOf(ancestorId),
+                            parentId = parentId,
+                            depth = depth,
+                            role = role,
+                            priority = priority,
+                            tags = tags,
+                            query = null,
+                            createdAfter = createdAfter,
+                            createdBefore = createdBefore,
+                            modifiedAfter = modifiedAfter,
+                            modifiedBefore = modifiedBefore,
+                            roleChangedAfter = roleChangedAfter,
+                            roleChangedBefore = roleChangedBefore,
+                            type = typeFilter,
+                            claimStatus = claimStatusFilter
                         )
-                        // total = raw SQL count (countByFilters), unaffected by validation drops.
-                        // Invariant: total = returned + skipped + notFetched (rows beyond limit/offset).
-                        put("total", JsonPrimitive(totalCount))
-                        put("returned", JsonPrimitive(items.size))
-                        if (skipped > 0) put("skipped", JsonPrimitive(skipped))
-                        put("limit", JsonPrimitive(limit))
-                        put("offset", JsonPrimitive(offset))
-                    }
-                successResponse(data)
+                ) {
+                    is Result.Success -> countResult.data
+                    is Result.Error -> return errorResponse(countResult.error.message, ErrorCodes.DATABASE_ERROR)
+                }
+            } else {
+                when (
+                    val countResult =
+                        context.workItemRepository().countByFilters(
+                            parentId = parentId,
+                            depth = depth,
+                            role = role,
+                            priority = priority,
+                            tags = tags,
+                            query = null, // LIKE-based query removed; FTS goes through executeFtsSearch
+                            createdAfter = createdAfter,
+                            createdBefore = createdBefore,
+                            modifiedAfter = modifiedAfter,
+                            modifiedBefore = modifiedBefore,
+                            roleChangedAfter = roleChangedAfter,
+                            roleChangedBefore = roleChangedBefore,
+                            type = typeFilter,
+                            claimStatus = claimStatusFilter
+                        )
+                ) {
+                    is Result.Success -> countResult.data
+                    is Result.Error -> return errorResponse(countResult.error.message, ErrorCodes.DATABASE_ERROR)
+                }
             }
-            is Result.Error ->
-                errorResponse(
-                    result.error.message,
-                    ErrorCodes.DATABASE_ERROR
+
+        // findInScope returns a plain List<WorkItem> (no per-row validation-drop tracking like
+        // ItemFetchResult.skipped), so the scoped path always reports skipped=0.
+        val itemsAndSkipped: Pair<List<WorkItem>, Int> =
+            if (ancestorId != null) {
+                when (
+                    val result =
+                        context.workItemRepository().findInScope(
+                            rootIds = setOf(ancestorId),
+                            parentId = parentId,
+                            depth = depth,
+                            role = role,
+                            priority = priority,
+                            tags = tags,
+                            query = null,
+                            createdAfter = createdAfter,
+                            createdBefore = createdBefore,
+                            modifiedAfter = modifiedAfter,
+                            modifiedBefore = modifiedBefore,
+                            roleChangedAfter = roleChangedAfter,
+                            roleChangedBefore = roleChangedBefore,
+                            sortBy = sortBy,
+                            sortOrder = sortOrder,
+                            limit = limit,
+                            offset = offset,
+                            type = typeFilter,
+                            claimStatus = claimStatusFilter
+                        )
+                ) {
+                    is Result.Success -> Pair(result.data, 0)
+                    is Result.Error -> return errorResponse(result.error.message, ErrorCodes.DATABASE_ERROR)
+                }
+            } else {
+                when (
+                    val result =
+                        context.workItemRepository().findByFilters(
+                            parentId = parentId,
+                            depth = depth,
+                            role = role,
+                            priority = priority,
+                            tags = tags,
+                            query = null, // LIKE-based query removed; FTS goes through executeFtsSearch
+                            createdAfter = createdAfter,
+                            createdBefore = createdBefore,
+                            modifiedAfter = modifiedAfter,
+                            modifiedBefore = modifiedBefore,
+                            roleChangedAfter = roleChangedAfter,
+                            roleChangedBefore = roleChangedBefore,
+                            sortBy = sortBy,
+                            sortOrder = sortOrder,
+                            limit = limit,
+                            offset = offset,
+                            type = typeFilter,
+                            claimStatus = claimStatusFilter
+                        )
+                ) {
+                    is Result.Success -> Pair(result.data.items, result.data.skipped)
+                    is Result.Error -> return errorResponse(result.error.message, ErrorCodes.DATABASE_ERROR)
+                }
+            }
+        val items = itemsAndSkipped.first
+        val skipped = itemsAndSkipped.second
+
+        val chains: Map<java.util.UUID, List<WorkItem>> =
+            if (includeAncestors && items.isNotEmpty()) {
+                val chainResult = context.workItemRepository().findAncestorChains(items.map { it.id }.toSet())
+                (chainResult as? Result.Success)?.data ?: emptyMap()
+            } else {
+                emptyMap()
+            }
+
+        val data =
+            buildJsonObject {
+                put(
+                    "items",
+                    JsonArray(
+                        items.map { item ->
+                            buildSearchResultItem(item, claimStatusFilter, includeAncestors, chains)
+                        }
+                    )
                 )
-        }
+                // total = raw SQL count (countByFilters/countInScope), unaffected by validation drops.
+                // Invariant: total = returned + skipped + notFetched (rows beyond limit/offset).
+                put("total", JsonPrimitive(totalCount))
+                put("returned", JsonPrimitive(items.size))
+                if (skipped > 0) put("skipped", JsonPrimitive(skipped))
+                put("limit", JsonPrimitive(limit))
+                put("offset", JsonPrimitive(offset))
+            }
+        return successResponse(data)
     }
 
     /**

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/UpdateItemHandler.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/UpdateItemHandler.kt
@@ -253,5 +253,7 @@ class UpdateItemHandler(
      * Caught by the per-item `catch (e: Exception)` block above and converted into a failure entry;
      * never surfaced past [execute].
      */
-    private class DepthCascadeException(message: String) : Exception(message)
+    private class DepthCascadeException(
+        message: String
+    ) : Exception(message)
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/UpdateItemHandler.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/UpdateItemHandler.kt
@@ -104,10 +104,11 @@ class UpdateItemHandler(
                     throw ToolValidationException("Item '$itemId': complexity must be between 1 and 10")
                 }
 
-                // Handle parentId change and depth recomputation
+                // Handle parentId change and depth/rootId recomputation
                 val parentIdStr = extractItemString(itemObj, "parentId")
                 val newParentId: UUID?
                 val newDepth: Int
+                val newRootId: UUID?
                 if (parentIdStr != null) {
                     newParentId = resolveWorkItemIdString(parentIdStr, context, "Item '$itemId': 'parentId'")
 
@@ -118,14 +119,26 @@ class UpdateItemHandler(
                             repo = repo,
                             errorPrefix = "Item '$itemId'"
                         )
+
+                    // rootId: inherit the new parent's root (or the parent's own id, if the
+                    // parent predates the root_id backfill and has no rootId yet).
+                    newRootId =
+                        when (val parentResult = repo.getById(newParentId)) {
+                            is Result.Success -> parentResult.data.rootId ?: parentResult.data.id
+                            is Result.Error -> throw ToolValidationException(
+                                "Item '$itemId': parent '$newParentId' not found"
+                            )
+                        }
                 } else if (itemObj.containsKey("parentId") && itemObj["parentId"] is JsonNull) {
-                    // Explicitly set parentId to null (move to root)
+                    // Explicitly set parentId to null (move to root) — the item becomes its own root.
                     newParentId = null
                     newDepth = 0
+                    newRootId = id
                 } else {
                     // No parentId change
                     newParentId = existing.parentId
                     newDepth = existing.depth
+                    newRootId = existing.rootId
                 }
 
                 // Apply partial update using the update builder for monotonic modifiedAt
@@ -133,6 +146,7 @@ class UpdateItemHandler(
                     existing.update { item ->
                         item.copy(
                             parentId = newParentId,
+                            rootId = newRootId,
                             title = newTitle ?: item.title,
                             description = newDescription,
                             summary = newSummary ?: item.summary,
@@ -149,18 +163,30 @@ class UpdateItemHandler(
                         )
                     }
 
-                // When the depth actually changes, the item's own write and the descendant-depth
-                // cascade must succeed or fail together — wrap both in a shared transaction so a
-                // cascade failure (e.g. a version-mismatch conflict on a descendant) rolls back the
-                // parent's own depth write too, rather than leaving the tree half-updated.
+                // When the parent actually changes, the item's own write and the
+                // descendant-depth/rootId cascade must succeed or fail together — wrap both in a
+                // shared transaction so a cascade failure (e.g. a version-mismatch conflict on a
+                // descendant) rolls back the parent's own write too, rather than leaving the tree
+                // half-updated. Gated on parentId change rather than depthDelta != 0: moving an
+                // item between two different root subtrees at the same depth leaves depth
+                // unchanged but still requires a rootId cascade over every descendant.
                 val depthDelta = newDepth - existing.depth
+                val parentChanged = newParentId != existing.parentId
                 var updateResult: Result<WorkItem>? = null
-                if (depthDelta != 0) {
+                if (parentChanged) {
                     repo.inTransaction {
                         val txResult = repo.update(updatedItem)
                         updateResult = txResult
                         if (txResult is Result.Success) {
-                            when (val cascadeResult = hierarchyValidator.recomputeDescendantDepths(id, depthDelta, repo)) {
+                            // newRootId is always non-null on this branch: parentChanged is only
+                            // true when either the parent-lookup branch (always non-null) or the
+                            // move-to-root branch (= id) set it — never the unchanged branch. The
+                            // `?: id` fallback exists only to satisfy the nullable type, not as a
+                            // reachable behavior.
+                            when (
+                                val cascadeResult =
+                                    hierarchyValidator.recomputeDescendantDepths(id, depthDelta, newRootId ?: id, repo)
+                            ) {
                                 is Result.Success -> {}
                                 is Result.Error -> throw DepthCascadeException(
                                     "Item '$itemId': failed to update descendant depths: ${cascadeResult.error.message}"

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsTool.kt
@@ -62,6 +62,20 @@ Items in TERMINAL role are never included.
                         }
                     )
                     put(
+                        "ancestorId",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "UUID or hex prefix (4+ chars) of an item whose subtree (any depth, inclusive) " +
+                                        "candidate items are limited to. Composes with `parentId` (both applied). " +
+                                        "Omitted = unscoped, byte-identical to current behavior."
+                                )
+                            )
+                        }
+                    )
+                    put(
                         "includeDetails",
                         buildJsonObject {
                             put("type", JsonPrimitive("boolean"))
@@ -90,6 +104,8 @@ Items in TERMINAL role are never included.
     ): JsonElement {
         val (parentId, parentIdError) = resolveItemId(params, "parentId", context, required = false)
         if (parentIdError != null) return parentIdError
+        val (ancestorId, ancestorIdError) = resolveItemId(params, "ancestorId", context, required = false)
+        if (ancestorIdError != null) return ancestorIdError
         val includeDetails = optionalBoolean(params, "includeDetails", false)
         val includeAncestors = optionalBoolean(params, "includeAncestors", false)
 
@@ -102,7 +118,20 @@ Items in TERMINAL role are never included.
 
         for (role in candidateRoles) {
             val items =
-                if (parentId != null) {
+                if (ancestorId != null) {
+                    // Scoped path: findInScope composes ancestorId's subtree restriction with the
+                    // existing optional parentId filter in a single call.
+                    when (
+                        val result =
+                            workItemRepo.findInScope(rootIds = setOf(ancestorId), parentId = parentId, role = role, limit = 500)
+                    ) {
+                        is Result.Success -> result.data
+                        is Result.Error -> {
+                            logger.warn("Failed to query items for role $role: ${result.error.message}")
+                            emptyList()
+                        }
+                    }
+                } else if (parentId != null) {
                     when (val result = workItemRepo.findByFilters(parentId = parentId, role = role, limit = 500)) {
                         is Result.Success -> result.data.items
                         is Result.Error -> {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
@@ -100,6 +100,22 @@ session-resume, neither → health-check); explicit `mode` takes precedence.
                         }
                     )
                     put(
+                        "ancestorId",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "UUID or hex prefix (4+ chars) of an item whose subtree (any depth, inclusive) " +
+                                        "scopes health-check and session-resume results (active/blocked/stalled items " +
+                                        "and the claim summary). Ignored in item mode. Omitted = unscoped. In " +
+                                        "session-resume mode, `recentTransitions` is NOT scoped by this parameter " +
+                                        "even when set — it always reflects transitions across the whole tree."
+                                )
+                            )
+                        }
+                    )
+                    put(
                         "includeAncestors",
                         buildJsonObject {
                             put("type", JsonPrimitive("boolean"))
@@ -130,6 +146,7 @@ session-resume, neither → health-check); explicit `mode` takes precedence.
         }
         // Validate itemId if present — accepts full UUID or short hex prefix
         validateIdOrPrefix(params, "itemId", required = false)
+        validateIdOrPrefix(params, "ancestorId", required = false)
         // Validate since if present
         parseInstant(params, "since")
     }
@@ -140,6 +157,8 @@ session-resume, neither → health-check); explicit `mode` takes precedence.
     ): JsonElement {
         val (itemId, idError) = resolveItemId(params, "itemId", context, required = false)
         if (idError != null) return idError
+        val (ancestorId, ancestorIdError) = resolveItemId(params, "ancestorId", context, required = false)
+        if (ancestorIdError != null) return ancestorIdError
         val sinceInstant = parseInstant(params, "since")
         val includeAncestors = optionalBoolean(params, "includeAncestors", false)
         val transitionLimit =
@@ -157,9 +176,9 @@ session-resume, neither → health-check); explicit `mode` takes precedence.
             }
             explicitMode == "session-resume" || (explicitMode == null && sinceInstant != null) -> {
                 if (sinceInstant == null) return errorResponse("mode=session-resume requires since parameter", ErrorCodes.VALIDATION_ERROR)
-                executeSessionResumeMode(sinceInstant, context, includeAncestors, transitionLimit)
+                executeSessionResumeMode(sinceInstant, context, includeAncestors, transitionLimit, ancestorId)
             }
-            else -> executeHealthCheckMode(context, includeAncestors)
+            else -> executeHealthCheckMode(context, includeAncestors, ancestorId)
         }
     }
 
@@ -277,15 +296,17 @@ session-resume, neither → health-check); explicit `mode` takes precedence.
         since: java.time.Instant,
         context: ToolExecutionContext,
         includeAncestors: Boolean,
-        transitionLimit: Int = 10
+        transitionLimit: Int = 10,
+        ancestorId: java.util.UUID? = null
     ): JsonElement {
         val workItemRepo = context.workItemRepository()
+        val scopeIds = ancestorId?.let { setOf(it) }
 
         // Fetch work and review items in parallel, merge results
         val (workItems, reviewItems) =
             coroutineScope {
-                val workDeferred = async { workItemRepo.findByRole(Role.WORK, limit = 200) }
-                val reviewDeferred = async { workItemRepo.findByRole(Role.REVIEW, limit = 200) }
+                val workDeferred = async { workItemRepo.findByRole(Role.WORK, limit = 200, rootIds = scopeIds) }
+                val reviewDeferred = async { workItemRepo.findByRole(Role.REVIEW, limit = 200, rootIds = scopeIds) }
 
                 Pair(
                     workDeferred.await().getOrElse(emptyList()),
@@ -294,7 +315,10 @@ session-resume, neither → health-check); explicit `mode` takes precedence.
             }
         val activeItems = workItems + reviewItems
 
-        // Recent transitions since the given timestamp
+        // Recent transitions since the given timestamp — NOT scoped by ancestorId (see field
+        // description on the `ancestorId` parameterSchema): scoping transitions would require
+        // plumbing the resolved scope set through the transition-item lookup, which the task
+        // scope note flagged as invasive; documented as a known limitation instead.
         val recentTransitions =
             context
                 .roleTransitionRepository()
@@ -397,9 +421,11 @@ session-resume, neither → health-check); explicit `mode` takes precedence.
 
     private suspend fun executeHealthCheckMode(
         context: ToolExecutionContext,
-        includeAncestors: Boolean
+        includeAncestors: Boolean,
+        ancestorId: java.util.UUID? = null
     ): JsonElement {
         val workItemRepo = context.workItemRepository()
+        val scopeIds = ancestorId?.let { setOf(it) }
 
         // Fetch work, review, and blocked items in parallel; also compute claim summary
         val workItems: List<io.github.jpicklyk.mcptask.current.domain.model.WorkItem>
@@ -407,10 +433,10 @@ session-resume, neither → health-check); explicit `mode` takes precedence.
         val blockedItems: List<io.github.jpicklyk.mcptask.current.domain.model.WorkItem>
         val claimCounts: io.github.jpicklyk.mcptask.current.domain.repository.ClaimStatusCounts?
         coroutineScope {
-            val workDeferred = async { workItemRepo.findByRole(Role.WORK, limit = 200) }
-            val reviewDeferred = async { workItemRepo.findByRole(Role.REVIEW, limit = 200) }
-            val blockedDeferred = async { workItemRepo.findByRole(Role.BLOCKED, limit = 200) }
-            val claimDeferred = async { workItemRepo.countByClaimStatus(parentId = null) }
+            val workDeferred = async { workItemRepo.findByRole(Role.WORK, limit = 200, rootIds = scopeIds) }
+            val reviewDeferred = async { workItemRepo.findByRole(Role.REVIEW, limit = 200, rootIds = scopeIds) }
+            val blockedDeferred = async { workItemRepo.findByRole(Role.BLOCKED, limit = 200, rootIds = scopeIds) }
+            val claimDeferred = async { workItemRepo.countByClaimStatus(parentId = null, rootIds = scopeIds) }
 
             workItems = workDeferred.await().getOrElse(emptyList())
             reviewItems = reviewDeferred.await().getOrElse(emptyList())

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
@@ -72,6 +72,20 @@ parameter's schema description for field-level semantics.
                         }
                     )
                     put(
+                        "ancestorId",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "UUID or hex prefix (4+ chars) of an item whose subtree (any depth, inclusive) " +
+                                        "recommendations are limited to. Composes with `parentId` (both applied). " +
+                                        "Omitted = unscoped, byte-identical to current behavior."
+                                )
+                            )
+                        }
+                    )
+                    put(
                         "limit",
                         buildJsonObject {
                             put("type", JsonPrimitive("integer"))
@@ -210,6 +224,7 @@ parameter's schema description for field-level semantics.
         }
 
         validateIdOrPrefix(params, "parentId", required = false)
+        validateIdOrPrefix(params, "ancestorId", required = false)
         val limit = optionalInt(params, "limit")
         if (limit != null && (limit < 1 || limit > 20)) {
             throw ToolValidationException("limit must be between 1 and 20, got: $limit")
@@ -271,6 +286,8 @@ parameter's schema description for field-level semantics.
 
         val (parentId, parentIdError) = resolveItemId(params, "parentId", context, required = false)
         if (parentIdError != null) return parentIdError
+        val (ancestorId, ancestorIdError) = resolveItemId(params, "ancestorId", context, required = false)
+        if (ancestorIdError != null) return ancestorIdError
 
         val limit = optionalInt(params, "limit") ?: 1
         val includeDetails = optionalBoolean(params, "includeDetails", defaultValue = false)
@@ -308,6 +325,7 @@ parameter's schema description for field-level semantics.
                 roleChangedAfter = parsedRoleChangedAfter,
                 roleChangedBefore = parsedRoleChangedBefore,
                 orderBy = parsedOrderBy,
+                ancestorIds = ancestorId?.let { setOf(it) },
             )
 
         val workItemRepo = context.workItemRepository()
@@ -330,7 +348,8 @@ parameter's schema description for field-level semantics.
                         role = targetRole,
                         parentId = parentId,
                         excludeActiveClaims = false,
-                        limit = NextItemRecommender.OVER_FETCH_LIMIT
+                        limit = NextItemRecommender.OVER_FETCH_LIMIT,
+                        rootIds = ancestorId?.let { setOf(it) }
                     )
 
                 val candidates =

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/WorkItem.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/WorkItem.kt
@@ -7,6 +7,20 @@ import java.util.UUID
 data class WorkItem(
     val id: UUID = UUID.randomUUID(),
     val parentId: UUID? = null,
+    /**
+     * Denormalized id of this item's depth-0 ancestor (its own [id] when [depth] is 0).
+     * Maintained by the application layer: stamped on create (CreateItemHandler,
+     * ItemWriteRoutes POST /items) and restamped on reparent, for the moved item and every
+     * descendant, in the same sweep as the depth cascade (ItemHierarchyValidator, and its
+     * call sites in UpdateItemHandler / ItemWriteRoutes PATCH).
+     *
+     * Nullable and NOT validated against [depth] or [parentId] here — rows written before
+     * the root_id backfill migration (or in H2 test fixtures that construct [WorkItem]
+     * directly without going through the create/reparent paths) may legitimately have a
+     * null or stale value. Treat this as a best-effort denormalization for read-path scope
+     * filtering, not a structural invariant enforced at the domain layer.
+     */
+    val rootId: UUID? = null,
     val title: String,
     val description: String? = null,
     val summary: String = "",

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
@@ -433,7 +433,10 @@ interface WorkItemRepository {
      *   way as [findInScope]. [rootIds] and [parentId] compose with AND. An empty (non-null)
      *   [rootIds] set yields all-zero counts.
      */
-    suspend fun countByClaimStatus(parentId: UUID? = null, rootIds: Set<UUID>? = null): Result<ClaimStatusCounts>
+    suspend fun countByClaimStatus(
+        parentId: UUID? = null,
+        rootIds: Set<UUID>? = null
+    ): Result<ClaimStatusCounts>
 
     /**
      * Find work items that are within the subtree rooted at any of [rootIds] (roots included).

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
@@ -497,6 +497,15 @@ interface WorkItemRepository {
         type: String? = null,
         claimStatus: String? = null,
     ): Result<Int>
+
+    /**
+     * Count work items within the subtree rooted at any of [rootIds] (roots included), grouped by
+     * role. Mirrors [countChildrenByRole]'s per-role breakdown, but scoped to the full subtree
+     * (any depth) instead of direct children only. Roles with zero matches are omitted.
+     *
+     * When [rootIds] is empty, returns an empty map immediately.
+     */
+    suspend fun countInScopeByRole(rootIds: Set<UUID>): Result<Map<Role, Int>>
 }
 
 /**

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
@@ -106,9 +106,16 @@ interface WorkItemRepository {
         limit: Int = 50
     ): Result<List<WorkItem>>
 
+    /**
+     * @param rootIds Optional subtree scope. When null (default), unscoped — behavior is
+     *   identical to omitting the parameter. When non-null, results are additionally restricted
+     *   to items within the subtree(s) rooted at [rootIds] (roots included), resolved the same
+     *   way as [findInScope]. An empty (non-null) set yields an empty result — no matching rows.
+     */
     suspend fun findByRole(
         role: Role,
-        limit: Int = 50
+        limit: Int = 50,
+        rootIds: Set<UUID>? = null
     ): Result<List<WorkItem>>
 
     suspend fun findByDepth(
@@ -308,12 +315,17 @@ interface WorkItemRepository {
      * @param parentId        Optional parent UUID to scope results to direct children only.
      * @param excludeActiveClaims When true, omit items with a live (non-expired) claim.
      * @param limit           Maximum number of rows to return.
+     * @param rootIds Optional subtree scope. When null (default), unscoped — behavior is
+     *   identical to the pre-scoping contract. When non-null, results are additionally
+     *   restricted to items within the subtree(s) rooted at [rootIds] (roots included),
+     *   resolved the same way as [findInScope]. An empty (non-null) set yields an empty result.
      */
     suspend fun findForNextItem(
         role: Role,
         parentId: UUID? = null,
         excludeActiveClaims: Boolean = true,
-        limit: Int = 200
+        limit: Int = 200,
+        rootIds: Set<UUID>? = null
     ): Result<List<WorkItem>>
 
     /**
@@ -367,6 +379,10 @@ interface WorkItemRepository {
      *                          only ancestor claims held by a *different* agent disqualify a
      *                          candidate. When null, any live ancestor claim disqualifies the
      *                          candidate (strict exclusion for callers without actor context).
+     * @param rootIds Optional subtree scope. When null (default), unscoped — behavior is
+     *   identical to the pre-scoping contract. When non-null, candidates are additionally
+     *   restricted to items within the subtree(s) rooted at [rootIds] (roots included),
+     *   resolved the same way as [findInScope]. An empty (non-null) set yields an empty result.
      * @return [Result.Success] with the list of matching, claimable items (may be empty), or
      *         [Result.Error] on a database failure.
      */
@@ -386,6 +402,7 @@ interface WorkItemRepository {
         orderBy: NextItemOrder = NextItemOrder.PRIORITY_THEN_COMPLEXITY,
         limit: Int = 200,
         requestingAgentId: String? = null,
+        rootIds: Set<UUID>? = null,
     ): Result<List<WorkItem>>
 
     /**
@@ -402,8 +419,13 @@ interface WorkItemRepository {
      * Counts are computed at the DB level (SQL aggregation) — not load-all-rows-then-count.
      *
      * @param parentId Optional parent UUID to scope the aggregation.
+     * @param rootIds Optional subtree scope. When null (default), unscoped — behavior is
+     *   identical to the pre-scoping contract. When non-null, counts are additionally restricted
+     *   to items within the subtree(s) rooted at [rootIds] (roots included), resolved the same
+     *   way as [findInScope]. [rootIds] and [parentId] compose with AND. An empty (non-null)
+     *   [rootIds] set yields all-zero counts.
      */
-    suspend fun countByClaimStatus(parentId: UUID? = null): Result<ClaimStatusCounts>
+    suspend fun countByClaimStatus(parentId: UUID? = null, rootIds: Set<UUID>? = null): Result<ClaimStatusCounts>
 
     /**
      * Find work items that are within the subtree rooted at any of [rootIds] (roots included).

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
@@ -123,7 +123,14 @@ interface WorkItemRepository {
         limit: Int = 50
     ): Result<List<WorkItem>>
 
-    suspend fun findRoot(): Result<WorkItem?>
+    /**
+     * Find all project anchor items: depth-0 roots with `type = "project"`.
+     *
+     * Project anchors partition a shared database into per-project subtrees (see the
+     * project-root scoping convention). Returns an empty list when the workspace has no
+     * project anchors — e.g. a legacy single-project database that has not been adopted.
+     */
+    suspend fun findProjectRoots(): Result<List<WorkItem>>
 
     suspend fun search(
         query: String,
@@ -201,7 +208,8 @@ interface WorkItemRepository {
 
     /**
      * Find all root items (items with no parent), ordered newest-createdAt-first.
-     * Unlike findRoot() which expects a single root, this returns all parentless items.
+     * Unlike findProjectRoots() which returns only `type = "project"` anchors, this
+     * returns all parentless items regardless of type.
      *
      * Returns an [ItemFetchResult]: rows that fail domain validation are dropped rather than
      * failing the whole query — [ItemFetchResult.skipped] reports how many were dropped. Use

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/WorkItemsTable.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/WorkItemsTable.kt
@@ -6,6 +6,7 @@ import org.jetbrains.exposed.v1.javatime.timestamp
 
 object WorkItemsTable : UUIDTable("work_items") {
     val parentId = javaUUID("parent_id").nullable()
+    val rootId = javaUUID("root_id").nullable()
     val title = text("title")
     val description = text("description").nullable()
     val summary = text("summary").default("")
@@ -32,6 +33,7 @@ object WorkItemsTable : UUIDTable("work_items") {
     init {
         foreignKey(parentId to WorkItemsTable.id)
         index(isUnique = false, parentId)
+        index(isUnique = false, rootId)
         index(isUnique = false, role)
         index(isUnique = false, depth)
         index(isUnique = false, priority)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -1626,6 +1626,30 @@ class SQLiteWorkItemRepository(
         }
     }
 
+    override suspend fun countInScopeByRole(rootIds: Set<UUID>): Result<Map<Role, Int>> {
+        if (rootIds.isEmpty()) return Result.Success(emptyMap())
+
+        return try {
+            suspendTransaction(db = databaseManager.getDatabase()) {
+                val scopeIds = resolveScopeIds(rootIds)
+                if (scopeIds.isEmpty()) return@suspendTransaction Result.Success(emptyMap())
+
+                val scopeEntityIds = scopeIds.map { EntityID(it, WorkItemsTable) }
+                val counts =
+                    WorkItemsTable
+                        .selectAll()
+                        .where { WorkItemsTable.id inList scopeEntityIds }
+                        .mapNotNull { toWorkItemOrNull(it) }
+                        .groupBy { it.role }
+                        .mapValues { (_, items) -> items.size }
+                Result.Success(counts)
+            }
+        } catch (e: Exception) {
+            logger.error("Failed to countInScopeByRole for roots ${rootIds.size}: ${e.message}", e)
+            Result.Error(RepositoryError.DatabaseError("Failed to countInScopeByRole: ${e.message}", e))
+        }
+    }
+
     /**
      * Resolve a set of root UUIDs into the full set of UUIDs (roots + all descendants).
      *

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -234,6 +234,7 @@ class SQLiteWorkItemRepository(
         WorkItemsTable.insert {
             it[id] = item.id
             it[parentId] = item.parentId
+            it[rootId] = item.rootId
             it[title] = item.title
             it[description] = item.description
             it[summary] = item.summary
@@ -273,6 +274,7 @@ class SQLiteWorkItemRepository(
                     (WorkItemsTable.id eq item.id) and (WorkItemsTable.version eq item.version)
                 }) {
                     it[parentId] = item.parentId
+                    it[rootId] = item.rootId
                     it[title] = item.title
                     it[description] = item.description
                     it[summary] = item.summary
@@ -1875,6 +1877,7 @@ class SQLiteWorkItemRepository(
         WorkItem(
             id = row[WorkItemsTable.id].value,
             parentId = row[WorkItemsTable.parentId],
+            rootId = row[WorkItemsTable.rootId],
             title = row[WorkItemsTable.title],
             description = row[WorkItemsTable.description],
             summary = row[WorkItemsTable.summary],

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -368,14 +368,17 @@ class SQLiteWorkItemRepository(
             Result.Success(items)
         }
 
-    override suspend fun findRoot(): Result<WorkItem?> =
-        databaseManager.suspendedTransaction("Failed to find root WorkItem") {
-            val row =
+    override suspend fun findProjectRoots(): Result<List<WorkItem>> =
+        databaseManager.suspendedTransaction("Failed to find project root WorkItems") {
+            val items =
                 WorkItemsTable
                     .selectAll()
-                    .where { WorkItemsTable.parentId.isNull() and (WorkItemsTable.depth eq 0) }
-                    .singleOrNull()
-            Result.Success(row?.let { toWorkItemOrNull(it) })
+                    .where {
+                        WorkItemsTable.parentId.isNull() and
+                            (WorkItemsTable.depth eq 0) and
+                            (WorkItemsTable.type eq "project")
+                    }.mapNotNull { toWorkItemOrNull(it) }
+            Result.Success(items)
         }
 
     override suspend fun search(

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -1426,7 +1426,10 @@ class SQLiteWorkItemRepository(
         }
     }
 
-    override suspend fun countByClaimStatus(parentId: UUID?, rootIds: Set<UUID>?): Result<ClaimStatusCounts> {
+    override suspend fun countByClaimStatus(
+        parentId: UUID?,
+        rootIds: Set<UUID>?
+    ): Result<ClaimStatusCounts> {
         // Read DB-side clock ONCE before opening the transaction to avoid a nested
         // transaction/savepoint (dbNow() opens its own suspendTransaction internally).
         // Use DB-side clock so counts are consistent with the DB's view of claim freshness.

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -332,13 +332,23 @@ class SQLiteWorkItemRepository(
 
     override suspend fun findByRole(
         role: Role,
-        limit: Int
+        limit: Int,
+        rootIds: Set<UUID>?
     ): Result<List<WorkItem>> =
         databaseManager.suspendedTransaction("Failed to find WorkItems by role") {
+            val conditions = mutableListOf<Op<Boolean>>()
+            conditions.add(WorkItemsTable.role eq role.name.lowercase())
+
+            if (rootIds != null) {
+                val scopeIds = resolveScopeIds(rootIds)
+                if (scopeIds.isEmpty()) return@suspendedTransaction Result.Success(emptyList())
+                conditions.add(WorkItemsTable.id inList scopeIds.map { EntityID(it, WorkItemsTable) })
+            }
+
             val items =
                 WorkItemsTable
                     .selectAll()
-                    .where { WorkItemsTable.role eq role.name.lowercase() }
+                    .where { conditions.reduce { acc, op -> acc and op } }
                     .limit(limit)
                     .mapNotNull { toWorkItemOrNull(it) }
             Result.Success(items)
@@ -1189,7 +1199,8 @@ class SQLiteWorkItemRepository(
         role: Role,
         parentId: UUID?,
         excludeActiveClaims: Boolean,
-        limit: Int
+        limit: Int,
+        rootIds: Set<UUID>?
     ): Result<List<WorkItem>> {
         // Read DB-side clock ONCE before opening the transaction to avoid a nested
         // transaction/savepoint (dbNow() opens its own suspendTransaction internally).
@@ -1203,6 +1214,13 @@ class SQLiteWorkItemRepository(
 
             // Optional parent scope
             parentId?.let { conditions.add(WorkItemsTable.parentId eq it) }
+
+            // Optional subtree scope — expand rootIds to the full descendant set (roots included).
+            if (rootIds != null) {
+                val scopeIds = resolveScopeIds(rootIds)
+                if (scopeIds.isEmpty()) return@suspendedTransaction Result.Success(emptyList())
+                conditions.add(WorkItemsTable.id inList scopeIds.map { EntityID(it, WorkItemsTable) })
+            }
 
             // Claim filter: exclude items with an active (non-expired) claim.
             // An item is "actively claimed" when claimed_by IS NOT NULL AND claim_expires_at > now.
@@ -1244,6 +1262,7 @@ class SQLiteWorkItemRepository(
         orderBy: NextItemOrder,
         limit: Int,
         requestingAgentId: String?,
+        rootIds: Set<UUID>?,
     ): Result<List<WorkItem>> {
         // Read DB-side clock ONCE before opening the transaction to avoid a nested
         // transaction/savepoint (dbNow() opens its own suspendTransaction internally).
@@ -1257,6 +1276,13 @@ class SQLiteWorkItemRepository(
 
             // Optional parent scope
             parentId?.let { conditions.add(WorkItemsTable.parentId eq it) }
+
+            // Optional subtree scope — expand rootIds to the full descendant set (roots included).
+            if (rootIds != null) {
+                val scopeIds = resolveScopeIds(rootIds)
+                if (scopeIds.isEmpty()) return@suspendedTransaction Result.Success(emptyList())
+                conditions.add(WorkItemsTable.id inList scopeIds.map { EntityID(it, WorkItemsTable) })
+            }
 
             // Tag any-match — reuse buildTagFilter (OR logic within list)
             tags?.takeIf { it.isNotEmpty() }?.let { conditions.add(buildTagFilter(it)) }
@@ -1397,17 +1423,26 @@ class SQLiteWorkItemRepository(
         }
     }
 
-    override suspend fun countByClaimStatus(parentId: UUID?): Result<ClaimStatusCounts> {
+    override suspend fun countByClaimStatus(parentId: UUID?, rootIds: Set<UUID>?): Result<ClaimStatusCounts> {
         // Read DB-side clock ONCE before opening the transaction to avoid a nested
         // transaction/savepoint (dbNow() opens its own suspendTransaction internally).
         // Use DB-side clock so counts are consistent with the DB's view of claim freshness.
         val now = dbNow()
 
         return databaseManager.suspendedTransaction("Failed to count WorkItems by claim status") {
-            // Helper to build a base condition list optionally scoped to a parent
+            // Optional subtree scope — expand rootIds to the full descendant set (roots included).
+            // Resolved once and reused across all three claim-status conditions below.
+            val scopeIds = rootIds?.let { resolveScopeIds(it) }
+            if (scopeIds != null && scopeIds.isEmpty()) {
+                return@suspendedTransaction Result.Success(ClaimStatusCounts(active = 0, expired = 0, unclaimed = 0))
+            }
+            val scopeEntityIds = scopeIds?.map { EntityID(it, WorkItemsTable) }
+
+            // Helper to build a base condition list optionally scoped to a parent and/or subtree
             fun baseConditions(): MutableList<Op<Boolean>> {
                 val conds = mutableListOf<Op<Boolean>>()
                 parentId?.let { conds.add(WorkItemsTable.parentId eq it) }
+                scopeEntityIds?.let { conds.add(WorkItemsTable.id inList it) }
                 return conds
             }
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemWriteRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemWriteRoutes.kt
@@ -247,7 +247,12 @@ fun Route.itemWriteRoutes(
                             ?: return errorCaptured(HttpStatusCode.BadRequest, "validation_error", "Invalid parentId UUID: $pid")
                     }
 
+                // Pre-generate the id so a root-level create (parentId == null) can stamp
+                // rootId = own id without a second round trip.
+                val itemId = UUID.randomUUID()
+
                 val depth: Int
+                val rootId: UUID
                 if (parentId != null) {
                     val parentResult = workItemRepo.getById(parentId)
                     if (parentResult is Result.Error) {
@@ -256,9 +261,14 @@ fun Route.itemWriteRoutes(
                     if (!enforceScopeForItem(call, parentId, workItemRepo)) {
                         return errorCaptured(HttpStatusCode.Forbidden, "scope_forbidden", "Access denied for parent $parentId")
                     }
-                    depth = (parentResult as Result.Success).data.depth + 1
+                    val parentData = (parentResult as Result.Success).data
+                    depth = parentData.depth + 1
+                    // Inherit the parent's root (or the parent's own id, if the parent predates
+                    // the root_id backfill and has no rootId yet).
+                    rootId = parentData.rootId ?: parentData.id
                 } else {
                     depth = 0
+                    rootId = itemId
                 }
 
                 val priority =
@@ -273,10 +283,12 @@ fun Route.itemWriteRoutes(
                 val item =
                     try {
                         WorkItem(
+                            id = itemId,
                             title = dto.title,
                             description = dto.description,
                             summary = dto.summary ?: "",
                             parentId = parentId,
+                            rootId = rootId,
                             depth = depth,
                             type = dto.type,
                             priority = priority,
@@ -470,18 +482,26 @@ fun Route.itemWriteRoutes(
                             ?: return errorCaptured(HttpStatusCode.BadRequest, "validation_error", "Invalid parentId UUID: $pid")
                     }
 
-                val newDepth =
-                    if (newParentId == existing.parentId) {
-                        existing.depth
-                    } else if (newParentId == null) {
-                        0
-                    } else {
-                        val parentResult = workItemRepo.getById(newParentId)
-                        if (parentResult is Result.Error) {
-                            return errorCaptured(HttpStatusCode.BadRequest, "not_found", "Parent item $newParentId not found")
-                        }
-                        (parentResult as Result.Success).data.depth + 1
+                val newDepth: Int
+                val newRootId: UUID?
+                if (newParentId == existing.parentId) {
+                    newDepth = existing.depth
+                    newRootId = existing.rootId
+                } else if (newParentId == null) {
+                    // Move to root — the item becomes its own root.
+                    newDepth = 0
+                    newRootId = id
+                } else {
+                    val parentResult = workItemRepo.getById(newParentId)
+                    if (parentResult is Result.Error) {
+                        return errorCaptured(HttpStatusCode.BadRequest, "not_found", "Parent item $newParentId not found")
                     }
+                    val parentData = (parentResult as Result.Success).data
+                    newDepth = parentData.depth + 1
+                    // Inherit the new parent's root (or the parent's own id, if the parent
+                    // predates the root_id backfill and has no rootId yet).
+                    newRootId = parentData.rootId ?: parentData.id
+                }
 
                 val updated =
                     try {
@@ -499,6 +519,7 @@ fun Route.itemWriteRoutes(
                                 properties = patchDto.properties,
                                 metadata = patchDto.metadata,
                                 parentId = newParentId,
+                                rootId = newRootId,
                                 depth = newDepth,
                             )
                         }
@@ -506,20 +527,31 @@ fun Route.itemWriteRoutes(
                         return errorCaptured(HttpStatusCode.BadRequest, "validation_error", e.message ?: "Validation failed")
                     }
 
-                // When the depth actually changes, the item's own write and the descendant-depth
-                // cascade must succeed or fail together — wrap both in a shared transaction so a
-                // cascade failure (e.g. a version-mismatch conflict on a descendant) rolls back the
-                // parent's own depth write too, rather than leaving the tree half-updated.
+                // When the parent actually changes, the item's own write and the
+                // descendant-depth/rootId cascade must succeed or fail together — wrap both in a
+                // shared transaction so a cascade failure (e.g. a version-mismatch conflict on a
+                // descendant) rolls back the parent's own write too, rather than leaving the tree
+                // half-updated. Gated on parentId change rather than depthDelta != 0: moving an
+                // item between two different root subtrees at the same depth leaves depth
+                // unchanged but still requires a rootId cascade over every descendant.
                 val depthDelta = newDepth - existing.depth
+                val parentChanged = newParentId != existing.parentId
                 var updateResult: Result<WorkItem>? = null
                 var cascadeErrorMessage: String? = null
-                if (depthDelta != 0) {
+                if (parentChanged) {
                     try {
                         workItemRepo.inTransaction {
                             val txResult = workItemRepo.update(updated)
                             updateResult = txResult
                             if (txResult is Result.Success) {
-                                when (val cascadeResult = hierarchyValidator.recomputeDescendantDepths(id, depthDelta, workItemRepo)) {
+                                // newRootId is always non-null on this branch (see the if/else
+                                // above — only the unchanged-parent branch, which implies
+                                // parentChanged == false, can leave it null); `?: id` only
+                                // satisfies the nullable type.
+                                when (
+                                    val cascadeResult =
+                                        hierarchyValidator.recomputeDescendantDepths(id, depthDelta, newRootId ?: id, workItemRepo)
+                                ) {
                                     is Result.Success -> {}
                                     is Result.Error -> {
                                         cascadeErrorMessage = cascadeResult.error.message

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemWriteRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemWriteRoutes.kt
@@ -793,4 +793,6 @@ fun Route.itemWriteRoutes(
  * write succeeded. Caught immediately around the `inTransaction` call and converted into a 500
  * response; never surfaced to the client as a raw exception.
  */
-private class DepthCascadeException(message: String) : Exception(message)
+private class DepthCascadeException(
+    message: String
+) : Exception(message)

--- a/current/src/main/resources/db/migration/V9__Add_Root_Id.sql
+++ b/current/src/main/resources/db/migration/V9__Add_Root_Id.sql
@@ -1,0 +1,49 @@
+-- V9: Denormalized root_id column
+--
+-- Adds a nullable root_id column to work_items: the UUID of the item's depth-0 ancestor
+-- (or the item's own id when it IS the depth-0 root). This denormalizes what would
+-- otherwise require an unbounded ancestor walk (recursive CTE) on every scope-filtered
+-- query, at the cost of maintaining it on write (CreateItemHandler on create;
+-- ItemHierarchyValidator.recomputeDescendantDepths + its two call sites on reparent).
+--
+-- Additive only: SQLite's ALTER TABLE ADD COLUMN does not require table recreation
+-- (unlike V7's structural change), so this migration is a plain ALTER + backfill.
+--
+-- No FOREIGN KEY / REFERENCES clause: a depth-0 root's root_id equals its own id, i.e. a
+-- self-reference at INSERT time. SQLite FK enforcement is off by default in this project
+-- (see V7 notes — PRAGMA foreign_keys can't change mid-transaction), so this is harmless
+-- here, but omitting the constraint keeps the column consistent with how the Exposed
+-- WorkItemsTable.kt definition represents it (no explicit foreignKey() binding), avoiding
+-- any self-reference edge case on stricter FK-enforcing engines used elsewhere in the stack.
+--
+-- Nullable, no NOT NULL constraint: SQLite cannot add a NOT NULL column without a constant
+-- DEFAULT in a single ALTER, and a constant default is wrong here since every row needs a
+-- distinct backfilled value. Existing rows are backfilled below in this migration's
+-- transaction. Rows unreachable from any depth-0 root (a parent_id pointing at a
+-- since-deleted or otherwise missing id) are intentionally left with root_id = NULL — the
+-- documented "not backfilled / orphaned" state. New rows are always stamped with a non-null
+-- root_id by the application layer going forward.
+
+ALTER TABLE work_items ADD COLUMN root_id BLOB;
+
+CREATE INDEX idx_work_items_root_id ON work_items(root_id);
+
+-- Backfill: recursive walk from every depth-0 root (parent_id IS NULL) down through all
+-- descendants, seeding root_id = own id at each root and propagating it unchanged to every
+-- descendant. Correctly handles multiple independent root trees (each gets its own
+-- root_id). UPDATE ... FROM joins the CTE once rather than re-evaluating it via correlated
+-- subqueries. Requires SQLite >= 3.33 (UPDATE...FROM) — already satisfied by the >= 3.45
+-- baseline V7 established for the trigram tokenizer (bundled org.xerial:sqlite-jdbc:3.49.1.0).
+WITH RECURSIVE root_walk(id, computed_root_id) AS (
+    SELECT id, id
+    FROM   work_items
+    WHERE  parent_id IS NULL
+    UNION ALL
+    SELECT wi.id, rw.computed_root_id
+    FROM   work_items wi
+    JOIN   root_walk rw ON wi.parent_id = rw.id
+)
+UPDATE work_items
+SET    root_id = root_walk.computed_root_id
+FROM   root_walk
+WHERE  work_items.id = root_walk.id;

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/ItemHierarchyValidatorTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/ItemHierarchyValidatorTest.kt
@@ -25,6 +25,11 @@ import kotlin.test.assertTrue
  * descendant kept its stale absolute depth. These tests cover the cascade helper directly; the
  * MCP (`ManageItemsToolTest`) and REST (`WriteRoutesTest`) paths cover the two call sites that
  * wire this helper in.
+ *
+ * root_id context: the helper was later extended (denormalized root_id column) to also restamp
+ * `rootId` on every descendant in the same sweep as the depth delta — moving a subtree to a
+ * different root changes every descendant's root ancestor even when depth is unaffected (see the
+ * "restamps rootId ... same depth" test below).
  */
 class ItemHierarchyValidatorTest {
     private lateinit var repo: WorkItemRepository
@@ -54,16 +59,26 @@ class ItemHierarchyValidatorTest {
             result.data.depth
         }
 
+    private fun rootIdOf(id: UUID): UUID? =
+        runBlocking {
+            val result = repo.getById(id)
+            assertIs<Result.Success<WorkItem>>(result)
+            result.data.rootId
+        }
+
     @Test
-    fun `delta zero is a no-op`(): Unit =
+    fun `delta zero still restamps rootId when the root subtree changes`(): Unit =
         runBlocking {
             val root = create(WorkItem(title = "root", depth = 0))
             val child = create(WorkItem(title = "child", parentId = root.id, depth = 1))
 
-            val result = validator.recomputeDescendantDepths(root.id, 0, repo)
+            // Depth is unaffected (delta = 0), but the caller has determined the item's root
+            // changed (e.g. moved between two same-depth subtrees) — rootId must still restamp.
+            val result = validator.recomputeDescendantDepths(root.id, 0, root.id, repo)
 
             assertIs<Result.Success<Unit>>(result)
             assertEquals(1, depthOf(child.id), "Child depth must be untouched when delta is 0")
+            assertEquals(root.id, rootIdOf(child.id), "Child rootId must be stamped even when delta is 0")
         }
 
     @Test
@@ -76,11 +91,13 @@ class ItemHierarchyValidatorTest {
 
             // Simulate root having just moved one level deeper (delta = +1); recompute root's
             // descendants only (child, grandchild) — the root's own depth write is the caller's job.
-            val result = validator.recomputeDescendantDepths(root.id, 1, repo)
+            val result = validator.recomputeDescendantDepths(root.id, 1, root.id, repo)
 
             assertIs<Result.Success<Unit>>(result)
             assertEquals(2, depthOf(child.id), "Child should shift from depth 1 to 2")
             assertEquals(3, depthOf(grandchild.id), "Grandchild should shift from depth 2 to 3")
+            assertEquals(root.id, rootIdOf(child.id))
+            assertEquals(root.id, rootIdOf(grandchild.id))
         }
 
     @Test
@@ -95,12 +112,31 @@ class ItemHierarchyValidatorTest {
             val c = create(WorkItem(title = "c", parentId = b.id, depth = 2))
             val d = create(WorkItem(title = "d", parentId = c.id, depth = 3))
 
-            // B moved from depth 1 to depth 0 (became root): delta = -1.
-            val result = validator.recomputeDescendantDepths(b.id, -1, repo)
+            // B moved from depth 1 to depth 0 (became root): delta = -1, B becomes its own root.
+            val result = validator.recomputeDescendantDepths(b.id, -1, b.id, repo)
 
             assertIs<Result.Success<Unit>>(result)
             assertEquals(1, depthOf(c.id), "C should shift from depth 2 to 1")
             assertEquals(2, depthOf(d.id), "D should shift from depth 3 to 2")
+            assertEquals(b.id, rootIdOf(c.id), "C's root should now be B (B became its own root)")
+            assertEquals(b.id, rootIdOf(d.id), "D's root should now be B")
+        }
+
+    @Test
+    fun `restamps rootId for every descendant when moving between two roots at the same depth`(): Unit =
+        runBlocking {
+            // rootA(0) -> b(1) -> c(2). B moves to rootB (also depth 0): depth is unchanged
+            // (delta = 0) but every descendant's rootId must flip from rootA to rootB.
+            val rootA = create(WorkItem(title = "rootA", depth = 0))
+            val rootB = create(WorkItem(title = "rootB", depth = 0))
+            val b = create(WorkItem(title = "b", parentId = rootA.id, depth = 1))
+            val c = create(WorkItem(title = "c", parentId = b.id, depth = 2))
+
+            val result = validator.recomputeDescendantDepths(b.id, 0, rootB.id, repo)
+
+            assertIs<Result.Success<Unit>>(result)
+            assertEquals(2, depthOf(c.id), "C's depth is unaffected by a same-depth root swap")
+            assertEquals(rootB.id, rootIdOf(c.id), "C's rootId must flip to rootB even though depth didn't change")
         }
 
     @Test
@@ -108,7 +144,7 @@ class ItemHierarchyValidatorTest {
         runBlocking {
             val leaf = create(WorkItem(title = "leaf", depth = 0))
 
-            val result = validator.recomputeDescendantDepths(leaf.id, 2, repo)
+            val result = validator.recomputeDescendantDepths(leaf.id, 2, leaf.id, repo)
 
             assertIs<Result.Success<Unit>>(result)
         }
@@ -119,7 +155,7 @@ class ItemHierarchyValidatorTest {
             val root = create(WorkItem(title = "root", depth = 0))
             val child = create(WorkItem(title = "child", parentId = root.id, depth = 1))
 
-            validator.recomputeDescendantDepths(root.id, 1, repo)
+            validator.recomputeDescendantDepths(root.id, 1, root.id, repo)
 
             val updated = (repo.getById(child.id) as Result.Success<WorkItem>).data
             assertEquals(2, updated.depth)

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommenderTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/NextItemRecommenderTest.kt
@@ -227,6 +227,100 @@ class NextItemRecommenderTest {
         }
 
     // -----------------------------------------------------------------------
+    // Subtree scope (ancestorIds -> rootIds) forwarding
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `criteria ancestorIds is forwarded to findClaimable as rootIds`(): Unit =
+        runBlocking {
+            val scopeRoot = UUID.randomUUID()
+            val criteria = NextItemRecommender.Criteria(role = Role.WORK, ancestorIds = setOf(scopeRoot))
+            val item = workItem(role = Role.WORK)
+
+            coEvery {
+                workItemRepo.findClaimable(
+                    role = Role.WORK,
+                    parentId = null,
+                    tags = null,
+                    priority = null,
+                    type = null,
+                    complexityMax = null,
+                    createdAfter = null,
+                    createdBefore = null,
+                    modifiedAfter = null,
+                    modifiedBefore = null,
+                    roleChangedAfter = null,
+                    roleChangedBefore = null,
+                    orderBy = NextItemOrder.PRIORITY_THEN_COMPLEXITY,
+                    limit = 200,
+                    requestingAgentId = null,
+                    rootIds = setOf(scopeRoot),
+                )
+            } returns Result.Success(listOf(item))
+            stubNoDependencies()
+
+            val result = recommender.recommend(criteria, limit = 1)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size)
+
+            coVerify(exactly = 1) {
+                workItemRepo.findClaimable(
+                    role = Role.WORK,
+                    parentId = null,
+                    tags = null,
+                    priority = null,
+                    type = null,
+                    complexityMax = null,
+                    createdAfter = null,
+                    createdBefore = null,
+                    modifiedAfter = null,
+                    modifiedBefore = null,
+                    roleChangedAfter = null,
+                    roleChangedBefore = null,
+                    orderBy = NextItemOrder.PRIORITY_THEN_COMPLEXITY,
+                    limit = 200,
+                    requestingAgentId = null,
+                    rootIds = setOf(scopeRoot),
+                )
+            }
+        }
+
+    @Test
+    fun `default criteria ancestorIds is null - findClaimable called with rootIds null`(): Unit =
+        runBlocking {
+            val criteria = NextItemRecommender.Criteria()
+            val item = workItem()
+
+            stubFindClaimable(listOf(item))
+            stubNoDependencies()
+
+            val result = recommender.recommend(criteria, limit = 1)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(1, result.data.size)
+
+            coVerify(exactly = 1) {
+                workItemRepo.findClaimable(
+                    role = Role.QUEUE,
+                    parentId = null,
+                    tags = null,
+                    priority = null,
+                    type = null,
+                    complexityMax = null,
+                    createdAfter = null,
+                    createdBefore = null,
+                    modifiedAfter = null,
+                    modifiedBefore = null,
+                    roleChangedAfter = null,
+                    roleChangedBefore = null,
+                    orderBy = NextItemOrder.PRIORITY_THEN_COMPLEXITY,
+                    limit = 200,
+                    requestingAgentId = null,
+                    rootIds = null,
+                )
+            }
+        }
+
+    // -----------------------------------------------------------------------
     // Dependency-blocked items excluded
     // -----------------------------------------------------------------------
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
@@ -91,7 +91,7 @@ class ToolTokenBudgetTest {
      */
     private val perToolCeilings: Map<String, Int> =
         mapOf(
-            "query_items" to 6150, // was 4815; grew from the `schema` operation + `excludeTerminal` param merge
+            "query_items" to 7350, // was 6150; T2.5 added the overview `ancestorId` anchored mode
             "create_work_tree" to 3080,
             "get_next_item" to 3150, // was 2500; T2.3 added the `ancestorId` scope parameter
             "manage_dependencies" to 2585,
@@ -108,7 +108,7 @@ class ToolTokenBudgetTest {
         )
 
     /** Sum of the (unrounded) measured-per-tool-values * 1.15; see BUDGET PHILOSOPHY point 2. */
-    private val totalCeiling = 36_450
+    private val totalCeiling = 37_650
 
     // explicitNulls = false mirrors the compact-wire-shape convention already used elsewhere
     // in this codebase (see EventRoutes.kt / ItemWriteRoutes.kt / NoteWriteRoutes.kt) — a

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
@@ -93,22 +93,22 @@ class ToolTokenBudgetTest {
         mapOf(
             "query_items" to 6150, // was 4815; grew from the `schema` operation + `excludeTerminal` param merge
             "create_work_tree" to 3080,
+            "get_next_item" to 3150, // was 2500; T2.3 added the `ancestorId` scope parameter
             "manage_dependencies" to 2585,
             "manage_items" to 2520,
-            "get_next_item" to 2500, // was 2442; see note above
             "query_notes" to 2386,
+            "get_context" to 2650, // was 1909; T2.3 added the `ancestorId` scope parameter
             "claim_item" to 2100,
             "manage_notes" to 2057,
-            "get_context" to 1909,
             "complete_tree" to 1760, // was 1712; see note above
             "query_dependencies" to 1708,
             "advance_item" to 1450, // was 1407; see note above
-            "get_blocked_items" to 830, // was 792; see note above
+            "get_blocked_items" to 1250, // was 830; T2.3 added the `ancestorId` scope parameter
             "get_next_status" to 470,
         )
 
     /** Sum of the (unrounded) measured-per-tool-values * 1.15; see BUDGET PHILOSOPHY point 2. */
-    private val totalCeiling = 34_950
+    private val totalCeiling = 36_450
 
     // explicitNulls = false mirrors the compact-wire-shape convention already used elsewhere
     // in this codebase (see EventRoutes.kt / ItemWriteRoutes.kt / NoteWriteRoutes.kt) — a

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolIntegrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolIntegrationTest.kt
@@ -397,6 +397,139 @@ class CreateWorkTreeToolIntegrationTest {
         }
 
     // ──────────────────────────────────────────────────────────────────────────
+    // root_id stamping (create_work_tree is the third WorkItem-insert call site,
+    // alongside CreateItemHandler and the REST POST /items route)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `create mode without parentId stamps rootId as the root's own id, inherited by children and grandchildren`(): Unit =
+        runBlocking {
+            val params =
+                buildJsonObject {
+                    put("root", buildJsonObject { put("title", JsonPrimitive("New Root")) })
+                    put(
+                        "children",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("ref", JsonPrimitive("child"))
+                                    put("title", JsonPrimitive("Child"))
+                                }
+                            )
+                            add(
+                                buildJsonObject {
+                                    put("ref", JsonPrimitive("grandchild"))
+                                    put("parentRef", JsonPrimitive("child"))
+                                    put("title", JsonPrimitive("Grandchild"))
+                                }
+                            )
+                        }
+                    )
+                }
+            val result = tool.execute(params, context) as JsonObject
+            assertTrue(result["success"]!!.jsonPrimitive.boolean, "Create should succeed: $result")
+
+            val data = result["data"] as JsonObject
+            val rootId = UUID.fromString((data["root"] as JsonObject)["id"]!!.jsonPrimitive.content)
+            val childrenArr = data["children"] as JsonArray
+            val childId = UUID.fromString(childrenArr[0].jsonObject["id"]!!.jsonPrimitive.content)
+            val grandchildId = UUID.fromString(childrenArr[1].jsonObject["id"]!!.jsonPrimitive.content)
+
+            val root = (workItemRepository.getById(rootId) as Result.Success).data
+            val child = (workItemRepository.getById(childId) as Result.Success).data
+            val grandchild = (workItemRepository.getById(grandchildId) as Result.Success).data
+
+            assertEquals(rootId, root.rootId, "A newly created root with no parentId must be its own root")
+            assertEquals(rootId, child.rootId, "Child must inherit the new root's id")
+            assertEquals(rootId, grandchild.rootId, "Grandchild must inherit the same root id transitively")
+        }
+
+    @Test
+    fun `create mode with parentId stamps rootId inherited from the parent chain`(): Unit =
+        runBlocking {
+            // Pre-create an existing root to hang the new tree's root under.
+            val existingRootParams =
+                buildJsonObject { put("root", buildJsonObject { put("title", JsonPrimitive("Existing Root")) }) }
+            val existingRootResult = tool.execute(existingRootParams, context) as JsonObject
+            val existingRootId =
+                UUID.fromString((existingRootResult["data"] as JsonObject)["root"]!!.jsonObject["id"]!!.jsonPrimitive.content)
+
+            val params =
+                buildJsonObject {
+                    put("root", buildJsonObject { put("title", JsonPrimitive("New Root Under Parent")) })
+                    put("parentId", JsonPrimitive(existingRootId.toString()))
+                    put(
+                        "children",
+                        buildJsonArray {
+                            add(buildJsonObject { put("ref", JsonPrimitive("child")); put("title", JsonPrimitive("Child")) })
+                        }
+                    )
+                }
+            val result = tool.execute(params, context) as JsonObject
+            assertTrue(result["success"]!!.jsonPrimitive.boolean, "Create under parentId should succeed: $result")
+
+            val data = result["data"] as JsonObject
+            val newRootId = UUID.fromString((data["root"] as JsonObject)["id"]!!.jsonPrimitive.content)
+            val childId = UUID.fromString((data["children"] as JsonArray)[0].jsonObject["id"]!!.jsonPrimitive.content)
+
+            val newRoot = (workItemRepository.getById(newRootId) as Result.Success).data
+            val child = (workItemRepository.getById(childId) as Result.Success).data
+
+            assertEquals(
+                existingRootId,
+                newRoot.rootId,
+                "A new root created under parentId must inherit the parent's root (or the parent's own id)"
+            )
+            assertEquals(existingRootId, child.rootId, "Child must inherit the same inherited root id")
+        }
+
+    @Test
+    fun `attach mode - children inherit the existing root's effective rootId`(): Unit =
+        runBlocking {
+            // 1. Create an existing item at depth 0 that will become the attach root.
+            //    Its rootId is whatever CreateWorkTreeTool's own create-mode path stamps it
+            //    with — own id, since it has no parentId.
+            val existingItemParams =
+                buildJsonObject { put("root", buildJsonObject { put("title", JsonPrimitive("Attach Root")) }) }
+            val createResult = tool.execute(existingItemParams, context) as JsonObject
+            val existingRootId =
+                UUID.fromString((createResult["data"] as JsonObject)["root"]!!.jsonObject["id"]!!.jsonPrimitive.content)
+            val existingRoot = (workItemRepository.getById(existingRootId) as Result.Success).data
+            assertEquals(existingRootId, existingRoot.rootId, "Pre-created root should be its own root")
+
+            // 2. Attach two children (one direct, one grandchild) to the existing root.
+            val attachParams =
+                buildJsonObject {
+                    put("root", buildJsonObject { put("id", JsonPrimitive(existingRootId.toString())) })
+                    put(
+                        "children",
+                        buildJsonArray {
+                            add(buildJsonObject { put("ref", JsonPrimitive("c1")); put("title", JsonPrimitive("Attach Child")) })
+                            add(
+                                buildJsonObject {
+                                    put("ref", JsonPrimitive("gc1"))
+                                    put("parentRef", JsonPrimitive("c1"))
+                                    put("title", JsonPrimitive("Attach Grandchild"))
+                                }
+                            )
+                        }
+                    )
+                }
+            val attachResult = tool.execute(attachParams, context) as JsonObject
+            assertTrue(attachResult["success"]!!.jsonPrimitive.boolean, "Attach should succeed: $attachResult")
+
+            val childrenArr = (attachResult["data"] as JsonObject)["children"] as JsonArray
+            val c1Id = UUID.fromString(childrenArr[0].jsonObject["id"]!!.jsonPrimitive.content)
+            val gc1Id = UUID.fromString(childrenArr[1].jsonObject["id"]!!.jsonPrimitive.content)
+
+            val c1 = (workItemRepository.getById(c1Id) as Result.Success).data
+            val gc1 = (workItemRepository.getById(gc1Id) as Result.Success).data
+
+            assertEquals(existingRootId, c1.rootId, "Direct child must inherit the existing root's effective rootId")
+            assertEquals(existingRootId, gc1.rootId, "Grandchild must inherit the same root id transitively")
+        }
+
+    // ──────────────────────────────────────────────────────────────────────────
     // Top-level actor attribution persists on the DB row for every note
     //
     // Verifies the audit trail is intact end-to-end: actor.id, actor.kind, and

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolIntegrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeToolIntegrationTest.kt
@@ -461,7 +461,12 @@ class CreateWorkTreeToolIntegrationTest {
                     put(
                         "children",
                         buildJsonArray {
-                            add(buildJsonObject { put("ref", JsonPrimitive("child")); put("title", JsonPrimitive("Child")) })
+                            add(
+                                buildJsonObject {
+                                    put("ref", JsonPrimitive("child"))
+                                    put("title", JsonPrimitive("Child"))
+                                }
+                            )
                         }
                     )
                 }
@@ -504,7 +509,12 @@ class CreateWorkTreeToolIntegrationTest {
                     put(
                         "children",
                         buildJsonArray {
-                            add(buildJsonObject { put("ref", JsonPrimitive("c1")); put("title", JsonPrimitive("Attach Child")) })
+                            add(
+                                buildJsonObject {
+                                    put("ref", JsonPrimitive("c1"))
+                                    put("title", JsonPrimitive("Attach Child"))
+                                }
+                            )
                             add(
                                 buildJsonObject {
                                     put("ref", JsonPrimitive("gc1"))

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/ManageItemsToolTest.kt
@@ -5,6 +5,8 @@ import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
 import io.github.jpicklyk.mcptask.current.application.tools.ToolValidationException
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
 import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
@@ -2238,5 +2240,168 @@ class ManageItemsToolTest {
                 )
             val summary = tool.userSummary(params("operation" to JsonPrimitive("delete")), deleteResult, isError = false)
             assertEquals("Deleted 1 item(s)", summary)
+        }
+
+    // ──────────────────────────────────────────────
+    // root_id stamping (create + reparent)
+    // ──────────────────────────────────────────────
+    // rootId is not exposed in the tool's JSON response yet (EntityJsonSerializers.toFullJson /
+    // toMinimalJson), so these assert against the repository directly rather than the response.
+
+    @Test
+    fun `create with parentId stamps rootId inherited from the parent chain`() =
+        runBlocking {
+            suspend fun createItem(
+                title: String,
+                parentId: String? = null,
+            ): String {
+                val obj =
+                    buildJsonObject {
+                        put("title", JsonPrimitive(title))
+                        if (parentId != null) put("parentId", JsonPrimitive(parentId))
+                    }
+                val result =
+                    tool.execute(
+                        params("operation" to JsonPrimitive("create"), "items" to JsonArray(listOf(obj))),
+                        context
+                    ) as JsonObject
+                return (result["data"] as JsonObject)["items"]!!
+                    .jsonArray[0]
+                    .jsonObject["id"]!!
+                    .jsonPrimitive.content
+            }
+
+            suspend fun rootIdOf(itemId: String): UUID? {
+                val repo = repositoryProvider.workItemRepository()
+                val result = repo.getById(UUID.fromString(itemId))
+                assertIs<Result.Success<WorkItem>>(result)
+                return result.data.rootId
+            }
+
+            val rootId = createItem("Root")
+            val childId = createItem("Child", parentId = rootId)
+            val grandchildId = createItem("Grandchild", parentId = childId)
+
+            val rootUuid = UUID.fromString(rootId)
+            assertEquals(rootUuid, rootIdOf(rootId), "Root's rootId must be its own id")
+            assertEquals(rootUuid, rootIdOf(childId), "Child must inherit the root's id")
+            assertEquals(rootUuid, rootIdOf(grandchildId), "Grandchild must inherit the same root id")
+        }
+
+    @Test
+    fun `update parentId to a different root restamps rootId for item and descendants`() =
+        runBlocking {
+            suspend fun createItem(
+                title: String,
+                parentId: String? = null,
+            ): String {
+                val obj =
+                    buildJsonObject {
+                        put("title", JsonPrimitive(title))
+                        if (parentId != null) put("parentId", JsonPrimitive(parentId))
+                    }
+                val result =
+                    tool.execute(
+                        params("operation" to JsonPrimitive("create"), "items" to JsonArray(listOf(obj))),
+                        context
+                    ) as JsonObject
+                return (result["data"] as JsonObject)["items"]!!
+                    .jsonArray[0]
+                    .jsonObject["id"]!!
+                    .jsonPrimitive.content
+            }
+
+            suspend fun rootIdOf(itemId: String): UUID? {
+                val repo = repositoryProvider.workItemRepository()
+                val result = repo.getById(UUID.fromString(itemId))
+                assertIs<Result.Success<WorkItem>>(result)
+                return result.data.rootId
+            }
+
+            // Root A -> B -> C, plus an independent Root D.
+            val rootAId = createItem("Root A")
+            val bId = createItem("B", parentId = rootAId)
+            val cId = createItem("C", parentId = bId)
+            val rootDId = createItem("Root D")
+
+            // Move B under Root D: same depth (1), but rootId must flip for B and cascade to C.
+            val moveResult =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("update"),
+                        "items" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("id", JsonPrimitive(bId))
+                                        put("parentId", JsonPrimitive(rootDId))
+                                    }
+                                )
+                            )
+                    ),
+                    context
+                ) as JsonObject
+            assertTrue(moveResult["success"]!!.jsonPrimitive.boolean)
+
+            val rootDUuid = UUID.fromString(rootDId)
+            assertEquals(rootDUuid, rootIdOf(bId), "B's rootId must flip to Root D after reparent")
+            assertEquals(rootDUuid, rootIdOf(cId), "C must cascade to Root D even though its depth didn't change")
+        }
+
+    @Test
+    fun `update parentId to null restamps rootId to the item's own id`() =
+        runBlocking {
+            suspend fun createItem(
+                title: String,
+                parentId: String? = null,
+            ): String {
+                val obj =
+                    buildJsonObject {
+                        put("title", JsonPrimitive(title))
+                        if (parentId != null) put("parentId", JsonPrimitive(parentId))
+                    }
+                val result =
+                    tool.execute(
+                        params("operation" to JsonPrimitive("create"), "items" to JsonArray(listOf(obj))),
+                        context
+                    ) as JsonObject
+                return (result["data"] as JsonObject)["items"]!!
+                    .jsonArray[0]
+                    .jsonObject["id"]!!
+                    .jsonPrimitive.content
+            }
+
+            suspend fun rootIdOf(itemId: String): UUID? {
+                val repo = repositoryProvider.workItemRepository()
+                val result = repo.getById(UUID.fromString(itemId))
+                assertIs<Result.Success<WorkItem>>(result)
+                return result.data.rootId
+            }
+
+            val rootAId = createItem("Root A")
+            val bId = createItem("B", parentId = rootAId)
+            val cId = createItem("C", parentId = bId)
+
+            val moveResult =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("update"),
+                        "items" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("id", JsonPrimitive(bId))
+                                        put("parentId", JsonNull)
+                                    }
+                                )
+                            )
+                    ),
+                    context
+                ) as JsonObject
+            assertTrue(moveResult["success"]!!.jsonPrimitive.boolean)
+
+            val bUuid = UUID.fromString(bId)
+            assertEquals(bUuid, rootIdOf(bId), "B must become its own root after moving to root level")
+            assertEquals(bUuid, rootIdOf(cId), "C must cascade to B's new root id (B itself)")
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolAncestorScopeTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolAncestorScopeTest.kt
@@ -1,0 +1,203 @@
+package io.github.jpicklyk.mcptask.current.application.tools.items
+
+import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.*
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.*
+
+/**
+ * Tests for the `ancestorId` scope parameter on [QueryItemsTool]'s list-mode `search` (T2.3).
+ *
+ * `ancestorId` routes list-mode queries through the T2.2 scoped repository variants
+ * (`findInScope`/`countInScope`) instead of `findByFilters`/`countByFilters`. Coverage mirrors
+ * the repository-level scoped-variant tests: sibling-root isolation, omitted = unscoped parity,
+ * hex-prefix resolution, and empty-subtree scoping.
+ */
+class QueryItemsToolAncestorScopeTest {
+    private lateinit var context: ToolExecutionContext
+    private lateinit var tool: QueryItemsTool
+    private lateinit var manageTool: ManageItemsTool
+
+    @BeforeEach
+    fun setUp() {
+        val dbName = "test_ancestor_scope_${System.nanoTime()}"
+        val database = Database.connect("jdbc:h2:mem:$dbName;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+        val databaseManager = DatabaseManager(database)
+        DirectDatabaseSchemaManager().updateSchema()
+        val repositoryProvider = DefaultRepositoryProvider(databaseManager)
+        context = ToolExecutionContext(repositoryProvider)
+        tool = QueryItemsTool()
+        manageTool = ManageItemsTool()
+    }
+
+    private fun params(vararg pairs: Pair<String, JsonElement>) = JsonObject(mapOf(*pairs))
+
+    private suspend fun createItemId(
+        title: String,
+        parentId: UUID? = null
+    ): UUID {
+        val itemObj =
+            buildJsonObject {
+                put("title", JsonPrimitive(title))
+                parentId?.let { put("parentId", JsonPrimitive(it.toString())) }
+            }
+        val result =
+            manageTool.execute(
+                params(
+                    "operation" to JsonPrimitive("create"),
+                    "items" to JsonArray(listOf(itemObj))
+                ),
+                context
+            ) as JsonObject
+        val idStr =
+            (result["data"] as JsonObject)["items"]!!
+                .jsonArray[0]
+                .jsonObject["id"]!!
+                .jsonPrimitive.content
+        return UUID.fromString(idStr)
+    }
+
+    @Test
+    fun `search list mode without ancestorId is unscoped across all trees`(): Unit =
+        runBlocking {
+            val r1 = createItemId("Root 1")
+            createItemId("Child of R1", parentId = r1)
+            val r2 = createItemId("Root 2")
+            createItemId("Child of R2", parentId = r2)
+
+            val result =
+                tool.execute(
+                    params("operation" to JsonPrimitive("search")),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            // 2 roots + 2 children = 4 items total, unscoped
+            assertEquals(4, data["total"]!!.jsonPrimitive.int)
+        }
+
+    @Test
+    fun `search list mode scoped to R1 excludes R2's subtree (sibling isolation)`(): Unit =
+        runBlocking {
+            val r1 = createItemId("Root 1")
+            val c1 = createItemId("Child of R1", parentId = r1)
+            val r2 = createItemId("Root 2")
+            createItemId("Child of R2", parentId = r2)
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("search"),
+                        "ancestorId" to JsonPrimitive(r1.toString())
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            // R1 root + its child = 2 items; R2's subtree must be excluded
+            assertEquals(2, data["total"]!!.jsonPrimitive.int)
+            val ids = data["items"]!!.jsonArray.map { it.jsonObject["id"]!!.jsonPrimitive.content }.toSet()
+            assertTrue(r1.toString() in ids)
+            assertTrue(c1.toString() in ids)
+        }
+
+    @Test
+    fun `search list mode ancestorId resolves via hex prefix`(): Unit =
+        runBlocking {
+            val r1 = createItemId("Root 1")
+            createItemId("Child of R1", parentId = r1)
+            val r2 = createItemId("Root 2")
+            createItemId("Child of R2", parentId = r2)
+
+            val prefix = r1.toString().replace("-", "").take(8)
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("search"),
+                        "ancestorId" to JsonPrimitive(prefix)
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(2, data["total"]!!.jsonPrimitive.int)
+        }
+
+    @Test
+    fun `search list mode scoped to a childless leaf returns only that leaf`(): Unit =
+        runBlocking {
+            val r1 = createItemId("Root 1")
+            val leaf = createItemId("Leaf with no children", parentId = r1)
+            createItemId("Sibling of leaf", parentId = r1)
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("search"),
+                        "ancestorId" to JsonPrimitive(leaf.toString())
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(1, data["total"]!!.jsonPrimitive.int, "Leaf's own subtree is just itself")
+            assertEquals(
+                leaf.toString(),
+                data["items"]!!.jsonArray[0].jsonObject["id"]!!.jsonPrimitive.content
+            )
+        }
+
+    @Test
+    fun `search list mode ancestorId composes with existing filters (role)`(): Unit =
+        runBlocking {
+            val r1 = createItemId("Root 1")
+            val workChild =
+                run {
+                    val id = createItemId("Work child", parentId = r1)
+                    val item = (context.workItemRepository().getById(id) as Result.Success).data
+                    context.workItemRepository().update(
+                        item.copy(role = io.github.jpicklyk.mcptask.current.domain.model.Role.WORK)
+                    )
+                    id
+                }
+            createItemId("Queue child", parentId = r1) // stays QUEUE
+            val r2 = createItemId("Root 2")
+            val r2WorkChild =
+                run {
+                    val id = createItemId("R2 work child", parentId = r2)
+                    val item = (context.workItemRepository().getById(id) as Result.Success).data
+                    context.workItemRepository().update(
+                        item.copy(role = io.github.jpicklyk.mcptask.current.domain.model.Role.WORK)
+                    )
+                    id
+                }
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("search"),
+                        "ancestorId" to JsonPrimitive(r1.toString()),
+                        "role" to JsonPrimitive("work")
+                    ),
+                    context
+                ) as JsonObject
+
+            val data = result["data"] as JsonObject
+            assertEquals(1, data["total"]!!.jsonPrimitive.int, "Only R1's WORK child should match")
+            val ids = data["items"]!!.jsonArray.map { it.jsonObject["id"]!!.jsonPrimitive.content }.toSet()
+            assertTrue(workChild.toString() in ids)
+            assertTrue(r2WorkChild.toString() !in ids)
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolAncestorScopeTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolAncestorScopeTest.kt
@@ -155,7 +155,10 @@ class QueryItemsToolAncestorScopeTest {
             assertEquals(1, data["total"]!!.jsonPrimitive.int, "Leaf's own subtree is just itself")
             assertEquals(
                 leaf.toString(),
-                data["items"]!!.jsonArray[0].jsonObject["id"]!!.jsonPrimitive.content
+                data["items"]!!
+                    .jsonArray[0]
+                    .jsonObject["id"]!!
+                    .jsonPrimitive.content
             )
         }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolTest.kt
@@ -1678,6 +1678,168 @@ class QueryItemsToolTest {
         }
 
     // ──────────────────────────────────────────────
+    // Anchored overview (ancestorId) — T2.5
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `anchored overview renders ancestor's direct children as roots with full-subtree childCounts`(): Unit =
+        runBlocking {
+            // 3-level tree: anchor -> child -> 2 grandchildren (1 queue, 1 work).
+            // The child itself has no direct children of its own — the grandchildren are two
+            // levels below the anchor, so a scoped overview on `child` would show childCounts
+            // {queue: 1, work: 1} too, but here we assert the anchor's children array itself
+            // (i.e. `child`) carries a full-subtree roll-up, which is the point of this mode.
+            val anchorId = createItem("Project Anchor")
+            val childId = createItem("Feature Child", parentId = anchorId, role = "queue")
+            createItem("Grandchild Queue", parentId = childId, role = "queue")
+            val grandchildWorkId = createItem("Grandchild Work", parentId = childId, role = "queue")
+
+            advanceTool.execute(
+                buildJsonObject {
+                    put(
+                        "transitions",
+                        JsonArray(
+                            listOf(
+                                buildJsonObject {
+                                    put("itemId", JsonPrimitive(grandchildWorkId))
+                                    put("trigger", JsonPrimitive("start"))
+                                }
+                            )
+                        )
+                    )
+                },
+                context
+            )
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("overview"),
+                        "ancestorId" to JsonPrimitive(anchorId)
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+
+            val anchor = data["anchor"]!!.jsonObject
+            assertEquals(anchorId, anchor["id"]!!.jsonPrimitive.content)
+            assertEquals("Project Anchor", anchor["title"]!!.jsonPrimitive.content)
+
+            val items = data["items"]!!.jsonArray
+            assertEquals(1, items.size, "Anchor's direct child (Feature Child) is the sole root")
+            val childItem = items[0].jsonObject
+            assertEquals(childId, childItem["id"]!!.jsonPrimitive.content)
+
+            // Key difference from scoped overview: childCounts here is a FULL-SUBTREE roll-up
+            // (any depth), not direct-children-only — and must not include the child's own role.
+            val childCounts = childItem["childCounts"]!!.jsonObject
+            assertEquals(1, childCounts["queue"]!!.jsonPrimitive.int, "1 grandchild in queue (child's own queue role excluded)")
+            assertEquals(1, childCounts["work"]!!.jsonPrimitive.int, "1 grandchild in work")
+
+            assertEquals(1, data["total"]!!.jsonPrimitive.int)
+            assertFalse(data["truncated"]!!.jsonPrimitive.boolean)
+            assertEquals(0, data["offset"]!!.jsonPrimitive.int)
+        }
+
+    @Test
+    fun `anchored overview excludeTerminal true hides terminal children from items and total`(): Unit =
+        runBlocking {
+            val anchorId = createItem("Anchor With Terminal Child")
+            val activeChildId = createItem("Active Child", parentId = anchorId, role = "queue")
+            val terminalChildId = createItem("Terminal Child", parentId = anchorId, role = "queue")
+
+            advanceTool.execute(
+                buildJsonObject {
+                    put(
+                        "transitions",
+                        JsonArray(
+                            listOf(
+                                buildJsonObject {
+                                    put("itemId", JsonPrimitive(terminalChildId))
+                                    put("trigger", JsonPrimitive("complete"))
+                                }
+                            )
+                        )
+                    )
+                },
+                context
+            )
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("overview"),
+                        "ancestorId" to JsonPrimitive(anchorId),
+                        "excludeTerminal" to JsonPrimitive(true)
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            val items = data["items"]!!.jsonArray
+            assertEquals(1, items.size)
+            assertEquals(activeChildId, items[0].jsonObject["id"]!!.jsonPrimitive.content)
+            // total/truncated reflect the filtered set — same layer the global path applies
+            // excludeTerminal (unlike scoped overview, where childCounts stays unfiltered but
+            // here the roots set itself is what's filtered).
+            assertEquals(1, data["total"]!!.jsonPrimitive.int)
+        }
+
+    @Test
+    fun `anchored overview resolves ancestorId via hex prefix`(): Unit =
+        runBlocking {
+            val anchorId = createItem("Prefix Anchor")
+            createItem("Only Child", parentId = anchorId, role = "queue")
+
+            val prefix = anchorId.replace("-", "").take(8)
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("overview"),
+                        "ancestorId" to JsonPrimitive(prefix)
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(anchorId, data["anchor"]!!.jsonObject["id"]!!.jsonPrimitive.content)
+            assertEquals(1, data["items"]!!.jsonArray.size)
+        }
+
+    @Test
+    fun `overview rejects itemId and ancestorId supplied together`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(
+                params(
+                    "operation" to JsonPrimitive("overview"),
+                    "itemId" to JsonPrimitive(UUID.randomUUID().toString()),
+                    "ancestorId" to JsonPrimitive(UUID.randomUUID().toString())
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `global overview response omits the anchor envelope`(): Unit =
+        runBlocking {
+            createItem("Some Root")
+
+            val result =
+                tool.execute(
+                    params("operation" to JsonPrimitive("overview")),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertFalse(data.containsKey("anchor"), "Global overview must remain byte-identical — no anchor envelope")
+        }
+
+    // ──────────────────────────────────────────────
     // Schema operation (get_schema)
     // ──────────────────────────────────────────────
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsToolAncestorScopeTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsToolAncestorScopeTest.kt
@@ -111,7 +111,11 @@ class GetBlockedItemsToolAncestorScopeTest {
             val r2 = createItem("Root 2")
             createBlockedItem("Blocked child of R2", parentId = r2.id)
 
-            val prefix = r1.id.toString().replace("-", "").take(8)
+            val prefix =
+                r1.id
+                    .toString()
+                    .replace("-", "")
+                    .take(8)
             val result = tool.execute(params("ancestorId" to JsonPrimitive(prefix)), context)
 
             assertEquals(1, extractTotal(result))

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsToolAncestorScopeTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsToolAncestorScopeTest.kt
@@ -1,0 +1,153 @@
+package io.github.jpicklyk.mcptask.current.application.tools.workflow
+
+import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
+import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.*
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.*
+
+/**
+ * Tests for the `ancestorId` scope parameter on [GetBlockedItemsTool] (T2.3).
+ *
+ * `ancestorId` routes candidate-role fetching through `findInScope(rootIds=...)` (composing
+ * with the pre-existing `parentId` filter) instead of `findByFilters`/`findByRole`.
+ */
+class GetBlockedItemsToolAncestorScopeTest {
+    private lateinit var context: ToolExecutionContext
+    private lateinit var tool: GetBlockedItemsTool
+
+    @BeforeEach
+    fun setUp() {
+        val dbName = "test_ancestor_scope_${System.nanoTime()}"
+        val database = Database.connect("jdbc:h2:mem:$dbName;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+        val databaseManager = DatabaseManager(database)
+        DirectDatabaseSchemaManager().updateSchema()
+        val repositoryProvider = DefaultRepositoryProvider(databaseManager)
+        context = ToolExecutionContext(repositoryProvider)
+        tool = GetBlockedItemsTool()
+    }
+
+    private fun params(vararg pairs: Pair<String, JsonElement>) = JsonObject(mapOf(*pairs))
+
+    private suspend fun createItem(
+        title: String,
+        parentId: UUID? = null,
+        role: Role = Role.QUEUE,
+        depth: Int = if (parentId != null) 1 else 0
+    ): WorkItem {
+        val item = WorkItem(parentId = parentId, title = title, role = role, depth = depth)
+        return (context.workItemRepository().create(item) as Result.Success).data
+    }
+
+    /** Directly creates an explicitly BLOCKED item (bypassing the normal block/hold trigger). */
+    private suspend fun createBlockedItem(
+        title: String,
+        parentId: UUID? = null,
+        depth: Int = if (parentId != null) 1 else 0
+    ): WorkItem {
+        val item =
+            WorkItem(
+                title = title,
+                role = Role.BLOCKED,
+                previousRole = Role.WORK,
+                parentId = parentId,
+                depth = depth
+            )
+        return (context.workItemRepository().create(item) as Result.Success).data
+    }
+
+    private fun extractBlockedItems(result: JsonElement): JsonArray {
+        val data = (result as JsonObject)["data"] as JsonObject
+        return data["blockedItems"]!!.jsonArray
+    }
+
+    private fun extractTotal(result: JsonElement): Int = ((result as JsonObject)["data"] as JsonObject)["total"]!!.jsonPrimitive.int
+
+    @Test
+    fun `get_blocked_items without ancestorId is unscoped across all trees`(): Unit =
+        runBlocking {
+            val r1 = createItem("Root 1")
+            createBlockedItem("Blocked child of R1", parentId = r1.id)
+            val r2 = createItem("Root 2")
+            createBlockedItem("Blocked child of R2", parentId = r2.id)
+
+            val result = tool.execute(params(), context)
+            assertEquals(2, extractTotal(result))
+        }
+
+    @Test
+    fun `get_blocked_items scoped to R1 excludes R2's subtree (sibling isolation)`(): Unit =
+        runBlocking {
+            val r1 = createItem("Root 1")
+            val blockedR1 = createBlockedItem("Blocked child of R1", parentId = r1.id)
+            val r2 = createItem("Root 2")
+            createBlockedItem("Blocked child of R2", parentId = r2.id)
+
+            val result =
+                tool.execute(
+                    params("ancestorId" to JsonPrimitive(r1.id.toString())),
+                    context
+                )
+
+            assertEquals(1, extractTotal(result))
+            val ids = extractBlockedItems(result).map { it.jsonObject["itemId"]!!.jsonPrimitive.content }.toSet()
+            assertTrue(blockedR1.id.toString() in ids)
+        }
+
+    @Test
+    fun `get_blocked_items ancestorId resolves via hex prefix`(): Unit =
+        runBlocking {
+            val r1 = createItem("Root 1")
+            createBlockedItem("Blocked child of R1", parentId = r1.id)
+            val r2 = createItem("Root 2")
+            createBlockedItem("Blocked child of R2", parentId = r2.id)
+
+            val prefix = r1.id.toString().replace("-", "").take(8)
+            val result = tool.execute(params("ancestorId" to JsonPrimitive(prefix)), context)
+
+            assertEquals(1, extractTotal(result))
+        }
+
+    @Test
+    fun `get_blocked_items scoped to a childless leaf returns empty`(): Unit =
+        runBlocking {
+            val r1 = createItem("Root 1")
+            val leaf = createItem("Leaf with no children", parentId = r1.id)
+            createBlockedItem("Blocked sibling", parentId = r1.id)
+
+            val result = tool.execute(params("ancestorId" to JsonPrimitive(leaf.id.toString())), context)
+
+            assertEquals(0, extractTotal(result))
+        }
+
+    @Test
+    fun `get_blocked_items ancestorId composes with parentId`(): Unit =
+        runBlocking {
+            val r1 = createItem("Root 1")
+            val mid = createItem("Mid of R1", parentId = r1.id)
+            val blockedUnderMid = createBlockedItem("Blocked under mid", parentId = mid.id, depth = 2)
+            createBlockedItem("Blocked directly under R1", parentId = r1.id)
+
+            val result =
+                tool.execute(
+                    params(
+                        "ancestorId" to JsonPrimitive(r1.id.toString()),
+                        "parentId" to JsonPrimitive(mid.id.toString())
+                    ),
+                    context
+                )
+
+            assertEquals(1, extractTotal(result), "Only the blocked item directly under 'mid' should match")
+            val ids = extractBlockedItems(result).map { it.jsonObject["itemId"]!!.jsonPrimitive.content }.toSet()
+            assertTrue(blockedUnderMid.id.toString() in ids)
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolAncestorScopeTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolAncestorScopeTest.kt
@@ -1,0 +1,216 @@
+package io.github.jpicklyk.mcptask.current.application.tools.workflow
+
+import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
+import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.RoleTransition
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.*
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.*
+
+/**
+ * Tests for the `ancestorId` scope parameter on [GetContextTool]'s health-check and
+ * session-resume modes (T2.3). Uses a real H2 in-memory DB (via [DefaultRepositoryProvider])
+ * since subtree resolution requires actual parent-child rows.
+ *
+ * Item mode ignores `ancestorId` entirely (documented in the field's parameterSchema
+ * description) — not covered here since there is no scoping behavior to assert.
+ */
+class GetContextToolAncestorScopeTest {
+    private lateinit var context: ToolExecutionContext
+    private lateinit var tool: GetContextTool
+
+    @BeforeEach
+    fun setUp() {
+        val dbName = "test_ancestor_scope_${System.nanoTime()}"
+        val database = Database.connect("jdbc:h2:mem:$dbName;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+        val databaseManager = DatabaseManager(database)
+        DirectDatabaseSchemaManager().updateSchema()
+        val repositoryProvider = DefaultRepositoryProvider(databaseManager)
+        context = ToolExecutionContext(repositoryProvider)
+        tool = GetContextTool()
+    }
+
+    private fun params(vararg pairs: Pair<String, JsonElement>) = JsonObject(mapOf(*pairs))
+
+    private suspend fun createItem(
+        title: String,
+        parentId: UUID? = null,
+        role: Role = Role.QUEUE,
+        claimed: Boolean = false,
+        depth: Int = if (parentId != null) 1 else 0
+    ): WorkItem {
+        val now = Instant.now()
+        val item =
+            if (claimed) {
+                WorkItem(
+                    parentId = parentId,
+                    title = title,
+                    role = role,
+                    depth = depth,
+                    claimedBy = "agent-1",
+                    claimedAt = now,
+                    originalClaimedAt = now,
+                    claimExpiresAt = now.plusSeconds(900),
+                )
+            } else {
+                WorkItem(parentId = parentId, title = title, role = role, depth = depth)
+            }
+        return (context.workItemRepository().create(item) as Result.Success).data
+    }
+
+    private fun activeItemIds(result: JsonElement): Set<String> {
+        val data = (result as JsonObject)["data"] as JsonObject
+        return data["activeItems"]!!.jsonArray.map { it.jsonObject["id"]!!.jsonPrimitive.content }.toSet()
+    }
+
+    // ──────────────────────────────────────────────
+    // Health-check mode
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `health-check without ancestorId is unscoped across all trees`(): Unit =
+        runBlocking {
+            val r1 = createItem("Root 1")
+            createItem("Work child of R1", parentId = r1.id, role = Role.WORK)
+            val r2 = createItem("Root 2")
+            createItem("Work child of R2", parentId = r2.id, role = Role.WORK)
+
+            val result = tool.execute(params("mode" to JsonPrimitive("health-check")), context)
+            assertEquals(2, activeItemIds(result).size)
+        }
+
+    @Test
+    fun `health-check scoped to R1 excludes R2's active items (sibling isolation)`(): Unit =
+        runBlocking {
+            val r1 = createItem("Root 1")
+            val workR1 = createItem("Work child of R1", parentId = r1.id, role = Role.WORK)
+            val r2 = createItem("Root 2")
+            createItem("Work child of R2", parentId = r2.id, role = Role.WORK)
+
+            val result =
+                tool.execute(
+                    params(
+                        "mode" to JsonPrimitive("health-check"),
+                        "ancestorId" to JsonPrimitive(r1.id.toString())
+                    ),
+                    context
+                )
+
+            val ids = activeItemIds(result)
+            assertEquals(1, ids.size)
+            assertTrue(workR1.id.toString() in ids)
+        }
+
+    @Test
+    fun `health-check claimSummary is scoped to ancestorId's subtree`(): Unit =
+        runBlocking {
+            val r1 = createItem("Root 1")
+            createItem("Claimed child of R1", parentId = r1.id, claimed = true)
+            val r2 = createItem("Root 2")
+            createItem("Claimed child of R2", parentId = r2.id, claimed = true)
+
+            val result =
+                tool.execute(
+                    params(
+                        "mode" to JsonPrimitive("health-check"),
+                        "ancestorId" to JsonPrimitive(r1.id.toString())
+                    ),
+                    context
+                )
+
+            val claimSummary = ((result as JsonObject)["data"] as JsonObject)["claimSummary"]!!.jsonObject
+            assertEquals(1, claimSummary["active"]!!.jsonPrimitive.int, "Only R1's claimed child should count")
+        }
+
+    @Test
+    fun `health-check scoped to a childless leaf returns no active items`(): Unit =
+        runBlocking {
+            val r1 = createItem("Root 1")
+            val leafQueue = createItem("Queue leaf (not active)", parentId = r1.id)
+            createItem("Work sibling", parentId = r1.id, role = Role.WORK)
+
+            val result =
+                tool.execute(
+                    params(
+                        "mode" to JsonPrimitive("health-check"),
+                        "ancestorId" to JsonPrimitive(leafQueue.id.toString())
+                    ),
+                    context
+                )
+
+            assertTrue(activeItemIds(result).isEmpty(), "Leaf's own subtree has no WORK/REVIEW items")
+        }
+
+    // ──────────────────────────────────────────────
+    // Session-resume mode
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `session-resume scoped to R1 excludes R2's active items`(): Unit =
+        runBlocking {
+            val r1 = createItem("Root 1")
+            val workR1 = createItem("Work child of R1", parentId = r1.id, role = Role.WORK)
+            val r2 = createItem("Root 2")
+            createItem("Work child of R2", parentId = r2.id, role = Role.WORK)
+
+            val result =
+                tool.execute(
+                    params(
+                        "mode" to JsonPrimitive("session-resume"),
+                        "since" to JsonPrimitive(Instant.now().minusSeconds(3600).toString()),
+                        "ancestorId" to JsonPrimitive(r1.id.toString())
+                    ),
+                    context
+                )
+
+            val ids = activeItemIds(result)
+            assertEquals(1, ids.size)
+            assertTrue(workR1.id.toString() in ids)
+        }
+
+    @Test
+    fun `session-resume recentTransitions are NOT scoped by ancestorId (documented limitation)`(): Unit =
+        runBlocking {
+            val r1 = createItem("Root 1")
+            val r2 = createItem("Root 2")
+            val itemInR2 = createItem("Item in R2", parentId = r2.id, role = Role.WORK)
+
+            // Record a transition on an item outside R1's subtree.
+            context.roleTransitionRepository().create(
+                RoleTransition(
+                    itemId = itemInR2.id,
+                    fromRole = "queue",
+                    toRole = "work",
+                    trigger = "start"
+                )
+            )
+
+            val result =
+                tool.execute(
+                    params(
+                        "mode" to JsonPrimitive("session-resume"),
+                        "since" to JsonPrimitive(Instant.now().minusSeconds(3600).toString()),
+                        "ancestorId" to JsonPrimitive(r1.id.toString())
+                    ),
+                    context
+                )
+
+            val data = (result as JsonObject)["data"] as JsonObject
+            val transitionItemIds =
+                data["recentTransitions"]!!.jsonArray.map { it.jsonObject["itemId"]!!.jsonPrimitive.content }.toSet()
+            assertTrue(
+                itemInR2.id.toString() in transitionItemIds,
+                "recentTransitions must remain unscoped even when ancestorId is set (documented limitation)"
+            )
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolAncestorScopeTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolAncestorScopeTest.kt
@@ -1,0 +1,178 @@
+package io.github.jpicklyk.mcptask.current.application.tools.workflow
+
+import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
+import io.github.jpicklyk.mcptask.current.domain.model.Priority
+import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.*
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.*
+
+/**
+ * Tests for the `ancestorId` scope parameter on [GetNextItemTool] (T2.3).
+ *
+ * Covers both selection paths: the default recommender path (`NextItemRecommender.Criteria.ancestorIds`
+ * -> `findClaimable(rootIds=...)`) and the `includeClaimed=true` path
+ * (`findForNextItem(rootIds=...)`).
+ */
+class GetNextItemToolAncestorScopeTest {
+    private lateinit var context: ToolExecutionContext
+    private lateinit var tool: GetNextItemTool
+
+    @BeforeEach
+    fun setUp() {
+        val dbName = "test_ancestor_scope_${System.nanoTime()}"
+        val database = Database.connect("jdbc:h2:mem:$dbName;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+        val databaseManager = DatabaseManager(database)
+        DirectDatabaseSchemaManager().updateSchema()
+        val repositoryProvider = DefaultRepositoryProvider(databaseManager)
+        context = ToolExecutionContext(repositoryProvider)
+        tool = GetNextItemTool()
+    }
+
+    private fun params(vararg pairs: Pair<String, JsonElement>) = JsonObject(mapOf(*pairs))
+
+    private suspend fun createItem(
+        title: String,
+        parentId: UUID? = null,
+        role: Role = Role.QUEUE,
+        priority: Priority = Priority.MEDIUM,
+        claimed: Boolean = false,
+        depth: Int = if (parentId != null) 1 else 0
+    ): WorkItem {
+        val now = Instant.now()
+        val item =
+            if (claimed) {
+                WorkItem(
+                    parentId = parentId,
+                    title = title,
+                    role = role,
+                    priority = priority,
+                    depth = depth,
+                    claimedBy = "agent-1",
+                    claimedAt = now,
+                    originalClaimedAt = now,
+                    claimExpiresAt = now.plusSeconds(900),
+                )
+            } else {
+                WorkItem(parentId = parentId, title = title, role = role, priority = priority, depth = depth)
+            }
+        return (context.workItemRepository().create(item) as Result.Success).data
+    }
+
+    private fun extractRecommendations(result: JsonElement): JsonArray {
+        val data = (result as JsonObject)["data"] as JsonObject
+        return data["recommendations"]!!.jsonArray
+    }
+
+    private fun extractTotal(result: JsonElement): Int = ((result as JsonObject)["data"] as JsonObject)["total"]!!.jsonPrimitive.int
+
+    @Test
+    fun `get_next_item without ancestorId is unscoped across all trees`(): Unit =
+        runBlocking {
+            val r1 = createItem("Root 1")
+            createItem("Queue child of R1", parentId = r1.id)
+            val r2 = createItem("Root 2")
+            createItem("Queue child of R2", parentId = r2.id)
+
+            val result = tool.execute(params("limit" to JsonPrimitive(20)), context)
+            // 2 roots + 2 children, all QUEUE by default
+            assertEquals(4, extractTotal(result))
+        }
+
+    @Test
+    fun `get_next_item scoped to R1 excludes R2's subtree (sibling isolation)`(): Unit =
+        runBlocking {
+            val r1 = createItem("Root 1")
+            val c1 = createItem("Queue child of R1", parentId = r1.id)
+            val r2 = createItem("Root 2")
+            createItem("Queue child of R2", parentId = r2.id)
+
+            val result =
+                tool.execute(
+                    params(
+                        "ancestorId" to JsonPrimitive(r1.id.toString()),
+                        "limit" to JsonPrimitive(20)
+                    ),
+                    context
+                )
+
+            assertEquals(2, extractTotal(result), "R1 root + its child = 2")
+            val ids = extractRecommendations(result).map { it.jsonObject["itemId"]!!.jsonPrimitive.content }.toSet()
+            assertTrue(r1.id.toString() in ids)
+            assertTrue(c1.id.toString() in ids)
+        }
+
+    @Test
+    fun `get_next_item ancestorId resolves via hex prefix`(): Unit =
+        runBlocking {
+            val r1 = createItem("Root 1")
+            createItem("Queue child of R1", parentId = r1.id)
+            val r2 = createItem("Root 2")
+            createItem("Queue child of R2", parentId = r2.id)
+
+            val prefix = r1.id.toString().replace("-", "").take(8)
+            val result =
+                tool.execute(
+                    params(
+                        "ancestorId" to JsonPrimitive(prefix),
+                        "limit" to JsonPrimitive(20)
+                    ),
+                    context
+                )
+
+            assertEquals(2, extractTotal(result))
+        }
+
+    @Test
+    fun `get_next_item scoped to a childless leaf with no QUEUE items returns empty`(): Unit =
+        runBlocking {
+            val r1 = createItem("Root 1")
+            val leafWork = createItem("Work leaf (not queue)", parentId = r1.id, role = Role.WORK)
+            createItem("Queue sibling", parentId = r1.id)
+
+            val result =
+                tool.execute(
+                    params(
+                        "ancestorId" to JsonPrimitive(leafWork.id.toString()),
+                        "limit" to JsonPrimitive(20)
+                    ),
+                    context
+                )
+
+            assertEquals(0, extractTotal(result), "Leaf's own subtree has no QUEUE-role items")
+        }
+
+    @Test
+    fun `get_next_item includeClaimed=true honors ancestorId scoping`(): Unit =
+        runBlocking {
+            val r1 = createItem("Root 1")
+            val claimedInR1 = createItem("Claimed child of R1", parentId = r1.id, claimed = true)
+            val r2 = createItem("Root 2")
+            createItem("Claimed child of R2", parentId = r2.id, claimed = true)
+
+            val result =
+                tool.execute(
+                    params(
+                        "ancestorId" to JsonPrimitive(r1.id.toString()),
+                        "includeClaimed" to JsonPrimitive(true),
+                        "limit" to JsonPrimitive(20)
+                    ),
+                    context
+                )
+
+            // R1 root (unclaimed) + R1's claimed child = 2; R2's subtree must be excluded
+            assertEquals(2, extractTotal(result))
+            val ids = extractRecommendations(result).map { it.jsonObject["itemId"]!!.jsonPrimitive.content }.toSet()
+            assertTrue(claimedInR1.id.toString() in ids)
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolAncestorScopeTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemToolAncestorScopeTest.kt
@@ -120,7 +120,11 @@ class GetNextItemToolAncestorScopeTest {
             val r2 = createItem("Root 2")
             createItem("Queue child of R2", parentId = r2.id)
 
-            val prefix = r1.id.toString().replace("-", "").take(8)
+            val prefix =
+                r1.id
+                    .toString()
+                    .replace("-", "")
+                    .take(8)
             val result =
                 tool.execute(
                     params(

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/Fts5MigrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/Fts5MigrationTest.kt
@@ -80,6 +80,7 @@ class Fts5MigrationTest {
                     CREATE TABLE IF NOT EXISTS work_items (
                         id BLOB PRIMARY KEY DEFAULT (randomblob(16)),
                         parent_id BLOB REFERENCES work_items(id),
+                        root_id BLOB,
                         title TEXT NOT NULL,
                         description TEXT,
                         summary TEXT NOT NULL DEFAULT '',

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/V9RootIdMigrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/V9RootIdMigrationTest.kt
@@ -1,0 +1,271 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database
+
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteWorkItemRepository
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.sql.Connection
+import java.sql.DriverManager
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration test for the V9 migration (`V9__Add_Root_Id.sql`) — the denormalized `root_id`
+ * column and its recursive-CTE backfill.
+ *
+ * Follows the [Fts5MigrationTest] pattern: hand-build the *pre-migration* schema (V7/V8-final
+ * state, no `root_id` column) with raw SQL, seed rows with raw JDBC inserts (the domain
+ * repository can't be used here — it now always writes `root_id`, which doesn't exist until
+ * this migration runs), then apply the real V9 SQL file read straight off the classpath (not a
+ * hand-copied duplicate, to avoid drift between this test and the migration it verifies) and
+ * assert the backfilled values.
+ */
+class V9RootIdMigrationTest {
+    private lateinit var database: Database
+    private lateinit var databaseManager: DatabaseManager
+    private lateinit var keepAliveConnection: Connection
+
+    @BeforeEach
+    fun setUp() {
+        val dbName = "v9_root_id_${System.nanoTime()}"
+        val jdbcUrl = "jdbc:sqlite:file:$dbName?mode=memory&cache=shared"
+        keepAliveConnection = DriverManager.getConnection(jdbcUrl)
+        database = Database.connect(url = jdbcUrl, driver = "org.sqlite.JDBC")
+        TransactionManager.manager.defaultIsolationLevel = Connection.TRANSACTION_SERIALIZABLE
+        databaseManager = DatabaseManager(database)
+        createPreV9Schema()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        try {
+            TransactionManager.closeAndUnregister(database)
+        } catch (_: Exception) {
+        }
+        try {
+            keepAliveConnection.close()
+        } catch (_: Exception) {
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Pre-migration (V7/V8-final) schema — deliberately WITHOUT root_id
+    // ────────────────────────────────────────────────────────────────────────
+
+    private fun createPreV9Schema() {
+        transaction(db = database) {
+            exec(
+                """
+                CREATE TABLE work_items (
+                    id                   BLOB PRIMARY KEY DEFAULT (randomblob(16)),
+                    parent_id            BLOB REFERENCES work_items(id),
+                    title                TEXT NOT NULL,
+                    description          TEXT,
+                    summary              TEXT NOT NULL DEFAULT '',
+                    role                 TEXT NOT NULL DEFAULT 'queue',
+                    status_label         TEXT,
+                    previous_role        TEXT,
+                    priority             TEXT NOT NULL DEFAULT 'medium',
+                    complexity           INTEGER,
+                    requires_verification INTEGER NOT NULL DEFAULT 0,
+                    depth                INTEGER NOT NULL DEFAULT 0,
+                    metadata             TEXT,
+                    tags                 TEXT,
+                    type                 TEXT,
+                    properties           TEXT,
+                    created_at           TIMESTAMP NOT NULL,
+                    modified_at          TIMESTAMP NOT NULL,
+                    role_changed_at      TIMESTAMP NOT NULL,
+                    version              INTEGER NOT NULL DEFAULT 1,
+                    claimed_by           TEXT DEFAULT NULL,
+                    claimed_at           TEXT DEFAULT NULL,
+                    claim_expires_at     TEXT DEFAULT NULL,
+                    original_claimed_at  TEXT DEFAULT NULL
+                )
+                """.trimIndent()
+            )
+            exec("CREATE INDEX idx_work_items_parent ON work_items(parent_id)")
+            exec("CREATE INDEX idx_work_items_role ON work_items(role)")
+            exec("CREATE INDEX idx_work_items_depth ON work_items(depth)")
+        }
+    }
+
+    /**
+     * Reads the real `V9__Add_Root_Id.sql` off the classpath and executes each statement.
+     * Strips full-line `--` comments, then splits on `;` — safe here because none of the
+     * migration's statements contain an embedded semicolon.
+     */
+    private fun applyV9Migration() {
+        val resourceStream =
+            requireNotNull(Thread.currentThread().contextClassLoader.getResourceAsStream("db/migration/V9__Add_Root_Id.sql")) {
+                "V9__Add_Root_Id.sql not found on the test classpath"
+            }
+        val sqlText = resourceStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+        val withoutComments =
+            sqlText
+                .lineSequence()
+                .filterNot { it.trimStart().startsWith("--") }
+                .joinToString("\n")
+        val statements =
+            withoutComments
+                .split(";")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+
+        transaction(db = database) {
+            statements.forEach { statement -> exec(statement) }
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Raw seeding / reading helpers (bypass the repository — root_id doesn't exist pre-migration)
+    // ────────────────────────────────────────────────────────────────────────
+
+    private fun insertRawItem(
+        id: UUID,
+        parentId: UUID?,
+        title: String,
+        depth: Int = if (parentId == null) 0 else 1,
+    ) {
+        // created_at/modified_at/role_changed_at must be bound as a JDBC java.sql.Timestamp,
+        // matching what Exposed's timestamp() column type writes/reads through the driver.
+        // Neither a raw ISO-8601 string (java.time.Instant.toString()) nor SQLite's own
+        // datetime('now') text format is what the bundled xerial/sqlite-jdbc driver expects when
+        // parsing a TIMESTAMP column back out — both produce "Error parsing time stamp" on read.
+        val now = java.sql.Timestamp.from(java.time.Instant.now())
+        keepAliveConnection
+            .prepareStatement(
+                """
+                INSERT INTO work_items
+                    (id, parent_id, title, summary, role, priority, depth,
+                     created_at, modified_at, role_changed_at, version)
+                VALUES (?, ?, ?, '', 'queue', 'medium', ?, ?, ?, ?, 1)
+                """.trimIndent()
+            ).use { stmt ->
+                stmt.setBytes(1, uuidToBytes(id))
+                if (parentId != null) stmt.setBytes(2, uuidToBytes(parentId)) else stmt.setNull(2, java.sql.Types.BLOB)
+                stmt.setString(3, title)
+                stmt.setInt(4, depth)
+                stmt.setTimestamp(5, now)
+                stmt.setTimestamp(6, now)
+                stmt.setTimestamp(7, now)
+                stmt.executeUpdate()
+            }
+    }
+
+    private fun rootIdOfRaw(id: UUID): UUID? {
+        var result: UUID? = null
+        keepAliveConnection.prepareStatement("SELECT root_id FROM work_items WHERE id = ?").use { stmt ->
+            stmt.setBytes(1, uuidToBytes(id))
+            stmt.executeQuery().use { rs ->
+                if (rs.next()) {
+                    result = rs.getBytes("root_id")?.let { bytesToUuid(it) }
+                }
+            }
+        }
+        return result
+    }
+
+    private fun uuidToBytes(id: UUID): ByteArray {
+        val buf = java.nio.ByteBuffer.allocate(16)
+        buf.putLong(id.mostSignificantBits)
+        buf.putLong(id.leastSignificantBits)
+        return buf.array()
+    }
+
+    private fun bytesToUuid(bytes: ByteArray): UUID {
+        val buf = java.nio.ByteBuffer.wrap(bytes)
+        return UUID(buf.long, buf.long)
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Tests
+    // ────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `V9 migration adds the root_id column and index`(): Unit =
+        runBlocking {
+            applyV9Migration()
+
+            var hasColumn = false
+            transaction(db = database) {
+                exec("PRAGMA table_info(work_items)") { rs ->
+                    while (rs.next()) {
+                        if (rs.getString("name") == "root_id") hasColumn = true
+                    }
+                }
+            }
+            assertTrue(hasColumn, "Expected work_items.root_id column to exist after V9")
+
+            var hasIndex = false
+            transaction(db = database) {
+                exec("SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_work_items_root_id'") { rs ->
+                    hasIndex = rs.next()
+                }
+            }
+            assertTrue(hasIndex, "Expected idx_work_items_root_id index to exist after V9")
+        }
+
+    @Test
+    fun `V9 backfill assigns root_id correctly on a seeded multi-root 3-level tree`(): Unit =
+        runBlocking {
+            // Root A -> B -> C (3 levels)
+            val rootA = UUID.randomUUID()
+            val b = UUID.randomUUID()
+            val c = UUID.randomUUID()
+            insertRawItem(rootA, null, "Root A")
+            insertRawItem(b, rootA, "B")
+            insertRawItem(c, b, "C")
+
+            // Independent second root: Root B -> D
+            val rootB = UUID.randomUUID()
+            val d = UUID.randomUUID()
+            insertRawItem(rootB, null, "Root B")
+            insertRawItem(d, rootB, "D")
+
+            // Orphan: parent_id points at an id that was never inserted — must stay NULL,
+            // the recursive CTE never reaches it (it isn't seeded from a parent_id IS NULL row
+            // and its "parent" doesn't exist to be walked from either).
+            val orphan = UUID.randomUUID()
+            insertRawItem(orphan, UUID.randomUUID(), "Orphan")
+
+            applyV9Migration()
+
+            assertEquals(rootA, rootIdOfRaw(rootA), "Root A must be its own root")
+            assertEquals(rootA, rootIdOfRaw(b), "B must inherit Root A's id")
+            assertEquals(rootA, rootIdOfRaw(c), "C (grandchild) must inherit Root A's id")
+
+            assertEquals(rootB, rootIdOfRaw(rootB), "Root B must be its own root")
+            assertEquals(rootB, rootIdOfRaw(d), "D must inherit Root B's id, not Root A's")
+
+            assertNull(rootIdOfRaw(orphan), "Orphaned row (unreachable parent) must remain NULL after backfill")
+        }
+
+    @Test
+    fun `V9 backfill is visible through the repository mapper after migration`(): Unit =
+        runBlocking {
+            val root = UUID.randomUUID()
+            val child = UUID.randomUUID()
+            insertRawItem(root, null, "Root")
+            insertRawItem(child, root, "Child")
+
+            applyV9Migration()
+
+            val repository = SQLiteWorkItemRepository(databaseManager)
+            val rootResult = repository.getById(root)
+            val childResult = repository.getById(child)
+
+            assertIs<Result.Success<*>>(rootResult)
+            assertIs<Result.Success<*>>(childResult)
+            assertEquals(root, (rootResult as Result.Success).data.rootId)
+            assertEquals(root, (childResult as Result.Success).data.rootId)
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryScopedVariantsTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryScopedVariantsTest.kt
@@ -1,0 +1,373 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database.repository
+
+import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.ClaimStatusCounts
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteWorkItemRepository
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the subtree-scoped (`rootIds`) variants of [SQLiteWorkItemRepository.findForNextItem],
+ * [SQLiteWorkItemRepository.findClaimable], [SQLiteWorkItemRepository.findByRole], and
+ * [SQLiteWorkItemRepository.countByClaimStatus].
+ *
+ * Follows the coverage pattern of `SQLiteWorkItemRepositoryFindInScopeTest`: sibling-root
+ * isolation, unscoped (null) parity with pre-scoping behavior, empty-set scope yielding no
+ * rows, and deep-tree (3+ levels) inclusion. Uses H2 (via [DirectDatabaseSchemaManager]) as
+ * the rest of this package's repository tests do — the SQLite-vs-H2 CTE/BFS resolution paths
+ * inside `resolveScopeIds` are already covered directly by `SQLiteWorkItemRepositoryFindInScopeTest`,
+ * so these tests focus on scope composition with each method's own filter logic.
+ */
+class SQLiteWorkItemRepositoryScopedVariantsTest {
+    private lateinit var database: Database
+    private lateinit var databaseManager: DatabaseManager
+    private lateinit var repository: SQLiteWorkItemRepository
+
+    @BeforeEach
+    fun setUp() {
+        val dbName = "scoped_variants_${System.nanoTime()}"
+        database = Database.connect("jdbc:h2:mem:$dbName;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+        databaseManager = DatabaseManager(database)
+        DirectDatabaseSchemaManager().updateSchema()
+        repository = SQLiteWorkItemRepository(databaseManager)
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ────────────────────────────────────────────────────────────────────────
+
+    private fun newItem(
+        title: String,
+        parentId: UUID? = null,
+        depth: Int = 0,
+        role: Role = Role.QUEUE,
+        claimed: Boolean = false,
+        claimExpired: Boolean = false,
+    ): WorkItem {
+        val now = Instant.now()
+        return if (claimed) {
+            WorkItem(
+                title = title,
+                parentId = parentId,
+                depth = depth,
+                role = role,
+                claimedBy = "agent-1",
+                claimedAt = now.minusSeconds(60),
+                originalClaimedAt = now.minusSeconds(60),
+                claimExpiresAt = if (claimExpired) now.minusSeconds(1) else now.plusSeconds(3600),
+            )
+        } else {
+            WorkItem(title = title, parentId = parentId, depth = depth, role = role)
+        }
+    }
+
+    private fun create(item: WorkItem): WorkItem =
+        runBlocking {
+            val result = repository.create(item)
+            assertIs<Result.Success<WorkItem>>(result, "Expected item '${item.title}' to be created")
+            result.data
+        }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // findByRole
+    // ────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `findByRole unscoped (null) is unchanged - returns matching items across all trees`(): Unit =
+        runBlocking {
+            val r1 = create(newItem("root-1"))
+            val c1 = create(newItem("child-1", parentId = r1.id, depth = 1, role = Role.WORK))
+            val r2 = create(newItem("root-2"))
+            val c2 = create(newItem("child-2", parentId = r2.id, depth = 1, role = Role.WORK))
+
+            val result = repository.findByRole(role = Role.WORK, limit = 50)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            val ids = result.data.map { it.id }.toSet()
+            assertTrue(c1.id in ids)
+            assertTrue(c2.id in ids)
+            assertEquals(2, result.data.size)
+        }
+
+    @Test
+    fun `findByRole scoped to R1 excludes R2's subtree (sibling isolation)`(): Unit =
+        runBlocking {
+            val r1 = create(newItem("root-1"))
+            val c1 = create(newItem("child-1", parentId = r1.id, depth = 1, role = Role.WORK))
+            val r2 = create(newItem("root-2"))
+            val c2 = create(newItem("child-2", parentId = r2.id, depth = 1, role = Role.WORK))
+
+            val result = repository.findByRole(role = Role.WORK, limit = 50, rootIds = setOf(r1.id))
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            val ids = result.data.map { it.id }.toSet()
+            assertTrue(c1.id in ids, "R1's WORK child must be included")
+            assertTrue(c2.id !in ids, "R2's WORK child must be excluded when scoped to R1")
+            assertEquals(1, result.data.size)
+        }
+
+    @Test
+    fun `findByRole with empty rootIds returns nothing`(): Unit =
+        runBlocking {
+            val r1 = create(newItem("root-1"))
+            create(newItem("child-1", parentId = r1.id, depth = 1, role = Role.WORK))
+
+            val result = repository.findByRole(role = Role.WORK, limit = 50, rootIds = emptySet())
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertTrue(result.data.isEmpty(), "Empty rootIds must yield no rows")
+        }
+
+    @Test
+    fun `findByRole scoped includes deep-tree descendants (3+ levels)`(): Unit =
+        runBlocking {
+            val root = create(newItem("root"))
+            val l1 = create(newItem("level-1", parentId = root.id, depth = 1))
+            val l2 = create(newItem("level-2", parentId = l1.id, depth = 2))
+            val l3 = create(newItem("level-3", parentId = l2.id, depth = 3, role = Role.WORK))
+
+            val unrelatedRoot = create(newItem("unrelated"))
+            create(newItem("unrelated-child", parentId = unrelatedRoot.id, depth = 1, role = Role.WORK))
+
+            val result = repository.findByRole(role = Role.WORK, limit = 50, rootIds = setOf(root.id))
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            val ids = result.data.map { it.id }.toSet()
+            assertTrue(l3.id in ids, "Depth-3 descendant must be included via deep-tree scoping")
+            assertEquals(1, result.data.size)
+        }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // findForNextItem
+    // ────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `findForNextItem unscoped (null) is unchanged`(): Unit =
+        runBlocking {
+            val r1 = create(newItem("root-1"))
+            val c1 = create(newItem("child-1", parentId = r1.id, depth = 1, role = Role.QUEUE))
+            val r2 = create(newItem("root-2"))
+            val c2 = create(newItem("child-2", parentId = r2.id, depth = 1, role = Role.QUEUE))
+
+            val result = repository.findForNextItem(role = Role.QUEUE, excludeActiveClaims = false, limit = 50)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            val ids = result.data.map { it.id }.toSet()
+            assertTrue(c1.id in ids)
+            assertTrue(c2.id in ids)
+        }
+
+    @Test
+    fun `findForNextItem scoped to R1 excludes R2's subtree (sibling isolation)`(): Unit =
+        runBlocking {
+            val r1 = create(newItem("root-1"))
+            val c1 = create(newItem("child-1", parentId = r1.id, depth = 1, role = Role.QUEUE))
+            val r2 = create(newItem("root-2"))
+            val c2 = create(newItem("child-2", parentId = r2.id, depth = 1, role = Role.QUEUE))
+
+            val result =
+                repository.findForNextItem(
+                    role = Role.QUEUE,
+                    excludeActiveClaims = false,
+                    limit = 50,
+                    rootIds = setOf(r1.id),
+                )
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            val ids = result.data.map { it.id }.toSet()
+            assertTrue(r1.id in ids, "R1 root (also QUEUE role) must be included")
+            assertTrue(c1.id in ids)
+            assertTrue(r2.id !in ids, "R2's root must be excluded when scoped to R1")
+            assertTrue(c2.id !in ids, "R2's child must be excluded when scoped to R1")
+            assertEquals(2, result.data.size, "R1 root + c1 = 2 (both QUEUE role)")
+        }
+
+    @Test
+    fun `findForNextItem with empty rootIds returns nothing`(): Unit =
+        runBlocking {
+            create(newItem("root-1", role = Role.QUEUE))
+
+            val result =
+                repository.findForNextItem(
+                    role = Role.QUEUE,
+                    excludeActiveClaims = false,
+                    limit = 50,
+                    rootIds = emptySet(),
+                )
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertTrue(result.data.isEmpty())
+        }
+
+    @Test
+    fun `findForNextItem scoped includes deep-tree descendants (3+ levels)`(): Unit =
+        runBlocking {
+            val root = create(newItem("root", role = Role.QUEUE))
+            val l1 = create(newItem("level-1", parentId = root.id, depth = 1, role = Role.QUEUE))
+            val l2 = create(newItem("level-2", parentId = l1.id, depth = 2, role = Role.QUEUE))
+            val l3 = create(newItem("level-3", parentId = l2.id, depth = 3, role = Role.QUEUE))
+
+            val unrelatedRoot = create(newItem("unrelated", role = Role.QUEUE))
+            create(newItem("unrelated-child", parentId = unrelatedRoot.id, depth = 1, role = Role.QUEUE))
+
+            val result =
+                repository.findForNextItem(
+                    role = Role.QUEUE,
+                    excludeActiveClaims = false,
+                    limit = 50,
+                    rootIds = setOf(root.id),
+                )
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            val ids = result.data.map { it.id }.toSet()
+            assertTrue(l3.id in ids, "Depth-3 descendant must be included via deep-tree scoping")
+            assertEquals(4, result.data.size, "root + 3 levels = 4 items")
+        }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // findClaimable
+    // ────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `findClaimable unscoped (null) is unchanged`(): Unit =
+        runBlocking {
+            val r1 = create(newItem("root-1"))
+            val c1 = create(newItem("child-1", parentId = r1.id, depth = 1, role = Role.QUEUE))
+            val r2 = create(newItem("root-2"))
+            val c2 = create(newItem("child-2", parentId = r2.id, depth = 1, role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE, limit = 50)
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            val ids = result.data.map { it.id }.toSet()
+            assertTrue(c1.id in ids)
+            assertTrue(c2.id in ids)
+        }
+
+    @Test
+    fun `findClaimable scoped to R1 excludes R2's subtree (sibling isolation)`(): Unit =
+        runBlocking {
+            val r1 = create(newItem("root-1"))
+            val c1 = create(newItem("child-1", parentId = r1.id, depth = 1, role = Role.QUEUE))
+            val r2 = create(newItem("root-2"))
+            val c2 = create(newItem("child-2", parentId = r2.id, depth = 1, role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE, limit = 50, rootIds = setOf(r1.id))
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            val ids = result.data.map { it.id }.toSet()
+            assertTrue(r1.id in ids, "R1 root (also QUEUE role) must be included")
+            assertTrue(c1.id in ids)
+            assertTrue(r2.id !in ids, "R2's root must be excluded when scoped to R1")
+            assertTrue(c2.id !in ids, "R2's child must be excluded when scoped to R1")
+            assertEquals(2, result.data.size, "R1 root + c1 = 2 (both QUEUE role)")
+        }
+
+    @Test
+    fun `findClaimable with empty rootIds returns nothing`(): Unit =
+        runBlocking {
+            create(newItem("root-1", role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE, limit = 50, rootIds = emptySet())
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertTrue(result.data.isEmpty())
+        }
+
+    @Test
+    fun `findClaimable scoped includes deep-tree descendants (3+ levels)`(): Unit =
+        runBlocking {
+            val root = create(newItem("root", role = Role.QUEUE))
+            val l1 = create(newItem("level-1", parentId = root.id, depth = 1, role = Role.QUEUE))
+            val l2 = create(newItem("level-2", parentId = l1.id, depth = 2, role = Role.QUEUE))
+            val l3 = create(newItem("level-3", parentId = l2.id, depth = 3, role = Role.QUEUE))
+
+            val unrelatedRoot = create(newItem("unrelated", role = Role.QUEUE))
+            create(newItem("unrelated-child", parentId = unrelatedRoot.id, depth = 1, role = Role.QUEUE))
+
+            val result = repository.findClaimable(role = Role.QUEUE, limit = 50, rootIds = setOf(root.id))
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            val ids = result.data.map { it.id }.toSet()
+            assertTrue(l3.id in ids, "Depth-3 descendant must be included via deep-tree scoping")
+            assertEquals(4, result.data.size, "root + 3 levels = 4 items")
+        }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // countByClaimStatus
+    // ────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `countByClaimStatus unscoped (null) is unchanged`(): Unit =
+        runBlocking {
+            val r1 = create(newItem("root-1"))
+            create(newItem("c1-active", parentId = r1.id, depth = 1, claimed = true))
+            val r2 = create(newItem("root-2"))
+            create(newItem("c2-active", parentId = r2.id, depth = 1, claimed = true))
+
+            val result = repository.countByClaimStatus()
+            assertIs<Result.Success<ClaimStatusCounts>>(result)
+            assertEquals(2, result.data.active)
+        }
+
+    @Test
+    fun `countByClaimStatus scoped to R1 excludes R2's subtree (sibling isolation)`(): Unit =
+        runBlocking {
+            val r1 = create(newItem("root-1"))
+            create(newItem("c1-active", parentId = r1.id, depth = 1, claimed = true))
+            create(newItem("c1-expired", parentId = r1.id, depth = 1, claimed = true, claimExpired = true))
+            create(newItem("c1-unclaimed", parentId = r1.id, depth = 1))
+
+            val r2 = create(newItem("root-2"))
+            create(newItem("c2-active", parentId = r2.id, depth = 1, claimed = true))
+
+            val result = repository.countByClaimStatus(rootIds = setOf(r1.id))
+            assertIs<Result.Success<ClaimStatusCounts>>(result)
+            assertEquals(1, result.data.active, "Only R1's active claim should be counted")
+            assertEquals(1, result.data.expired)
+            assertEquals(2, result.data.unclaimed, "R1 root (unclaimed) + c1-unclaimed = 2")
+        }
+
+    @Test
+    fun `countByClaimStatus with empty rootIds returns all-zero counts`(): Unit =
+        runBlocking {
+            create(newItem("root-1"))
+            create(newItem("c1-active", claimed = true))
+
+            val result = repository.countByClaimStatus(rootIds = emptySet())
+            assertIs<Result.Success<ClaimStatusCounts>>(result)
+            assertEquals(0, result.data.active)
+            assertEquals(0, result.data.expired)
+            assertEquals(0, result.data.unclaimed)
+        }
+
+    @Test
+    fun `countByClaimStatus scoped includes deep-tree descendants (3+ levels)`(): Unit =
+        runBlocking {
+            val root = create(newItem("root"))
+            val l1 = create(newItem("level-1", parentId = root.id, depth = 1))
+            val l2 = create(newItem("level-2", parentId = l1.id, depth = 2))
+            create(newItem("level-3-active", parentId = l2.id, depth = 3, claimed = true))
+
+            val unrelatedRoot = create(newItem("unrelated"))
+            create(newItem("unrelated-active", parentId = unrelatedRoot.id, depth = 1, claimed = true))
+
+            val result = repository.countByClaimStatus(rootIds = setOf(root.id))
+            assertIs<Result.Success<ClaimStatusCounts>>(result)
+            assertEquals(1, result.data.active, "Only the depth-3 claimed descendant within scope must be counted")
+            assertEquals(3, result.data.unclaimed, "root + level-1 + level-2 = 3 unclaimed")
+        }
+
+    @Test
+    fun `countByClaimStatus composes rootIds and parentId with AND`(): Unit =
+        runBlocking {
+            val root = create(newItem("root"))
+            val directChildActive = create(newItem("direct-child-active", parentId = root.id, depth = 1, claimed = true))
+            val grandchild = create(newItem("grandchild", parentId = directChildActive.id, depth = 2))
+            create(newItem("grandchild-active", parentId = grandchild.id, depth = 3, claimed = true))
+
+            // Scope to root's subtree AND require direct children of root only.
+            val result = repository.countByClaimStatus(parentId = root.id, rootIds = setOf(root.id))
+            assertIs<Result.Success<ClaimStatusCounts>>(result)
+            assertEquals(1, result.data.active, "Only the direct child (not the deeper grandchild) should match parentId AND rootIds")
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryTest.kt
@@ -207,26 +207,33 @@ class SQLiteWorkItemRepositoryTest : BaseRepositoryTest() {
             assertEquals("Child", depthOne.data[0].title)
         }
 
-    // --- findRoot ---
+    // --- findProjectRoots ---
 
     @Test
-    fun `findRoot returns root item`() =
+    fun `findProjectRoots returns only depth-0 project-typed items`() =
         runBlocking {
-            val root = WorkItem(title = "Root", depth = 0, parentId = null)
-            repository.create(root)
+            val projectA = WorkItem(title = "Project A", depth = 0, type = "project")
+            val projectB = WorkItem(title = "Project B", depth = 0, type = "project")
+            val plainRoot = WorkItem(title = "Plain root", depth = 0)
+            repository.create(projectA)
+            repository.create(projectB)
+            repository.create(plainRoot)
+            // project-typed child must not match (depth filter)
+            repository.create(WorkItem(title = "Nested", parentId = projectA.id, depth = 1, type = "project"))
 
-            val result = repository.findRoot()
-            assertIs<Result.Success<WorkItem?>>(result)
-            assertNotNull(result.data)
-            assertEquals("Root", result.data.title)
+            val result = repository.findProjectRoots()
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(setOf("Project A", "Project B"), result.data.map { it.title }.toSet())
         }
 
     @Test
-    fun `findRoot returns null when no root exists`() =
+    fun `findProjectRoots returns empty when no project anchors exist`() =
         runBlocking {
-            val result = repository.findRoot()
-            assertIs<Result.Success<WorkItem?>>(result)
-            assertEquals(null, result.data)
+            repository.create(WorkItem(title = "Plain root", depth = 0))
+
+            val result = repository.findProjectRoots()
+            assertIs<Result.Success<List<WorkItem>>>(result)
+            assertEquals(emptyList(), result.data)
         }
 
     // --- search ---

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteWorkItemRepositoryTest.kt
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class SQLiteWorkItemRepositoryTest : BaseRepositoryTest() {

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/DeepHierarchyTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/DeepHierarchyTest.kt
@@ -63,6 +63,7 @@ class DeepHierarchyTest {
                 CREATE TABLE IF NOT EXISTS work_items (
                     id BLOB PRIMARY KEY DEFAULT (randomblob(16)),
                     parent_id BLOB REFERENCES work_items(id),
+                    root_id BLOB,
                     title TEXT NOT NULL,
                     description TEXT,
                     summary TEXT NOT NULL DEFAULT '',

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepositoryFindInScopeTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepositoryFindInScopeTest.kt
@@ -76,6 +76,7 @@ class SQLiteWorkItemRepositoryFindInScopeTest {
                 CREATE TABLE IF NOT EXISTS work_items (
                     id BLOB PRIMARY KEY DEFAULT (randomblob(16)),
                     parent_id BLOB REFERENCES work_items(id),
+                    root_id BLOB,
                     title TEXT NOT NULL,
                     description TEXT,
                     summary TEXT NOT NULL DEFAULT '',

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepositoryRootIdTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepositoryRootIdTest.kt
@@ -1,0 +1,243 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.repository
+
+import io.github.jpicklyk.mcptask.current.application.service.ItemHierarchyValidator
+import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.sql.Connection
+import java.sql.DriverManager
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * Integration tests for the denormalized `root_id` column against a real in-memory SQLite
+ * database (pattern: [SQLiteWorkItemRepositoryFindInScopeTest] — SQLite rather than H2, since
+ * these exercises go through [ItemHierarchyValidator.recomputeDescendantDepths]'s
+ * [WorkItemRepository.findDescendants] which relies on a SQLite-specific recursive CTE).
+ *
+ * These simulate what the two application-layer call sites (CreateItemHandler /
+ * UpdateItemHandler and their REST equivalents in ItemWriteRoutes) compute — the repository
+ * itself doesn't compute `rootId`, it just persists and round-trips whatever value it's given —
+ * so each test drives the repository the same way those handlers do.
+ */
+class SQLiteWorkItemRepositoryRootIdTest {
+    private lateinit var database: Database
+    private lateinit var databaseManager: DatabaseManager
+    private lateinit var repository: SQLiteWorkItemRepository
+    private lateinit var validator: ItemHierarchyValidator
+    private lateinit var keepAliveConnection: Connection
+
+    @BeforeEach
+    fun setUp() {
+        val dbName = "root_id_repo_${System.nanoTime()}"
+        val jdbcUrl = "jdbc:sqlite:file:$dbName?mode=memory&cache=shared"
+        keepAliveConnection = DriverManager.getConnection(jdbcUrl)
+        database = Database.connect(url = jdbcUrl, driver = "org.sqlite.JDBC")
+        TransactionManager.manager.defaultIsolationLevel = Connection.TRANSACTION_SERIALIZABLE
+        databaseManager = DatabaseManager(database)
+        createSchema()
+        repository = SQLiteWorkItemRepository(databaseManager)
+        validator = ItemHierarchyValidator()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        try {
+            TransactionManager.closeAndUnregister(database)
+        } catch (_: Exception) {
+        }
+        try {
+            keepAliveConnection.close()
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun createSchema() {
+        transaction(db = database) {
+            exec(
+                """
+                CREATE TABLE work_items (
+                    id BLOB PRIMARY KEY DEFAULT (randomblob(16)),
+                    parent_id BLOB REFERENCES work_items(id),
+                    root_id BLOB,
+                    title TEXT NOT NULL,
+                    description TEXT,
+                    summary TEXT NOT NULL DEFAULT '',
+                    role TEXT NOT NULL DEFAULT 'queue',
+                    status_label TEXT,
+                    previous_role TEXT,
+                    priority TEXT NOT NULL DEFAULT 'medium',
+                    complexity INTEGER,
+                    requires_verification INTEGER NOT NULL DEFAULT 0,
+                    depth INTEGER NOT NULL DEFAULT 0,
+                    metadata TEXT,
+                    tags TEXT,
+                    type TEXT,
+                    properties TEXT,
+                    created_at TIMESTAMP NOT NULL,
+                    modified_at TIMESTAMP NOT NULL,
+                    role_changed_at TIMESTAMP NOT NULL,
+                    version INTEGER NOT NULL DEFAULT 1,
+                    claimed_by TEXT DEFAULT NULL,
+                    claimed_at TEXT DEFAULT NULL,
+                    claim_expires_at TEXT DEFAULT NULL,
+                    original_claimed_at TEXT DEFAULT NULL
+                )
+                """.trimIndent()
+            )
+            exec("CREATE INDEX idx_work_items_parent ON work_items(parent_id)")
+            exec("CREATE INDEX idx_work_items_root_id ON work_items(root_id)")
+            exec("CREATE INDEX idx_work_items_role ON work_items(role)")
+            exec("CREATE INDEX idx_work_items_depth ON work_items(depth)")
+
+            // Minimal sibling tables (repository provider / findDescendants don't need these,
+            // but keep parity with the other SQLite repository test fixtures in this package).
+            exec(
+                """
+                CREATE TABLE IF NOT EXISTS notes (
+                    id BLOB PRIMARY KEY DEFAULT (randomblob(16)),
+                    work_item_id BLOB NOT NULL REFERENCES work_items(id),
+                    key TEXT NOT NULL,
+                    role TEXT NOT NULL DEFAULT 'queue',
+                    body TEXT NOT NULL DEFAULT '',
+                    created_at TIMESTAMP NOT NULL,
+                    modified_at TIMESTAMP NOT NULL,
+                    actor_id TEXT, actor_kind TEXT, actor_parent TEXT, actor_proof TEXT,
+                    verification_status TEXT, verification_verifier TEXT, verification_reason TEXT
+                )
+                """.trimIndent()
+            )
+            exec(
+                """
+                CREATE TABLE IF NOT EXISTS dependencies (
+                    id BLOB PRIMARY KEY DEFAULT (randomblob(16)),
+                    from_item_id BLOB NOT NULL REFERENCES work_items(id),
+                    to_item_id BLOB NOT NULL REFERENCES work_items(id),
+                    type TEXT NOT NULL,
+                    unblock_at TEXT,
+                    created_at TIMESTAMP NOT NULL
+                )
+                """.trimIndent()
+            )
+            exec(
+                """
+                CREATE TABLE IF NOT EXISTS role_transitions (
+                    id BLOB PRIMARY KEY DEFAULT (randomblob(16)),
+                    item_id BLOB NOT NULL REFERENCES work_items(id),
+                    from_role TEXT,
+                    to_role TEXT NOT NULL,
+                    trigger TEXT NOT NULL,
+                    summary TEXT,
+                    transition_at TIMESTAMP NOT NULL,
+                    actor_id TEXT, actor_kind TEXT, actor_parent TEXT, actor_proof TEXT,
+                    verification_status TEXT, verification_verifier TEXT, verification_reason TEXT
+                )
+                """.trimIndent()
+            )
+        }
+    }
+
+    private fun create(item: WorkItem): WorkItem =
+        runBlocking {
+            val result = repository.create(item)
+            assertIs<Result.Success<WorkItem>>(result, "Expected item '${item.title}' to be created")
+            result.data
+        }
+
+    private fun rootIdOf(id: UUID): UUID? =
+        runBlocking {
+            val result = repository.getById(id)
+            assertIs<Result.Success<WorkItem>>(result)
+            result.data.rootId
+        }
+
+    @Test
+    fun `create stamps rootId for root, child, and grandchild`(): Unit =
+        runBlocking {
+            // Root: rootId == own id, mirroring CreateItemHandler's "parentId == null -> own id".
+            val rootId = UUID.randomUUID()
+            val root = create(WorkItem(id = rootId, title = "Root", depth = 0, rootId = rootId, role = Role.QUEUE))
+
+            // Child: rootId inherited from parent (root.rootId ?: root.id).
+            val child =
+                create(
+                    WorkItem(
+                        title = "Child",
+                        parentId = root.id,
+                        depth = 1,
+                        rootId = root.rootId ?: root.id,
+                        role = Role.QUEUE
+                    )
+                )
+
+            // Grandchild: rootId still inherited from the same original root.
+            val grandchild =
+                create(
+                    WorkItem(
+                        title = "Grandchild",
+                        parentId = child.id,
+                        depth = 2,
+                        rootId = child.rootId ?: child.id,
+                        role = Role.QUEUE
+                    )
+                )
+
+            assertEquals(root.id, rootIdOf(root.id), "Root's rootId must be its own id")
+            assertEquals(root.id, rootIdOf(child.id), "Child must inherit the root's id")
+            assertEquals(root.id, rootIdOf(grandchild.id), "Grandchild must inherit the same root id")
+        }
+
+    @Test
+    fun `reparent restamps rootId for the moved item and every descendant`(): Unit =
+        runBlocking {
+            // Root A -> B -> C
+            val rootA = create(WorkItem(title = "Root A", depth = 0).let { it.copy(rootId = it.id) })
+            val b = create(WorkItem(title = "B", parentId = rootA.id, depth = 1, rootId = rootA.id))
+            val c = create(WorkItem(title = "C", parentId = b.id, depth = 2, rootId = rootA.id))
+
+            // Independent Root D
+            val rootD = create(WorkItem(title = "Root D", depth = 0).let { it.copy(rootId = it.id) })
+
+            // Move B under Root D — same depth (1), different root subtree entirely.
+            val movedB =
+                b.update { item ->
+                    item.copy(parentId = rootD.id, depth = 1, rootId = rootD.id)
+                }
+            val updateResult = repository.update(movedB)
+            assertIs<Result.Success<WorkItem>>(updateResult)
+
+            // Cascade: depth delta is 0 (B stayed at depth 1) but rootId must still restamp C.
+            val cascadeResult = validator.recomputeDescendantDepths(b.id, 0, rootD.id, repository)
+            assertIs<Result.Success<Unit>>(cascadeResult)
+
+            assertEquals(rootD.id, rootIdOf(b.id), "B's rootId must flip to Root D after reparent")
+            assertEquals(rootD.id, rootIdOf(c.id), "C must inherit B's new root (Root D), not the old Root A")
+            assertEquals(rootA.id, rootIdOf(rootA.id), "Root A itself is untouched by B's move")
+        }
+
+    @Test
+    fun `move-to-root makes the item its own root`(): Unit =
+        runBlocking {
+            val root = create(WorkItem(title = "Root", depth = 0).let { it.copy(rootId = it.id) })
+            val leaf = create(WorkItem(title = "Leaf", parentId = root.id, depth = 1, rootId = root.id))
+
+            // Move leaf to root: parentId = null, depth = 0, rootId = own id.
+            val movedLeaf =
+                leaf.update { item ->
+                    item.copy(parentId = null, depth = 0, rootId = leaf.id)
+                }
+            val updateResult = repository.update(movedLeaf)
+            assertIs<Result.Success<WorkItem>>(updateResult)
+
+            assertEquals(leaf.id, rootIdOf(leaf.id), "Leaf must become its own root after moving to root level")
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/SearchRoutesIntegrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/SearchRoutesIntegrationTest.kt
@@ -76,6 +76,7 @@ class SearchRoutesIntegrationTest {
                     CREATE TABLE IF NOT EXISTS work_items (
                         id BLOB PRIMARY KEY DEFAULT (randomblob(16)),
                         parent_id BLOB REFERENCES work_items(id),
+                        root_id BLOB,
                         title TEXT NOT NULL,
                         description TEXT,
                         summary TEXT NOT NULL DEFAULT '',

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/WriteRoutesTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/WriteRoutesTest.kt
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Test
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -165,6 +166,54 @@ class ItemCreateRouteTest {
             assertEquals(HttpStatusCode.BadRequest, response.status)
             val body = response.bodyAsText()
             assertTrue(body.contains("validation_error") || body.contains("not blank"), "Should have error: $body")
+        }
+
+    @Test
+    fun `POST items with parentId stamps rootId inherited from the parent`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val parent =
+                runBlocking {
+                    repo.workItemRepository().create(WorkItem(title = "Root", depth = 0)).getOrNull()!!
+                }
+            application { configureWriteTestApp(repo) }
+
+            // Root itself was created directly via the repository (not through this route), so
+            // it has no rootId yet — the create route must fall back to the parent's own id.
+            val response =
+                client.post("/api/v1/items") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"title":"Child","parentId":"${parent.id}"}""")
+                }
+            assertEquals(HttpStatusCode.Created, response.status)
+            val childId = extractId(response.bodyAsText())
+            assertNotNull(childId)
+
+            val persistedChild = runBlocking { repo.workItemRepository().getById(UUID.fromString(childId)) }
+            assertIs<Result.Success<WorkItem>>(persistedChild)
+            assertEquals(parent.id, persistedChild.data.rootId, "Child must inherit the root's id")
+        }
+
+    @Test
+    fun `POST items without parentId stamps rootId as its own id`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            application { configureWriteTestApp(repo) }
+
+            val response =
+                client.post("/api/v1/items") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"title":"New Root"}""")
+                }
+            assertEquals(HttpStatusCode.Created, response.status)
+            val itemId = extractId(response.bodyAsText())
+            assertNotNull(itemId)
+
+            val persisted = runBlocking { repo.workItemRepository().getById(UUID.fromString(itemId)) }
+            assertIs<Result.Success<WorkItem>>(persisted)
+            assertEquals(UUID.fromString(itemId), persisted.data.rootId, "A root-level item must be its own root")
         }
 }
 
@@ -444,6 +493,84 @@ class ItemPatchRouteTest {
             // C must cascade from depth 2 to depth 3 even though this PATCH only targeted B.
             val persistedC = runBlocking { repo.workItemRepository().getById(c.id) }
             assertEquals(3, (persistedC as Result.Success).data.depth, "C's depth must cascade with B's move")
+        }
+
+    @Test
+    fun `PATCH items parentId change to a different root restamps rootId for item and descendants`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            // Root A -> B -> C, plus an independent Root D — both created directly via the
+            // repository with an explicit rootId, mirroring what the create route would stamp.
+            val (_, b, c, rootD) =
+                runBlocking {
+                    val a =
+                        repo.workItemRepository().create(WorkItem(title = "Root A", depth = 0)).getOrNull()!!
+                    val aWithRoot =
+                        repo.workItemRepository().update(a.copy(rootId = a.id)).getOrNull()!!
+                    val b =
+                        repo.workItemRepository()
+                            .create(WorkItem(title = "B", parentId = aWithRoot.id, depth = 1, rootId = aWithRoot.id))
+                            .getOrNull()!!
+                    val c =
+                        repo.workItemRepository()
+                            .create(WorkItem(title = "C", parentId = b.id, depth = 2, rootId = aWithRoot.id))
+                            .getOrNull()!!
+                    val d =
+                        repo.workItemRepository().create(WorkItem(title = "Root D", depth = 0)).getOrNull()!!
+                    val dWithRoot =
+                        repo.workItemRepository().update(d.copy(rootId = d.id)).getOrNull()!!
+                    listOf(aWithRoot, b, c, dWithRoot)
+                }
+            application { configureWriteTestApp(repo) }
+
+            // Move B under Root D: same depth (1), but rootId must flip for B and cascade to C.
+            val etag = "\"v1-${b.modifiedAt.toEpochMilli()}\""
+            val response =
+                client.patch("/api/v1/items/${b.id}") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    header(HttpHeaders.IfMatch, etag)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"parentId":"${rootD.id}"}""")
+                }
+            assertEquals(HttpStatusCode.OK, response.status)
+
+            val persistedB = runBlocking { repo.workItemRepository().getById(b.id) }
+            val persistedC = runBlocking { repo.workItemRepository().getById(c.id) }
+            assertIs<Result.Success<WorkItem>>(persistedB)
+            assertIs<Result.Success<WorkItem>>(persistedC)
+            assertEquals(rootD.id, persistedB.data.rootId, "B's rootId must flip to Root D after reparent")
+            assertEquals(rootD.id, persistedC.data.rootId, "C must cascade to Root D even though depth didn't change")
+        }
+
+    @Test
+    fun `PATCH items parentId null restamps rootId to the item's own id`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val (parent, child) =
+                runBlocking {
+                    val p = repo.workItemRepository().create(WorkItem(title = "Parent", depth = 0)).getOrNull()!!
+                    val pWithRoot = repo.workItemRepository().update(p.copy(rootId = p.id)).getOrNull()!!
+                    val c =
+                        repo.workItemRepository()
+                            .create(WorkItem(title = "Child", parentId = pWithRoot.id, depth = 1, rootId = pWithRoot.id))
+                            .getOrNull()!!
+                    Pair(pWithRoot, c)
+                }
+            application { configureWriteTestApp(repo) }
+
+            val etag = "\"v1-${child.modifiedAt.toEpochMilli()}\""
+            val response =
+                client.patch("/api/v1/items/${child.id}") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    header(HttpHeaders.IfMatch, etag)
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"parentId":null}""")
+                }
+            assertEquals(HttpStatusCode.OK, response.status)
+
+            val persistedChild = runBlocking { repo.workItemRepository().getById(child.id) }
+            assertIs<Result.Success<WorkItem>>(persistedChild)
+            assertEquals(child.id, persistedChild.data.rootId, "Child must become its own root after moving to root level")
         }
 
     @Test

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/WriteRoutesTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/WriteRoutesTest.kt
@@ -508,11 +508,13 @@ class ItemPatchRouteTest {
                     val aWithRoot =
                         repo.workItemRepository().update(a.copy(rootId = a.id)).getOrNull()!!
                     val b =
-                        repo.workItemRepository()
+                        repo
+                            .workItemRepository()
                             .create(WorkItem(title = "B", parentId = aWithRoot.id, depth = 1, rootId = aWithRoot.id))
                             .getOrNull()!!
                     val c =
-                        repo.workItemRepository()
+                        repo
+                            .workItemRepository()
                             .create(WorkItem(title = "C", parentId = b.id, depth = 2, rootId = aWithRoot.id))
                             .getOrNull()!!
                     val d =
@@ -551,7 +553,8 @@ class ItemPatchRouteTest {
                     val p = repo.workItemRepository().create(WorkItem(title = "Parent", depth = 0)).getOrNull()!!
                     val pWithRoot = repo.workItemRepository().update(p.copy(rootId = p.id)).getOrNull()!!
                     val c =
-                        repo.workItemRepository()
+                        repo
+                            .workItemRepository()
                             .create(WorkItem(title = "Child", parentId = pWithRoot.id, depth = 1, rootId = pWithRoot.id))
                             .getOrNull()!!
                     Pair(pWithRoot, c)

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/test/BaseFts5RepositoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/test/BaseFts5RepositoryTest.kt
@@ -49,6 +49,7 @@ abstract class BaseFts5RepositoryTest {
                 CREATE TABLE IF NOT EXISTS work_items (
                     id BLOB PRIMARY KEY DEFAULT (randomblob(16)),
                     parent_id BLOB REFERENCES work_items(id),
+                    root_id BLOB,
                     title TEXT NOT NULL,
                     description TEXT,
                     summary TEXT NOT NULL DEFAULT '',


### PR DESCRIPTION
## Summary

PR 2 of 4 in the transport-unified project-root scoping feature (design record: MCP observation `7fab0fb4`). Adds the server-side primitives that let one database hold multiple projects, each anchored at a depth-0 `type: "project"` item, with opt-in subtree scoping on the read/workflow tool surface. Omitting the new parameters preserves byte-identical whole-DB behavior everywhere — scoping is a convention, never enforced.

## Changes

- **`root_id` denormalized column** (`V9__Add_Root_Id.sql`): nullable, indexed, backfilled via recursive CTE; stamped on create (all three insert paths: `manage_items`, REST POST, `create_work_tree`) and restamped on reparent in the same sweep that fixes descendant depths (#219). O(1) project-root lookup for the upcoming per-root schema layer.
- **Scoped repository variants**: `findByRole` / `findForNextItem` / `findClaimable` / `countByClaimStatus` gain optional `rootIds` (same `resolveScopeIds` subtree semantics as `findInScope`); `NextItemRecommender.Criteria.ancestorIds`.
- **`ancestorId` on the MCP tool surface**: `query_items` list mode, `get_next_item`, `get_context` (health-check + session-resume), `get_blocked_items`. UUID-or-prefix, composes with existing filters. Documented limitation: session-resume `recentTransitions` stays unscoped.
- **Anchored overview**: `query_items(operation="overview", ancestorId=X)` renders X's children as the roots set with full-subtree role roll-ups (`countInScopeByRole`) — the project-dashboard entry point. Mutually exclusive with `itemId`.
- **`findProjectRoots()`** replaces the dead singleton `findRoot()`.

## Tests

Suite grew 2,415 → 2,477 (+62), 0 failures; ktlint clean. Each task independently reviewed (verdicts in the MCP items' review notes); one review-remediation cycle on the `create_work_tree` stamping gap.

## Follow-ups (non-blocking, recorded in MCP review notes)

`parent.rootId`-null fallback branch untested (symmetric across call sites); anchored-overview multi-child pagination untested; three extraction candidates for a future simplify pass.

MCP refs: feature `c47446df` (T2.1 `21048842`, T2.2 `21c76118`, T2.3 `d3bbea90`, T2.4 `f0d58ae2`, T2.5 `75e2f154`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012M9cBWioQoehDxABDaRDsS