### PR TITLE
feat(schema): per-root config layer — project_config storage, layered resolveSchema, manage_project_config tool

### DIFF
--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1741,13 +1741,17 @@ Supports two operations, selected via `operation`:
 #### `push`
 
 Validates, in order:
-1. `rootItemId` must resolve to an existing WorkItem.
-2. That WorkItem must be depth 0 (a project root) — configs anchor to roots only.
-3. If the root's `type` is not `"project"`, the push still succeeds but the response includes a
+1. `configYaml` must not exceed **128 KiB** (131,072 bytes, UTF-8) — rejected before any parse
+   attempt (CWE-770: bounds parse cost and storage growth against a hostile or oversized payload).
+2. `rootItemId` must resolve to an existing WorkItem.
+3. That WorkItem must be depth 0 (a project root) — configs anchor to roots only.
+4. If the root's `type` is not `"project"`, the push still succeeds but the response includes a
    non-fatal `warning` field (a naming convention, not an enforced constraint).
-4. `configYaml` is parsed via the same parser `PerRootConfigService` uses on every read. Unparseable
-   YAML is rejected here — nothing is stored — so a broken config can never silently exist server-side
-   and fall through to the global schema on a later read.
+5. `configYaml` is parsed via the same parser `PerRootConfigService` uses on every read, using a
+   YAML *safe* constructor that only ever builds plain maps/lists/scalars (see **Parse safety**
+   below). Unparseable or unsafe YAML is rejected here — nothing is stored — so a broken or
+   malicious config can never silently exist server-side and fall through to the global schema on
+   a later read.
 
 On success, stores the document and returns its fingerprint. Pushing byte-identical content is
 naturally idempotent: the fingerprint returned is unchanged, so a caller can `get` first and skip
@@ -1757,7 +1761,17 @@ the push when fingerprints already match — no separate idempotency-key machine
 |---|---|---|---|
 | `operation` | string (`"push"` \| `"get"`) | Yes | Selects the operation |
 | `rootItemId` | string (UUID or 4+ char hex prefix) | Yes | Project root WorkItem — must be depth 0 for `push` |
-| `configYaml` | string | Yes (push only) | Raw config.yaml text to store for this root |
+| `configYaml` | string | Yes (push only) | Raw config.yaml text to store for this root; max 128 KiB |
+
+**Parse safety.** `configYaml` is parsed with SnakeYAML's `SafeConstructor` rather than its default
+`Constructor`. The default constructor will instantiate an arbitrary Java type named by a YAML
+`!!`-tag — a well-known deserialization-RCE class of vulnerability (CWE-502) — which matters here
+specifically because `configYaml` is attacker-reachable input pushed over the MCP protocol, not a
+trusted local file read from disk. `SafeConstructor` only ever builds plain maps, lists, and
+scalars, which is everything a config document legitimately needs; any `!!`-tagged custom type is
+rejected as a parse failure instead of being instantiated. The same fix applies everywhere per-root
+config bytes are parsed (`PerRootConfigService`, on every schema-resolving read) and to the global
+`.taskorchestrator/config.yaml` loader.
 
 **Example.**
 
@@ -1786,9 +1800,10 @@ the push when fingerprints already match — no separate idempotency-key machine
 
 | Condition | `error.code` |
 |---|---|
+| `configYaml` exceeds 128 KiB | `VALIDATION_ERROR` (message names the limit and the actual size) |
 | `rootItemId` does not resolve to an existing WorkItem | `RESOURCE_NOT_FOUND` |
 | Root WorkItem has `depth != 0` | `VALIDATION_ERROR` |
-| `configYaml` fails to parse (invalid YAML syntax/shape) | `VALIDATION_ERROR` (message includes the parse detail) |
+| `configYaml` fails to parse (invalid/unsafe YAML syntax or shape, including `!!`-tagged custom types — see **Parse safety** above) | `VALIDATION_ERROR` (message includes the parse detail) |
 | Storage failure | `DATABASE_ERROR` |
 
 #### `get`
@@ -1817,6 +1832,16 @@ Reads back the stored config for a root.
 `actor` parameter — its writes aren't part of the per-note/per-item attribution model (a config
 document has no "author" note field to stamp), so mirroring the actor-claim/verification machinery
 would add complexity with no corresponding read surface to expose it through.
+
+**Trust-model caveat.** `manage_project_config` can silently rewrite a project's gate configuration
+(required notes, review phases, trait routing) for every item under a root. Under
+`MCP_TRANSPORT=http`, the `/mcp` endpoint is **unauthenticated regardless of REST API auth mode** —
+any client that can reach the port can call `push` for any root. This is not a gap introduced by
+this tool; it's the existing MCP transport trust model (see
+[`fleet-deployment.md`](./fleet-deployment.md), "MCP HTTP Transport (`/mcp`) Is Unauthenticated —
+Read First") applying to config data the same way it already applies to every other MCP tool.
+Fence `/mcp` at the network layer per that guidance before exposing `MCP_TRANSPORT=http` beyond a
+single trusted process.
 
 ---
 

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The v3 server exposes 14 MCP tools organized around a single **WorkItem** graph model. Every
+The v3 server exposes 15 MCP tools organized around a single **WorkItem** graph model. Every
 entity — whether a project, feature, or task — is a WorkItem with a `role` (queue, work, review,
 blocked, terminal), optional `parentId`, a `type` field that selects a work-item schema (lifecycle
 mode + required notes), optional `tags` for categorization, and optional `traits` that compose
@@ -30,6 +30,7 @@ FTS5 search (two-tokenizer design, RRF fusion, scope filtering, backlinks, score
 | `get_next_item` | Workflow | Read | Priority-ranked recommendation of next actionable item |
 | `get_blocked_items` | Workflow | Read | All items blocked by dependency or explicit block trigger |
 | `claim_item` | Workflow | Write | Atomically claim or release work items for exclusive ownership |
+| `manage_project_config` | System | Write/Read | Push or read back per-root config YAML for the layered schema resolver |
 
 ---
 
@@ -1723,6 +1724,99 @@ dependency edges). Terminal items are never included.
 `satisfied` is true when the blocker has reached its `effectiveUnblockRole`.
 
 `blockerCount` reflects only the number of **unsatisfied** blockers (not total blockers). For `"explicit"` items with no dependency blockers, `blockerCount` is 0.
