### PR TITLE
feat(plugin): project-scope integration — hook injection, skill wiring, /adopt-project-scope

### DIFF
--- a/claude-plugins/task-orchestrator/hooks/session-start.mjs
+++ b/claude-plugins/task-orchestrator/hooks/session-start.mjs
@@ -1,13 +1,139 @@
 #!/usr/bin/env node
-// Session Start Hook — injects current v3 workflow guidance
-const output = {
-  hookSpecificOutput: {
-    hookEventName: "SessionStart",
-    additionalContext: `## Task Orchestrator — Session Context
+// Session Start Hook — injects current v3 workflow guidance, plus project
+// scope (rootId/name) when .taskorchestrator/config.yaml declares a `project:` block.
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// Locate config.yaml — check AGENT_CONFIG_DIR, then walk up from cwd to find
+// the project root containing .taskorchestrator/. This handles worktrees where
+// cwd is nested under .claude/worktrees/<name>/ but config is at the repo root.
+// Pattern reused from skill-enforcement.mjs / enforce-actor-attribution.mjs.
+function findConfigPath() {
+  const candidates = [];
+  if (process.env.AGENT_CONFIG_DIR) {
+    candidates.push(resolve(process.env.AGENT_CONFIG_DIR, '.taskorchestrator', 'config.yaml'));
+  }
+  let dir = process.cwd();
+  const root = resolve(dir, '/');
+  while (dir !== root) {
+    candidates.push(resolve(dir, '.taskorchestrator', 'config.yaml'));
+    dir = resolve(dir, '..');
+  }
+  for (const candidate of candidates) {
+    try {
+      return readFileSync(candidate, 'utf-8');
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+// Parse the top-level `project:` block:
+//   project:
+//     rootId: "<uuid>"
+//     name: "<project name>"
+// Values may be quoted or bare. Returns { rootId, name } or null if the block
+// is absent or has no rootId.
+function parseProjectBlock(configContent) {
+  if (!configContent) return null;
+
+  let inProjectSection = false;
+  let rootId = null;
+  let name = null;
+
+  for (const line of configContent.split('\n')) {
+    const trimmed = line.trim();
+
+    if (/^project\s*:\s*$/.test(trimmed)) {
+      inProjectSection = true;
+      continue;
+    }
+
+    // Any other top-level (non-indented, non-empty) line ends the section.
+    if (inProjectSection && /^\S/.test(line)) {
+      inProjectSection = false;
+    }
+
+    if (inProjectSection) {
+      const rootIdMatch = trimmed.match(/^rootId\s*:\s*["']?([^"'#]+?)["']?\s*(#.*)?$/);
+      if (rootIdMatch) {
+        rootId = rootIdMatch[1].trim();
+        continue;
+      }
+      const nameMatch = trimmed.match(/^name\s*:\s*["']?([^"'#]+?)["']?\s*(#.*)?$/);
+      if (nameMatch) {
+        name = nameMatch[1].trim();
+        continue;
+      }
+    }
+  }
+
+  if (!rootId) return null;
+  return { rootId, name };
+}
+
+const BASE_GUIDANCE = `## Task Orchestrator — Session Context
 
 - Use \`advance_item\` for role transitions — not raw status edits.
 - Hierarchy: items have parentId and depth (max 3).
-- To resume: call \`get_context()\` with no args to see active and stalled items.`
+- To resume: call \`get_context()\` with no args to see active and stalled items.`;
+
+function buildContext() {
+  let configContent = null;
+  try {
+    configContent = findConfigPath();
+  } catch {
+    return BASE_GUIDANCE;
+  }
+
+  if (!configContent) {
+    return BASE_GUIDANCE;
+  }
+
+  let project = null;
+  try {
+    project = parseProjectBlock(configContent);
+  } catch {
+    return BASE_GUIDANCE;
+  }
+
+  if (!project) {
+    return `${BASE_GUIDANCE}
+
+## Project Scope
+
+This workspace is not project-scoped — no \`project:\` block found in \`.taskorchestrator/config.yaml\`.
+Run \`/adopt-project-scope\` (existing DBs) or \`/quick-start\` (fresh workspaces) to set one up.`;
+  }
+
+  const label = project.name ? `${project.name} (\`${project.rootId}\`)` : `\`${project.rootId}\``;
+
+  return `${BASE_GUIDANCE}
+
+## Project Scope
+
+Active project: ${label}
+
+- Pass \`ancestorId: "${project.rootId}"\` on \`query_items\` (list mode), \`get_next_item\`, \`get_context\`, and \`get_blocked_items\` to scope results to this project.
+- Anchor new root-level items under this project by setting \`parentId: "${project.rootId}"\`.
+- Process-global containers (Session Retrospectives, Improvement Proposals, agent-observations) stay OUTSIDE the project root at depth 0 — do not anchor them under \`${project.rootId}\`.`;
+}
+
+let additionalContext;
+try {
+  additionalContext = buildContext();
+} catch {
+  // Fail-open: any unexpected error falls back to static guidance so a broken
+  // hook never blocks session start.
+  additionalContext = BASE_GUIDANCE;
+}
+
+const output = {
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext
   }
 };
 process.stdout.write(JSON.stringify(output));

--- a/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
+++ b/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
@@ -54,6 +54,10 @@ Review applies only when the item's schema declares review-phase notes; otherwis
 5. **Know current state** — query MCP before deciding; `role="work"` filters resolve to all work-phase statuses
 6. **Communicate concisely** — status first, action second
 
+## Project Scope
+
+When session context carries a project rootId (injected by the SessionStart hook from `.taskorchestrator/config.yaml`'s `project:` block), operate project-scoped by default: pass `ancestorId: "<rootId>"` on `query_items` list mode, `get_next_item`, `get_context`, and `get_blocked_items`; anchor new root-level items under the project root via `parentId`. Process-global containers (Session Retrospectives, Improvement Proposals, `agent-observation` items) stay at depth 0 outside any project root — never anchor or scope those. Without a configured rootId, whole-workspace behavior is unchanged; suggest `/adopt-project-scope` only when the user mentions multiple projects sharing a database.
+
 ## Delegation
 
 | Task type | Model |

--- a/claude-plugins/task-orchestrator/skills/adopt-project-scope/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/adopt-project-scope/SKILL.md
@@ -80,21 +80,24 @@ Build a probe where a grandchild's depth MUST change when a middle node is re-pa
    manage_items(operation="update", items=[{ id: M, parentId: A }])
    ```
    Post-fix, M becomes depth 2 and G becomes depth 3.
-4. Read the grandchild's depth:
+4. Read the grandchild's depth and capture it:
    ```
    query_items(operation="get", id=G)
    ```
+5. Delete the probe **immediately, before acting on the result** — this runs on every path, pass or fail:
+   ```
+   manage_items(operation="delete", ids=[P], recursive=true)
+   ```
+6. Now evaluate the captured depth:
    - `depth == 3` → fix is present. Continue.
-   - `depth == 2` (stale) → **abort**:
+   - `depth == 2` (stale) → **abort** (probe already deleted):
      ```
      ⊘ Server is missing the reparent depth-sweep fix (bug 99a3e642).
        Bulk re-parenting on this server would corrupt subtree depths.
        Upgrade the Task Orchestrator server (PR #219/#220 or later) and retry.
      ```
-5. **Always** delete the probe, pass or fail, before continuing or aborting:
-   ```
-   manage_items(operation="delete", ids=[P], recursive=true)
-   ```
+
+**`--dry-run` skips this probe entirely** — no execution will happen, so the capability check is unnecessary and the dry run stays genuinely mutation-free. The probe runs only on the real-execution path, after the user confirms in Step 3.
 
 ### 1d — Config-push capability (tolerant)
 
@@ -232,7 +235,7 @@ Render a before/after table:
 
 |                     | Before | After |
 |---------------------|--------|-------|
-| Depth-0 roots       | 5      | 3     |
+| Depth-0 roots       | 5      | 4     |
 | Under project anchor| 0      | 2     |
 | Global containers   | 2      | 2     |
 | Cleanup candidates  | 1      | 1 (flagged, not moved) |

--- a/claude-plugins/task-orchestrator/skills/adopt-project-scope/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/adopt-project-scope/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: adopt-project-scope
+description: "Migrates an already-populated, unscoped Task Orchestrator database in place to the project-scoping convention — creates a project anchor root, re-parents existing work trees under it, and writes rootId back to config.yaml. Use when a user says: adopt project scope, migrate this database to project scoping, make this DB multi-project, project-scope this workspace, adopt existing database, or set up project scoping for an existing DB."
+argument-hint: "[project name] [--dry-run]"
+---
+
+# Adopt Project Scope — In-Place Migration to Project Scoping
+
+Take an existing, unscoped database (many depth-0 roots, no project anchor) and migrate it in place to the project-scoping convention: one `type=project` root that owns the workspace's work trees, with its UUID written back to `.taskorchestrator/config.yaml` under a `project:` block. Global containers (retrospectives, observations) stay at depth 0; test artifacts are flagged for cleanup, never moved or deleted.
+
+This is a **destructive-by-execution** skill: the EXECUTE step re-parents real items. It defaults to a dry run and never mutates anything without an explicit confirmation. The only thing it ever deletes is its own throwaway server-probe tree.
+
+**Non-goals:** cross-DB consolidation (merging items from a second database); merging multiple existing project anchors into one; any server-side enforcement of scope. This skill adopts a single workspace's single database.
+
+---
+
+## Step 0 — Parse Arguments
+
+- **Project name** — the first non-flag token(s) in `$ARGUMENTS`. If absent, do not guess; ask for it in Step 3 (the dry-run plan) via `AskUserQuestion` before any mutation.
+- **`--dry-run`** — if present, the skill stops after Step 3 (the plan) and performs zero mutations regardless of confirmation. The dry run is ALSO always rendered before execution even without the flag; the flag only forces an early exit.
+
+---
+
+## Step 1 — Preflight (abort gates)
+
+Run these checks in order. Each abort prints a clear, user-facing reason and stops.
+
+### 1a — Already adopted?
+
+Read `.taskorchestrator/config.yaml`. If it contains a `project:` block with a non-empty `rootId:`, the workspace is already scoped:
+
+```
+◆ Workspace already adopted — config.yaml already points at project root <rootId>.
+  Nothing to do. Use /work-summary to inspect the existing project tree.
+```
+
+Stop. (If the file is missing entirely, that is fine — a fresh unscoped DB has no config `project:` block. Continue.)
+
+### 1b — Existing anchor already in the DB?
+
+```
+query_items(operation="search", type="project", depth=0)
+```
+
+(list mode — `query` omitted, filtering by `type` and `depth`.)
+
+- **No results** → continue to 1c.
+- **One or more results** → do NOT silently create a second anchor. Offer, via `AskUserQuestion`:
+  1. **Attach to existing** — write the existing anchor's UUID into `config.yaml` (skip anchor creation in EXECUTE; still re-parent MOVE roots under it) and continue.
+  2. **Abort** — stop and let the user resolve the ambiguity manually.
+
+  If the user picks "attach", record the existing anchor UUID as `ANCHOR_ID` and note that EXECUTE step (a) is skipped.
+
+### 1c — Server capability probe (the depth-sweep fix)
+
+Bulk re-parenting is exactly the scenario that a pre-fix server corrupts: on a pre-#219/#220 server, re-parenting a subtree does NOT recompute descendant depths (bug `99a3e642`), so this skill would silently leave the moved trees with wrong depths. Verify the fix is deployed with a disposable probe, then delete it.
+
+Build a probe where a grandchild's depth MUST change when a middle node is re-parented deeper:
+
+1. Create a throwaway root and a two-level branch under it in one call:
+   ```
+   manage_items(operation="create", items=[
+     { title: "zzprobe-root",  type: "container", priority: "low" }
+   ])
+   ```
+   Capture its UUID as `P`.
+2. Create the branch (sequential parentage, small tree):
+   ```
+   manage_items(operation="create", items=[
+     { title: "zzprobe-A",   parentId: P,  priority: "low" }     → capture as A (depth 1)
+   ])
+   manage_items(operation="create", items=[
+     { title: "zzprobe-M",   parentId: P,  priority: "low" },    → capture as M (depth 1, sibling of A)
+     { title: "zzprobe-G",   parentId: M,  priority: "low" }     → capture as G (depth 2, child of M)
+   ])
+   ```
+   (Create M before G so G can reference it; batch where the array ordering allows.)
+3. Re-parent the middle node M **under A** (making it deeper):
+   ```
+   manage_items(operation="update", items=[{ id: M, parentId: A }])
+   ```
+   Post-fix, M becomes depth 2 and G becomes depth 3.
+4. Read the grandchild's depth:
+   ```
+   query_items(operation="get", id=G)
+   ```
+   - `depth == 3` → fix is present. Continue.
+   - `depth == 2` (stale) → **abort**:
+     ```
+     ⊘ Server is missing the reparent depth-sweep fix (bug 99a3e642).
+       Bulk re-parenting on this server would corrupt subtree depths.
+       Upgrade the Task Orchestrator server (PR #219/#220 or later) and retry.
+     ```
+5. **Always** delete the probe, pass or fail, before continuing or aborting:
+   ```
+   manage_items(operation="delete", ids=[P], recursive=true)
+   ```
+
+### 1d — Config-push capability (tolerant)
+
+`manage_project_config` may be absent on older servers. Do not probe it destructively here — just remember to attempt the push in EXECUTE step (d) and, if the tool is unavailable, skip it with a note rather than failing the whole adoption. The local `config.yaml` write (step c) is the source of truth; the server push is a convenience sync.
+
+---
+
+## Step 2 — Inventory & Classify
+
+Full depth-0 census:
+
+```
+query_items(operation="overview", excludeTerminal=false, includeChildren=true, limit=<total>)
+```
+
+If the response reports `truncated: true`, re-issue with `limit` set to the reported `total` so no root is missed.
+
+Classify **every depth-0 root** into exactly one bucket:
+
+| Bucket | Rule | Action |
+|--------|------|--------|
+| **KEEP-GLOBAL** | Title matches a global container — `Session Retrospectives`, `Improvement Proposals`; OR the root is a `container` (tag or `type`) whose children are `agent-observation` items; OR the root itself is tagged `agent-observation`. | Stays at depth 0. |
+| **MOVE** | Any work container or work tree (a root with work/queue/review children), and any standalone work item. Everything that is real project work. | Re-parented under the new anchor. |
+| **CLEANUP-CANDIDATE** | Evident test artifacts: titles containing `probe`, `smoke`, `depth-test`, `zzprobe`; or tags matching `mtest-*`. | **Flagged only** — never moved, never deleted. Recommend `/batch-complete`. |
+
+**Ambiguous roots** (no clear rule match — e.g., an untagged standalone item that could be work or a stray container): do NOT guess. Collect them and present via `AskUserQuestion` (`multiSelect`) asking which should MOVE vs stay KEEP-GLOBAL. Test-artifact-looking items always go to CLEANUP-CANDIDATE without asking.
+
+---
+
+## Step 3 — Dry-Run Plan (always shown; `--dry-run` stops here)
+
+Render the full plan before any mutation. Require explicit confirmation to proceed.
+
+```
+◆ Adopt Project Scope — Plan   [project: "<name>"]
+
+| Root | ID | Classification | Action |
+|------|----|----------------|--------|
+| Auth System | `a1b2c3d4` | MOVE | re-parent under new anchor |
+| Payments | `e5f6a7b8` | MOVE | re-parent under new anchor |
+| Session Retrospectives | `c9d0e1f2` | KEEP-GLOBAL | stays at depth 0 |
+| Improvement Proposals | `13243546` | KEEP-GLOBAL | stays at depth 0 |
+| zzprobe-smoke-tree | `5768798a` | CLEANUP-CANDIDATE | flag for /batch-complete (not moved) |
+
+Summary: 2 move · 2 stay global · 1 cleanup candidate
+Execution will create a "<name>" project anchor and re-parent 2 tree(s) under it.
+```
+
+- If the project name is still unknown, ask for it now via `AskUserQuestion` before showing the final counts.
+- **`--dry-run`**: stop here. State plainly: "Dry run — no changes made. Re-run without --dry-run to execute."
+- Otherwise, confirm via `AskUserQuestion`:
+  ```
+  ◆ Proceed with adoption? This re-parents <N> tree(s) under a new project anchor.
+    1. Yes — execute
+    2. No — abort, make no changes
+  ```
+  Wait for the answer. Only "Yes" proceeds.
+
+---
+
+## Step 4 — Execute
+
+Perform in this order. Record pre-execution counts first (used by Step 5): the depth-0 root count, the MOVE count, and the KEEP-GLOBAL count from Step 2.
+
+**(a) Create the project anchor** — skip if attaching to an existing anchor (Step 1b):
+
+```
+manage_items(operation="create", items=[{
+  title: "<project name>",
+  type: "project",
+  summary: "Project anchor — subtree scope for <project name>",
+  priority: "low"
+}])
+```
+
+Capture the new UUID as `ANCHOR_ID`.
+
+**(b) Batch re-parent the MOVE roots** — one call, `items` array (never a sequential call per root):
+
+```
+manage_items(operation="update", items=[
+  { id: "<move-root-1>", parentId: ANCHOR_ID },
+  { id: "<move-root-2>", parentId: ANCHOR_ID },
+  ...
+])
+```
+
+This relies on the depth-sweep fix verified in Step 1c — each moved subtree's descendant depths and `root_id` are recomputed server-side.
+
+**(c) Write the `project:` block into `config.yaml`** — read-modify-write, preserving ALL existing content:
+
+- Read the current `.taskorchestrator/config.yaml` text (create the file with just the block if it does not exist).
+- Insert this top-level block (surgical insert/append — do NOT regenerate or reformat the rest of the file; leave `work_item_schemas:`, `traits:`, `actor_authentication:`, comments, and formatting byte-for-byte intact):
+  ```yaml
+  project:
+    rootId: "<ANCHOR_ID>"
+    name: "<project name>"
+  ```
+- If a `project:` key somehow already exists (it should not — Step 1a would have aborted), update its `rootId`/`name` in place rather than adding a duplicate key.
+
+**(d) Push the config server-side** (tolerant — skip if the tool is absent):
+
+```
+manage_project_config(operation="push", rootItemId=ANCHOR_ID, configYaml="<full config.yaml text>")
+```
+
+- A `warning` field about the root's type is only returned when the anchor's `type` is not `project`; since step (a) sets `type: "project"`, none is expected. Report it if present but treat it as non-fatal.
+- If `manage_project_config` is unavailable on this server, skip this step and note: "Config pushed locally only — server does not support manage_project_config; the local config.yaml is authoritative."
+
+---
+
+## Step 5 — Verify & Reconcile
+
+Confirm the migration landed correctly. On ANY mismatch, report loudly and do NOT auto-rollback (say the remedy explicitly).
+
+1. **Anchored child count** — the new anchor's direct children must equal the MOVE count:
+   ```
+   query_items(operation="overview", ancestorId=ANCHOR_ID)
+   ```
+   The anchor's direct-child count must equal `N move`.
+2. **Global census** — remaining depth-0 roots must reconcile:
+   ```
+   query_items(operation="overview", excludeTerminal=false, limit=<total>)
+   ```
+   Expected depth-0 roots = KEEP-GLOBAL count + 1 (the anchor) + any CLEANUP-CANDIDATE roots left in place (cleanup candidates were flagged, not moved). Confirm the moved roots are no longer at depth 0.
+3. **Depth spot-check** — pick one moved tree that had a grandchild; confirm the grandchild's depth increased by exactly 1 from its pre-move value (the anchor added one level above the old root):
+   ```
+   query_items(operation="get", id="<grandchild-of-a-moved-tree>")
+   ```
+
+Render a before/after table:
+
+```
+✓ Adoption Complete — "<project name>"  (anchor `<8-char-id>`)
+
+|                     | Before | After |
+|---------------------|--------|-------|
+| Depth-0 roots       | 5      | 3     |
+| Under project anchor| 0      | 2     |
+| Global containers   | 2      | 2     |
+| Cleanup candidates  | 1      | 1 (flagged, not moved) |
+
+↳ Config: project.rootId written to .taskorchestrator/config.yaml
+↳ Server push: applied | skipped (tool absent)
+↳ Cleanup candidates flagged for /batch-complete: <titles>
+```
+
+**On mismatch** (e.g., anchored child count ≠ MOVE count):
+
+```
+⚠ Reconciliation mismatch — expected <X> children under the anchor, found <Y>.
+  No rollback was performed. To undo: re-parent the affected roots back to depth 0
+  with manage_items(operation="update", items=[{ id, parentId: null }]) for each,
+  then delete the anchor. Investigate before retrying.
+```
+
+Remind the user that schema changes / new config require an MCP reconnect (`/mcp`) to take effect if they rely on per-root schema resolution immediately.
+
+---
+
+## Safety Summary
+
+- **Default dry run.** No mutation without an explicit `AskUserQuestion` "Yes".
+- **Never deletes user data.** Cleanup candidates are only *flagged*; the sole deletion is the throwaway server probe in Step 1c.
+- **Never regenerates config.yaml.** The `project:` block is surgically inserted; all other content is preserved verbatim.
+- **Abort, don't corrupt.** A pre-fix server (missing the depth-sweep) aborts in preflight rather than silently corrupting subtree depths.
+- **No auto-rollback.** On verify mismatch, the skill reports the manual remedy rather than guessing at an undo.
+
+---
+
+## Verification (before first real run)
+
+Per the specification, exercise the skill against a COPY of a production-shaped DB:
+
+1. **Dry run on the copy** must produce zero mutations and a correct classification table.
+2. **Execute on the copy** and confirm Step 5 count reconciliation passes (depth-0 roots, anchored children, grandchild depth +1).
+
+Only after the copy passes should the skill be run against the real database.

--- a/claude-plugins/task-orchestrator/skills/create-item/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/create-item/SKILL.md
@@ -24,6 +24,15 @@ If title or type cannot be inferred with confidence, use `AskUserQuestion` with 
 
 ## Step 2 — Scan containers
 
+Resolve the project rootId first: check session context for a rootId injected by the SessionStart hook, or read `.taskorchestrator/config.yaml`'s top-level `project.rootId` (a file read, not an MCP call).
+
+**If a rootId is known:**
+```
+query_items(operation="overview", ancestorId="<rootId>", includeChildren=true)
+```
+Category containers (Bugs, Features, Tech Debt, etc.) are expected as direct children of the project root — anchor new items there. **Exception:** `agent-observation` items always stay at global depth 0, outside any project root, regardless of whether a rootId is known — they're process-global, not project-scoped.
+
+**If no rootId is known**, fall back to an unscoped scan and the classification below (this is also the exact behavior from before project scoping existed):
 ```
 query_items(operation="overview", includeChildren=true)
 ```
@@ -68,6 +77,8 @@ Empty (no project root exists):
   → Yes: create project root → create category under it → create item
   → No: create category container at depth 0 → create item under it
 ```
+
+**Exception (all branches):** `agent-observation` items never anchor under a project root or category container — they are process-global containers that live at depth 0 alongside (not under) any project root, per Step 2.
 
 ---
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
@@ -41,6 +41,8 @@ Check if `.taskorchestrator/config.yaml` exists by reading it.
 
 **If the file exists:** Read and parse it. Proceed to Step 3.
 
+> **Note:** `project:` is a recognized top-level key alongside `work_item_schemas`, `traits`, and `actor_authentication` — it anchors this repo to a project root item and is read only by other skills (`quick-start`, `/adopt-project-scope`), never by this skill. Do not treat it as unknown, and never drop or rewrite it — every write operation in Step 3 (CREATE/EDIT/DELETE) must carry it through unchanged. See `references/config-format.md` → Project Scoping for its fields.
+
 ---
 
 ## Step 3 — Route to Operation

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
@@ -129,7 +129,14 @@ For detailed workflow, see `references/validate-workflow.md` in this skill folde
 
 **For write operations (CREATE, EDIT, DELETE):**
 - Show what changed in the config file
-- Remind: **MCP reconnect required** (`/mcp`) for schema changes to take effect — the server caches schemas on first access
+- **Sync to server (if project-scoped):** Check whether the config has a top-level `project.rootId` (see Step 2's note and `references/config-format.md` → Project Scoping). If present, check the tool list for `manage_project_config` — older servers may not expose it, in which case note this to the user and skip (the config.yaml write above is authoritative locally; the server picks it up on its normal read path once the tool becomes available). If the tool is available, call:
+  ```
+  manage_project_config(operation="push", rootItemId="<project.rootId>", configYaml="<full current file text>")
+  ```
+  - Success → report the returned `fingerprint`. Re-pushing identical content later returns the same fingerprint (idempotent) — safe to call after every write without pre-checking.
+  - `VALIDATION_ERROR` → the server rejected the YAML (e.g. a construct its parser can't accept). The local file is already saved — tell the user the parse error from the response and to fix `.taskorchestrator/config.yaml`, then re-run VALIDATE and retry the push.
+  - A `warning` field on a successful response → relay it to the user as-is (non-fatal — e.g. the root item's `type` isn't `"project"`).
+- Remind: **MCP reconnect required** (`/mcp`) for schema changes to take effect on the *global* config path — the server caches `.taskorchestrator/config.yaml` on first access. A successful per-root push above takes effect immediately for items scoped to that root, without needing reconnect.
 
 **For VIEW and VALIDATE:** The output from Step 3 is the deliverable — no additional report needed.
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
@@ -316,6 +316,56 @@ When `did_allowlist` or `did_pattern` is set, the verifier resolves the JWT's `i
 
 ---
 
+## Project Scoping
+
+The `project:` section is a top-level key alongside `work_item_schemas`, `traits`, and `actor_authentication`. It anchors this repository's work to a single depth-0 MCP item.
+
+```yaml
+project:
+  rootId: "<uuid>"
+  name: "<project name>"
+
+work_item_schemas:
+  # ...
+```
+
+Default: absent — a workspace with no `project:` block is unscoped.
+
+### Fields
+
+| Field | Required | Type | Notes |
+|-------|----------|------|-------|
+| `rootId` | yes | string (UUID) | UUID of the depth-0 item tagged `type: "project"` that anchors this repo's work |
+| `name` | no | string | Human-readable project name shown in dashboards and skill output |
+
+### Behavior
+
+- **Client-side only.** The MCP server never reads this block from `config.yaml` — not in stdio mode, not in HTTP mode. It exists purely for Claude Code: the SessionStart hook and plugin skills read it to scope their output to `rootId`.
+- **Created by** the `quick-start` bootstrap flow or `/adopt-project-scope` when the user opts into anchoring session context to a single project root item.
+- **Opt-in convention.** Scoping is not enforced — its absence just means skills operate without a default root anchor, falling back to unscoped behavior.
+- The same scoping can also be pushed server-side via `manage_project_config` so it's visible beyond this local config file; see the project-scoping integration docs for the full push mechanism.
+
+**Example:**
+
+```yaml
+project:
+  rootId: "3f9a1c2e-8b4d-4a11-9c3f-2d6e7a8b9c0d"
+  name: "Task Orchestrator"
+
+work_item_schemas:
+  feature-task:
+    lifecycle: auto
+    notes:
+      - key: implementation-notes
+        role: work
+        required: true
+        description: "What was built and why"
+```
+
+> **manage-schemas write operations must preserve this block untouched** — see the create/edit/delete workflow docs in this skill folder.
+
+---
+
 ## Note Body Length Limits
 
 Top-level `note_limits.mode` (`warn`, default, or `reject`) governs what happens when a note body exceeds its schema `maxLength`, checked at `manage_notes` upsert time against the resolved body (inline `body` or file-read via `bodyFromFile`): `warn` accepts the note with a `warning` field on its result; `reject` fails that note with `code: NOTE_BODY_TOO_LONG`.

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
@@ -343,7 +343,7 @@ Default: absent — a workspace with no `project:` block is unscoped.
 - **Client-side only.** The MCP server never reads this block from `config.yaml` — not in stdio mode, not in HTTP mode. It exists purely for Claude Code: the SessionStart hook and plugin skills read it to scope their output to `rootId`.
 - **Created by** the `quick-start` bootstrap flow or `/adopt-project-scope` when the user opts into anchoring session context to a single project root item.
 - **Opt-in convention.** Scoping is not enforced — its absence just means skills operate without a default root anchor, falling back to unscoped behavior.
-- The same scoping can also be pushed server-side via `manage_project_config` so it's visible beyond this local config file; see the project-scoping integration docs for the full push mechanism.
+- The same scoping can also be pushed server-side via `manage_project_config` so it's visible beyond this local config file; see the project-scoping integration docs for the full push mechanism. In practice this push is triggered automatically by `manage-schemas`' write-operation report step (Step 4) and by `quick-start`'s bootstrap step (Step 1.5) whenever a `project.rootId` is present — both push the full config file text, not just this block, since the server itself never reads `project:`.
 
 **Example:**
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/create-workflow.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/create-workflow.md
@@ -176,6 +176,8 @@ Check if `.taskorchestrator/config.yaml` exists:
 - **Exists:** Read it, merge the new schema under `work_item_schemas:`, write back
 - **Doesn't exist:** Create `.taskorchestrator/` directory and write the file with the new schema under `work_item_schemas:`
 
+**Preserve all other top-level keys verbatim.** Only the `work_item_schemas:` (or `note_schemas:`) section may change. Every other top-level key present in the file — `project`, `actor_authentication`, `note_limits`, `traits`, and any key not recognized by this skill — must be carried through unchanged. Do not reconstruct the file from a parsed-and-regenerated schema model, since that silently drops blocks this skill doesn't know about; splice the new schema into the existing text (or reproduce every other top-level block exactly as read).
+
 After writing, remind the user: **MCP reconnect required** (`/mcp`) for the schema to take effect.
 
 ---

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/delete-workflow.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/delete-workflow.md
@@ -42,6 +42,8 @@ Remove the schema key and all its entries from the appropriate section (`work_it
 work_item_schemas:
 ```
 
+**Preserve all other top-level keys verbatim.** Deleting a schema must not touch `project`, `actor_authentication`, `note_limits`, `traits`, or any other top-level key — carry them through exactly as read rather than reconstructing the file from a parsed model.
+
 Write the updated file back.
 
 ---

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/edit-workflow.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/edit-workflow.md
@@ -95,6 +95,8 @@ Require explicit confirmation before applying.
 
 ## Write Back
 
+**Preserve all other top-level keys verbatim.** Only the schema being edited may change — carry through `project`, `actor_authentication`, `note_limits`, `traits`, and any other top-level key exactly as read. Do not regenerate the whole file from a parsed-and-reserialized model; splice the edited schema back into the existing text rather than reconstructing the file from scratch.
+
 Write the modified config back to `.taskorchestrator/config.yaml`. Show a diff-style summary of what changed:
 
 ```

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/validate-workflow.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/validate-workflow.md
@@ -15,6 +15,7 @@ Parse the file. If YAML is invalid, report the parse error with line number (if 
 - At least one of `work_item_schemas` or `note_schemas` must exist at the top level
 - Each must be a mapping (not a list or scalar)
 - `traits` is an optional top-level key — if present, must be a mapping
+- `project` is an optional top-level key — recognized, not schema-related; if present, must be a mapping containing `rootId` (string, required) and optionally `name` (string). Do not flag as unknown and do not modify it. See `references/config-format.md` → Project Scoping
 - `actor_authentication` is an optional top-level key — if present, must be a mapping containing `enabled` (boolean)
 - `actor_authentication.verifier` (if present) must be a mapping
 - `verifier.type` must be one of: `noop`, `jwks` (warn on unknown type)
@@ -81,6 +82,7 @@ For each note in each schema (and trait):
   note_schemas: 1 schema (legacy)
   traits: 2 traits
   actor_authentication: enabled, verifier: jwks
+  project: "Task Orchestrator" (rootId set)
 
   Errors (must fix):
     ✗ bug-fix.fix-summary: missing "required" field

--- a/claude-plugins/task-orchestrator/skills/post-plan-workflow/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/post-plan-workflow/SKILL.md
@@ -13,6 +13,7 @@ Plan approval is the green light for the full pipeline. Proceed through all thre
 Complete materialization **before** any implementation begins.
 
 1. **Create MCP items** from the approved plan using `create_work_tree` (preferred for structured work with dependencies) or `manage_items` (for individual items). Apply appropriate schema tags based on the plan and the project's `.taskorchestrator/config.yaml` — this activates gate enforcement for each item. If the config defines separate schemas for containers vs. child tasks, apply the appropriate tag at each level.
+   - **Anchor the root under the project when known:** resolve the project rootId from session context (injected by the SessionStart hook) or `.taskorchestrator/config.yaml`'s `project.rootId`. When known, set the new root item's `parentId` to that rootId (directly, or to the appropriate category container beneath it if one already exists) so materialized work lands inside the project's tree instead of at a bare depth 0. When no rootId is known, create at depth 0 as before.
 2. **Wire dependency edges** between items — use `BLOCKS` for sequencing, `fan-out`/`fan-in` patterns for parallel work
 3. **Check `expectedNotes` in create responses** — if the item's tags match a schema, the response includes the expected note keys and phases. Fill required queue-phase notes (`requirements`, `acceptance-criteria`, etc.) with content from the plan before advancing.
 4. **Verify all item UUIDs exist** — confirm the full item graph is materialized before proceeding
@@ -31,7 +32,7 @@ Dispatch subagents to execute the plan:
 - **Agents own phase entry only** — each agent calls `advance_item(trigger="start")` once to enter work phase, fills work-phase notes, and returns. The orchestrator handles all further transitions (work→review or work→terminal depending on schema). Agents do NOT call `advance_item` a second time
 - Fill work-phase notes (`implementation-notes`, `test-results`, etc.) as the agent works
 - Respect dependency ordering — do not dispatch an agent for a blocked item until its blockers complete
-- **Between waves:** call `get_blocked_items(parentId=...)` to confirm upstream items completed — dependency gating implicitly verifies agents transitioned their items. If downstream items are still blocked, investigate the upstream blocker
+- **Between waves:** call `get_blocked_items(ancestorId="<featureRootId>")` to confirm upstream items completed — dependency gating implicitly verifies agents transitioned their items. `ancestorId` catches blockers anywhere in the feature's subtree (not just direct children, which `parentId` alone would miss). If downstream items are still blocked, investigate the upstream blocker
 - **Do not** call `advance_item` or `complete_tree` for terminal transitions on items delegated to agents — the orchestrator reviews and advances to terminal after agents return
 
 Do NOT use `AskUserQuestion` between phases — proceed autonomously.

--- a/claude-plugins/task-orchestrator/skills/pre-plan-workflow/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/pre-plan-workflow/SKILL.md
@@ -14,11 +14,15 @@ The definition floor is the baseline of existing work, documentation requirement
 
 ## Step 1: Check Existing MCP State
 
+Resolve the project rootId first: check session context for a rootId injected by the SessionStart hook, or read `.taskorchestrator/config.yaml`'s top-level `project.rootId` (a file read, not an MCP call).
+
 Call the health check to see what's already tracked:
 
 ```
 get_context()
 ```
+
+When a rootId is known, pass it to scope the check to this project: `get_context(ancestorId="<rootId>")`. When no rootId is known, call unscoped exactly as shown — this is the same behavior as before project scoping existed.
 
 **If active or stalled items exist:**
 - Identify items related to the current request — avoid planning work that duplicates what's already tracked

--- a/claude-plugins/task-orchestrator/skills/quick-start/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/quick-start/SKILL.md
@@ -10,14 +10,45 @@ Interactive onboarding that teaches by doing. Detects your workspace state and a
 
 ## Step 1: Detect Workspace State
 
+Resolve the project rootId first: check session context for a rootId injected by the SessionStart hook, or read `.taskorchestrator/config.yaml`'s top-level `project.rootId` (a file read, not an MCP call).
+
 Call the health check to determine which path to follow:
 
 ```
 get_context()
 ```
 
+When a rootId is known, pass it to scope the check to this project: `get_context(ancestorId="<rootId>")`. When no rootId is known — the common case for a truly fresh workspace, or one that hasn't been bootstrapped yet — call unscoped exactly as shown.
+
 **If no active or stalled items exist** — follow the **Fresh-Start Path** (Steps 2-8).
 **If active items exist** — follow the **Orientation Path** (Steps A-C).
+
+---
+
+## Step 1.5: Project Anchor Bootstrap (if needed)
+
+Before following either path, check whether this workspace has a project anchor yet:
+
+- If `.taskorchestrator/config.yaml` does not exist at all, skip this step — that's the truly fresh workspace covered by the Fresh-Start Path below. Bootstrap can happen on a later run once a config file exists (e.g., after `/manage-schemas` creates one).
+- If `.taskorchestrator/config.yaml` exists and already has a top-level `project:` block, read its `rootId` and use it for scoping throughout this session — no bootstrap needed.
+- If `.taskorchestrator/config.yaml` exists but has **no** `project:` block, offer to create one via `AskUserQuestion`: *"This workspace doesn't have a project anchor yet — want me to create one? It lets `/work-summary`, `/create-item`, and other skills scope to just this project if multiple projects ever share the same database."*
+
+If the user accepts:
+
+1. Determine a project name — from `$ARGUMENTS`, conversation context, or by asking.
+2. Create the anchor item at depth 0:
+   ```
+   manage_items(operation="create", items=[{title: "<project name>", type: "project", priority: "low"}])
+   ```
+3. Write the canonical block into `.taskorchestrator/config.yaml`:
+   ```yaml
+   project:
+     rootId: "<created-item-uuid>"
+     name: "<project name>"
+   ```
+4. Older servers may not expose it, so check the tool list before calling — if a `manage_project_config` tool is available, also push the same block server-side so it takes effect immediately without waiting on a config reload. If the tool isn't available, the config.yaml write from step 3 is authoritative on its own; the server will pick it up on its normal config read path.
+
+If the user declines, proceed unscoped — nothing else in this skill requires an anchor.
 
 ---
 
@@ -210,12 +241,14 @@ get_context()
 query_items(operation="overview", includeChildren=true)
 ```
 
+Add `ancestorId="<rootId>"` to both when a rootId is known (resolved in Step 1) — this keeps the orientation dashboard scoped to the current project in multi-project workspaces. Call unscoped exactly as shown when no rootId is known.
+
 Present a condensed dashboard with these sections:
 
 - **Active Work** (role=work or review): items currently in progress — show title, role, and ancestor path
 - **Blocked / Stalled**: items that cannot advance — either dependency-blocked or missing required notes
 - **Containers**: root items with child counts by role
-- **Recommendations**: from `get_next_item(limit=3, includeDetails=true)`
+- **Recommendations**: from `get_next_item(limit=3, includeDetails=true)` — add `ancestorId="<rootId>"` when known
 
 Use status symbols: `◉` in-progress, `⊘` blocked, `○` pending, `✓` completed
 

--- a/claude-plugins/task-orchestrator/skills/quick-start/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/quick-start/SKILL.md
@@ -46,7 +46,15 @@ If the user accepts:
      rootId: "<created-item-uuid>"
      name: "<project name>"
    ```
-4. Older servers may not expose it, so check the tool list before calling — if a `manage_project_config` tool is available, also push the same block server-side so it takes effect immediately without waiting on a config reload. If the tool isn't available, the config.yaml write from step 3 is authoritative on its own; the server will pick it up on its normal config read path.
+4. Older servers may not expose it, so check the tool list before calling — if a `manage_project_config` tool is available, push the full current file text (not just the `project:` block — the server never reads that block itself; see `references/config-format.md` → Project Scoping) so per-root schema resolution picks it up immediately without waiting on a config reload:
+   ```
+   manage_project_config(operation="push", rootItemId="<created-item-uuid>", configYaml="<full current file text from step 3>")
+   ```
+   - Success → the returned `fingerprint` confirms the push landed; re-pushing identical content later returns the same fingerprint (idempotent).
+   - `VALIDATION_ERROR` → surface the parse error to the user; the config.yaml write from step 3 is already saved locally, so nothing is lost — tell them to fix the file and retry the push (or run `/manage-schemas validate`).
+   - A `warning` field → relay it to the user (non-fatal).
+
+   If the tool isn't available, note this and skip — the config.yaml write from step 3 is authoritative on its own; the server will pick it up on its normal config read path.
 
 If the user declines, proceed unscoped — nothing else in this skill requires an anchor.
 

--- a/claude-plugins/task-orchestrator/skills/ralph/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/ralph/SKILL.md
@@ -25,9 +25,14 @@ Determine what subset of the queue to drain.
 | `tag=<value>` | Items whose `tags` field contains `<value>` (substring) |
 | `type=<value>` | Items with this exact `type` |
 | `priority=<value>` | Items at this priority (`high`, `medium`, `low`) |
-| `parentId=<uuid-or-prefix>` | Only descendants of this container |
+| `parentId=<uuid-or-prefix>` | Only direct children of this container |
+| `ancestorId=<uuid-or-prefix>` | Only items anywhere in this ancestor's subtree, any depth — broader than `parentId`. Used for the queue **preview** in Step 3; see the note below Step 1 on where it does and doesn't reach. |
 
-Multiple keys combine with AND (space-separated). Examples: `tag=bug-fix priority=high`, `type=quick-fix`, `parentId=89d02e32`.
+Multiple keys combine with AND (space-separated). Examples: `tag=bug-fix priority=high`, `type=quick-fix`, `parentId=89d02e32`, `ancestorId=<projectRootId>`.
+
+**Project-scoped default:** when a project rootId is known (session context injected by the SessionStart hook, or `.taskorchestrator/config.yaml`'s `project.rootId`), default the filter to include `ancestorId=<rootId>` unless the user explicitly asks to drain across all projects (e.g., "ralph everything", "drain across all projects"). This keeps the Step 3 preview scoped to the current project when multiple project roots share one database.
+
+**Known limitation — `ancestorId` is preview-only.** The Step 3 preview uses `query_items`, which supports `ancestorId`. The actual per-iteration claim (`claim_item`, driven by `iteration-prompt.md`) does **not** support `ancestorId` — its selector only understands `tag`, `type`, `priority`, and `parentId` (see that file's filter-key table). So a filter like `ancestorId=<projectRootId>` will scope what you *see* in the preview but is silently dropped when translated for the actual drain — iterations will still claim from the whole queue unless the filter also includes a `parentId`/`tag`/`type` that discriminates the project's items. If precise per-project draining matters, prefer tagging or typing items distinctly per project until `claim_item` gains `ancestorId` support.
 
 **If `$ARGUMENTS` is empty**, ask the user via `AskUserQuestion`:
 
@@ -76,6 +81,8 @@ Show what the loop will see. Use `query_items` with the resolved filter to displ
 ```
 query_items(operation="search", role="queue", claimStatus="unclaimed", limit=10, ...)
 ```
+
+Pass `ancestorId="<rootId>"` in `...` when a project rootId is known (resolved above) and the filter didn't already override scope — this gives an accurate project-scoped preview, subject to the preview-only limitation noted in Step 1.
 
 Display:
 

--- a/claude-plugins/task-orchestrator/skills/session-retrospective/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/session-retrospective/SKILL.md
@@ -32,6 +32,17 @@ This returns the root item and its children. Collect all item UUIDs from the ove
 
 **If no root item ID provided:**
 
+Check for a known project root: session context injected by the SessionStart hook, or a `project.rootId` entry in `.taskorchestrator/config.yaml`.
+
+**If a project rootId is known**, scope both fallback calls to that subtree so concurrent runs in other projects sharing the same DB aren't conflated into this retrospective:
+
+```
+get_context(ancestorId="<rootId>") — active, blocked, stalled items within the project subtree
+query_items(operation="search", role="terminal", sortBy="modifiedAt", sortOrder="desc", limit=20, ancestorId="<rootId>")
+```
+
+**If no project rootId is configured**, fall back to the prior global behavior (unchanged):
+
 ```
 get_context() — active, blocked, stalled items
 query_items(operation="search", role="terminal", sortBy="modifiedAt", sortOrder="desc", limit=20)
@@ -150,6 +161,8 @@ Read the trend memory file `memory/retrospectives.md` from the auto memory direc
 
 ### 5a. Find or create container
 
+This container is process-global by design — it is the shared, cross-project learning layer, so it deliberately lives outside any project root and this search stays unscoped even when a project rootId is known.
+
 ```
 query_items(operation="search", query="Session Retrospectives", depth=0, limit=5)
 ```
@@ -160,20 +173,26 @@ If no match with that exact title at depth 0, create it:
 manage_items(operation="create", items=[{
   title: "Session Retrospectives",
   summary: "Container for structured post-implementation analyses.",
+  type: "container",
+  tags: "container",
   priority: "low"
 }])
 ```
 
 ### 5b. Create retrospective item
 
+If a project rootId (or project name from `.taskorchestrator/config.yaml` `project.name`) is known, include it in the title so a shared-DB container holding retrospectives from multiple projects stays attributable:
+
 ```
 manage_items(operation="create", items=[{
-  title: "Retrospective — <root-item-title> — <YYYY-MM-DD>",
+  title: "Retrospective — <project-name> — <root-item-title> — <YYYY-MM-DD>",
   summary: "<one-sentence summary of key findings>",
   tags: "session-retrospective",
   parentId: "<container-uuid>"
 }])
 ```
+
+If no project name is known, omit that segment: `"Retrospective — <root-item-title> — <YYYY-MM-DD>"`.
 
 ### 5c. Fill schema notes
 
@@ -235,11 +254,13 @@ Check the updated trend memory (from step 6). For each trend with **Sessions >= 
 
 ### 7a. Find or create proposals container
 
+This container is also process-global by design (same rationale as 5a) — it stays outside any project root, and this search stays unscoped even when a project rootId is known.
+
 ```
 query_items(operation="search", query="Improvement Proposals", depth=0, limit=5)
 ```
 
-Create if missing (same pattern as 5a).
+Create if missing (same pattern as 5a — include `type: "container"` and `tags: "container"`).
 
 ### 7b. Create proposal items
 
@@ -348,3 +369,12 @@ Omit sections with no data (e.g., no improvement proposals -> omit that table). 
 **Container not found**
 - Cause: First time creating retrospectives or improvement proposals
 - Solution: Skill creates containers lazily at steps 5a and 7a. No action needed.
+
+**Retrospective pulled in another project's items**
+- Cause: Shared multi-project DB with no project scope configured, so the step 1a fallback scan searched globally instead of within the current project's subtree.
+- Solution: Configure `project.rootId` in `.taskorchestrator/config.yaml`, or pass the root item UUID as an argument to the skill:
+```yaml
+project:
+  rootId: "<uuid>"
+  name: "<project name>"
+```

--- a/claude-plugins/task-orchestrator/skills/work-summary/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/work-summary/SKILL.md
@@ -18,7 +18,20 @@ Supplement the data with brief observations only when there is a genuine anomaly
 |--------------|------|
 | empty | **Lean** (default) |
 | the literal word `full` | **Full Inventory** |
+| the literal word `all` | **Multi-Project** — one condensed section per known project root |
 | anything else | **Scoped** — resolve to a UUID via `query_items(operation="search", query=$ARGUMENTS, limit=5)`; prefer the best-matching root or container item; if ambiguous, present matches via `AskUserQuestion` |
+
+---
+
+## Step 0.5 — Project Scope Resolution
+
+Before running Lean, Full, or Multi-Project mode, resolve the project rootId:
+
+- Check session context for a rootId injected by the SessionStart hook.
+- Otherwise, read `.taskorchestrator/config.yaml`'s top-level `project.rootId` field (a file read, not an MCP call).
+- **If no rootId is found by either path, behavior is exactly as before this feature existed** — every call below runs unscoped (whole-DB), and no `ancestorId` param is passed. This is the common case for single-project workspaces.
+
+When a rootId is known, Lean and Full mode calls pass it as `ancestorId="<rootId>"` (noted inline below). Scoped mode is unaffected — it already resolves its own scope UUID per invocation via FTS.
 
 ---
 
@@ -26,12 +39,12 @@ Supplement the data with brief observations only when there is a genuine anomaly
 
 ### Data collection (all parallel)
 
-1. `query_items(operation="overview", includeChildren=true, excludeTerminal=true)` — non-terminal roots with their children arrays and childCounts. **Fallback for older servers:** if `excludeTerminal` is rejected as an unknown parameter, call `query_items(operation="overview")` *without* `includeChildren`, then fetch children only where needed: for each non-terminal root whose `childCounts` show non-terminal children, `query_items(operation="search", parentId="<id>")` in parallel. Never fetch children of terminal roots.
-2. `get_context()` — health-check: active items, blocked items, stalled items, claim summary.
-3. `get_context(mode="session-resume", since="<now minus 48h, ISO 8601>")` — recent role transitions (the "where did I leave off" signal).
-4. `get_next_item(limit=5, includeDetails=true)` — ranked recommendations with parentId/tags.
-5. `query_items(operation="search", role="queue", limit=1)` — read `total` for the true queued count.
-6. `query_items(operation="search", role="terminal", limit=1)` — read `total` for the true done count.
+1. `query_items(operation="overview", includeChildren=true, excludeTerminal=true)` — non-terminal roots with their children arrays and childCounts. Add `ancestorId="<rootId>"` when a rootId is known, to anchor the overview to this project. **Fallback for older servers:** if `excludeTerminal` is rejected as an unknown parameter, call `query_items(operation="overview")` *without* `includeChildren` (still pass `ancestorId` if known), then fetch children only where needed: for each non-terminal root whose `childCounts` show non-terminal children, `query_items(operation="search", parentId="<id>")` in parallel. Never fetch children of terminal roots.
+2. `get_context()` — health-check: active items, blocked items, stalled items, claim summary. Add `ancestorId="<rootId>"` when known.
+3. `get_context(mode="session-resume", since="<now minus 48h, ISO 8601>")` — recent role transitions (the "where did I leave off" signal). Add `ancestorId="<rootId>"` when known — but note the **known limitation**: `recentTransitions` is NOT scoped by `ancestorId` even when passed; it always reflects the whole tree, not just this project.
+4. `get_next_item(limit=5, includeDetails=true)` — ranked recommendations with parentId/tags. Add `ancestorId="<rootId>"` when known.
+5. `query_items(operation="search", role="queue", limit=1)` — read `total` for the true queued count. Add `ancestorId="<rootId>"` when known.
+6. `query_items(operation="search", role="terminal", limit=1)` — read `total` for the true done count. Add `ancestorId="<rootId>"` when known.
 
 **Headline counts must come from these sources, never from eyeballing the overview payload** — overview covers roots + direct children only and may be truncated.
 
@@ -100,10 +113,12 @@ Everything lean mode shows, plus the complete per-container inventory.
 
 ### Data collection (all parallel)
 
-1. `query_items(operation="overview", includeChildren=true)` — all roots. **If the response has `truncated: true`, re-issue with `limit=<total>`** so nothing is silently missing.
-2. `get_context()` — health-check.
-3. `get_next_item(limit=5, includeDetails=true)`.
-4. Role-total queries as in lean mode (queue + terminal, `limit=1`).
+1. `query_items(operation="overview", includeChildren=true)` — all roots. Add `ancestorId="<rootId>"` when a rootId is known, to anchor the roots list to this project. **If the response has `truncated: true`, re-issue with `limit=<total>`** so nothing is silently missing.
+2. `get_context()` — health-check. Add `ancestorId="<rootId>"` when known.
+3. `get_next_item(limit=5, includeDetails=true)`. Add `ancestorId="<rootId>"` when known.
+4. Role-total queries as in lean mode (queue + terminal, `limit=1`, same `ancestorId` rule).
+
+Per-container fetches within the inventory (below) are already `itemId`-scoped and need no change.
 
 ### Sections, in order
 
@@ -135,6 +150,8 @@ Everything lean mode shows, plus the complete per-container inventory.
 
 ## Scoped Mode (`$ARGUMENTS` = UUID or title)
 
+Unchanged by project scoping — already resolves its own scope UUID per invocation, independent of any project rootId.
+
 Use the resolved UUID as the scope for full-inventory-style rendering of one subtree:
 
 1. `query_items(operation="overview", itemId="<parentId>")` — scoped overview.
@@ -142,6 +159,31 @@ Use the resolved UUID as the scope for full-inventory-style rendering of one sub
 3. `get_next_item(limit=5, parentId="<parentId>", includeDetails=true)` — scoped recommendations.
 
 Render the Full Inventory sections for that subtree only. All shared rules apply.
+
+---
+
+## Multi-Project Mode (`$ARGUMENTS` = `all`)
+
+Enumerate every known project anchor and render one condensed section per project — for workspaces where multiple project roots share the same database.
+
+1. `query_items(operation="search", type="project", depth=0)` — list all depth-0 items typed `project` (the anchors created by `/quick-start`'s bootstrap flow or manually via `/manage-schemas`).
+2. If none are found, say so and stop: "No project anchors found — run `/quick-start` to bootstrap one, or use `/work-summary` (no arguments) for the whole-DB view."
+3. For each anchor found, in parallel:
+   - `query_items(operation="overview", ancestorId="<anchor-id>", includeChildren=true, excludeTerminal=true)`
+   - `get_context(ancestorId="<anchor-id>")`
+   - `get_next_item(limit=3, includeDetails=true, ancestorId="<anchor-id>")`
+
+Render, per project, with a clear per-project header:
+
+```
+### ◆ <Project Name> (`<8-char-id>`)
+N active · N blocked · N queued
+
+**Attention:** <up to 2 blocked/stalled items, or "none">
+**Next up:** <top get_next_item result, or "nothing queued">
+```
+
+Keep each section condensed — this mode is a cross-project scan, not a per-project deep dive. Point the user at `/work-summary` (unscoped, or with that project's rootId once resolved) for the full dashboard on any one project.
 
 ---
 


### PR DESCRIPTION
## Summary

PR 4 of 4 — the final PR of the transport-unified project-root scoping feature (design record: MCP observation `7fab0fb4`). The server primitives (#219, #220, #221) get their client: the plugin now reads each repo's project anchor, injects it into every session, scopes all read/dashboard skills to the project subtree, and ships a guided migration for existing databases.

## Changes

- **SessionStart hook** reads `project.rootId`/`name` from `.taskorchestrator/config.yaml` (canonical top-level `project:` block) and injects scoping guidance; fail-open on any parse error; bootstrap notice when unconfigured.
- **Skill wiring**: work-summary (scoped lean/full + new multi-project `all` mode via anchored overview), create-item, pre/post-plan-workflow, ralph, quick-start (+ anchor bootstrap flow) — all pass `ancestorId` when a rootId is configured; whole-workspace behavior unchanged otherwise. Known limitation documented: `claim_item` has no scope param yet.
- **Retrospective fixes** (`5a5e0f85`): run-gathering is project-scoped so concurrent runs on a shared DB don't conflate; Session Retrospectives / Improvement Proposals containers stay process-global by design and are now `container`-typed so dashboards shelve them.
- **manage-schemas hardening**: audit proved the write-back docs would have dropped unknown top-level config blocks — preserve-verbatim directives added to all three write paths; `project:` documented in config-format.md; config-push sync steps added (manage-schemas + quick-start push the full file via `manage_project_config`, tolerant of older servers).
- **`/adopt-project-scope`** (new skill): in-place migration — capability-probe preflight (aborts on servers lacking the depth-sweep fix), classify depth-0 roots (move / keep-global / flag-for-cleanup), mutation-free dry run, confirmed execution, count reconciliation. Never deletes user data.
- **Output style**: project-scope-by-default section.

## Review

Consolidated 7-item review (single reviewer over the branch diff): 6 clean passes, adoption skill pass-with-notes — its three observations fixed in `c672963`. Hook behavior verified by direct node runs against five fixture scenarios; every tool parameter the skills reference was source-verified against merged main. The quick-start scoping tension vs. the earlier plugin-impact finding was adjudicated: conditional-on-rootId scoping preserves the whole-workspace onboarding view when unconfigured.

## Post-merge

Plugin content is cached — remove and re-add the marketplace to pick up changes (`/plugin marketplace add .claude-plugin` → `/plugin enable task-orchestrator@task-orchestrator-marketplace`). No version bumps here (release via `/prepare-release`).

MCP refs: feature `8452e3e8` (T4.1 `ed342245`, T4.2 `aaa03c6f`, T4.3 `b2ee495d`, T4.4 `d92f1024`, T4.5 `dec58dc0`, T4.6 `2f737c10`, T4.7 `2ec8bba2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012M9cBWioQoehDxABDaRDsS