### PR TITLE
fix(deps): bump sqlite-jdbc to 3.53.2.0 — close CVE-2025-6965

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ mcpSdk = "0.12.0"
 ktor = "3.3.3"
 
 # Database
-sqlite = "3.49.1.0"
+sqlite = "3.53.2.0"
 exposed = "1.2.0"
 flyway = "11.8.2"
 


### PR DESCRIPTION
## Summary
Bumps `sqlite-jdbc` `3.49.1.0` → `3.53.2.0` to close **CVE-2025-6965** (SQLite aggregate-term memory corruption, CVSS up to 9.8).

## Why
PR #113's commit message claimed the earlier bump to `3.49.1.0` addressed CVE-2025-6965 — but it did not. The vulnerability was fixed upstream in **SQLite 3.50.2**, and `sqlite-jdbc 3.49.1.0` bundles SQLite 3.49.1, which predates the fix. The repo has therefore been carrying the live critical CVE since #113. `3.53.2.0` is the latest stable release (bundles SQLite 3.53.2).

## Verification
- `./gradlew build` green — full `:current:test` + `:current:check` pass, only pre-existing lint warnings.
- Single-line change to `gradle/libs.versions.toml`; no source changes.

## Related
Closes the sqlite portion of "Address dependency CVEs and version hygiene" (MCP `d92e1ebd`). Flyway (transitive CVE-2024-7254 → 11.8.2) and the Exposed 1.0.0-beta → 1.2.0 graduation were already delivered in PR #113 and later releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)