+
+---
+
+## Category: System
+
+### manage_project_config
+
+**Purpose.** Transport-agnostic config sync: a client pushes its repo's `.taskorchestrator/config.yaml`
+text keyed by a project root's WorkItem UUID; `ToolExecutionContext.resolveSchema()` layers this
+per-root config over the global config on every schema-resolving read (see `PerRootConfigService` —
+hot-reload is a property of that read path, so no separate reload call is needed after a push).
+
+Supports two operations, selected via `operation`:
+
+#### `push`
+
+Validates, in order:
+1. `rootItemId` must resolve to an existing WorkItem.
+2. That WorkItem must be depth 0 (a project root) — configs anchor to roots only.
+3. If the root's `type` is not `"project"`, the push still succeeds but the response includes a
+   non-fatal `warning` field (a naming convention, not an enforced constraint).
+4. `configYaml` is parsed via the same parser `PerRootConfigService` uses on every read. Unparseable
+   YAML is rejected here — nothing is stored — so a broken config can never silently exist server-side
+   and fall through to the global schema on a later read.
+
+On success, stores the document and returns its fingerprint. Pushing byte-identical content is
+naturally idempotent: the fingerprint returned is unchanged, so a caller can `get` first and skip
+the push when fingerprints already match — no separate idempotency-key machinery is needed.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `operation` | string (`"push"` \| `"get"`) | Yes | Selects the operation |
+| `rootItemId` | string (UUID or 4+ char hex prefix) | Yes | Project root WorkItem — must be depth 0 for `push` |
+| `configYaml` | string | Yes (push only) | Raw config.yaml text to store for this root |
+
+**Example.**
+
+```json
+{
+  "operation": "push",
+  "rootItemId": "3f9c2b10-...",
+  "configYaml": "work_item_schemas:\n  feature-task:\n    notes:\n      - key: spec\n        role: queue\n        required: true\n"
+}
+```
+
+**Response (success).**
+
+```json
+{
+  "rootItemId": "3f9c2b10-...",
+  "fingerprint": "a94a8fe5cc...",
+  "updatedAt": "2026-07-14T18:40:00Z",
+  "warning": "Root item type is 'null', not 'project' — config pushed anyway (a naming convention, not an enforced constraint)"
+}
+```
+
+`warning` is only present when the root's `type` is not `"project"`.
+
+**Error cases.**
+
+| Condition | `error.code` |
+|---|---|
+| `rootItemId` does not resolve to an existing WorkItem | `RESOURCE_NOT_FOUND` |
+| Root WorkItem has `depth != 0` | `VALIDATION_ERROR` |
+| `configYaml` fails to parse (invalid YAML syntax/shape) | `VALIDATION_ERROR` (message includes the parse detail) |
+| Storage failure | `DATABASE_ERROR` |
+
+#### `get`
+
+Reads back the stored config for a root.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `operation` | string (`"push"` \| `"get"`) | Yes | Selects the operation |
+| `rootItemId` | string (UUID or 4+ char hex prefix) | Yes | Project root WorkItem to read the config for |
+
+**Response (success).**
+
+```json
+{
+  "rootItemId": "3f9c2b10-...",
+  "configYaml": "work_item_schemas:\n  ...\n",
+  "fingerprint": "a94a8fe5cc...",
+  "updatedAt": "2026-07-14T18:40:00Z"
+}
+```
+
+**Response (no config pushed for this root).** `error.code` is `RESOURCE_NOT_FOUND`.
+
+**Note on actor attribution.** Unlike `manage_notes`/`manage_items`, this tool does not accept an
+`actor` parameter — its writes aren't part of the per-note/per-item attribution model (a config
+document has no "author" note field to stamp), so mirroring the actor-claim/verification machinery
+would add complexity with no corresponding read surface to expose it through.
 
 ---
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceService.kt
@@ -162,7 +162,7 @@ class AdvanceService(
     private val dependencyRepository: DependencyRepository,
     private val noteRepository: NoteRepository,
     private val statusLabelService: StatusLabelService,
-    private val schemaResolver: (WorkItem) -> WorkItemSchema?
+    private val schemaResolver: suspend (WorkItem) -> WorkItemSchema?
 ) {
     private val handler = RoleTransitionHandler()
     private val cascadeDetector = CascadeDetector()

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/CascadeDetector.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/CascadeDetector.kt
@@ -95,7 +95,7 @@ class CascadeDetector {
     suspend fun detectCascades(
         item: WorkItem,
         workItemRepository: WorkItemRepository,
-        schemaResolver: ((WorkItem) -> WorkItemSchema?)? = null
+        schemaResolver: (suspend (WorkItem) -> WorkItemSchema?)? = null
     ): List<CascadeEvent> {
         val parentId = item.parentId ?: return emptyList()
         return detectCascadesRecursive(parentId, workItemRepository, depth = 0, schemaResolver = schemaResolver)
@@ -105,7 +105,7 @@ class CascadeDetector {
         parentId: UUID,
         workItemRepository: WorkItemRepository,
         depth: Int,
-        schemaResolver: ((WorkItem) -> WorkItemSchema?)? = null
+        schemaResolver: (suspend (WorkItem) -> WorkItemSchema?)? = null
     ): List<CascadeEvent> {
         // Get role counts for all children of the parent
         val countsResult = workItemRepository.countChildrenByRole(parentId)
@@ -227,7 +227,7 @@ class CascadeDetector {
     suspend fun detectReopenCascades(
         item: WorkItem,
         workItemRepository: WorkItemRepository,
-        schemaResolver: ((WorkItem) -> WorkItemSchema?)? = null
+        schemaResolver: (suspend (WorkItem) -> WorkItemSchema?)? = null
     ): List<CascadeEvent> {
         // Only applies to items that just entered QUEUE via reopen
         if (item.role != Role.QUEUE) return emptyList()

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
@@ -17,6 +17,7 @@ import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
 import io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.NoteRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.RoleTransitionRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
 import io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService
@@ -73,6 +74,9 @@ class ToolExecutionContext(
 
     /** Access to the atomic work-tree creation executor. */
     fun workTreeExecutor(): WorkTreeExecutor = repositoryProvider.workTreeExecutor()
+
+    /** Access to per-root config (raw YAML document) CRUD operations. */
+    fun projectConfigRepository(): ProjectConfigRepository = repositoryProvider.projectConfigRepository()
 
     /**
      * Resolves the effective [WorkItemSchema] for a [WorkItem], including trait note merging.

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
@@ -19,8 +19,10 @@ import io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.NoteRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.RoleTransitionRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
+import io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 /**
  * Execution context provided to all MCP tools during invocation.
@@ -43,6 +45,7 @@ class ToolExecutionContext(
             repositoryProvider.workItemRepository(),
             repositoryProvider.dependencyRepository()
         ),
+    private val perRootConfigService: PerRootConfigService? = null,
 ) {
     /** Access to WorkItem CRUD and query operations. */
     fun workItemRepository(): WorkItemRepository = repositoryProvider.workItemRepository()
@@ -74,7 +77,37 @@ class ToolExecutionContext(
     /**
      * Resolves the effective [WorkItemSchema] for a [WorkItem], including trait note merging.
      *
-     * Resolution order:
+     * ## Root layering
+     *
+     * When [item] has a non-null `rootId` and this context was constructed with a
+     * [perRootConfigService], every lookup below first consults that root's pushed config
+     * (via [PerRootConfigService]) before falling back to the global `.taskorchestrator/config.yaml`
+     * loader ([noteSchemaService]). A null `rootId` (legacy pre-backfill rows, or no
+     * [perRootConfigService] wired) skips the per-root layer entirely — zero extra calls, behavior
+     * byte-identical to before this layering was added.
+     *
+     * Per-key fallback table (`?:` reads as "per-root miss defers to global"):
+     *
+     * | Resolution step | Expression |
+     * |---|---|
+     * | Type lookup | `perRoot.getSchemaForType(rootId, type) ?: global.getSchemaForType(type)` |
+     * | Tag lookup | whole-algorithm-first: run the existing first-tag-match/"default" match against the per-root schema map; only defer the WHOLE algorithm to global if the per-root layer has no config row or no match at all |
+     * | Trait notes | `perRoot.getTraitNotes(rootId, name) ?: global.getTraitNotes(name)`, per trait name |
+     * | "default" schema | folded into the type/tag rules above — a per-root `default` entry wins over the global one wherever the surrounding rule would have used it |
+     *
+     * **Known limitation:** [PerRootConfigService.getSchemaForType] has no internal `"default"`
+     * fallback (unlike [NoteSchemaService.getSchemaForType], which falls back to its own
+     * `workItemSchemas["default"]` when the exact type misses). So for the *type* lookup step, a
+     * per-root config that defines no exact match for `item.type` defers entirely to
+     * `global.getSchemaForType(type)` — which may itself resolve to the *global* default schema,
+     * bypassing any per-root default. Only an explicit per-root entry for `item.type` (or the tag
+     * path's own `default` handling) overrides the global result. This mirrors the resolution
+     * expression the per-root schema layering design specifies for the type step.
+     *
+     * Note length limits ([NoteSchemaService.getNoteLimitsMode]) and anything else not exposed by
+     * [PerRootConfigService] stay global-only — [PerRootConfigService] does not expose them.
+     *
+     * Resolution order (unchanged from before layering, now with the per-root prefix above):
      * 1. If the item has a `type`, look up the schema by type via [NoteSchemaService.getSchemaForType].
      * 2. If no type or no type-based schema found, look up by tags via [NoteSchemaService.getSchemaForTags]
      *    (first matching tag wins; falls back to default schema if no tag matches).
@@ -85,7 +118,7 @@ class ToolExecutionContext(
      * - Per-item traits from the item's `properties` JSON (`traits` array via [PropertiesHelper])
      * - Base schema note keys always win; first-trait-in-order wins for duplicate trait keys
      */
-    fun resolveSchema(item: WorkItem): WorkItemSchema? {
+    suspend fun resolveSchema(item: WorkItem): WorkItemSchema? {
         val service = noteSchemaService()
         val baseSchema = resolveBaseSchema(item, service) ?: return null
         return mergeTraits(item, baseSchema, service)
@@ -96,22 +129,36 @@ class ToolExecutionContext(
      * Convenience wrapper around [resolveSchema] + [WorkItemSchema.hasReviewPhase].
      * Returns false when no schema matches (schema-free mode — skip REVIEW).
      */
-    fun resolveHasReviewPhase(item: WorkItem): Boolean = resolveSchema(item)?.hasReviewPhase() ?: false
+    suspend fun resolveHasReviewPhase(item: WorkItem): Boolean = resolveSchema(item)?.hasReviewPhase() ?: false
 
     /**
-     * Resolves the base schema without trait merging. Type-first lookup with tag fallback.
+     * Resolves the base schema without trait merging. Type-first lookup with tag fallback, each
+     * layered per-root-then-global — see [resolveSchema]'s KDoc for the full fallback table.
      */
-    private fun resolveBaseSchema(
+    private suspend fun resolveBaseSchema(
         item: WorkItem,
         service: NoteSchemaService
     ): WorkItemSchema? {
-        // Type-first lookup
+        val rootId = item.rootId
+        val perRoot = perRootConfigService
+
+        // Type-first lookup: an exact per-root type match wins; otherwise defer entirely to the
+        // global lookup (which has its own type -> "default" fallback — see class KDoc above).
         item.type?.let { type ->
-            service.getSchemaForType(type)?.let { return it }
+            val perRootMatch = if (rootId != null && perRoot != null) perRoot.getSchemaForType(rootId, type) else null
+            (perRootMatch ?: service.getSchemaForType(type))?.let { return it }
         }
+
+        // Tag fallback: run the per-root schema map through the SAME first-tag-match/"default"
+        // algorithm first; only fall through to the global tag algorithm when the per-root layer
+        // has no config row for this root, or no tag (nor "default") matches within it.
+        val tags = item.tagList()
+        if (rootId != null && perRoot != null) {
+            resolvePerRootTagMatch(rootId, tags, perRoot)?.let { return it }
+        }
+
         // Tag fallback: find the matched tag, then look up the full WorkItemSchema
         // to preserve lifecycleMode and defaultTraits from config
-        val tags = item.tagList()
         val tagNotes = service.getSchemaForTags(tags) ?: return null
         val matchedType =
             if (tags.isEmpty()) {
@@ -126,15 +173,41 @@ class ToolExecutionContext(
     }
 
     /**
-     * Merges trait notes into the base schema. Collects default_traits from config +
-     * per-item traits from properties JSON, looks up notes for each, and appends
-     * to the base schema notes (base key wins on duplicates).
+     * Runs the same "first matching tag wins, else `default`" algorithm [resolveBaseSchema] uses
+     * against the global service, but against [rootId]'s per-root schema map instead. Per-root
+     * schema map keys (type/tag names) and their [WorkItemSchema] values come straight from
+     * [PerRootConfigService.getSchemas], which already carries lifecycle/defaultTraits — no
+     * separate "fetch notes, then re-fetch the full schema" step is needed here (unlike the global
+     * path, which has two parallel maps for historical reasons).
+     *
+     * Returns null when there is no per-root config row for [rootId], or no tag (nor `"default"`)
+     * matches within it — either case means "defer to the global tag algorithm".
      */
-    private fun mergeTraits(
+    private suspend fun resolvePerRootTagMatch(
+        rootId: UUID,
+        tags: List<String>,
+        perRoot: PerRootConfigService
+    ): WorkItemSchema? {
+        val schemas = perRoot.getSchemas(rootId) ?: return null
+        for (tag in tags) {
+            schemas[tag]?.let { return it }
+        }
+        return schemas["default"]
+    }
+
+    /**
+     * Merges trait notes into the base schema. Collects default_traits from config +
+     * per-item traits from properties JSON, looks up notes for each (per-root config for
+     * [item]'s root taking precedence over the global trait definition — see [resolveSchema]'s
+     * KDoc), and appends to the base schema notes (base key wins on duplicates).
+     */
+    private suspend fun mergeTraits(
         item: WorkItem,
         baseSchema: WorkItemSchema,
         service: NoteSchemaService
     ): WorkItemSchema {
+        val rootId = item.rootId
+        val perRoot = perRootConfigService
         val defaultTraits = baseSchema.defaultTraits
         val itemTraits = PropertiesHelper.extractTraits(item.properties)
         val allTraits = (defaultTraits + itemTraits).distinct()
@@ -143,7 +216,8 @@ class ToolExecutionContext(
 
         val traitNotes = mutableListOf<NoteSchemaEntry>()
         for (traitName in allTraits) {
-            val notes = service.getTraitNotes(traitName)
+            val perRootNotes = if (rootId != null && perRoot != null) perRoot.getTraitNotes(rootId, traitName) else null
+            val notes = perRootNotes ?: service.getTraitNotes(traitName)
             if (notes == null) {
                 logger.warn("Unknown trait '{}' on item '{}'; skipping", traitName, item.id)
                 continue

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigTool.kt
@@ -6,7 +6,9 @@ import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlSchemaParser
 import io.modelcontextprotocol.kotlin.sdk.types.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.*
+import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
 
 /**
  * MCP tool for pushing and reading back per-root config YAML — the transport-agnostic sync path
@@ -31,13 +33,16 @@ Push or read back per-root config YAML for the layered schema resolver — a cli
 `.taskorchestrator/config.yaml` document keyed by a project root's WorkItem UUID, which the
 resolver layers over the global config on every schema-resolving read (no separate reload step).
 
-**push** — validates, in order: the root item must exist; it must be depth 0 (configs anchor to
-project roots only, error otherwise); if the root's `type` is not "project", the response includes
-a non-fatal `warning` field (a naming convention, not an enforced constraint) but the push still
-succeeds. `configYaml` is parse-validated BEFORE storing — unparseable YAML is rejected with the
-parse error and never written, so a broken config can never silently fall through to the global
-schema on a later read. Pushing byte-identical content is naturally idempotent: the returned
-`fingerprint` is unchanged, so callers can `get` first and skip the push when fingerprints match.
+**push** — validates, in order: `configYaml` must not exceed 128 KiB (rejected before any parse
+attempt); the root item must exist; it must be depth 0 (configs anchor to project roots only, error
+otherwise); if the root's `type` is not "project", the response includes a non-fatal `warning` field
+(a naming convention, not an enforced constraint) but the push still succeeds. `configYaml` is then
+parse-validated BEFORE storing, using a safe YAML constructor that only builds plain maps/lists/
+scalars (arbitrary `!!`-tagged Java type construction is rejected, not silently ignored) —
+unparseable or unsafe YAML is rejected with the parse error and never written, so a broken or
+malicious config can never silently exist server-side. Pushing byte-identical content is naturally
+idempotent: the returned `fingerprint` is unchanged, so callers can `get` first and skip the push
+when fingerprints match.
 
 **get** — returns the stored `configYaml` + `fingerprint` + `updatedAt` for a root, or a
 not-found error when no config has been pushed for it.
@@ -84,7 +89,8 @@ not-found error when no config has been pushed for it.
                             put(
                                 "description",
                                 JsonPrimitive(
-                                    "Raw config.yaml text to store for this root (push only); parse-validated before storing"
+                                    "Raw config.yaml text to store for this root (push only); max 128 KiB, " +
+                                        "parse-validated before storing"
                                 )
                             )
                         }
@@ -142,6 +148,15 @@ not-found error when no config has been pushed for it.
         val (rootItemId, idError) = resolveItemId(params, "rootItemId", context)
         if (idError != null) return idError
         val configYaml = requireString(params, "configYaml")
+
+        val sizeBytes = configYaml.toByteArray(Charsets.UTF_8).size
+        if (sizeBytes > MAX_CONFIG_YAML_BYTES) {
+            return errorResponse(
+                "configYaml is $sizeBytes bytes, exceeds the $MAX_CONFIG_YAML_BYTES byte " +
+                    "($MAX_CONFIG_YAML_KIB KiB) limit",
+                ErrorCodes.VALIDATION_ERROR
+            )
+        }
 
         val itemResult = context.workItemRepository().getById(rootItemId!!)
         val item =
@@ -243,6 +258,14 @@ not-found error when no config has been pushed for it.
      * every future read, a confusing failure mode discovered only much later. Returns the parse
      * failure message, or null when [configYaml] parses cleanly.
      *
+     * Uses [SafeConstructor] rather than SnakeYAML's default `Constructor` — `configYaml` is
+     * attacker-reachable input (pushed over the MCP protocol by a caller, not read from a trusted
+     * local file), and the default `Constructor` will happily instantiate an arbitrary Java type
+     * named by a `!!`-tag (the SnakeYAML deserialization-RCE gadget class, CWE-502). `SafeConstructor`
+     * only ever builds plain maps/lists/scalars, which is all a config document legitimately needs;
+     * any `!!`-tagged custom type throws [org.yaml.snakeyaml.constructor.ConstructorException] before
+     * anything is instantiated, and that exception is caught below like any other parse failure.
+     *
      * Soft validation warnings collected by [YamlSchemaParser.parseRoot] (e.g. a note entry
      * missing `key`, an invalid `lifecycle` value) are NOT treated as rejection here — only a hard
      * YAML syntax/shape failure (invalid syntax, or a non-map document) is. Those soft warnings
@@ -251,7 +274,7 @@ not-found error when no config has been pushed for it.
     private fun validateYaml(configYaml: String): String? =
         try {
             @Suppress("UNCHECKED_CAST")
-            val root = Yaml().load<Map<String, Any>>(configYaml)
+            val root = Yaml(SafeConstructor(LoaderOptions())).load<Map<String, Any>>(configYaml)
             if (root != null) {
                 YamlSchemaParser.parseRoot(root, warnOnMissingSchemas = false)
             }
@@ -261,4 +284,16 @@ not-found error when no config has been pushed for it.
         ) {
             e.message ?: e.javaClass.simpleName
         }
+
+    companion object {
+        /** `configYaml` size limit for `push`, in KiB — see [MAX_CONFIG_YAML_BYTES]. */
+        private const val MAX_CONFIG_YAML_KIB = 128
+
+        /**
+         * Hard cap on a pushed `configYaml` document's UTF-8 byte size (CWE-770: uncontrolled
+         * resource consumption). Enforced before any parse attempt, well above any legitimate
+         * config document, and small enough to bound parse cost against a hostile payload.
+         */
+        const val MAX_CONFIG_YAML_BYTES = MAX_CONFIG_YAML_KIB * 1024
+    }
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigTool.kt
@@ -1,0 +1,264 @@
+package io.github.jpicklyk.mcptask.current.application.tools.config
+
+import io.github.jpicklyk.mcptask.current.application.tools.*
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlSchemaParser
+import io.modelcontextprotocol.kotlin.sdk.types.ToolAnnotations
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.serialization.json.*
+import org.yaml.snakeyaml.Yaml
+
+/**
+ * MCP tool for pushing and reading back per-root config YAML — the transport-agnostic sync path
+ * for the layered schema resolver (see [io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext.resolveSchema]).
+ *
+ * A client pushes its repo's `.taskorchestrator/config.yaml` text keyed by a project root's
+ * WorkItem UUID; [io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService]
+ * picks up the change on the very next schema-resolving read (hot-reload is a property of that
+ * service's read path — this tool does not need to invalidate anything itself).
+ *
+ * Supports two operations:
+ * - **push**: validates the target root (must exist, must be depth 0), parse-validates the YAML
+ *   BEFORE storing it, then upserts via [io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository].
+ * - **get**: reads back the stored config + fingerprint for a root, or a not-found error.
+ */
+class ManageProjectConfigTool : BaseToolDefinition() {
+    override val name = "manage_project_config"
+
+    override val description =
+        """
+Push or read back per-root config YAML for the layered schema resolver — a client-pushed
+`.taskorchestrator/config.yaml` document keyed by a project root's WorkItem UUID, which the
+resolver layers over the global config on every schema-resolving read (no separate reload step).
+
+**push** — validates, in order: the root item must exist; it must be depth 0 (configs anchor to
+project roots only, error otherwise); if the root's `type` is not "project", the response includes
+a non-fatal `warning` field (a naming convention, not an enforced constraint) but the push still
+succeeds. `configYaml` is parse-validated BEFORE storing — unparseable YAML is rejected with the
+parse error and never written, so a broken config can never silently fall through to the global
+schema on a later read. Pushing byte-identical content is naturally idempotent: the returned
+`fingerprint` is unchanged, so callers can `get` first and skip the push when fingerprints match.
+
+**get** — returns the stored `configYaml` + `fingerprint` + `updatedAt` for a root, or a
+not-found error when no config has been pushed for it.
+        """.trimIndent()
+
+    override val category = ToolCategory.SYSTEM
+
+    override val toolAnnotations =
+        ToolAnnotations(
+            readOnlyHint = false,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        )
+
+    override val parameterSchema =
+        ToolSchema(
+            properties =
+                buildJsonObject {
+                    put(
+                        "operation",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("Operation: push, get"))
+                            put("enum", JsonArray(listOf("push", "get").map { JsonPrimitive(it) }))
+                        }
+                    )
+                    put(
+                        "rootItemId",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "Project root WorkItem UUID or hex prefix (4+ chars) — must be a depth-0 item for push"
+                                )
+                            )
+                        }
+                    )
+                    put(
+                        "configYaml",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "Raw config.yaml text to store for this root (push only); parse-validated before storing"
+                                )
+                            )
+                        }
+                    )
+                },
+            required = listOf("operation", "rootItemId")
+        )
+
+    override fun validateParams(params: JsonElement) {
+        val operation = requireString(params, "operation")
+        when (operation) {
+            "push" -> {
+                validateIdOrPrefix(params, "rootItemId", required = true)
+                requireString(params, "configYaml")
+            }
+            "get" -> validateIdOrPrefix(params, "rootItemId", required = true)
+            else -> throw ToolValidationException("Invalid operation: $operation. Must be push or get")
+        }
+    }
+
+    override suspend fun execute(
+        params: JsonElement,
+        context: ToolExecutionContext
+    ): JsonElement =
+        when (val operation = requireString(params, "operation")) {
+            "push" -> executePush(params, context)
+            "get" -> executeGet(params, context)
+            else -> errorResponse("Invalid operation: $operation. Must be push or get", ErrorCodes.VALIDATION_ERROR)
+        }
+
+    override fun userSummary(
+        params: JsonElement,
+        result: JsonElement,
+        isError: Boolean
+    ): String {
+        val op = (params as? JsonObject)?.get("operation")?.let { (it as? JsonPrimitive)?.content } ?: "unknown"
+        if (isError) return "manage_project_config($op) failed"
+        val data = (result as? JsonObject)?.get("data") as? JsonObject
+        val rootItemId = data?.get("rootItemId")?.let { (it as? JsonPrimitive)?.content } ?: "unknown"
+        return when (op) {
+            "push" -> "Pushed project config for root $rootItemId"
+            "get" -> "Retrieved project config for root $rootItemId"
+            else -> super.userSummary(params, result, isError)
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // push
+    // ──────────────────────────────────────────────
+
+    private suspend fun executePush(
+        params: JsonElement,
+        context: ToolExecutionContext
+    ): JsonElement {
+        val (rootItemId, idError) = resolveItemId(params, "rootItemId", context)
+        if (idError != null) return idError
+        val configYaml = requireString(params, "configYaml")
+
+        val itemResult = context.workItemRepository().getById(rootItemId!!)
+        val item =
+            when (itemResult) {
+                is Result.Success -> itemResult.data
+                is Result.Error -> return errorResponse(
+                    "Root WorkItem not found: $rootItemId",
+                    ErrorCodes.RESOURCE_NOT_FOUND
+                )
+            }
+
+        if (item.depth != 0) {
+            return errorResponse(
+                "rootItemId must reference a depth-0 (root) WorkItem; '$rootItemId' has depth ${item.depth}",
+                ErrorCodes.VALIDATION_ERROR
+            )
+        }
+
+        val typeWarning =
+            if (item.type != "project") {
+                "Root item type is '${item.type ?: "null"}', not 'project' — config pushed anyway " +
+                    "(a naming convention, not an enforced constraint)"
+            } else {
+                null
+            }
+
+        val parseError = validateYaml(configYaml)
+        if (parseError != null) {
+            return errorResponse(
+                "configYaml failed to parse: $parseError",
+                ErrorCodes.VALIDATION_ERROR,
+                details = parseError
+            )
+        }
+
+        return when (val result = context.projectConfigRepository().upsert(rootItemId, configYaml)) {
+            is Result.Success -> {
+                val config = result.data
+                successResponse(
+                    buildJsonObject {
+                        put("rootItemId", JsonPrimitive(config.rootItemId.toString()))
+                        put("fingerprint", JsonPrimitive(config.fingerprint))
+                        put("updatedAt", JsonPrimitive(config.updatedAt.toString()))
+                        typeWarning?.let { put("warning", JsonPrimitive(it)) }
+                    }
+                )
+            }
+            is Result.Error ->
+                errorResponse(
+                    "Failed to store project config: ${result.error.message}",
+                    ErrorCodes.DATABASE_ERROR
+                )
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // get
+    // ──────────────────────────────────────────────
+
+    private suspend fun executeGet(
+        params: JsonElement,
+        context: ToolExecutionContext
+    ): JsonElement {
+        val (rootItemId, idError) = resolveItemId(params, "rootItemId", context)
+        if (idError != null) return idError
+
+        return when (val result = context.projectConfigRepository().get(rootItemId!!)) {
+            is Result.Success -> {
+                val config =
+                    result.data ?: return errorResponse(
+                        "No project config found for root: $rootItemId",
+                        ErrorCodes.RESOURCE_NOT_FOUND
+                    )
+                successResponse(
+                    buildJsonObject {
+                        put("rootItemId", JsonPrimitive(config.rootItemId.toString()))
+                        put("configYaml", JsonPrimitive(config.configYaml))
+                        put("fingerprint", JsonPrimitive(config.fingerprint))
+                        put("updatedAt", JsonPrimitive(config.updatedAt.toString()))
+                    }
+                )
+            }
+            is Result.Error ->
+                errorResponse(
+                    "Failed to read project config: ${result.error.message}",
+                    ErrorCodes.DATABASE_ERROR
+                )
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // YAML parse-validation
+    // ──────────────────────────────────────────────
+
+    /**
+     * Parses [configYaml] the same way [io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService]
+     * will on every subsequent read (via the shared [YamlSchemaParser]), but BEFORE storing — a
+     * stored-but-unparseable config would otherwise silently fall through to the global schema on
+     * every future read, a confusing failure mode discovered only much later. Returns the parse
+     * failure message, or null when [configYaml] parses cleanly.
+     *
+     * Soft validation warnings collected by [YamlSchemaParser.parseRoot] (e.g. a note entry
+     * missing `key`, an invalid `lifecycle` value) are NOT treated as rejection here — only a hard
+     * YAML syntax/shape failure (invalid syntax, or a non-map document) is. Those soft warnings
+     * mirror the global config loader's existing behavior: skip the offending entry, keep going.
+     */
+    private fun validateYaml(configYaml: String): String? =
+        try {
+            @Suppress("UNCHECKED_CAST")
+            val root = Yaml().load<Map<String, Any>>(configYaml)
+            if (root != null) {
+                YamlSchemaParser.parseRoot(root, warnOnMissingSchemas = false)
+            }
+            null
+        } catch (
+            @Suppress("TooGenericExceptionCaught") e: Exception
+        ) {
+            e.message ?: e.javaClass.simpleName
+        }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ProjectConfig.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ProjectConfig.kt
@@ -1,0 +1,20 @@
+package io.github.jpicklyk.mcptask.current.domain.model
+
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * A stored per-root config document: the raw YAML text for one project root, plus a content
+ * fingerprint used to detect changes for hot-reload.
+ *
+ * @property rootItemId the depth-0 WorkItem this config is scoped to
+ * @property configYaml the raw YAML document as written by the caller
+ * @property fingerprint SHA-256 hex digest of [configYaml]'s UTF-8 bytes
+ * @property updatedAt when this row was last upserted
+ */
+data class ProjectConfig(
+    val rootItemId: UUID,
+    val configYaml: String,
+    val fingerprint: String,
+    val updatedAt: Instant
+)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/ProjectConfigRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/ProjectConfigRepository.kt
@@ -1,0 +1,39 @@
+package io.github.jpicklyk.mcptask.current.domain.repository
+
+import io.github.jpicklyk.mcptask.current.domain.model.ProjectConfig
+import java.util.UUID
+
+/**
+ * Persists per-root config YAML documents (see [io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ProjectConfigTable]).
+ *
+ * One row per root: [upsert] replaces the existing row for a given [UUID] root item rather than
+ * inserting a second row (`root_item_id` is unique). Deleting the root item cascades to delete
+ * its row (FK `ON DELETE CASCADE`) — [delete] here is for explicit config-only removal.
+ */
+interface ProjectConfigRepository {
+    /**
+     * Inserts or replaces the config row for [rootItemId] with [configYaml], computing and
+     * storing a SHA-256 fingerprint of its bytes. Returns the stored [ProjectConfig] (with the
+     * computed fingerprint and the write timestamp) on success.
+     */
+    suspend fun upsert(
+        rootItemId: UUID,
+        configYaml: String
+    ): Result<ProjectConfig>
+
+    /** Returns the full stored config for [rootItemId] (yaml + fingerprint + updatedAt), or null if no row exists. */
+    suspend fun get(rootItemId: UUID): Result<ProjectConfig?>
+
+    /**
+     * Returns only the stored fingerprint for [rootItemId], or null if no row exists.
+     *
+     * A cheap companion to [get] that avoids reading the `config_yaml` TEXT column — used by
+     * [io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService]'s cache to
+     * decide, on every read, whether a re-parse is needed without paying for the full document
+     * when the cached fingerprint still matches.
+     */
+    suspend fun getFingerprint(rootItemId: UUID): Result<String?>
+
+    /** Deletes the config row for [rootItemId], if any. Returns true if a row was deleted. */
+    suspend fun delete(rootItemId: UUID): Result<Boolean>
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigService.kt
@@ -1,0 +1,139 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.config
+
+import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
+import io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import org.slf4j.LoggerFactory
+import org.yaml.snakeyaml.Yaml
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Parses and caches per-root config YAML documents (stored via [ProjectConfigRepository]),
+ * exposing the same schema/trait surface as [YamlWorkItemSchemaService] but scoped to a single
+ * project root (a depth-0 WorkItem UUID) instead of the single global `.taskorchestrator/config.yaml`.
+ *
+ * This is the storage + service layer ONLY. Nothing here decides *when* a per-root config should
+ * override the global one, or merges the two — that resolution logic belongs to
+ * `ToolExecutionContext.resolveSchema()` (a follow-on task), which is deliberately not touched by
+ * this class.
+ *
+ * ## Hot-reload contract
+ *
+ * Every read ([getSchemas], [getSchemaForType], [getTraitNotes], [getAllTraits]) goes through
+ * [resolve], which:
+ *  1. Issues a cheap fingerprint-only read ([ProjectConfigRepository.getFingerprint]) — this never
+ *     touches the `config_yaml` TEXT column.
+ *  2. Compares it against this instance's in-memory cache for that root.
+ *  3. On a match, returns the cached parse with no further I/O.
+ *  4. On a mismatch (including "no cache entry yet"), reads the full row, re-parses, and replaces
+ *     the cache entry.
+ *
+ * Because step 1 runs on *every* call rather than relying on a push-based invalidation signal, a
+ * config pushed by [ProjectConfigRepository.upsert] — from this process or from a different one
+ * entirely (e.g. another server instance sharing the same SQLite file) — becomes visible on the
+ * very next read. No restart, no explicit cache-bust call, no coordination between instances
+ * beyond the shared DB row. This is what "hot-reload" means for this service: it is a property of
+ * every read path, not a separate mechanism that must be remembered to invoke.
+ *
+ * ## Failure handling
+ *
+ * Parse failures (malformed YAML) are logged as warnings and treated as "no per-root config" —
+ * [resolve] returns null, callers fall through to the global `.taskorchestrator/config.yaml`
+ * loader. This class never throws on a read.
+ */
+class PerRootConfigService(
+    private val repository: ProjectConfigRepository
+) {
+    private val logger = LoggerFactory.getLogger(PerRootConfigService::class.java)
+
+    private data class CacheEntry(
+        val fingerprint: String,
+        val parsed: YamlSchemaParser.ParsedConfig
+    )
+
+    /** In-memory cache keyed by root item UUID. Populated lazily on first [resolve] per root. */
+    private val cache = ConcurrentHashMap<UUID, CacheEntry>()
+
+    /** Returns the resolved `work_item_schemas` map for [rootItemId], or null when no config row exists or it fails to parse. */
+    suspend fun getSchemas(rootItemId: UUID): Map<String, WorkItemSchema>? = resolve(rootItemId)?.workItemSchemas
+
+    /** Returns the [WorkItemSchema] for [type] under [rootItemId]'s config, or null if no row/parse/type match. */
+    suspend fun getSchemaForType(
+        rootItemId: UUID,
+        type: String
+    ): WorkItemSchema? = resolve(rootItemId)?.workItemSchemas?.get(type)
+
+    /** Returns the note schema entries for trait [traitName] under [rootItemId]'s config, or null. */
+    suspend fun getTraitNotes(
+        rootItemId: UUID,
+        traitName: String
+    ): List<NoteSchemaEntry>? = resolve(rootItemId)?.traits?.get(traitName)
+
+    /** Returns all trait definitions for [rootItemId]'s config, or null when no config row exists or it fails to parse. */
+    suspend fun getAllTraits(rootItemId: UUID): Map<String, List<NoteSchemaEntry>>? = resolve(rootItemId)?.traits
+
+    /**
+     * Returns the parsed config for [rootItemId], reusing the cached parse when the DB
+     * fingerprint hasn't changed since it was cached. Returns null when there is no config row
+     * for this root, or the stored YAML fails to parse (see class doc — failures fall through to
+     * the global loader rather than throwing).
+     */
+    private suspend fun resolve(rootItemId: UUID): YamlSchemaParser.ParsedConfig? {
+        val currentFingerprint = (repository.getFingerprint(rootItemId) as? Result.Success)?.data
+        if (currentFingerprint == null) {
+            // No config row for this root (or the fingerprint read failed) — drop any stale
+            // cache entry (e.g. the row was deleted since we last cached it) and report "no config".
+            cache.remove(rootItemId)
+            return null
+        }
+
+        cache[rootItemId]?.let { cached ->
+            if (cached.fingerprint == currentFingerprint) return cached.parsed
+        }
+
+        val stored = (repository.get(rootItemId) as? Result.Success)?.data
+        if (stored == null) {
+            cache.remove(rootItemId)
+            return null
+        }
+
+        val parsed =
+            parseYaml(rootItemId, stored.configYaml) ?: run {
+                cache.remove(rootItemId)
+                return null
+            }
+
+        cache[rootItemId] = CacheEntry(stored.fingerprint, parsed)
+        return parsed
+    }
+
+    /**
+     * Parses [configYaml] via the shared [YamlSchemaParser] (same schema/trait structures as
+     * [YamlWorkItemSchemaService]). Unknown top-level keys (e.g. a `project:` block used by other
+     * per-root settings) are ignored silently — [YamlSchemaParser] only reads the keys it knows
+     * about. Passes `warnOnMissingSchemas = false`: unlike the global config file, a per-root
+     * document legitimately may carry no `work_item_schemas:`/`note_schemas:` section at all (it
+     * might exist purely for other per-root settings), so this must NOT emit the global loader's
+     * "no schemas loaded" warning.
+     */
+    private fun parseYaml(
+        rootItemId: UUID,
+        configYaml: String
+    ): YamlSchemaParser.ParsedConfig? =
+        try {
+            @Suppress("UNCHECKED_CAST")
+            val root = Yaml().load<Map<String, Any>>(configYaml)
+            if (root == null) {
+                YamlSchemaParser.ParsedConfig(emptyMap(), emptyMap(), emptyMap(), emptyList())
+            } else {
+                YamlSchemaParser.parseRoot(root, warnOnMissingSchemas = false)
+            }
+        } catch (
+            @Suppress("TooGenericExceptionCaught") e: Exception
+        ) {
+            logger.warn("Failed to parse per-root config for root {}: {}", rootItemId, e.message)
+            null
+        }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigService.kt
@@ -5,7 +5,9 @@ import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
 import io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import org.slf4j.LoggerFactory
+import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
@@ -117,6 +119,13 @@ class PerRootConfigService(
      * document legitimately may carry no `work_item_schemas:`/`note_schemas:` section at all (it
      * might exist purely for other per-root settings), so this must NOT emit the global loader's
      * "no schemas loaded" warning.
+     *
+     * Parses via [SafeConstructor] rather than SnakeYAML's default `Constructor`: [configYaml]
+     * originates from [ProjectConfigRepository], which stores whatever a caller pushed over the
+     * MCP protocol (see `ManageProjectConfigTool`) — attacker-reachable input, not a trusted local
+     * file. The default `Constructor` will instantiate an arbitrary Java type named by a `!!`-tag
+     * (CWE-502); `SafeConstructor` only ever builds plain maps/lists/scalars, which is all this
+     * document format needs, and rejects anything else as a parse failure (caught below).
      */
     private fun parseYaml(
         rootItemId: UUID,
@@ -124,7 +133,7 @@ class PerRootConfigService(
     ): YamlSchemaParser.ParsedConfig? =
         try {
             @Suppress("UNCHECKED_CAST")
-            val root = Yaml().load<Map<String, Any>>(configYaml)
+            val root = Yaml(SafeConstructor(LoaderOptions())).load<Map<String, Any>>(configYaml)
             if (root == null) {
                 YamlSchemaParser.ParsedConfig(emptyMap(), emptyMap(), emptyMap(), emptyList())
             } else {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt
@@ -1,9 +1,7 @@
 package io.github.jpicklyk.mcptask.current.infrastructure.config
 
 import io.github.jpicklyk.mcptask.current.application.service.WorkItemSchemaService
-import io.github.jpicklyk.mcptask.current.domain.model.LifecycleMode
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
-import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
 import org.slf4j.LoggerFactory
 import org.yaml.snakeyaml.Yaml
@@ -55,22 +53,8 @@ class YamlWorkItemSchemaService(
 ) : WorkItemSchemaService {
     private val logger = LoggerFactory.getLogger(YamlWorkItemSchemaService::class.java)
 
-    /**
-     * Holds the result of a schema load: the parsed schemas and any warnings collected.
-     */
-    private data class SchemaLoadResult(
-        val schemas: Map<String, List<NoteSchemaEntry>>,
-        val workItemSchemas: Map<String, WorkItemSchema>,
-        val traits: Map<String, List<NoteSchemaEntry>>,
-        val warnings: MutableList<String>,
-        // Mirrors the companion's DEFAULT_NOTE_LIMITS_MODE constant ("warn") — kept as a literal
-        // here since a nested class default parameter cannot forward-reference the outer
-        // companion object during initialization.
-        val noteLimitsMode: String = "warn"
-    )
-
     /** Lazily loaded schema cache and warnings. Initialized once on first access. */
-    private val loadResult: SchemaLoadResult by lazy { loadSchemas() }
+    private val loadResult: YamlSchemaParser.ParsedConfig by lazy { loadSchemas() }
 
     /** Lazily loaded tag→entries schema cache. */
     private val schemas: Map<String, List<NoteSchemaEntry>> get() = loadResult.schemas
@@ -114,7 +98,7 @@ class YamlWorkItemSchemaService(
     /**
      * Returns the configured `note_limits.mode` ("warn" or "reject"), defaulting to "warn"
      * when the config file is absent, the `note_limits` block is absent, or the value is
-     * invalid (a load warning is recorded in the latter case — see [parseNoteLimitsMode]).
+     * invalid (a load warning is recorded in the latter case — see [YamlSchemaParser]).
      */
     override fun getNoteLimitsMode(): String = loadResult.noteLimitsMode
 
@@ -138,43 +122,33 @@ class YamlWorkItemSchemaService(
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
-    private fun loadSchemas(): SchemaLoadResult {
-        val warnings = mutableListOf<String>()
-
+    /**
+     * Reads and parses the config file, delegating the "root map -> schemas/traits/warnings"
+     * step to [YamlSchemaParser.parseRoot] (shared with [PerRootConfigService]). This method
+     * retains only the file-specific concerns: existence check, IO, YAML syntax-error handling,
+     * and the summary log line.
+     */
+    private fun loadSchemas(): YamlSchemaParser.ParsedConfig {
         if (!configPath.toFile().exists()) {
             logger.debug("No config file found at {}; running in schema-free mode", configPath)
-            return SchemaLoadResult(emptyMap(), emptyMap(), emptyMap(), warnings)
+            return YamlSchemaParser.ParsedConfig(emptyMap(), emptyMap(), emptyMap(), emptyList())
         }
 
         return try {
             val yaml = Yaml()
             FileReader(configPath.toFile()).use { reader ->
-                val root =
-                    yaml.load<Map<String, Any>>(reader)
-                        ?: return@use SchemaLoadResult(emptyMap(), emptyMap(), emptyMap(), warnings)
-
-                val parsedTraits = parseTraits(root, warnings)
-                val parsedNoteLimitsMode = parseNoteLimitsMode(root, warnings)
-
-                when {
-                    root.containsKey("work_item_schemas") -> {
-                        parseWorkItemSchemas(root, warnings).copy(traits = parsedTraits, noteLimitsMode = parsedNoteLimitsMode)
-                    }
-                    root.containsKey("note_schemas") -> {
-                        parseLegacyNoteSchemas(root, warnings).copy(traits = parsedTraits, noteLimitsMode = parsedNoteLimitsMode)
-                    }
-                    else -> {
-                        warnings.add("Config file is missing 'note_schemas' key; no schemas loaded")
-                        SchemaLoadResult(emptyMap(), emptyMap(), parsedTraits, warnings, parsedNoteLimitsMode)
-                    }
+                @Suppress("UNCHECKED_CAST")
+                val root = yaml.load<Map<String, Any>>(reader)
+                if (root == null) {
+                    YamlSchemaParser.ParsedConfig(emptyMap(), emptyMap(), emptyMap(), emptyList())
+                } else {
+                    YamlSchemaParser.parseRoot(root)
                 }
             }
         } catch (e: Exception) {
             val msg = "Failed to load note schemas from '$configPath': ${e.message}"
-            warnings.add(msg)
             logger.warn(msg)
-            SchemaLoadResult(emptyMap(), emptyMap(), emptyMap(), warnings)
+            YamlSchemaParser.ParsedConfig(emptyMap(), emptyMap(), emptyMap(), listOf(msg))
         }.also { result ->
             result.warnings.forEach { w -> logger.warn(w) }
             val totalEntries = result.schemas.values.sumOf { it.size }
@@ -187,209 +161,7 @@ class YamlWorkItemSchemaService(
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
-    private fun parseWorkItemSchemas(
-        root: Map<String, Any>,
-        warnings: MutableList<String>
-    ): SchemaLoadResult {
-        val rawSchemas =
-            root["work_item_schemas"] as? Map<String, Any>
-                ?: return SchemaLoadResult(emptyMap(), emptyMap(), emptyMap(), warnings)
-
-        val schemasMap = mutableMapOf<String, List<NoteSchemaEntry>>()
-        val workItemSchemasMap = mutableMapOf<String, WorkItemSchema>()
-
-        for ((schemaName, rawValue) in rawSchemas) {
-            val schemaMap = rawValue as? Map<String, Any> ?: continue
-
-            val lifecycleRaw = schemaMap["lifecycle"] as? String
-            val lifecycleMode =
-                if (lifecycleRaw != null) {
-                    val parsed = LifecycleMode.fromString(lifecycleRaw)
-                    if (parsed == null) {
-                        warnings.add(
-                            "Schema '$schemaName' has invalid lifecycle value '$lifecycleRaw'; defaulting to AUTO"
-                        )
-                        LifecycleMode.AUTO
-                    } else {
-                        parsed
-                    }
-                } else {
-                    LifecycleMode.AUTO
-                }
-
-            @Suppress("UNCHECKED_CAST")
-            val defaultTraits = (schemaMap["default_traits"] as? List<String>) ?: emptyList()
-
-            val rawNotes = schemaMap["notes"] as? List<Map<String, Any>> ?: emptyList()
-            val entries =
-                rawNotes.mapIndexedNotNull { index, raw ->
-                    parseEntry(raw, schemaName, index, warnings)
-                }
-
-            schemasMap[schemaName] = entries
-            workItemSchemasMap[schemaName] =
-                WorkItemSchema(
-                    type = schemaName,
-                    lifecycleMode = lifecycleMode,
-                    notes = entries,
-                    defaultTraits = defaultTraits
-                )
-        }
-
-        return SchemaLoadResult(schemasMap, workItemSchemasMap, emptyMap(), warnings)
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun parseLegacyNoteSchemas(
-        root: Map<String, Any>,
-        warnings: MutableList<String>
-    ): SchemaLoadResult {
-        val noteSchemas =
-            root["note_schemas"] as? Map<String, Any>
-                ?: return SchemaLoadResult(emptyMap(), emptyMap(), emptyMap(), warnings)
-
-        val schemasMap = mutableMapOf<String, List<NoteSchemaEntry>>()
-        val workItemSchemasMap = mutableMapOf<String, WorkItemSchema>()
-
-        for ((schemaName, rawEntries) in noteSchemas) {
-            val entryList = rawEntries as? List<Map<String, Any>> ?: emptyList()
-            val entries =
-                entryList.mapIndexedNotNull { index, raw ->
-                    parseEntry(raw, schemaName, index, warnings)
-                }
-            schemasMap[schemaName] = entries
-            // Wrap into WorkItemSchema with AUTO lifecycle for backward compat
-            workItemSchemasMap[schemaName] =
-                WorkItemSchema(
-                    type = schemaName,
-                    lifecycleMode = LifecycleMode.AUTO,
-                    notes = entries
-                )
-        }
-
-        return SchemaLoadResult(schemasMap, workItemSchemasMap, emptyMap(), warnings)
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun parseTraits(
-        root: Map<String, Any>,
-        warnings: MutableList<String>
-    ): Map<String, List<NoteSchemaEntry>> {
-        val traitsRaw = root["traits"] as? Map<String, Any> ?: return emptyMap()
-        return traitsRaw.entries.associate { (traitName, rawValue) ->
-            val rawMap = rawValue as? Map<String, Any> ?: emptyMap()
-            val notesList = rawMap["notes"] as? List<Map<String, Any>> ?: emptyList()
-            val entries =
-                notesList.mapIndexedNotNull { index, raw ->
-                    parseEntry(raw, "trait:$traitName", index, warnings)
-                }
-            traitName to entries
-        }
-    }
-
-    private fun parseEntry(
-        raw: Map<String, Any>,
-        schemaName: String,
-        index: Int,
-        warnings: MutableList<String>
-    ): NoteSchemaEntry? {
-        val key = raw["key"] as? String
-        if (key == null) {
-            warnings.add("Schema '$schemaName' entry[$index] is missing required field 'key'; skipping")
-            return null
-        }
-
-        val roleRaw = raw["role"] as? String
-        if (roleRaw == null) {
-            warnings.add("Schema '$schemaName' entry[$index] (key='$key') is missing required field 'role'; skipping")
-            return null
-        }
-
-        val parsedRole = VALID_SCHEMA_ROLES[roleRaw]
-        if (parsedRole == null) {
-            logger.warn(
-                "Skipping schema entry '{}': invalid role '{}' (valid: {})",
-                key,
-                roleRaw,
-                VALID_SCHEMA_ROLES.keys
-            )
-            return null
-        }
-
-        val requiredRaw = raw["required"]
-        val required =
-            if (requiredRaw != null && requiredRaw !is Boolean) {
-                warnings.add(
-                    "Schema '$schemaName' entry (key='$key') has non-boolean 'required' value '$requiredRaw'; defaulting to false"
-                )
-                false
-            } else {
-                requiredRaw as? Boolean ?: false
-            }
-
-        val description = raw["description"] as? String ?: ""
-        val guidance = raw["guidance"] as? String
-        val skill = raw["skill"] as? String
-
-        val maxLengthRaw = raw["maxLength"]
-        val maxLength =
-            if (maxLengthRaw != null && maxLengthRaw !is Number) {
-                warnings.add(
-                    "Schema '$schemaName' entry (key='$key') has non-numeric 'maxLength' value '$maxLengthRaw'; ignoring"
-                )
-                null
-            } else {
-                (maxLengthRaw as? Number)?.toInt()
-            }
-
-        return NoteSchemaEntry(
-            key = key,
-            role = parsedRole,
-            required = required,
-            description = description,
-            guidance = guidance,
-            skill = skill,
-            maxLength = maxLength,
-        )
-    }
-
-    /**
-     * Parses the top-level `note_limits.mode` key, defaulting to [DEFAULT_NOTE_LIMITS_MODE]
-     * ("warn") when the block is absent or the value is not one of [VALID_NOTE_LIMITS_MODES].
-     * An invalid (non-empty, unrecognized) value is recorded as a load warning.
-     */
-    @Suppress("UNCHECKED_CAST")
-    private fun parseNoteLimitsMode(
-        root: Map<String, Any>,
-        warnings: MutableList<String>
-    ): String {
-        val noteLimits = root["note_limits"] as? Map<String, Any> ?: return DEFAULT_NOTE_LIMITS_MODE
-        val modeRaw = noteLimits["mode"] as? String ?: return DEFAULT_NOTE_LIMITS_MODE
-        if (modeRaw !in VALID_NOTE_LIMITS_MODES) {
-            warnings.add(
-                "Invalid note_limits.mode value '$modeRaw'; defaulting to '$DEFAULT_NOTE_LIMITS_MODE' " +
-                    "(valid: $VALID_NOTE_LIMITS_MODES)"
-            )
-            return DEFAULT_NOTE_LIMITS_MODE
-        }
-        return modeRaw
-    }
-
     companion object {
-        private val VALID_SCHEMA_ROLES =
-            mapOf(
-                "queue" to Role.QUEUE,
-                "work" to Role.WORK,
-                "review" to Role.REVIEW,
-            )
-
-        /** Default `note_limits.mode` when unconfigured: accept notes over maxLength, just warn. */
-        const val DEFAULT_NOTE_LIMITS_MODE = "warn"
-
-        /** Recognized `note_limits.mode` values. */
-        private val VALID_NOTE_LIMITS_MODES = setOf("warn", "reject")
-
         fun resolveDefaultConfigPath(): java.nio.file.Path {
             val projectRoot =
                 Paths.get(

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt
@@ -4,7 +4,9 @@ import io.github.jpicklyk.mcptask.current.application.service.WorkItemSchemaServ
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
 import org.slf4j.LoggerFactory
+import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
 import java.io.FileReader
 import java.nio.file.Paths
 import java.security.MessageDigest
@@ -127,6 +129,11 @@ class YamlWorkItemSchemaService(
      * step to [YamlSchemaParser.parseRoot] (shared with [PerRootConfigService]). This method
      * retains only the file-specific concerns: existence check, IO, YAML syntax-error handling,
      * and the summary log line.
+     *
+     * Parses via [SafeConstructor] rather than SnakeYAML's default `Constructor` — matching
+     * [PerRootConfigService]'s parse of the same shared format, so a `!!`-tagged arbitrary-Java-type
+     * payload (CWE-502) is rejected the same way regardless of whether it arrived via a locally
+     * edited `.taskorchestrator/config.yaml` or a pushed per-root document.
      */
     private fun loadSchemas(): YamlSchemaParser.ParsedConfig {
         if (!configPath.toFile().exists()) {
@@ -135,7 +142,7 @@ class YamlWorkItemSchemaService(
         }
 
         return try {
-            val yaml = Yaml()
+            val yaml = Yaml(SafeConstructor(LoaderOptions()))
             FileReader(configPath.toFile()).use { reader ->
                 @Suppress("UNCHECKED_CAST")
                 val root = yaml.load<Map<String, Any>>(reader)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlSchemaParser.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlSchemaParser.kt
@@ -1,0 +1,273 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.config
+
+import io.github.jpicklyk.mcptask.current.domain.model.LifecycleMode
+import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
+import org.slf4j.LoggerFactory
+
+/**
+ * Parses a already-YAML-deserialized config root map (`work_item_schemas:` / `note_schemas:` /
+ * `traits:` / `note_limits:`) into the schema/trait structures the rest of the application
+ * consumes.
+ *
+ * Extracted from [YamlWorkItemSchemaService] so both the global config loader (file-backed,
+ * `.taskorchestrator/config.yaml`) and [PerRootConfigService] (DB-backed, one YAML document per
+ * project root) share exactly one parsing implementation — there is no behavioral difference
+ * between "global schema YAML" and "per-root schema YAML" beyond *where the bytes come from* and
+ * whether a missing schemas section is worth warning about (see [warnOnMissingSchemas]).
+ *
+ * [YamlWorkItemSchemaService.loadSchemas] retains its own responsibilities that this object does
+ * NOT take on: resolving the config file path, checking file existence, reading bytes, and
+ * catching/logging file-level exceptions (YAML syntax errors, IO errors). Only the "given a
+ * parsed `Map<String, Any>` root, produce schemas/traits/warnings" step lives here.
+ */
+internal object YamlSchemaParser {
+    private val logger = LoggerFactory.getLogger(YamlSchemaParser::class.java)
+
+    private val VALID_SCHEMA_ROLES =
+        mapOf(
+            "queue" to Role.QUEUE,
+            "work" to Role.WORK,
+            "review" to Role.REVIEW,
+        )
+
+    /** Default `note_limits.mode` when unconfigured: accept notes over maxLength, just warn. */
+    const val DEFAULT_NOTE_LIMITS_MODE = "warn"
+
+    /** Recognized `note_limits.mode` values. */
+    private val VALID_NOTE_LIMITS_MODES = setOf("warn", "reject")
+
+    /** Result of parsing a config root map: schemas, traits, warnings, and the note-limits mode. */
+    data class ParsedConfig(
+        val schemas: Map<String, List<NoteSchemaEntry>>,
+        val workItemSchemas: Map<String, WorkItemSchema>,
+        val traits: Map<String, List<NoteSchemaEntry>>,
+        val warnings: List<String>,
+        val noteLimitsMode: String = DEFAULT_NOTE_LIMITS_MODE
+    )
+
+    /**
+     * Parses [root] into a [ParsedConfig].
+     *
+     * Precedence: `work_item_schemas:` wins entirely over `note_schemas:` when both are present;
+     * `note_schemas:` is the legacy format (wrapped into [WorkItemSchema] with AUTO lifecycle for
+     * backward compatibility). When neither key is present, [warnOnMissingSchemas] controls
+     * whether a "no schemas loaded" warning is recorded — the global file-backed loader wants
+     * this warning (a `.taskorchestrator/config.yaml` with no schema section is almost always a
+     * mistake), but a per-root config document legitimately may carry only other settings with no
+     * schema section at all, so callers with looser expectations pass `false`.
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun parseRoot(
+        root: Map<String, Any>,
+        warnOnMissingSchemas: Boolean = true
+    ): ParsedConfig {
+        val warnings = mutableListOf<String>()
+        val parsedTraits = parseTraits(root, warnings)
+        val parsedNoteLimitsMode = parseNoteLimitsMode(root, warnings)
+
+        val base =
+            when {
+                root.containsKey("work_item_schemas") -> parseWorkItemSchemas(root, warnings)
+                root.containsKey("note_schemas") -> parseLegacyNoteSchemas(root, warnings)
+                else -> {
+                    if (warnOnMissingSchemas) {
+                        warnings.add("Config file is missing 'note_schemas' key; no schemas loaded")
+                    }
+                    ParsedConfig(emptyMap(), emptyMap(), emptyMap(), warnings)
+                }
+            }
+
+        return base.copy(traits = parsedTraits, warnings = warnings, noteLimitsMode = parsedNoteLimitsMode)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun parseWorkItemSchemas(
+        root: Map<String, Any>,
+        warnings: MutableList<String>
+    ): ParsedConfig {
+        val rawSchemas =
+            root["work_item_schemas"] as? Map<String, Any>
+                ?: return ParsedConfig(emptyMap(), emptyMap(), emptyMap(), warnings)
+
+        val schemasMap = mutableMapOf<String, List<NoteSchemaEntry>>()
+        val workItemSchemasMap = mutableMapOf<String, WorkItemSchema>()
+
+        for ((schemaName, rawValue) in rawSchemas) {
+            val schemaMap = rawValue as? Map<String, Any> ?: continue
+
+            val lifecycleRaw = schemaMap["lifecycle"] as? String
+            val lifecycleMode =
+                if (lifecycleRaw != null) {
+                    val parsed = LifecycleMode.fromString(lifecycleRaw)
+                    if (parsed == null) {
+                        warnings.add(
+                            "Schema '$schemaName' has invalid lifecycle value '$lifecycleRaw'; defaulting to AUTO"
+                        )
+                        LifecycleMode.AUTO
+                    } else {
+                        parsed
+                    }
+                } else {
+                    LifecycleMode.AUTO
+                }
+
+            @Suppress("UNCHECKED_CAST")
+            val defaultTraits = (schemaMap["default_traits"] as? List<String>) ?: emptyList()
+
+            val rawNotes = schemaMap["notes"] as? List<Map<String, Any>> ?: emptyList()
+            val entries =
+                rawNotes.mapIndexedNotNull { index, raw ->
+                    parseEntry(raw, schemaName, index, warnings)
+                }
+
+            schemasMap[schemaName] = entries
+            workItemSchemasMap[schemaName] =
+                WorkItemSchema(
+                    type = schemaName,
+                    lifecycleMode = lifecycleMode,
+                    notes = entries,
+                    defaultTraits = defaultTraits
+                )
+        }
+
+        return ParsedConfig(schemasMap, workItemSchemasMap, emptyMap(), warnings)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun parseLegacyNoteSchemas(
+        root: Map<String, Any>,
+        warnings: MutableList<String>
+    ): ParsedConfig {
+        val noteSchemas =
+            root["note_schemas"] as? Map<String, Any>
+                ?: return ParsedConfig(emptyMap(), emptyMap(), emptyMap(), warnings)
+
+        val schemasMap = mutableMapOf<String, List<NoteSchemaEntry>>()
+        val workItemSchemasMap = mutableMapOf<String, WorkItemSchema>()
+
+        for ((schemaName, rawEntries) in noteSchemas) {
+            val entryList = rawEntries as? List<Map<String, Any>> ?: emptyList()
+            val entries =
+                entryList.mapIndexedNotNull { index, raw ->
+                    parseEntry(raw, schemaName, index, warnings)
+                }
+            schemasMap[schemaName] = entries
+            // Wrap into WorkItemSchema with AUTO lifecycle for backward compat
+            workItemSchemasMap[schemaName] =
+                WorkItemSchema(
+                    type = schemaName,
+                    lifecycleMode = LifecycleMode.AUTO,
+                    notes = entries
+                )
+        }
+
+        return ParsedConfig(schemasMap, workItemSchemasMap, emptyMap(), warnings)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun parseTraits(
+        root: Map<String, Any>,
+        warnings: MutableList<String>
+    ): Map<String, List<NoteSchemaEntry>> {
+        val traitsRaw = root["traits"] as? Map<String, Any> ?: return emptyMap()
+        return traitsRaw.entries.associate { (traitName, rawValue) ->
+            val rawMap = rawValue as? Map<String, Any> ?: emptyMap()
+            val notesList = rawMap["notes"] as? List<Map<String, Any>> ?: emptyList()
+            val entries =
+                notesList.mapIndexedNotNull { index, raw ->
+                    parseEntry(raw, "trait:$traitName", index, warnings)
+                }
+            traitName to entries
+        }
+    }
+
+    private fun parseEntry(
+        raw: Map<String, Any>,
+        schemaName: String,
+        index: Int,
+        warnings: MutableList<String>
+    ): NoteSchemaEntry? {
+        val key = raw["key"] as? String
+        if (key == null) {
+            warnings.add("Schema '$schemaName' entry[$index] is missing required field 'key'; skipping")
+            return null
+        }
+
+        val roleRaw = raw["role"] as? String
+        if (roleRaw == null) {
+            warnings.add("Schema '$schemaName' entry[$index] (key='$key') is missing required field 'role'; skipping")
+            return null
+        }
+
+        val parsedRole = VALID_SCHEMA_ROLES[roleRaw]
+        if (parsedRole == null) {
+            logger.warn(
+                "Skipping schema entry '{}': invalid role '{}' (valid: {})",
+                key,
+                roleRaw,
+                VALID_SCHEMA_ROLES.keys
+            )
+            return null
+        }
+
+        val requiredRaw = raw["required"]
+        val required =
+            if (requiredRaw != null && requiredRaw !is Boolean) {
+                warnings.add(
+                    "Schema '$schemaName' entry (key='$key') has non-boolean 'required' value '$requiredRaw'; defaulting to false"
+                )
+                false
+            } else {
+                requiredRaw as? Boolean ?: false
+            }
+
+        val description = raw["description"] as? String ?: ""
+        val guidance = raw["guidance"] as? String
+        val skill = raw["skill"] as? String
+
+        val maxLengthRaw = raw["maxLength"]
+        val maxLength =
+            if (maxLengthRaw != null && maxLengthRaw !is Number) {
+                warnings.add(
+                    "Schema '$schemaName' entry (key='$key') has non-numeric 'maxLength' value '$maxLengthRaw'; ignoring"
+                )
+                null
+            } else {
+                (maxLengthRaw as? Number)?.toInt()
+            }
+
+        return NoteSchemaEntry(
+            key = key,
+            role = parsedRole,
+            required = required,
+            description = description,
+            guidance = guidance,
+            skill = skill,
+            maxLength = maxLength,
+        )
+    }
+
+    /**
+     * Parses the top-level `note_limits.mode` key, defaulting to [DEFAULT_NOTE_LIMITS_MODE]
+     * ("warn") when the block is absent or the value is not one of [VALID_NOTE_LIMITS_MODES].
+     * An invalid (non-empty, unrecognized) value is recorded as a load warning.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun parseNoteLimitsMode(
+        root: Map<String, Any>,
+        warnings: MutableList<String>
+    ): String {
+        val noteLimits = root["note_limits"] as? Map<String, Any> ?: return DEFAULT_NOTE_LIMITS_MODE
+        val modeRaw = noteLimits["mode"] as? String ?: return DEFAULT_NOTE_LIMITS_MODE
+        if (modeRaw !in VALID_NOTE_LIMITS_MODES) {
+            warnings.add(
+                "Invalid note_limits.mode value '$modeRaw'; defaulting to '$DEFAULT_NOTE_LIMITS_MODE' " +
+                    "(valid: $VALID_NOTE_LIMITS_MODES)"
+            )
+            return DEFAULT_NOTE_LIMITS_MODE
+        }
+        return modeRaw
+    }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/ProjectConfigTable.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/ProjectConfigTable.kt
@@ -1,0 +1,26 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database.schema
+
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
+import org.jetbrains.exposed.v1.core.java.javaUUID
+import org.jetbrains.exposed.v1.javatime.timestamp
+
+/**
+ * One row per project root (a depth-0 WorkItem): a raw YAML config document scoped to that root,
+ * plus a content fingerprint used by [io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService]
+ * to detect changes and hot-reload its in-memory parse without a server restart.
+ *
+ * Mirrors [RoleTransitionsTable]'s style: a single FK to [WorkItemsTable] with `ON DELETE CASCADE`
+ * so deleting a root item automatically removes its config row.
+ */
+object ProjectConfigTable : UUIDTable("project_config") {
+    val rootItemId = javaUUID("root_item_id")
+    val configYaml = text("config_yaml")
+    val fingerprint = text("fingerprint")
+    val updatedAt = timestamp("updated_at")
+
+    init {
+        foreignKey(rootItemId to WorkItemsTable.id, onDelete = ReferenceOption.CASCADE)
+        uniqueIndex(rootItemId)
+    }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/management/DirectDatabaseSchemaManager.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/management/DirectDatabaseSchemaManager.kt
@@ -2,6 +2,7 @@ package io.github.jpicklyk.mcptask.current.infrastructure.database.schema.manage
 
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.DependenciesTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.NotesTable
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ProjectConfigTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.RoleTransitionsTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.WorkItemsTable
 import org.jetbrains.exposed.v1.core.vendors.H2Dialect
@@ -16,15 +17,16 @@ import org.slf4j.LoggerFactory
  *
  * Table dependency graph:
  * 1. WorkItemsTable (no external dependencies, self-referencing parentId)
- * 2. NotesTable (depends on WorkItemsTable)
- * 3. DependenciesTable (depends on WorkItemsTable)
- * 4. RoleTransitionsTable (depends on WorkItemsTable)
+ * 2. ProjectConfigTable (depends on WorkItemsTable)
+ * 3. NotesTable (depends on WorkItemsTable)
+ * 4. DependenciesTable (depends on WorkItemsTable)
+ * 5. RoleTransitionsTable (depends on WorkItemsTable)
  *
  * Virtual tables (FTS5, follow their backing tables):
- * 5. work_items_fts_trigram (external-content over WorkItemsTable)
- * 6. work_items_fts_text    (external-content over WorkItemsTable)
- * 7. notes_fts_trigram      (external-content over NotesTable)
- * 8. notes_fts_text         (external-content over NotesTable)
+ * 6. work_items_fts_trigram (external-content over WorkItemsTable)
+ * 7. work_items_fts_text    (external-content over WorkItemsTable)
+ * 8. notes_fts_trigram      (external-content over NotesTable)
+ * 9. notes_fts_text         (external-content over NotesTable)
  *
  * Triggers (registered after their backing tables):
  * - work_items_cycle_check, work_items_cycle_check_update (cycle detection on parent_id)
@@ -38,6 +40,7 @@ class DirectDatabaseSchemaManager : DatabaseSchemaManager {
     private val tables =
         arrayOf(
             WorkItemsTable,
+            ProjectConfigTable,
             NotesTable,
             DependenciesTable,
             RoleTransitionsTable,

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/DefaultRepositoryProvider.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/DefaultRepositoryProvider.kt
@@ -3,6 +3,7 @@ package io.github.jpicklyk.mcptask.current.infrastructure.repository
 import io.github.jpicklyk.mcptask.current.application.service.WorkTreeExecutor
 import io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.NoteRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.RoleTransitionRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
@@ -22,6 +23,7 @@ class DefaultRepositoryProvider(
     private val noteRepo by lazy { SQLiteNoteRepository(databaseManager) }
     private val dependencyRepo by lazy { SQLiteDependencyRepository(databaseManager) }
     private val roleTransitionRepo by lazy { SQLiteRoleTransitionRepository(databaseManager) }
+    private val projectConfigRepo by lazy { SQLiteProjectConfigRepository(databaseManager) }
     private val workTreeExecutorInstance by lazy { SQLiteWorkTreeService(databaseManager, workItemRepo, noteRepo) }
 
     override fun workItemRepository(): WorkItemRepository = workItemRepo
@@ -31,6 +33,8 @@ class DefaultRepositoryProvider(
     override fun dependencyRepository(): DependencyRepository = dependencyRepo
 
     override fun roleTransitionRepository(): RoleTransitionRepository = roleTransitionRepo
+
+    override fun projectConfigRepository(): ProjectConfigRepository = projectConfigRepo
 
     override fun database(): org.jetbrains.exposed.v1.jdbc.Database? = databaseManager.getDatabase()
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/RepositoryProvider.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/RepositoryProvider.kt
@@ -3,6 +3,7 @@ package io.github.jpicklyk.mcptask.current.infrastructure.repository
 import io.github.jpicklyk.mcptask.current.application.service.WorkTreeExecutor
 import io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.NoteRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.RoleTransitionRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
 
@@ -18,6 +19,8 @@ interface RepositoryProvider {
     fun dependencyRepository(): DependencyRepository
 
     fun roleTransitionRepository(): RoleTransitionRepository
+
+    fun projectConfigRepository(): ProjectConfigRepository
 
     fun database(): org.jetbrains.exposed.v1.jdbc.Database?
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteProjectConfigRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteProjectConfigRepository.kt
@@ -1,0 +1,101 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.repository
+
+import io.github.jpicklyk.mcptask.current.domain.model.ProjectConfig
+import io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ProjectConfigTable
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.select
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.upsert
+import java.security.MessageDigest
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * SQLite implementation of [ProjectConfigRepository], backed by [ProjectConfigTable].
+ *
+ * Upsert uses the same atomic `INSERT … ON CONFLICT DO UPDATE` pattern as
+ * [SQLiteNoteRepository.upsertRow] (keyed on the unique `root_item_id` column here instead of
+ * `(work_item_id, key)`) to avoid a SELECT-then-branch TOCTOU race between concurrent writers for
+ * the same root.
+ */
+class SQLiteProjectConfigRepository(
+    private val databaseManager: DatabaseManager
+) : ProjectConfigRepository {
+    override suspend fun upsert(
+        rootItemId: UUID,
+        configYaml: String
+    ): Result<ProjectConfig> =
+        databaseManager.suspendedTransaction("Failed to upsert ProjectConfig") {
+            val fingerprint = computeFingerprint(configYaml)
+            val now = Instant.now()
+
+            ProjectConfigTable.upsert(
+                keys = arrayOf(ProjectConfigTable.rootItemId),
+                onUpdate = {
+                    it[ProjectConfigTable.configYaml] = configYaml
+                    it[ProjectConfigTable.fingerprint] = fingerprint
+                    it[ProjectConfigTable.updatedAt] = now
+                },
+            ) {
+                it[ProjectConfigTable.rootItemId] = rootItemId
+                it[ProjectConfigTable.configYaml] = configYaml
+                it[ProjectConfigTable.fingerprint] = fingerprint
+                it[ProjectConfigTable.updatedAt] = now
+            }
+
+            Result.Success(
+                ProjectConfig(
+                    rootItemId = rootItemId,
+                    configYaml = configYaml,
+                    fingerprint = fingerprint,
+                    updatedAt = now
+                )
+            )
+        }
+
+    override suspend fun get(rootItemId: UUID): Result<ProjectConfig?> =
+        databaseManager.suspendedTransaction("Failed to get ProjectConfig") {
+            val row =
+                ProjectConfigTable
+                    .selectAll()
+                    .where { ProjectConfigTable.rootItemId eq rootItemId }
+                    .singleOrNull()
+            Result.Success(row?.let { mapRowToProjectConfig(it) })
+        }
+
+    override suspend fun getFingerprint(rootItemId: UUID): Result<String?> =
+        databaseManager.suspendedTransaction("Failed to get ProjectConfig fingerprint") {
+            val fingerprint =
+                ProjectConfigTable
+                    .select(ProjectConfigTable.fingerprint)
+                    .where { ProjectConfigTable.rootItemId eq rootItemId }
+                    .singleOrNull()
+                    ?.get(ProjectConfigTable.fingerprint)
+            Result.Success(fingerprint)
+        }
+
+    override suspend fun delete(rootItemId: UUID): Result<Boolean> =
+        databaseManager.suspendedTransaction("Failed to delete ProjectConfig") {
+            val deletedCount = ProjectConfigTable.deleteWhere { ProjectConfigTable.rootItemId eq rootItemId }
+            Result.Success(deletedCount > 0)
+        }
+
+    private fun mapRowToProjectConfig(row: ResultRow): ProjectConfig =
+        ProjectConfig(
+            rootItemId = row[ProjectConfigTable.rootItemId],
+            configYaml = row[ProjectConfigTable.configYaml],
+            fingerprint = row[ProjectConfigTable.fingerprint],
+            updatedAt = row[ProjectConfigTable.updatedAt]
+        )
+
+    /** Mirrors [io.github.jpicklyk.mcptask.current.infrastructure.config.YamlWorkItemSchemaService.getConfigFingerprint]'s SHA-256 approach. */
+    private fun computeFingerprint(configYaml: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(configYaml.toByteArray(Charsets.UTF_8))
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/events/EventPublishingRepositoryProvider.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/events/EventPublishingRepositoryProvider.kt
@@ -7,6 +7,7 @@ import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.NoteRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.domain.repository.RoleTransitionRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
@@ -351,6 +352,8 @@ class EventPublishingRepositoryProvider(
     override fun dependencyRepository(): DependencyRepository = wrappedDependencyRepo
 
     override fun roleTransitionRepository(): RoleTransitionRepository = delegate.roleTransitionRepository()
+
+    override fun projectConfigRepository(): ProjectConfigRepository = delegate.projectConfigRepository()
 
     override fun database() = delegate.database()
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemWriteRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemWriteRoutes.kt
@@ -16,6 +16,7 @@ import io.github.jpicklyk.mcptask.current.domain.model.UserTrigger
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.infrastructure.config.AppConfig
+import io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.audit.ApiAuditBridge
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiCapability
@@ -208,7 +209,15 @@ fun Route.itemWriteRoutes(
     // Schema-resolution context — reuses the EXACT trait-merging + review-phase logic from
     // AdvanceItemTool (via ToolExecutionContext.resolveHasReviewPhase). Repository access is shared;
     // no MCP behavior is affected since this context is read-only for schema resolution here.
-    val schemaResolutionContext = ToolExecutionContext(repositoryProvider, schemaService)
+    // perRootConfigService is passed by name (all other trailing ToolExecutionContext params keep
+    // their defaults) so REST advances get the SAME per-root schema layering as MCP tool calls —
+    // otherwise this independently-constructed context would silently resolve global-only.
+    val schemaResolutionContext =
+        ToolExecutionContext(
+            repositoryProvider,
+            schemaService,
+            perRootConfigService = PerRootConfigService(repositoryProvider.projectConfigRepository()),
+        )
 
     // ─── POST /items ─────────────────────────────────────────────────────────
     requireCapability(ApiCapability.WRITE_ITEMS) {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
@@ -5,6 +5,7 @@ import io.github.jpicklyk.mcptask.current.application.service.WorkItemSchemaServ
 import io.github.jpicklyk.mcptask.current.application.tools.ToolDefinition
 import io.github.jpicklyk.mcptask.current.application.tools.compound.CompleteTreeTool
 import io.github.jpicklyk.mcptask.current.application.tools.compound.CreateWorkTreeTool
+import io.github.jpicklyk.mcptask.current.application.tools.config.ManageProjectConfigTool
 import io.github.jpicklyk.mcptask.current.application.tools.dependency.ManageDependenciesTool
 import io.github.jpicklyk.mcptask.current.application.tools.dependency.QueryDependenciesTool
 import io.github.jpicklyk.mcptask.current.application.tools.items.ManageItemsTool
@@ -391,6 +392,8 @@ internal fun buildMcpTools(): List<ToolDefinition> =
         CreateWorkTreeTool(),
         // Phase 3: Context
         GetContextTool(),
+        // Per-root schema layering: transport-agnostic config sync
+        ManageProjectConfigTool(),
     )
 
 /**

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/ServerComposition.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/ServerComposition.kt
@@ -12,6 +12,7 @@ import io.github.jpicklyk.mcptask.current.infrastructure.config.ApiAuthConfigLoa
 import io.github.jpicklyk.mcptask.current.infrastructure.config.AppConfig
 import io.github.jpicklyk.mcptask.current.infrastructure.config.DefaultJwksKeySetProvider
 import io.github.jpicklyk.mcptask.current.infrastructure.config.JwksActorVerifier
+import io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService
 import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlActorAuthenticationConfigService
 import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlNoteSchemaService
 import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlStatusLabelService
@@ -121,6 +122,10 @@ class ServerComposition(
                 effectiveProvider.workItemRepository(),
                 effectiveProvider.dependencyRepository(),
             )
+        // Per-root schema layer (T3.2): resolveSchema() consults this root's pushed config before
+        // falling back to the global noteSchemaService above. Shares effectiveProvider so MCP tools
+        // and REST routes see the same (possibly event-publishing-decorated) project_config access.
+        val perRootConfigService = PerRootConfigService(effectiveProvider.projectConfigRepository())
         val toolContext =
             ToolExecutionContext(
                 effectiveProvider,
@@ -131,6 +136,7 @@ class ServerComposition(
                 degradedModePolicy,
                 idempotencyCache,
                 nextItemRecommender,
+                perRootConfigService,
             )
         logger.info(
             "Repository provider and tool context initialized (API {})",

--- a/current/src/main/resources/db/migration/V10__Project_Config.sql
+++ b/current/src/main/resources/db/migration/V10__Project_Config.sql
@@ -1,0 +1,28 @@
+-- V10: Per-root project configuration storage
+--
+-- Adds `project_config`, a one-row-per-root table holding a raw YAML config document scoped to a
+-- single project root (a depth-0 WorkItem, identified by root_item_id). This is the storage layer
+-- for per-root schema/trait overrides (T3.2 resolveSchema integration and T3.3 MCP tool surface
+-- build on top of this table via PerRootConfigService — neither is touched by this migration).
+--
+-- Pure CREATE TABLE — no ALTER COLUMN, no table recreation. Follows the exact conventions of the
+-- existing single-parent-FK tables (see notes / dependencies / role_transitions above): BLOB id
+-- with a randomblob(16) default, a plain (non-inline-UNIQUE) column plus a separate
+-- CREATE UNIQUE INDEX statement for the uniqueness constraint, and `ON DELETE CASCADE` on the FK
+-- to work_items(id) — enforced because this project turns on `PRAGMA foreign_keys = ON` at
+-- connection time (see DatabaseManager.initialize), unlike the root_id column added in V9 which
+-- deliberately omits a FK (self-reference at insert time, not applicable here).
+--
+-- One row per root: root_item_id is NOT NULL and unique — a root can have at most one
+-- project_config row. Upserts (via PerRootConfigService / ProjectConfigRepository) replace the
+-- existing row's config_yaml/fingerprint/updated_at rather than inserting a second row.
+
+CREATE TABLE project_config (
+    id              BLOB PRIMARY KEY DEFAULT (randomblob(16)),
+    root_item_id    BLOB NOT NULL REFERENCES work_items(id) ON DELETE CASCADE,
+    config_yaml     TEXT NOT NULL,
+    fingerprint     TEXT NOT NULL,
+    updated_at      TIMESTAMP NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_project_config_root_item_id ON project_config(root_item_id);

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolDocumentationConsistencyTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolDocumentationConsistencyTest.kt
@@ -2,6 +2,7 @@ package io.github.jpicklyk.mcptask.current.application.tools
 
 import io.github.jpicklyk.mcptask.current.application.tools.compound.CompleteTreeTool
 import io.github.jpicklyk.mcptask.current.application.tools.compound.CreateWorkTreeTool
+import io.github.jpicklyk.mcptask.current.application.tools.config.ManageProjectConfigTool
 import io.github.jpicklyk.mcptask.current.application.tools.dependency.ManageDependenciesTool
 import io.github.jpicklyk.mcptask.current.application.tools.dependency.QueryDependenciesTool
 import io.github.jpicklyk.mcptask.current.application.tools.items.ManageItemsTool
@@ -57,6 +58,7 @@ class ToolDocumentationConsistencyTest {
             GetNextStatusTool(),
             CompleteTreeTool(),
             CreateWorkTreeTool(),
+            ManageProjectConfigTool(),
         )
 
     @Test

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContextPerRootIntegrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContextPerRootIntegrationTest.kt
@@ -1,0 +1,147 @@
+package io.github.jpicklyk.mcptask.current.application.tools
+
+import io.github.jpicklyk.mcptask.current.application.service.NoteSchemaService
+import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteProjectConfigRepository
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteWorkItemRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * DB-backed integration test proving [ToolExecutionContext.resolveSchema] actually layers a
+ * REAL [PerRootConfigService] (backed by a real `project_config` row via
+ * [SQLiteProjectConfigRepository]) over the global [NoteSchemaService] mock — as opposed to the
+ * sibling [ToolExecutionContextResolveSchemaTest], which mocks [PerRootConfigService] itself and
+ * therefore never exercises the DB round-trip or [io.github.jpicklyk.mcptask.current.infrastructure.config.YamlSchemaParser]
+ * parsing path.
+ *
+ * Scenario: two project roots share one [ToolExecutionContext]. Root A has a per-root config
+ * pushed for it; root B does not. An item under root A resolves the per-root schema; a sibling
+ * item under root B (same type) resolves the global schema unchanged.
+ */
+class ToolExecutionContextPerRootIntegrationTest {
+    private lateinit var database: Database
+    private lateinit var databaseManager: DatabaseManager
+    private lateinit var perRootConfigService: PerRootConfigService
+    private lateinit var noteSchemaService: NoteSchemaService
+    private lateinit var context: ToolExecutionContext
+    private lateinit var rootWithConfig: UUID
+    private lateinit var rootWithoutConfig: UUID
+
+    private val globalSchema =
+        WorkItemSchema(
+            type = "feature-task",
+            notes = listOf(NoteSchemaEntry(key = "global-note", role = Role.WORK, required = false))
+        )
+
+    @BeforeEach
+    fun setUp() =
+        runBlocking {
+            val dbName = "test_${System.nanoTime()}"
+            database = Database.connect("jdbc:h2:mem:$dbName;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+            databaseManager = DatabaseManager(database)
+            DirectDatabaseSchemaManager().updateSchema()
+
+            val repository = SQLiteProjectConfigRepository(databaseManager)
+            perRootConfigService = PerRootConfigService(repository)
+
+            // project_config.root_item_id has a real FK to work_items(id) — both roots must exist
+            // as actual WorkItem rows, or upsert() below fails its FK check (caught internally by
+            // suspendedTransaction and returned as a silent Result.Error, never an exception).
+            val workItemRepository = SQLiteWorkItemRepository(databaseManager)
+            val rootA = workItemRepository.create(WorkItem(title = "Root With Config"))
+            val rootB = workItemRepository.create(WorkItem(title = "Root Without Config"))
+            rootWithConfig = (rootA as Result.Success).data.id
+            rootWithoutConfig = (rootB as Result.Success).data.id
+
+            val perRootYaml =
+                """
+                work_item_schemas:
+                  feature-task:
+                    notes:
+                      - key: per-root-note
+                        role: work
+                        required: false
+                """.trimIndent()
+            val upsertResult = repository.upsert(rootWithConfig, perRootYaml)
+            assertTrue(
+                upsertResult is Result.Success,
+                "Test setup precondition: per-root config upsert must succeed, got $upsertResult"
+            )
+            // rootWithoutConfig intentionally has no pushed config row.
+
+            noteSchemaService = mockk()
+            every { noteSchemaService.getSchemaForType("feature-task") } returns globalSchema
+            every { noteSchemaService.getSchemaForTags(any()) } returns null
+            every { noteSchemaService.getDefaultTraits(any()) } returns emptyList()
+            every { noteSchemaService.getTraitNotes(any()) } returns null
+
+            val repositoryProvider = mockk<RepositoryProvider>(relaxed = true)
+            context =
+                ToolExecutionContext(
+                    repositoryProvider,
+                    noteSchemaService,
+                    perRootConfigService = perRootConfigService
+                )
+        }
+
+    private fun makeItem(
+        rootId: UUID?,
+        type: String = "feature-task"
+    ): WorkItem =
+        WorkItem(
+            id = UUID.randomUUID(),
+            title = "Test Item",
+            type = type,
+            rootId = rootId,
+            depth = 0
+        )
+
+    @Test
+    fun `item under a root with pushed config resolves the per-root schema`() =
+        runBlocking {
+            val item = makeItem(rootId = rootWithConfig)
+
+            val result = context.resolveSchema(item)
+
+            assertNotNull(result)
+            assertEquals(1, result.notes.size)
+            assertEquals("per-root-note", result.notes[0].key, "Must resolve the per-root note, not the global one")
+        }
+
+    @Test
+    fun `sibling item under a root with no pushed config resolves the global schema unchanged`() =
+        runBlocking {
+            val item = makeItem(rootId = rootWithoutConfig)
+
+            val result = context.resolveSchema(item)
+
+            assertEquals(globalSchema, result, "No config row for this root — must fall through to the global schema untouched")
+        }
+
+    @Test
+    fun `item with null rootId resolves the global schema unchanged`() =
+        runBlocking {
+            val item = makeItem(rootId = null)
+
+            val result = context.resolveSchema(item)
+
+            assertEquals(globalSchema, result)
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContextResolveSchemaTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContextResolveSchemaTest.kt
@@ -2,9 +2,14 @@ package io.github.jpicklyk.mcptask.current.application.tools
 
 import io.github.jpicklyk.mcptask.current.application.service.NoteSchemaService
 import io.github.jpicklyk.mcptask.current.domain.model.*
+import io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.UUID
@@ -47,13 +52,15 @@ class ToolExecutionContextResolveSchemaTest {
 
     private fun makeItem(
         type: String? = null,
-        tags: String? = null
+        tags: String? = null,
+        rootId: UUID? = null
     ): WorkItem =
         WorkItem(
             id = UUID.randomUUID(),
             title = "Test Item",
             type = type,
             tags = tags,
+            rootId = rootId,
             // need parentId=null and depth=0 to be valid
             depth = 0
         )
@@ -71,132 +78,142 @@ class ToolExecutionContextResolveSchemaTest {
     // ──────────────────────────────────────────────
 
     @Test
-    fun `resolveSchema returns type-based schema when item has type and schema exists`() {
-        val item = makeItem(type = "feature-task", tags = "some-tag")
-        val expected = schemaWithReview("feature-task")
+    fun `resolveSchema returns type-based schema when item has type and schema exists`() =
+        runBlocking {
+            val item = makeItem(type = "feature-task", tags = "some-tag")
+            val expected = schemaWithReview("feature-task")
 
-        every { noteSchemaService.getSchemaForType("feature-task") } returns expected
-        // Tags should NOT be consulted when type lookup succeeds
-        every { noteSchemaService.getSchemaForTags(any()) } throws AssertionError("should not call getSchemaForTags")
+            every { noteSchemaService.getSchemaForType("feature-task") } returns expected
+            // Tags should NOT be consulted when type lookup succeeds
+            every { noteSchemaService.getSchemaForTags(any()) } throws AssertionError("should not call getSchemaForTags")
 
-        val result = context.resolveSchema(item)
-        assertEquals(expected, result)
-    }
+            val result = context.resolveSchema(item)
+            assertEquals(expected, result)
+        }
 
     @Test
-    fun `resolveSchema falls back to tag lookup when type lookup returns null`() {
-        val item = makeItem(type = "unknown-type", tags = "feature-task")
-        val tagSchema = schemaWithReview("feature-task")
+    fun `resolveSchema falls back to tag lookup when type lookup returns null`() =
+        runBlocking {
+            val item = makeItem(type = "unknown-type", tags = "feature-task")
+            val tagSchema = schemaWithReview("feature-task")
 
-        every { noteSchemaService.getSchemaForType("unknown-type") } returns null
-        every { noteSchemaService.getSchemaForTags(listOf("feature-task")) } returns tagSchema.notes
+            every { noteSchemaService.getSchemaForType("unknown-type") } returns null
+            every { noteSchemaService.getSchemaForTags(listOf("feature-task")) } returns tagSchema.notes
 
-        val result = context.resolveSchema(item)
-        assertNotNull(result)
-        assertTrue(result.hasReviewPhase())
-        assertEquals(tagSchema.notes, result.notes)
-    }
+            val result = context.resolveSchema(item)
+            assertNotNull(result)
+            assertTrue(result.hasReviewPhase())
+            assertEquals(tagSchema.notes, result.notes)
+        }
 
     // ──────────────────────────────────────────────
     // No-type items use tag lookup
     // ──────────────────────────────────────────────
 
     @Test
-    fun `resolveSchema uses tag lookup when item has no type`() {
-        val item = makeItem(type = null, tags = "feature-task")
-        val tagSchema = schemaWithReview("feature-task")
+    fun `resolveSchema uses tag lookup when item has no type`() =
+        runBlocking {
+            val item = makeItem(type = null, tags = "feature-task")
+            val tagSchema = schemaWithReview("feature-task")
 
-        every { noteSchemaService.getSchemaForTags(listOf("feature-task")) } returns tagSchema.notes
+            every { noteSchemaService.getSchemaForTags(listOf("feature-task")) } returns tagSchema.notes
 
-        val result = context.resolveSchema(item)
-        assertNotNull(result)
-        assertEquals(tagSchema.notes, result.notes)
-    }
-
-    @Test
-    fun `resolveSchema returns null when no type and tag lookup returns null`() {
-        val item = makeItem(type = null, tags = "unmatched-tag")
-
-        every { noteSchemaService.getSchemaForTags(listOf("unmatched-tag")) } returns null
-
-        val result = context.resolveSchema(item)
-        assertNull(result)
-    }
+            val result = context.resolveSchema(item)
+            assertNotNull(result)
+            assertEquals(tagSchema.notes, result.notes)
+        }
 
     @Test
-    fun `resolveSchema returns null for schema-free item with no type and no tags`() {
-        val item = makeItem(type = null, tags = null)
+    fun `resolveSchema returns null when no type and tag lookup returns null`() =
+        runBlocking {
+            val item = makeItem(type = null, tags = "unmatched-tag")
 
-        every { noteSchemaService.getSchemaForTags(emptyList()) } returns null
+            every { noteSchemaService.getSchemaForTags(listOf("unmatched-tag")) } returns null
 
-        val result = context.resolveSchema(item)
-        assertNull(result)
-    }
+            val result = context.resolveSchema(item)
+            assertNull(result)
+        }
 
     @Test
-    fun `resolveSchema returns default schema when item has no tags and getSchemaForTags returns default entries`() {
-        val item = makeItem(type = null, tags = null)
-        val defaultEntries = listOf(workEntry())
+    fun `resolveSchema returns null for schema-free item with no type and no tags`() =
+        runBlocking {
+            val item = makeItem(type = null, tags = null)
 
-        // Service returns a default schema for empty tag list (internal fallback in YamlNoteSchemaService)
-        every { noteSchemaService.getSchemaForTags(emptyList()) } returns defaultEntries
+            every { noteSchemaService.getSchemaForTags(emptyList()) } returns null
 
-        val result = context.resolveSchema(item)
-        assertNotNull(result)
-        assertEquals("default", result.type)
-        assertEquals(defaultEntries, result.notes)
-    }
+            val result = context.resolveSchema(item)
+            assertNull(result)
+        }
+
+    @Test
+    fun `resolveSchema returns default schema when item has no tags and getSchemaForTags returns default entries`() =
+        runBlocking {
+            val item = makeItem(type = null, tags = null)
+            val defaultEntries = listOf(workEntry())
+
+            // Service returns a default schema for empty tag list (internal fallback in YamlNoteSchemaService)
+            every { noteSchemaService.getSchemaForTags(emptyList()) } returns defaultEntries
+
+            val result = context.resolveSchema(item)
+            assertNotNull(result)
+            assertEquals("default", result.type)
+            assertEquals(defaultEntries, result.notes)
+        }
 
     // ──────────────────────────────────────────────
     // Multi-tag items: first-match semantics
     // ──────────────────────────────────────────────
 
     @Test
-    fun `resolveSchema uses first matching tag when multiple tags and first has no schema`() {
-        val item = makeItem(type = null, tags = "no-match, feature-task")
+    fun `resolveSchema uses first matching tag when multiple tags and first has no schema`() =
+        runBlocking {
+            val item = makeItem(type = null, tags = "no-match, feature-task")
 
-        // Full list lookup returns the schema (first-match logic inside service)
-        every { noteSchemaService.getSchemaForTags(listOf("no-match", "feature-task")) } returns
-            schemaWithReview("feature-task").notes
+            // Full list lookup returns the schema (first-match logic inside service)
+            every { noteSchemaService.getSchemaForTags(listOf("no-match", "feature-task")) } returns
+                schemaWithReview("feature-task").notes
 
-        // Individual tag lookups used to determine matched key
-        every { noteSchemaService.getSchemaForTags(listOf("no-match")) } returns null
-        every { noteSchemaService.getSchemaForTags(listOf("feature-task")) } returns
-            schemaWithReview("feature-task").notes
+            // Individual tag lookups used to determine matched key
+            every { noteSchemaService.getSchemaForTags(listOf("no-match")) } returns null
+            every { noteSchemaService.getSchemaForTags(listOf("feature-task")) } returns
+                schemaWithReview("feature-task").notes
 
-        val result = context.resolveSchema(item)
-        assertNotNull(result)
-        assertEquals("feature-task", result.type)
-        assertTrue(result.hasReviewPhase())
-    }
+            val result = context.resolveSchema(item)
+            assertNotNull(result)
+            assertEquals("feature-task", result.type)
+            assertTrue(result.hasReviewPhase())
+        }
 
     // ──────────────────────────────────────────────
     // resolveHasReviewPhase
     // ──────────────────────────────────────────────
 
     @Test
-    fun `resolveHasReviewPhase returns true when schema has review phase`() {
-        val item = makeItem(type = "feature-task")
-        every { noteSchemaService.getSchemaForType("feature-task") } returns schemaWithReview("feature-task")
+    fun `resolveHasReviewPhase returns true when schema has review phase`() =
+        runBlocking {
+            val item = makeItem(type = "feature-task")
+            every { noteSchemaService.getSchemaForType("feature-task") } returns schemaWithReview("feature-task")
 
-        assertTrue(context.resolveHasReviewPhase(item))
-    }
-
-    @Test
-    fun `resolveHasReviewPhase returns false when schema has no review phase`() {
-        val item = makeItem(type = "simple-task")
-        every { noteSchemaService.getSchemaForType("simple-task") } returns schemaWithoutReview("simple-task")
-
-        assertFalse(context.resolveHasReviewPhase(item))
-    }
+            assertTrue(context.resolveHasReviewPhase(item))
+        }
 
     @Test
-    fun `resolveHasReviewPhase returns false when no schema matches`() {
-        val item = makeItem(type = null, tags = null)
-        every { noteSchemaService.getSchemaForTags(emptyList()) } returns null
+    fun `resolveHasReviewPhase returns false when schema has no review phase`() =
+        runBlocking {
+            val item = makeItem(type = "simple-task")
+            every { noteSchemaService.getSchemaForType("simple-task") } returns schemaWithoutReview("simple-task")
 
-        assertFalse(context.resolveHasReviewPhase(item))
-    }
+            assertFalse(context.resolveHasReviewPhase(item))
+        }
+
+    @Test
+    fun `resolveHasReviewPhase returns false when no schema matches`() =
+        runBlocking {
+            val item = makeItem(type = null, tags = null)
+            every { noteSchemaService.getSchemaForTags(emptyList()) } returns null
+
+            assertFalse(context.resolveHasReviewPhase(item))
+        }
 
     // ──────────────────────────────────────────────
     // Trait merging
@@ -222,227 +239,377 @@ class ToolExecutionContextResolveSchemaTest {
     ): NoteSchemaEntry = NoteSchemaEntry(key = key, role = role, required = true, description = "Trait note: $key")
 
     @Test
-    fun `resolveSchema merges trait notes after base schema notes`() {
-        val baseSchema =
-            WorkItemSchema(
-                type = "feature-task",
-                notes = listOf(workEntry()),
-                defaultTraits = listOf("needs-security-review")
-            )
-        every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
-        every { noteSchemaService.getTraitNotes("needs-security-review") } returns listOf(traitEntry("security-assessment"))
-        every { noteSchemaService.getDefaultTraits("feature-task") } returns listOf("needs-security-review")
+    fun `resolveSchema merges trait notes after base schema notes`() =
+        runBlocking {
+            val baseSchema =
+                WorkItemSchema(
+                    type = "feature-task",
+                    notes = listOf(workEntry()),
+                    defaultTraits = listOf("needs-security-review")
+                )
+            every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
+            every { noteSchemaService.getTraitNotes("needs-security-review") } returns listOf(traitEntry("security-assessment"))
+            every { noteSchemaService.getDefaultTraits("feature-task") } returns listOf("needs-security-review")
 
-        val item = makeItem(type = "feature-task")
-        val result = context.resolveSchema(item)!!
+            val item = makeItem(type = "feature-task")
+            val result = context.resolveSchema(item)!!
 
-        assertEquals(2, result.notes.size)
-        assertEquals("work-note", result.notes[0].key)
-        assertEquals("security-assessment", result.notes[1].key)
-    }
-
-    @Test
-    fun `resolveSchema base key wins over trait key with same name`() {
-        val baseSchema =
-            WorkItemSchema(
-                type = "feature-task",
-                notes = listOf(NoteSchemaEntry(key = "shared-key", role = Role.WORK, required = false, description = "base")),
-                defaultTraits = listOf("my-trait")
-            )
-        every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
-        every { noteSchemaService.getTraitNotes("my-trait") } returns
-            listOf(
-                NoteSchemaEntry(key = "shared-key", role = Role.REVIEW, required = true, description = "trait")
-            )
-        every { noteSchemaService.getDefaultTraits("feature-task") } returns listOf("my-trait")
-
-        val item = makeItem(type = "feature-task")
-        val result = context.resolveSchema(item)!!
-
-        assertEquals(1, result.notes.size)
-        assertEquals("base", result.notes[0].description)
-    }
+            assertEquals(2, result.notes.size)
+            assertEquals("work-note", result.notes[0].key)
+            assertEquals("security-assessment", result.notes[1].key)
+        }
 
     @Test
-    fun `resolveSchema skips unknown traits with no error`() {
-        val baseSchema =
-            WorkItemSchema(
-                type = "feature-task",
-                notes = listOf(workEntry()),
-                defaultTraits = listOf("nonexistent-trait")
-            )
-        every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
-        every { noteSchemaService.getTraitNotes("nonexistent-trait") } returns null
-        every { noteSchemaService.getDefaultTraits("feature-task") } returns listOf("nonexistent-trait")
+    fun `resolveSchema base key wins over trait key with same name`() =
+        runBlocking {
+            val baseSchema =
+                WorkItemSchema(
+                    type = "feature-task",
+                    notes = listOf(NoteSchemaEntry(key = "shared-key", role = Role.WORK, required = false, description = "base")),
+                    defaultTraits = listOf("my-trait")
+                )
+            every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
+            every { noteSchemaService.getTraitNotes("my-trait") } returns
+                listOf(
+                    NoteSchemaEntry(key = "shared-key", role = Role.REVIEW, required = true, description = "trait")
+                )
+            every { noteSchemaService.getDefaultTraits("feature-task") } returns listOf("my-trait")
 
-        val item = makeItem(type = "feature-task")
-        val result = context.resolveSchema(item)!!
+            val item = makeItem(type = "feature-task")
+            val result = context.resolveSchema(item)!!
 
-        assertEquals(1, result.notes.size)
-        assertEquals("work-note", result.notes[0].key)
-    }
-
-    @Test
-    fun `resolveSchema merges per-item traits from properties JSON`() {
-        val baseSchema = WorkItemSchema(type = "feature-task", notes = listOf(workEntry()))
-        every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
-        every { noteSchemaService.getTraitNotes("needs-perf-review") } returns listOf(traitEntry("performance-baseline", Role.QUEUE))
-        every { noteSchemaService.getDefaultTraits("feature-task") } returns emptyList()
-
-        val item =
-            makeItemWithProperties(
-                type = "feature-task",
-                properties = """{"traits": ["needs-perf-review"]}"""
-            )
-        val result = context.resolveSchema(item)!!
-
-        assertEquals(2, result.notes.size)
-        assertEquals("performance-baseline", result.notes[1].key)
-    }
+            assertEquals(1, result.notes.size)
+            assertEquals("base", result.notes[0].description)
+        }
 
     @Test
-    fun `resolveSchema unions default and per-item traits with deduplication`() {
-        val baseSchema =
-            WorkItemSchema(
-                type = "feature-task",
-                notes = listOf(workEntry()),
-                defaultTraits = listOf("trait-a")
-            )
-        every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
-        every { noteSchemaService.getTraitNotes("trait-a") } returns listOf(traitEntry("note-a"))
-        every { noteSchemaService.getTraitNotes("trait-b") } returns listOf(traitEntry("note-b"))
-        every { noteSchemaService.getDefaultTraits("feature-task") } returns listOf("trait-a")
+    fun `resolveSchema skips unknown traits with no error`() =
+        runBlocking {
+            val baseSchema =
+                WorkItemSchema(
+                    type = "feature-task",
+                    notes = listOf(workEntry()),
+                    defaultTraits = listOf("nonexistent-trait")
+                )
+            every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
+            every { noteSchemaService.getTraitNotes("nonexistent-trait") } returns null
+            every { noteSchemaService.getDefaultTraits("feature-task") } returns listOf("nonexistent-trait")
 
-        val item =
-            makeItemWithProperties(
-                type = "feature-task",
-                properties = """{"traits": ["trait-a", "trait-b"]}"""
-            )
-        val result = context.resolveSchema(item)!!
+            val item = makeItem(type = "feature-task")
+            val result = context.resolveSchema(item)!!
 
-        assertEquals(3, result.notes.size)
-        assertEquals("note-a", result.notes[1].key)
-        assertEquals("note-b", result.notes[2].key)
-    }
+            assertEquals(1, result.notes.size)
+            assertEquals("work-note", result.notes[0].key)
+        }
 
     @Test
-    fun `resolveSchema returns base schema unchanged when no traits`() {
-        val baseSchema = WorkItemSchema(type = "feature-task", notes = listOf(workEntry()))
-        every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
-        every { noteSchemaService.getDefaultTraits("feature-task") } returns emptyList()
+    fun `resolveSchema merges per-item traits from properties JSON`() =
+        runBlocking {
+            val baseSchema = WorkItemSchema(type = "feature-task", notes = listOf(workEntry()))
+            every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
+            every { noteSchemaService.getTraitNotes("needs-perf-review") } returns listOf(traitEntry("performance-baseline", Role.QUEUE))
+            every { noteSchemaService.getDefaultTraits("feature-task") } returns emptyList()
 
-        val item = makeItem(type = "feature-task")
-        val result = context.resolveSchema(item)!!
+            val item =
+                makeItemWithProperties(
+                    type = "feature-task",
+                    properties = """{"traits": ["needs-perf-review"]}"""
+                )
+            val result = context.resolveSchema(item)!!
 
-        assertEquals(baseSchema, result)
-    }
-
-    @Test
-    fun `resolveHasReviewPhase returns true when trait adds review note`() {
-        val baseSchema =
-            WorkItemSchema(
-                type = "feature-task",
-                notes = listOf(workEntry()),
-                defaultTraits = listOf("needs-review-trait")
-            )
-        every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
-        every { noteSchemaService.getTraitNotes("needs-review-trait") } returns listOf(traitEntry("review-from-trait", Role.REVIEW))
-        every { noteSchemaService.getDefaultTraits("feature-task") } returns listOf("needs-review-trait")
-
-        val item = makeItem(type = "feature-task")
-        assertTrue(context.resolveHasReviewPhase(item))
-    }
+            assertEquals(2, result.notes.size)
+            assertEquals("performance-baseline", result.notes[1].key)
+        }
 
     @Test
-    fun `resolveSchema first trait wins for duplicate trait note keys`() {
-        val baseSchema =
-            WorkItemSchema(
-                type = "feature-task",
-                notes = listOf(workEntry()),
-                defaultTraits = listOf("trait-a", "trait-b")
-            )
-        every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
-        every { noteSchemaService.getTraitNotes("trait-a") } returns
-            listOf(
-                NoteSchemaEntry(key = "duplicate-key", role = Role.REVIEW, required = true, description = "from trait-a")
-            )
-        every { noteSchemaService.getTraitNotes("trait-b") } returns
-            listOf(
-                NoteSchemaEntry(key = "duplicate-key", role = Role.QUEUE, required = false, description = "from trait-b")
-            )
-        every { noteSchemaService.getDefaultTraits("feature-task") } returns listOf("trait-a", "trait-b")
+    fun `resolveSchema unions default and per-item traits with deduplication`() =
+        runBlocking {
+            val baseSchema =
+                WorkItemSchema(
+                    type = "feature-task",
+                    notes = listOf(workEntry()),
+                    defaultTraits = listOf("trait-a")
+                )
+            every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
+            every { noteSchemaService.getTraitNotes("trait-a") } returns listOf(traitEntry("note-a"))
+            every { noteSchemaService.getTraitNotes("trait-b") } returns listOf(traitEntry("note-b"))
+            every { noteSchemaService.getDefaultTraits("feature-task") } returns listOf("trait-a")
 
-        val item = makeItem(type = "feature-task")
-        val result = context.resolveSchema(item)!!
+            val item =
+                makeItemWithProperties(
+                    type = "feature-task",
+                    properties = """{"traits": ["trait-a", "trait-b"]}"""
+                )
+            val result = context.resolveSchema(item)!!
 
-        assertEquals(2, result.notes.size)
-        assertEquals("from trait-a", result.notes[1].description)
-    }
+            assertEquals(3, result.notes.size)
+            assertEquals("note-a", result.notes[1].key)
+            assertEquals("note-b", result.notes[2].key)
+        }
+
+    @Test
+    fun `resolveSchema returns base schema unchanged when no traits`() =
+        runBlocking {
+            val baseSchema = WorkItemSchema(type = "feature-task", notes = listOf(workEntry()))
+            every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
+            every { noteSchemaService.getDefaultTraits("feature-task") } returns emptyList()
+
+            val item = makeItem(type = "feature-task")
+            val result = context.resolveSchema(item)!!
+
+            assertEquals(baseSchema, result)
+        }
+
+    @Test
+    fun `resolveHasReviewPhase returns true when trait adds review note`() =
+        runBlocking {
+            val baseSchema =
+                WorkItemSchema(
+                    type = "feature-task",
+                    notes = listOf(workEntry()),
+                    defaultTraits = listOf("needs-review-trait")
+                )
+            every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
+            every { noteSchemaService.getTraitNotes("needs-review-trait") } returns listOf(traitEntry("review-from-trait", Role.REVIEW))
+            every { noteSchemaService.getDefaultTraits("feature-task") } returns listOf("needs-review-trait")
+
+            val item = makeItem(type = "feature-task")
+            assertTrue(context.resolveHasReviewPhase(item))
+        }
+
+    @Test
+    fun `resolveSchema first trait wins for duplicate trait note keys`() =
+        runBlocking {
+            val baseSchema =
+                WorkItemSchema(
+                    type = "feature-task",
+                    notes = listOf(workEntry()),
+                    defaultTraits = listOf("trait-a", "trait-b")
+                )
+            every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
+            every { noteSchemaService.getTraitNotes("trait-a") } returns
+                listOf(
+                    NoteSchemaEntry(key = "duplicate-key", role = Role.REVIEW, required = true, description = "from trait-a")
+                )
+            every { noteSchemaService.getTraitNotes("trait-b") } returns
+                listOf(
+                    NoteSchemaEntry(key = "duplicate-key", role = Role.QUEUE, required = false, description = "from trait-b")
+                )
+            every { noteSchemaService.getDefaultTraits("feature-task") } returns listOf("trait-a", "trait-b")
+
+            val item = makeItem(type = "feature-task")
+            val result = context.resolveSchema(item)!!
+
+            assertEquals(2, result.notes.size)
+            assertEquals("from trait-a", result.notes[1].description)
+        }
 
     // ──────────────────────────────────────────────
     // Bug regression: schema fallback preserves lifecycleMode + defaultTraits (Bug 5)
     // ──────────────────────────────────────────────
 
     @Test
-    fun `resolveSchema preserves lifecycleMode and defaultTraits on default fallback (bug 5 regression)`() {
-        // Scenario: item has tags ["bug","tools-layer"], no type set.
-        // No individual tag matches a schema.
-        // getSchemaForTags(["bug","tools-layer"]) falls back to default entries.
-        // getSchemaForType("default") returns a WorkItemSchema with MANUAL lifecycle + defaultTraits.
-        // Before fix: getSchemaForTags was called a THIRD time in the fallback constructor.
-        //   (Redundant, but functionally equivalent — the real risk is a future refactor breaks capture.)
-        //   The fix captures tagNotes once and reuses them. Verified via: getSchemaForType("default") returned.
-        val item = makeItem(type = null, tags = "bug,tools-layer")
-        val defaultNotes = listOf(workEntry())
-        val defaultSchema =
-            WorkItemSchema(
-                type = "default",
-                lifecycleMode = LifecycleMode.MANUAL,
-                notes = defaultNotes,
-                defaultTraits = listOf("some-trait")
+    fun `resolveSchema preserves lifecycleMode and defaultTraits on default fallback (bug 5 regression)`() =
+        runBlocking {
+            // Scenario: item has tags ["bug","tools-layer"], no type set.
+            // No individual tag matches a schema.
+            // getSchemaForTags(["bug","tools-layer"]) falls back to default entries.
+            // getSchemaForType("default") returns a WorkItemSchema with MANUAL lifecycle + defaultTraits.
+            // Before fix: getSchemaForTags was called a THIRD time in the fallback constructor.
+            //   (Redundant, but functionally equivalent — the real risk is a future refactor breaks capture.)
+            //   The fix captures tagNotes once and reuses them. Verified via: getSchemaForType("default") returned.
+            val item = makeItem(type = null, tags = "bug,tools-layer")
+            val defaultNotes = listOf(workEntry())
+            val defaultSchema =
+                WorkItemSchema(
+                    type = "default",
+                    lifecycleMode = LifecycleMode.MANUAL,
+                    notes = defaultNotes,
+                    defaultTraits = listOf("some-trait")
+                )
+
+            // Individual tag lookups return null (neither "bug" nor "tools-layer" matches)
+            every { noteSchemaService.getSchemaForTags(listOf("bug")) } returns null
+            every { noteSchemaService.getSchemaForTags(listOf("tools-layer")) } returns null
+            // Full tag list lookup falls back to default schema entries
+            every { noteSchemaService.getSchemaForTags(listOf("bug", "tools-layer")) } returns defaultNotes
+            // getSchemaForType("default") returns the full WorkItemSchema with lifecycle + traits
+            every { noteSchemaService.getSchemaForType("default") } returns defaultSchema
+
+            val result = context.resolveSchema(item)
+            assertNotNull(result, "Should return a schema (default fallback)")
+            assertEquals("default", result.type)
+            assertEquals(
+                LifecycleMode.MANUAL,
+                result.lifecycleMode,
+                "lifecycleMode must be preserved from the WorkItemSchema returned by getSchemaForType"
             )
-
-        // Individual tag lookups return null (neither "bug" nor "tools-layer" matches)
-        every { noteSchemaService.getSchemaForTags(listOf("bug")) } returns null
-        every { noteSchemaService.getSchemaForTags(listOf("tools-layer")) } returns null
-        // Full tag list lookup falls back to default schema entries
-        every { noteSchemaService.getSchemaForTags(listOf("bug", "tools-layer")) } returns defaultNotes
-        // getSchemaForType("default") returns the full WorkItemSchema with lifecycle + traits
-        every { noteSchemaService.getSchemaForType("default") } returns defaultSchema
-
-        val result = context.resolveSchema(item)
-        assertNotNull(result, "Should return a schema (default fallback)")
-        assertEquals("default", result.type)
-        assertEquals(
-            LifecycleMode.MANUAL,
-            result.lifecycleMode,
-            "lifecycleMode must be preserved from the WorkItemSchema returned by getSchemaForType"
-        )
-        assertEquals(listOf("some-trait"), result.defaultTraits, "defaultTraits must be preserved from the WorkItemSchema")
-        assertEquals(defaultNotes, result.notes)
-    }
+            assertEquals(listOf("some-trait"), result.defaultTraits, "defaultTraits must be preserved from the WorkItemSchema")
+            assertEquals(defaultNotes, result.notes)
+        }
 
     @Test
-    fun `resolveSchema uses captured tagNotes when getSchemaForType returns null (bug 5 graceful fallback)`() {
-        // Scenario: item has multiple tags, none individually match a schema,
-        // getSchemaForTags(fullList) returns default notes (default fallback inside the service),
-        // but getSchemaForType("default") returns null (default not defined as a full WorkItemSchema).
-        // Before fix: getSchemaForTags(tags) was called a SECOND time inside the fallback constructor.
-        // After fix: tagNotes is captured once and reused — functionally equivalent, no redundant call.
-        val item = makeItem(type = null, tags = "bug,tools-layer")
-        val fallbackNotes = listOf(workEntry())
+    fun `resolveSchema uses captured tagNotes when getSchemaForType returns null (bug 5 graceful fallback)`() =
+        runBlocking {
+            // Scenario: item has multiple tags, none individually match a schema,
+            // getSchemaForTags(fullList) returns default notes (default fallback inside the service),
+            // but getSchemaForType("default") returns null (default not defined as a full WorkItemSchema).
+            // Before fix: getSchemaForTags(tags) was called a SECOND time inside the fallback constructor.
+            // After fix: tagNotes is captured once and reused — functionally equivalent, no redundant call.
+            val item = makeItem(type = null, tags = "bug,tools-layer")
+            val fallbackNotes = listOf(workEntry())
 
-        // Individual tag lookups return null — no single tag matches
-        every { noteSchemaService.getSchemaForTags(listOf("bug")) } returns null
-        every { noteSchemaService.getSchemaForTags(listOf("tools-layer")) } returns null
-        // Full tag list returns notes (service's internal default fallback)
-        every { noteSchemaService.getSchemaForTags(listOf("bug", "tools-layer")) } returns fallbackNotes
-        // getSchemaForType("default") returns null — no full WorkItemSchema defined for default
-        every { noteSchemaService.getSchemaForType("default") } returns null
+            // Individual tag lookups return null — no single tag matches
+            every { noteSchemaService.getSchemaForTags(listOf("bug")) } returns null
+            every { noteSchemaService.getSchemaForTags(listOf("tools-layer")) } returns null
+            // Full tag list returns notes (service's internal default fallback)
+            every { noteSchemaService.getSchemaForTags(listOf("bug", "tools-layer")) } returns fallbackNotes
+            // getSchemaForType("default") returns null — no full WorkItemSchema defined for default
+            every { noteSchemaService.getSchemaForType("default") } returns null
 
-        val result = context.resolveSchema(item)
-        assertNotNull(result, "Should return a bare schema using the captured tagNotes")
-        assertEquals("default", result.type)
-        assertEquals(fallbackNotes, result.notes, "Notes must come from the already-captured getSchemaForTags result — no redundant call")
-    }
+            val result = context.resolveSchema(item)
+            assertNotNull(result, "Should return a bare schema using the captured tagNotes")
+            assertEquals("default", result.type)
+            assertEquals(
+                fallbackNotes,
+                result.notes,
+                "Notes must come from the already-captured getSchemaForTags result — no redundant call"
+            )
+        }
+
+    // ──────────────────────────────────────────────
+    // T3.2: per-root config layering (perRootConfigService)
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `resolveSchema per-root type match overrides global type lookup`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>()
+            val perRootSchema = schemaWithReview("feature-task")
+            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns perRootSchema
+
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
+
+            val item = makeItem(type = "feature-task", rootId = rootId)
+            val result = ctx.resolveSchema(item)
+
+            assertEquals(perRootSchema, result)
+            // The global type lookup must be short-circuited once the per-root layer matches.
+            verify(exactly = 0) { noteSchemaService.getSchemaForType("feature-task") }
+        }
+
+    @Test
+    fun `resolveSchema per-root type miss falls through to global type lookup`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>()
+            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns null
+
+            val globalSchema = schemaWithReview("feature-task")
+            every { noteSchemaService.getSchemaForType("feature-task") } returns globalSchema
+
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
+
+            val item = makeItem(type = "feature-task", rootId = rootId)
+            val result = ctx.resolveSchema(item)
+
+            assertEquals(globalSchema, result)
+            coVerify(exactly = 1) { perRoot.getSchemaForType(rootId, "feature-task") }
+        }
+
+    @Test
+    fun `resolveSchema with null rootId skips the per-root layer entirely`() =
+        runBlocking {
+            val perRoot = mockk<PerRootConfigService>()
+            val globalSchema = schemaWithReview("feature-task")
+            every { noteSchemaService.getSchemaForType("feature-task") } returns globalSchema
+
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
+
+            val item = makeItem(type = "feature-task", rootId = null)
+            val result = ctx.resolveSchema(item)
+
+            assertEquals(globalSchema, result)
+            // Zero interactions with the per-root layer at all — not just the type-lookup method.
+            coVerify(exactly = 0) { perRoot.getSchemaForType(any(), any()) }
+            coVerify(exactly = 0) { perRoot.getSchemas(any()) }
+            coVerify(exactly = 0) { perRoot.getTraitNotes(any(), any()) }
+        }
+
+    @Test
+    fun `resolveSchema per-root trait notes override the global trait definition`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>()
+
+            val baseSchema =
+                WorkItemSchema(
+                    type = "feature-task",
+                    notes = listOf(workEntry()),
+                    defaultTraits = listOf("needs-perf-review")
+                )
+            // Type lookup misses per-root and falls to the global base schema — trait layering is
+            // independent of where the base schema itself came from.
+            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns null
+            every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
+            every { noteSchemaService.getDefaultTraits("feature-task") } returns listOf("needs-perf-review")
+
+            val perRootTraitNote = traitEntry("performance-baseline-per-root")
+            coEvery { perRoot.getTraitNotes(rootId, "needs-perf-review") } returns listOf(perRootTraitNote)
+
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
+
+            val item = makeItem(type = "feature-task", rootId = rootId)
+            val result = ctx.resolveSchema(item)!!
+
+            assertEquals(2, result.notes.size)
+            assertEquals("performance-baseline-per-root", result.notes[1].key)
+            // The global trait lookup must be short-circuited once the per-root layer provides notes.
+            verify(exactly = 0) { noteSchemaService.getTraitNotes("needs-perf-review") }
+        }
+
+    @Test
+    fun `resolveSchema per-root default schema wins in the tag fallback path`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>()
+            val perRootDefault = WorkItemSchema(type = "default", notes = listOf(workEntry()))
+            coEvery { perRoot.getSchemas(rootId) } returns mapOf("default" to perRootDefault)
+
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
+
+            val item = makeItem(type = null, tags = "unmatched-tag", rootId = rootId)
+            val result = ctx.resolveSchema(item)
+
+            assertEquals(perRootDefault, result)
+            // The global tag algorithm must be short-circuited once the per-root tag/"default" match resolves.
+            verify(exactly = 0) { noteSchemaService.getSchemaForTags(any()) }
+        }
+
+    @Test
+    fun `resolveSchema treats a null perRootConfigService identically to a per-root config miss`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val globalSchema = schemaWithReview("feature-task")
+            every { noteSchemaService.getSchemaForType("feature-task") } returns globalSchema
+
+            // No perRootConfigService wired at all (default null) — must behave exactly like a
+            // wired service that returns null for every call (e.g. a per-root config row that
+            // fails to parse). PerRootConfigService's contract treats "no row" and "parse failure"
+            // identically (both return null); this asserts resolveSchema treats "no service" the
+            // same way too, so all three collapse to the one "fall through to global" behavior.
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctxWithoutService = ToolExecutionContext(repoProvider, noteSchemaService)
+
+            val item = makeItem(type = "feature-task", rootId = rootId)
+            val result = ctxWithoutService.resolveSchema(item)
+
+            assertEquals(globalSchema, result)
+        }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
@@ -2,6 +2,7 @@ package io.github.jpicklyk.mcptask.current.application.tools
 
 import io.github.jpicklyk.mcptask.current.application.tools.compound.CompleteTreeTool
 import io.github.jpicklyk.mcptask.current.application.tools.compound.CreateWorkTreeTool
+import io.github.jpicklyk.mcptask.current.application.tools.config.ManageProjectConfigTool
 import io.github.jpicklyk.mcptask.current.application.tools.dependency.ManageDependenciesTool
 import io.github.jpicklyk.mcptask.current.application.tools.dependency.QueryDependenciesTool
 import io.github.jpicklyk.mcptask.current.application.tools.items.ManageItemsTool
@@ -74,6 +75,7 @@ class ToolTokenBudgetTest {
             GetNextStatusTool(),
             CompleteTreeTool(),
             CreateWorkTreeTool(),
+            ManageProjectConfigTool(),
         )
 
     /**
@@ -105,10 +107,11 @@ class ToolTokenBudgetTest {
             "advance_item" to 1450, // was 1407; see note above
             "get_blocked_items" to 1250, // was 830; T2.3 added the `ancestorId` scope parameter
             "get_next_status" to 470,
+            "manage_project_config" to 1900, // T3.3: new tool, measured 1609 chars
         )
 
     /** Sum of the (unrounded) measured-per-tool-values * 1.15; see BUDGET PHILOSOPHY point 2. */
-    private val totalCeiling = 37_650
+    private val totalCeiling = 39_550
 
     // explicitNulls = false mirrors the compact-wire-shape convention already used elsewhere
     // in this codebase (see EventRoutes.kt / ItemWriteRoutes.kt / NoteWriteRoutes.kt) — a

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigToolTest.kt
@@ -194,6 +194,43 @@ class ManageProjectConfigToolTest {
     }
 
     @Test
+    fun `push with a SnakeYAML type-tag payload is rejected as a parse error and stores nothing`() {
+        // A `!!`-tag payload attempting arbitrary Java object instantiation — the class of
+        // deserialization-RCE gadget SnakeYAML's unsafe default Constructor would build (CWE-502).
+        // With SafeConstructor wired in, this must be rejected at the tag-resolution stage, before
+        // any object is ever instantiated — proven here by asserting nothing gets stored, exactly
+        // like the "unparseable YAML" case above.
+        val maliciousYaml = "!!java.net.URL [\"http://169.254.169.254/latest/meta-data/\"]"
+
+        val result = push(rootId.toString(), maliciousYaml)
+
+        assertFalse(isSuccess(result))
+        assertEquals(ErrorCodes.VALIDATION_ERROR, errorOf(result)["code"]!!.jsonPrimitive.content)
+
+        val getResult = get(rootId.toString())
+        assertFalse(isSuccess(getResult))
+        assertEquals(ErrorCodes.RESOURCE_NOT_FOUND, errorOf(getResult)["code"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `push with oversized configYaml is rejected before any parse attempt`() {
+        val oversized = "x".repeat(ManageProjectConfigTool.MAX_CONFIG_YAML_BYTES + 1)
+
+        val result = push(rootId.toString(), oversized)
+
+        assertFalse(isSuccess(result))
+        val error = errorOf(result)
+        assertEquals(ErrorCodes.VALIDATION_ERROR, error["code"]!!.jsonPrimitive.content)
+        val message = error["message"]!!.jsonPrimitive.content
+        assertTrue(message.contains(ManageProjectConfigTool.MAX_CONFIG_YAML_BYTES.toString()))
+        assertTrue(message.contains((ManageProjectConfigTool.MAX_CONFIG_YAML_BYTES + 1).toString()))
+
+        val getResult = get(rootId.toString())
+        assertFalse(isSuccess(getResult))
+        assertEquals(ErrorCodes.RESOURCE_NOT_FOUND, errorOf(getResult)["code"]!!.jsonPrimitive.content)
+    }
+
+    @Test
     fun `idempotent re-push of identical content returns the same fingerprint`() {
         val first = push(rootId.toString(), validYaml)
         val second = push(rootId.toString(), validYaml)

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigToolTest.kt
@@ -1,0 +1,299 @@
+package io.github.jpicklyk.mcptask.current.application.tools.config
+
+import io.github.jpicklyk.mcptask.current.application.tools.ErrorCodes
+import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
+import io.github.jpicklyk.mcptask.current.application.tools.ToolValidationException
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteProjectConfigRepository
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteWorkItemRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.*
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Exercises [ManageProjectConfigTool] against a real H2-backed [SQLiteProjectConfigRepository] and
+ * [SQLiteWorkItemRepository] (mirroring [io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContextPerRootIntegrationTest]'s
+ * DB-backed style) rather than mocking the repository — push validation depends on real WorkItem
+ * rows (depth, type) and the parse-before-store contract depends on nothing being written when
+ * `configYaml` is invalid, both of which are easiest to prove against a real table.
+ */
+class ManageProjectConfigToolTest {
+    private lateinit var tool: ManageProjectConfigTool
+    private lateinit var databaseManager: DatabaseManager
+    private lateinit var workItemRepository: SQLiteWorkItemRepository
+    private lateinit var projectConfigRepository: SQLiteProjectConfigRepository
+    private lateinit var context: ToolExecutionContext
+    private lateinit var rootId: UUID
+
+    private val validYaml =
+        """
+        work_item_schemas:
+          feature-task:
+            notes:
+              - key: spec
+                role: queue
+                required: true
+        """.trimIndent()
+
+    @BeforeEach
+    fun setUp() =
+        runBlocking {
+            tool = ManageProjectConfigTool()
+
+            val dbName = "test_${System.nanoTime()}"
+            val database = Database.connect("jdbc:h2:mem:$dbName;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+            databaseManager = DatabaseManager(database)
+            DirectDatabaseSchemaManager().updateSchema()
+
+            workItemRepository = SQLiteWorkItemRepository(databaseManager)
+            projectConfigRepository = SQLiteProjectConfigRepository(databaseManager)
+
+            val repositoryProvider = mockk<RepositoryProvider>(relaxed = true)
+            every { repositoryProvider.workItemRepository() } returns workItemRepository
+            every { repositoryProvider.projectConfigRepository() } returns projectConfigRepository
+
+            context = ToolExecutionContext(repositoryProvider)
+
+            val root =
+                (workItemRepository.create(WorkItem(title = "Project Root", type = "project")) as Result.Success).data
+            rootId = root.id
+        }
+
+    private fun params(vararg pairs: Pair<String, JsonElement>) = JsonObject(mapOf(*pairs))
+
+    private fun isSuccess(result: JsonElement): Boolean = (result as JsonObject)["success"]!!.jsonPrimitive.boolean
+
+    private fun dataOf(result: JsonElement): JsonObject = (result as JsonObject)["data"] as JsonObject
+
+    private fun errorOf(result: JsonElement): JsonObject = (result as JsonObject)["error"] as JsonObject
+
+    private fun push(
+        rootItemId: String,
+        configYaml: String
+    ): JsonElement =
+        runBlocking {
+            tool.execute(
+                params(
+                    "operation" to JsonPrimitive("push"),
+                    "rootItemId" to JsonPrimitive(rootItemId),
+                    "configYaml" to JsonPrimitive(configYaml)
+                ),
+                context
+            )
+        }
+
+    private fun get(rootItemId: String): JsonElement =
+        runBlocking {
+            tool.execute(
+                params(
+                    "operation" to JsonPrimitive("get"),
+                    "rootItemId" to JsonPrimitive(rootItemId)
+                ),
+                context
+            )
+        }
+
+    // ──────────────────────────────────────────────
+    // push
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `push happy path returns fingerprint`() {
+        val result = push(rootId.toString(), validYaml)
+
+        assertTrue(isSuccess(result))
+        val data = dataOf(result)
+        assertEquals(rootId.toString(), data["rootItemId"]!!.jsonPrimitive.content)
+        assertFalse(data["fingerprint"]!!.jsonPrimitive.content.isBlank())
+        assertNotNull(data["updatedAt"])
+        assertNull(data["warning"], "root is type='project' — no warning expected")
+    }
+
+    @Test
+    fun `push with hex-prefix rootItemId resolves the item`() {
+        val prefix = rootId.toString().replace("-", "").take(8)
+
+        val result = push(prefix, validYaml)
+
+        assertTrue(isSuccess(result))
+        assertEquals(rootId.toString(), dataOf(result)["rootItemId"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `push to nonexistent root returns error`() {
+        val result = push(UUID.randomUUID().toString(), validYaml)
+
+        assertFalse(isSuccess(result))
+        assertEquals(ErrorCodes.RESOURCE_NOT_FOUND, errorOf(result)["code"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `push to non-depth-0 item returns error`() {
+        runBlocking {
+            val parent = (workItemRepository.create(WorkItem(title = "Parent")) as Result.Success).data
+            val child =
+                (
+                    workItemRepository.create(
+                        WorkItem(title = "Child", parentId = parent.id, depth = 1)
+                    ) as Result.Success
+                ).data
+
+            val result = push(child.id.toString(), validYaml)
+
+            assertFalse(isSuccess(result))
+            assertEquals(ErrorCodes.VALIDATION_ERROR, errorOf(result)["code"]!!.jsonPrimitive.content)
+            assertTrue(errorOf(result)["message"]!!.jsonPrimitive.content.contains("depth-0"))
+        }
+    }
+
+    @Test
+    fun `push to non-project-typed root succeeds with a warning field`() {
+        runBlocking {
+            val untyped = (workItemRepository.create(WorkItem(title = "Untyped Root")) as Result.Success).data
+
+            val result = push(untyped.id.toString(), validYaml)
+
+            assertTrue(isSuccess(result))
+            val warning = dataOf(result)["warning"]?.jsonPrimitive?.content
+            assertNotNull(warning, "expected a non-fatal warning for a non-'project'-typed root")
+            assertTrue(warning.contains("project"))
+        }
+    }
+
+    @Test
+    fun `push unparseable YAML returns error containing parse detail and stores no row`() {
+        val badYaml = "work_item_schemas: [this is not, a valid: map"
+
+        val result = push(rootId.toString(), badYaml)
+
+        assertFalse(isSuccess(result))
+        val error = errorOf(result)
+        assertEquals(ErrorCodes.VALIDATION_ERROR, error["code"]!!.jsonPrimitive.content)
+        assertTrue(error["message"]!!.jsonPrimitive.content.contains("failed to parse"))
+
+        // No row must have been stored — a broken config must never silently exist server-side.
+        val getResult = get(rootId.toString())
+        assertFalse(isSuccess(getResult))
+        assertEquals(ErrorCodes.RESOURCE_NOT_FOUND, errorOf(getResult)["code"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `idempotent re-push of identical content returns the same fingerprint`() {
+        val first = push(rootId.toString(), validYaml)
+        val second = push(rootId.toString(), validYaml)
+
+        assertTrue(isSuccess(first))
+        assertTrue(isSuccess(second))
+        assertEquals(
+            dataOf(first)["fingerprint"]!!.jsonPrimitive.content,
+            dataOf(second)["fingerprint"]!!.jsonPrimitive.content
+        )
+    }
+
+    // ──────────────────────────────────────────────
+    // get
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `get returns stored config`() {
+        push(rootId.toString(), validYaml)
+
+        val result = get(rootId.toString())
+
+        assertTrue(isSuccess(result))
+        val data = dataOf(result)
+        assertEquals(rootId.toString(), data["rootItemId"]!!.jsonPrimitive.content)
+        assertEquals(validYaml, data["configYaml"]!!.jsonPrimitive.content)
+        assertFalse(data["fingerprint"]!!.jsonPrimitive.content.isBlank())
+        assertNotNull(data["updatedAt"])
+    }
+
+    @Test
+    fun `get with no row returns NOT_FOUND`() {
+        val result = get(rootId.toString())
+
+        assertFalse(isSuccess(result))
+        assertEquals(ErrorCodes.RESOURCE_NOT_FOUND, errorOf(result)["code"]!!.jsonPrimitive.content)
+    }
+
+    // ──────────────────────────────────────────────
+    // validateParams
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `validateParams rejects push without configYaml`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(
+                params(
+                    "operation" to JsonPrimitive("push"),
+                    "rootItemId" to JsonPrimitive(rootId.toString())
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `validateParams rejects an unknown operation`() {
+        assertFailsWith<ToolValidationException> {
+            tool.validateParams(
+                params(
+                    "operation" to JsonPrimitive("delete"),
+                    "rootItemId" to JsonPrimitive(rootId.toString())
+                )
+            )
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    // End-to-end: pushed config is visible through ToolExecutionContext.resolveSchema
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `pushed config resolves through ToolExecutionContext for an item under that root`() {
+        runBlocking {
+            val pushResult = push(rootId.toString(), validYaml)
+            assertTrue(isSuccess(pushResult))
+
+            val perRootConfigService = PerRootConfigService(projectConfigRepository)
+            val resolvingContext =
+                ToolExecutionContext(
+                    mockk<RepositoryProvider>(relaxed = true).also {
+                        every { it.workItemRepository() } returns workItemRepository
+                        every { it.projectConfigRepository() } returns projectConfigRepository
+                    },
+                    perRootConfigService = perRootConfigService
+                )
+
+            val childItem =
+                WorkItem(
+                    id = UUID.randomUUID(),
+                    title = "Child under configured root",
+                    type = "feature-task",
+                    rootId = rootId,
+                    depth = 0
+                )
+
+            val resolved = resolvingContext.resolveSchema(childItem)
+
+            assertNotNull(resolved, "expected the per-root pushed schema to resolve, not schema-free mode")
+            assertEquals(1, resolved.notes.size)
+            assertEquals("spec", resolved.notes[0].key)
+        }
+    }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigServiceTest.kt
@@ -1,0 +1,262 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.config
+
+import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteProjectConfigRepository
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteWorkItemRepository
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * DB-backed tests for [PerRootConfigService], adapted from [YamlNoteSchemaServiceTest]'s
+ * temp-dir style — here the "file" is a `project_config` row instead of a temp
+ * `.taskorchestrator/config.yaml`.
+ */
+class PerRootConfigServiceTest {
+    private lateinit var database: Database
+    private lateinit var databaseManager: DatabaseManager
+    private lateinit var repository: SQLiteProjectConfigRepository
+    private lateinit var workItemRepository: SQLiteWorkItemRepository
+    private lateinit var service: PerRootConfigService
+    private lateinit var rootItemId: UUID
+
+    @BeforeEach
+    fun setUp() =
+        runBlocking {
+            val dbName = "test_${System.nanoTime()}"
+            database = Database.connect("jdbc:h2:mem:$dbName;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+            databaseManager = DatabaseManager(database)
+            DirectDatabaseSchemaManager().updateSchema()
+            repository = SQLiteProjectConfigRepository(databaseManager)
+            workItemRepository = SQLiteWorkItemRepository(databaseManager)
+            service = PerRootConfigService(repository)
+
+            val root = WorkItem(title = "Project Root")
+            workItemRepository.create(root)
+            rootItemId = root.id
+        }
+
+    // --- No config row ---
+
+    @Test
+    fun `getSchemas returns null when no config row exists`() =
+        runBlocking {
+            assertNull(service.getSchemas(rootItemId))
+        }
+
+    @Test
+    fun `getTraitNotes returns null when no config row exists`() =
+        runBlocking {
+            assertNull(service.getTraitNotes(rootItemId, "needs-migration-review"))
+        }
+
+    // --- Parse: work_item_schemas format ---
+
+    @Test
+    fun `getSchemas parses work_item_schemas format`() =
+        runBlocking {
+            repository.upsert(
+                rootItemId,
+                """
+work_item_schemas:
+  feature-task:
+    lifecycle: auto
+    notes:
+      - key: acceptance-criteria
+        role: queue
+        required: true
+        description: "Acceptance criteria"
+                """.trimIndent()
+            )
+
+            val schemas = service.getSchemas(rootItemId)
+            assertNotNull(schemas)
+            val schema = schemas["feature-task"]
+            assertNotNull(schema)
+            assertEquals(1, schema.notes.size)
+            assertEquals("acceptance-criteria", schema.notes[0].key)
+            assertEquals(Role.QUEUE, schema.notes[0].role)
+        }
+
+    @Test
+    fun `getSchemaForType returns the matching schema by type`() =
+        runBlocking {
+            repository.upsert(
+                rootItemId,
+                """
+work_item_schemas:
+  bug-fix:
+    notes:
+      - key: repro-steps
+        role: queue
+        required: true
+        description: "Repro steps"
+                """.trimIndent()
+            )
+
+            val schema = service.getSchemaForType(rootItemId, "bug-fix")
+            assertNotNull(schema)
+            assertEquals("repro-steps", schema.notes[0].key)
+
+            assertNull(service.getSchemaForType(rootItemId, "unknown-type"))
+        }
+
+    @Test
+    fun `getTraitNotes returns trait entries from traits block`() =
+        runBlocking {
+            repository.upsert(
+                rootItemId,
+                """
+traits:
+  needs-migration-review:
+    notes:
+      - key: migration-assessment
+        role: queue
+        required: true
+        description: "Migration assessment"
+        skill: "migration-review"
+                """.trimIndent()
+            )
+
+            val traitNotes = service.getTraitNotes(rootItemId, "needs-migration-review")
+            assertNotNull(traitNotes)
+            assertEquals(1, traitNotes.size)
+            assertEquals("migration-assessment", traitNotes[0].key)
+            assertEquals("migration-review", traitNotes[0].skill)
+
+            assertNull(service.getTraitNotes(rootItemId, "unknown-trait"))
+        }
+
+    // --- Unknown top-level keys ignored silently, no schemas section required ---
+
+    @Test
+    fun `config with only unrelated top-level keys parses to empty schemas without warning-driven failure`() =
+        runBlocking {
+            repository.upsert(
+                rootItemId,
+                """
+project:
+  name: "Some Project"
+                """.trimIndent()
+            )
+
+            val schemas = service.getSchemas(rootItemId)
+            assertNotNull(schemas, "A per-root config with no schema section is still a valid (empty) parse, not null")
+            assertTrue(schemas.isEmpty())
+        }
+
+    // --- Parse failure -> null (fall through to global config) ---
+
+    @Test
+    fun `malformed YAML returns null rather than throwing`() =
+        runBlocking {
+            repository.upsert(rootItemId, "work_item_schemas: [\ninvalid yaml: :\n  - broken")
+
+            assertNull(service.getSchemas(rootItemId))
+        }
+
+    // --- Cache hit: identical fingerprint reuses the cached parse ---
+
+    @Test
+    fun `repeated reads with unchanged content return equivalent parsed schemas`() =
+        runBlocking {
+            repository.upsert(
+                rootItemId,
+                """
+work_item_schemas:
+  default:
+    notes:
+      - key: implementation-notes
+        role: work
+        required: true
+        description: "Implementation notes"
+                """.trimIndent()
+            )
+
+            val first = service.getSchemas(rootItemId)
+            val second = service.getSchemas(rootItemId)
+            val third = service.getSchemas(rootItemId)
+
+            assertNotNull(first)
+            assertNotNull(second)
+            assertNotNull(third)
+            assertEquals(first.keys, second.keys)
+            assertEquals(first.keys, third.keys)
+            assertEquals(first["default"]?.notes, second["default"]?.notes)
+        }
+
+    // --- Hot reload: upsert new content is visible on next read, no restart / no invalidation call ---
+
+    @Test
+    fun `hot-reload — upserting new content is reflected on the very next read`() =
+        runBlocking {
+            repository.upsert(
+                rootItemId,
+                """
+work_item_schemas:
+  default:
+    notes:
+      - key: original-note
+        role: work
+        required: true
+        description: "Original"
+                """.trimIndent()
+            )
+
+            val before = service.getSchemas(rootItemId)
+            assertEquals(listOf("original-note"), before?.get("default")?.notes?.map { it.key })
+
+            repository.upsert(
+                rootItemId,
+                """
+work_item_schemas:
+  default:
+    notes:
+      - key: replaced-note
+        role: work
+        required: true
+        description: "Replaced"
+                """.trimIndent()
+            )
+
+            val after = service.getSchemas(rootItemId)
+            assertEquals(
+                listOf("replaced-note"),
+                after?.get("default")?.notes?.map { it.key },
+                "Expected the new config to be visible on the very next read after upsert, with no restart or explicit invalidation"
+            )
+        }
+
+    // --- Config row deleted after being cached -> falls back to null ---
+
+    @Test
+    fun `getSchemas returns null after the config row is deleted, even if previously cached`() =
+        runBlocking {
+            repository.upsert(
+                rootItemId,
+                """
+work_item_schemas:
+  default:
+    notes:
+      - key: some-note
+        role: work
+        required: true
+        description: "Some note"
+                """.trimIndent()
+            )
+            assertNotNull(service.getSchemas(rootItemId), "Sanity check: cached once before delete")
+
+            repository.delete(rootItemId)
+
+            assertNull(service.getSchemas(rootItemId))
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/V10ProjectConfigMigrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/V10ProjectConfigMigrationTest.kt
@@ -1,0 +1,207 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database
+
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.SQLException
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration test for the V10 migration (`V10__Project_Config.sql`) — the new `project_config`
+ * table and its `ON DELETE CASCADE` relationship to `work_items`.
+ *
+ * Follows the [V9RootIdMigrationTest] pattern: hand-build a minimal pre-V10 `work_items` table
+ * with raw SQL (only the columns needed to insert/delete rows — `project_config` only references
+ * `work_items.id`), apply the real V10 SQL file read straight off the classpath, then assert
+ * table/index existence, the unique constraint on `root_item_id`, and cascade-delete behavior via
+ * raw JDBC. `PRAGMA foreign_keys = ON` is set explicitly here (unlike [V9RootIdMigrationTest],
+ * which doesn't need FK enforcement for an unconstrained column) since cascade delete IS the
+ * behavior under test.
+ */
+class V10ProjectConfigMigrationTest {
+    private lateinit var database: Database
+    private lateinit var keepAliveConnection: Connection
+
+    @BeforeEach
+    fun setUp() {
+        val dbName = "v10_project_config_${System.nanoTime()}"
+        val jdbcUrl = "jdbc:sqlite:file:$dbName?mode=memory&cache=shared"
+        keepAliveConnection = DriverManager.getConnection(jdbcUrl)
+        keepAliveConnection.createStatement().use { it.execute("PRAGMA foreign_keys = ON") }
+        database = Database.connect(url = jdbcUrl, driver = "org.sqlite.JDBC")
+        TransactionManager.manager.defaultIsolationLevel = Connection.TRANSACTION_SERIALIZABLE
+        createMinimalWorkItemsTable()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        try {
+            TransactionManager.closeAndUnregister(database)
+        } catch (_: Exception) {
+        }
+        try {
+            keepAliveConnection.close()
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun createMinimalWorkItemsTable() {
+        transaction(db = database) {
+            exec(
+                """
+                CREATE TABLE work_items (
+                    id    BLOB PRIMARY KEY DEFAULT (randomblob(16)),
+                    title TEXT NOT NULL
+                )
+                """.trimIndent()
+            )
+        }
+    }
+
+    /**
+     * Reads the real `V10__Project_Config.sql` off the classpath and executes each statement.
+     * Strips full-line `--` comments, then splits on `;` — safe here since none of the migration's
+     * statements contain an embedded semicolon (mirrors [V9RootIdMigrationTest.applyV9Migration]).
+     */
+    private fun applyV10Migration() {
+        val resourceStream =
+            requireNotNull(
+                Thread.currentThread().contextClassLoader.getResourceAsStream("db/migration/V10__Project_Config.sql")
+            ) { "V10__Project_Config.sql not found on the test classpath" }
+        val sqlText = resourceStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+        val withoutComments =
+            sqlText
+                .lineSequence()
+                .filterNot { it.trimStart().startsWith("--") }
+                .joinToString("\n")
+        val statements =
+            withoutComments
+                .split(";")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+
+        transaction(db = database) {
+            statements.forEach { statement -> exec(statement) }
+        }
+    }
+
+    private fun insertWorkItem(
+        id: UUID,
+        title: String
+    ) {
+        keepAliveConnection.prepareStatement("INSERT INTO work_items (id, title) VALUES (?, ?)").use { stmt ->
+            stmt.setBytes(1, uuidToBytes(id))
+            stmt.setString(2, title)
+            stmt.executeUpdate()
+        }
+    }
+
+    private fun insertProjectConfig(
+        id: UUID,
+        rootItemId: UUID,
+        configYaml: String,
+        fingerprint: String
+    ) {
+        keepAliveConnection
+            .prepareStatement(
+                """
+                INSERT INTO project_config (id, root_item_id, config_yaml, fingerprint, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                """.trimIndent()
+            ).use { stmt ->
+                stmt.setBytes(1, uuidToBytes(id))
+                stmt.setBytes(2, uuidToBytes(rootItemId))
+                stmt.setString(3, configYaml)
+                stmt.setString(4, fingerprint)
+                stmt.setTimestamp(5, java.sql.Timestamp.from(Instant.now()))
+                stmt.executeUpdate()
+            }
+    }
+
+    private fun countProjectConfigRows(rootItemId: UUID): Int {
+        var count = 0
+        keepAliveConnection.prepareStatement("SELECT COUNT(*) FROM project_config WHERE root_item_id = ?").use { stmt ->
+            stmt.setBytes(1, uuidToBytes(rootItemId))
+            stmt.executeQuery().use { rs ->
+                if (rs.next()) count = rs.getInt(1)
+            }
+        }
+        return count
+    }
+
+    private fun uuidToBytes(id: UUID): ByteArray {
+        val buf = ByteBuffer.allocate(16)
+        buf.putLong(id.mostSignificantBits)
+        buf.putLong(id.leastSignificantBits)
+        return buf.array()
+    }
+
+    @Test
+    fun `V10 migration creates the project_config table and unique index`(): Unit =
+        runBlocking {
+            applyV10Migration()
+
+            var hasTable = false
+            transaction(db = database) {
+                exec("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'project_config'") { rs ->
+                    hasTable = rs.next()
+                }
+            }
+            assertTrue(hasTable, "Expected project_config table to exist after V10")
+
+            var hasIndex = false
+            transaction(db = database) {
+                exec(
+                    "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_project_config_root_item_id'"
+                ) { rs ->
+                    hasIndex = rs.next()
+                }
+            }
+            assertTrue(hasIndex, "Expected idx_project_config_root_item_id index to exist after V10")
+        }
+
+    @Test
+    fun `V10 root_item_id is unique — a second insert for the same root fails`(): Unit =
+        runBlocking {
+            applyV10Migration()
+            val root = UUID.randomUUID()
+            insertWorkItem(root, "Root")
+            insertProjectConfig(UUID.randomUUID(), root, "work_item_schemas: {}", "fp1")
+
+            var threw = false
+            try {
+                insertProjectConfig(UUID.randomUUID(), root, "work_item_schemas: {}", "fp2")
+            } catch (e: SQLException) {
+                threw = true
+            }
+            assertTrue(threw, "Expected a UNIQUE constraint violation on a second insert for the same root_item_id")
+        }
+
+    @Test
+    fun `V10 deleting the root work item cascades to delete its project_config row`(): Unit =
+        runBlocking {
+            applyV10Migration()
+            val root = UUID.randomUUID()
+            insertWorkItem(root, "Root")
+            insertProjectConfig(UUID.randomUUID(), root, "work_item_schemas: {}", "fp1")
+
+            assertEquals(1, countProjectConfigRows(root), "Sanity check: config row exists before delete")
+
+            keepAliveConnection.prepareStatement("DELETE FROM work_items WHERE id = ?").use { stmt ->
+                stmt.setBytes(1, uuidToBytes(root))
+                stmt.executeUpdate()
+            }
+
+            assertEquals(0, countProjectConfigRows(root), "Expected ON DELETE CASCADE to remove the project_config row")
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteProjectConfigRepositoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteProjectConfigRepositoryTest.kt
@@ -1,0 +1,147 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database.repository
+
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteProjectConfigRepository
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteWorkItemRepository
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SQLiteProjectConfigRepositoryTest {
+    private lateinit var database: Database
+    private lateinit var databaseManager: DatabaseManager
+    private lateinit var projectConfigRepository: SQLiteProjectConfigRepository
+    private lateinit var workItemRepository: SQLiteWorkItemRepository
+    private lateinit var rootItemId: UUID
+
+    @BeforeEach
+    fun setUp() =
+        runBlocking {
+            val dbName = "test_${System.nanoTime()}"
+            database = Database.connect("jdbc:h2:mem:$dbName;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+            databaseManager = DatabaseManager(database)
+            DirectDatabaseSchemaManager().updateSchema()
+            projectConfigRepository = SQLiteProjectConfigRepository(databaseManager)
+            workItemRepository = SQLiteWorkItemRepository(databaseManager)
+
+            val root = WorkItem(title = "Project Root")
+            workItemRepository.create(root)
+            rootItemId = root.id
+        }
+
+    // --- get: no row ---
+
+    @Test
+    fun `get returns null when no config row exists`() =
+        runBlocking {
+            val result = projectConfigRepository.get(rootItemId)
+            assertIs<Result.Success<*>>(result)
+            assertNull((result as Result.Success).data)
+        }
+
+    @Test
+    fun `getFingerprint returns null when no config row exists`() =
+        runBlocking {
+            val result = projectConfigRepository.getFingerprint(rootItemId)
+            assertIs<Result.Success<*>>(result)
+            assertNull((result as Result.Success).data)
+        }
+
+    // --- upsert: fresh insert ---
+
+    @Test
+    fun `upsert stores config and returns it with a computed fingerprint`() =
+        runBlocking {
+            val yaml = "work_item_schemas:\n  default: {}\n"
+            val result = projectConfigRepository.upsert(rootItemId, yaml)
+            assertIs<Result.Success<*>>(result)
+            val stored = (result as Result.Success).data
+            assertEquals(rootItemId, stored.rootItemId)
+            assertEquals(yaml, stored.configYaml)
+            assertTrue(stored.fingerprint.isNotBlank())
+
+            val fetched = projectConfigRepository.get(rootItemId)
+            assertIs<Result.Success<*>>(fetched)
+            assertEquals(stored.configYaml, (fetched as Result.Success).data?.configYaml)
+            assertEquals(stored.fingerprint, fetched.data?.fingerprint)
+        }
+
+    @Test
+    fun `fingerprint is stable for identical content and changes when content changes`() =
+        runBlocking {
+            val yamlA = "work_item_schemas:\n  default: {}\n"
+            val firstUpsert = (projectConfigRepository.upsert(rootItemId, yamlA) as Result.Success).data
+            val secondUpsertSameContent = (projectConfigRepository.upsert(rootItemId, yamlA) as Result.Success).data
+            assertEquals(
+                firstUpsert.fingerprint,
+                secondUpsertSameContent.fingerprint,
+                "Fingerprint must be stable across upserts of identical content"
+            )
+
+            val yamlB = "work_item_schemas:\n  default: {}\n  other: {}\n"
+            val thirdUpsertDifferentContent = (projectConfigRepository.upsert(rootItemId, yamlB) as Result.Success).data
+            assertTrue(
+                thirdUpsertDifferentContent.fingerprint != firstUpsert.fingerprint,
+                "Fingerprint must change when content changes"
+            )
+        }
+
+    // --- upsert: replaces existing row (one row per root) ---
+
+    @Test
+    fun `upsert replaces the existing row for the same root rather than inserting a second row`() =
+        runBlocking {
+            projectConfigRepository.upsert(rootItemId, "work_item_schemas:\n  default: {}\n")
+            val second = projectConfigRepository.upsert(rootItemId, "work_item_schemas:\n  other: {}\n")
+            assertIs<Result.Success<*>>(second)
+
+            val fetched = (projectConfigRepository.get(rootItemId) as Result.Success).data
+            assertEquals("work_item_schemas:\n  other: {}\n", fetched?.configYaml)
+        }
+
+    // --- delete ---
+
+    @Test
+    fun `delete removes the config row and returns true`() =
+        runBlocking {
+            projectConfigRepository.upsert(rootItemId, "work_item_schemas:\n  default: {}\n")
+
+            val deleteResult = projectConfigRepository.delete(rootItemId)
+            assertIs<Result.Success<*>>(deleteResult)
+            assertTrue((deleteResult as Result.Success).data)
+
+            val fetched = projectConfigRepository.get(rootItemId)
+            assertNull((fetched as Result.Success).data)
+        }
+
+    @Test
+    fun `delete returns false when no config row exists`() =
+        runBlocking {
+            val deleteResult = projectConfigRepository.delete(rootItemId)
+            assertIs<Result.Success<*>>(deleteResult)
+            assertTrue(!(deleteResult as Result.Success).data)
+        }
+
+    // --- FK cascade: deleting the root work item removes its config row ---
+
+    @Test
+    fun `deleting the root work item cascades to delete its project_config row`() =
+        runBlocking {
+            projectConfigRepository.upsert(rootItemId, "work_item_schemas:\n  default: {}\n")
+
+            workItemRepository.delete(rootItemId)
+
+            val fetched = projectConfigRepository.get(rootItemId)
+            assertIs<Result.Success<*>>(fetched)
+            assertNull((fetched as Result.Success).data, "Expected CASCADE delete to remove the project_config row")
+        }
+}


### PR DESCRIPTION
## Summary

PR 3 of 4 in the transport-unified project-root scoping feature (design record: MCP observation `7fab0fb4`). Each project root can now carry its own schema/trait configuration, stored server-side and hot-reloaded on push — the repo's `.taskorchestrator/config.yaml` stays the authoring surface, and a new MCP tool syncs it up on any transport.

## Changes

- **`project_config` table** (`V10__Project_Config.sql`): one row per project root (UNIQUE FK, CASCADE delete), raw YAML + SHA-256 fingerprint + updated_at.
- **`PerRootConfigService`**: fingerprint-compare-per-read caching — a push becomes visible on the very next read, no restart, correct across multiple server instances. Parse failures fall through to global config. Shared `YamlSchemaParser` extracted from the global loader (pure code move, 57 unchanged regression tests).
- **Layered `resolveSchema`**: per-key fallback (type / tag / default / trait-name) — per-root config → global YAML → built-in default. Zero extra queries when an item has no `root_id`; all nine resolution call sites unchanged. Includes an unbriefed fix: REST's separately-constructed `ToolExecutionContext` would have silently stayed global-only.
- **`manage_project_config` MCP tool** (15th tool): `push` (parse-validate-before-store, depth-0 required, non-`project` type warns, 128 KiB cap) and `get` (config + fingerprint). End-to-end composition test proves push → hot-reload → layered resolve.

## Security (needs-security-review gate)

The independent security review caught and drove remediation of unsafe SnakeYAML deserialization (CWE-502) on client-supplied config: `SafeConstructor` now used at every parse site of pushable content including the global loader, with an SSRF-flavored `!!`-tag rejection test. A trust-model caveat documents that `/mcp` over HTTP is unauthenticated (pre-existing platform gap, now tracked as MCP observation `63528f7f`).

## Tests

Suite 2,477 → 2,521 (+44), 0 failures; ktlint clean. Follow-ups recorded in MCP review notes: shared `safeYaml()` helper/lint rule, dual `PerRootConfigService` instance dedup, per-root `note_limits`.

MCP refs: feature `62311d26` (T3.1 `762501e5`, T3.2 `8535bf4c`, T3.3 `e6ae8662`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012M9cBWioQoehDxABDaRDsS