### PR TITLE
fix(complete_tree): skip already-terminal items before gate check

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt
@@ -2,6 +2,7 @@ package io.github.jpicklyk.mcptask.current.application.tools.compound
 
 import io.github.jpicklyk.mcptask.current.application.service.RoleTransitionHandler
 import io.github.jpicklyk.mcptask.current.application.tools.*
+import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.modelcontextprotocol.kotlin.sdk.types.ToolAnnotations
@@ -368,6 +369,23 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
                 continue
             }
 
+            // Items already in a terminal role are recorded as skipped and never gate-checked.
+            // A terminal item is already done, so it must NOT gate-fail on unfilled notes and must
+            // NOT propagate a skip to its dependents — a terminal dependency is satisfied.
+            if (item.role == Role.TERMINAL) {
+                skippedCount++
+                resultsList.add(
+                    buildJsonObject {
+                        put("itemId", JsonPrimitive(itemId.toString()))
+                        put("title", JsonPrimitive(item.title))
+                        put("applied", JsonPrimitive(false))
+                        put("skipped", JsonPrimitive(true))
+                        put("skippedReason", JsonPrimitive("already terminal"))
+                    }
+                )
+                continue
+            }
+
             // Gate check: required notes must be filled for "complete" trigger
             val missingKeys = checkGate(item, trigger, context)
             if (missingKeys.isNotEmpty()) {
@@ -447,27 +465,41 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
 
         // Step 5: Process root item last (after all descendants), if requested
         if (rootItem != null) {
-            val missingKeys = checkGate(rootItem, trigger, context)
-            if (missingKeys.isNotEmpty()) {
-                gateFailureCount++
+            if (rootItem.role == Role.TERMINAL) {
+                // Already terminal — record as skipped, never gate-check (mirrors the descendant path).
+                skippedCount++
                 resultsList.add(
                     buildJsonObject {
                         put("itemId", JsonPrimitive(rootItem.id.toString()))
                         put("title", JsonPrimitive(rootItem.title))
                         put("applied", JsonPrimitive(false))
-                        put("gateErrors", JsonArray(missingKeys.map { JsonPrimitive("missing: $it") }))
+                        put("skipped", JsonPrimitive(true))
+                        put("skippedReason", JsonPrimitive("already terminal"))
                     }
                 )
             } else {
-                processItem(
-                    rootItem,
-                    trigger,
-                    handler,
-                    context,
-                    resultsList,
-                    onComplete = { completedCount++ },
-                    onSkip = { skippedCount++ }
-                )
+                val missingKeys = checkGate(rootItem, trigger, context)
+                if (missingKeys.isNotEmpty()) {
+                    gateFailureCount++
+                    resultsList.add(
+                        buildJsonObject {
+                            put("itemId", JsonPrimitive(rootItem.id.toString()))
+                            put("title", JsonPrimitive(rootItem.title))
+                            put("applied", JsonPrimitive(false))
+                            put("gateErrors", JsonArray(missingKeys.map { JsonPrimitive("missing: $it") }))
+                        }
+                    )
+                } else {
+                    processItem(
+                        rootItem,
+                        trigger,
+                        handler,
+                        context,
+                        resultsList,
+                        onComplete = { completedCount++ },
+                        onSkip = { skippedCount++ }
+                    )
+                }
             }
         }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeToolTest.kt
@@ -351,6 +351,135 @@ class CompleteTreeToolTest {
         }
 
     // ──────────────────────────────────────────────
+    // Regression (obs 821379ea): already-terminal items must be skipped, never gate-checked,
+    // and must not propagate a skip to their dependents.
+    // ──────────────────────────────────────────────
+
+    /** Builds a gated context whose schema requires one queue-phase note for feature-task items. */
+    private fun gatedContextRequiringAcceptanceCriteria(): ToolExecutionContext {
+        val schemaEntries =
+            listOf(
+                NoteSchemaEntry(
+                    key = "acceptance-criteria",
+                    role = Role.QUEUE,
+                    required = true,
+                    description = "Acceptance criteria"
+                )
+            )
+        val noteSchemaService =
+            object : NoteSchemaService {
+                override fun getSchemaForTags(tags: List<String>): List<NoteSchemaEntry>? =
+                    if ("feature-task" in tags) schemaEntries else null
+            }
+        val gatedRepoProvider = mockk<RepositoryProvider>()
+        every { gatedRepoProvider.workItemRepository() } returns workItemRepo
+        every { gatedRepoProvider.dependencyRepository() } returns depRepo
+        every { gatedRepoProvider.noteRepository() } returns noteRepo
+        every { gatedRepoProvider.roleTransitionRepository() } returns roleTransitionRepo
+        return ToolExecutionContext(gatedRepoProvider, noteSchemaService)
+    }
+
+    @Test
+    fun `terminal item is skipped not gate-failed even with unfilled required notes`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            // A cancelled (terminal) item whose feature-task schema requires a note it never got.
+            val item = makeItem(id = itemId, title = "Cancelled Item", role = Role.TERMINAL, tags = "feature-task")
+            val gatedContext = gatedContextRequiringAcceptanceCriteria()
+
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+            every { depRepo.findByToItemId(itemId) } returns emptyList()
+            // Deliberately do NOT mock noteRepo.findByItemId — a regression that gate-checks a
+            // terminal item would call it and fail this test with an unmocked-call error.
+
+            val params = buildItemIdsParams(listOf(itemId))
+            val result = tool.execute(params, gatedContext)
+
+            val r = extractResults(result)[0].jsonObject
+            assertFalse(r["applied"]!!.jsonPrimitive.boolean)
+            assertTrue(r["skipped"]!!.jsonPrimitive.boolean, "terminal item should be skipped")
+            assertEquals("already terminal", r["skippedReason"]!!.jsonPrimitive.content)
+            assertNull(r["gateErrors"], "terminal item must NOT be gate-checked")
+
+            val summary = extractSummary(result)
+            assertEquals(0, summary["completed"]!!.jsonPrimitive.int)
+            assertEquals(1, summary["skipped"]!!.jsonPrimitive.int)
+            assertEquals(0, summary["gateFailures"]!!.jsonPrimitive.int)
+        }
+
+    @Test
+    fun `dependent of a terminal item completes and is not skipped`(): Unit =
+        runBlocking {
+            val idA = UUID.randomUUID() // already-cancelled blocker (terminal, gated, no notes)
+            val idB = UUID.randomUUID() // ready dependent
+
+            val itemA = makeItem(id = idA, title = "Cancelled Blocker", role = Role.TERMINAL, tags = "feature-task")
+            val itemB = makeItem(id = idB, title = "Ready Dependent", role = Role.QUEUE)
+
+            // A blocks B — before the fix, A's spurious gate failure skipped B ("dependency gate failed").
+            val depAtoB = Dependency(fromItemId = idA, toItemId = idB, type = DependencyType.BLOCKS)
+
+            val gatedContext = gatedContextRequiringAcceptanceCriteria()
+
+            coEvery { workItemRepo.getById(idA) } returns Result.Success(itemA)
+            coEvery { workItemRepo.getById(idB) } returns Result.Success(itemB)
+            coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+            coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+
+            every { depRepo.findByToItemId(idA) } returns emptyList()
+            every { depRepo.findByToItemId(idB) } returns listOf(depAtoB)
+
+            val params = buildItemIdsParams(listOf(idA, idB))
+            val result = tool.execute(params, gatedContext)
+
+            val resultMap =
+                extractResults(result).associate {
+                    val obj = it.jsonObject
+                    UUID.fromString(obj["itemId"]!!.jsonPrimitive.content) to obj
+                }
+
+            val rA = resultMap[idA]!!
+            assertTrue(rA["skipped"]!!.jsonPrimitive.boolean, "terminal A should be skipped")
+            assertEquals("already terminal", rA["skippedReason"]!!.jsonPrimitive.content)
+
+            val rB = resultMap[idB]!!
+            assertTrue(
+                rB["applied"]!!.jsonPrimitive.boolean,
+                "B must complete — a terminal dependency is satisfied, not a gate failure"
+            )
+
+            val summary = extractSummary(result)
+            assertEquals(1, summary["completed"]!!.jsonPrimitive.int)
+            assertEquals(1, summary["skipped"]!!.jsonPrimitive.int)
+            assertEquals(0, summary["gateFailures"]!!.jsonPrimitive.int)
+        }
+
+    @Test
+    fun `root item already terminal is skipped not gate-failed`(): Unit =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val rootItem = makeItem(id = rootId, title = "Done Feature", role = Role.TERMINAL, tags = "feature-task")
+            val gatedContext = gatedContextRequiringAcceptanceCriteria()
+
+            coEvery { workItemRepo.findDescendants(rootId) } returns Result.Success(emptyList())
+            coEvery { workItemRepo.getById(rootId) } returns Result.Success(rootItem)
+
+            val params = buildRootIdParams(rootId) // includeRoot defaults true
+            val result = tool.execute(params, gatedContext)
+
+            val r = extractResults(result)[0].jsonObject
+            assertEquals(rootId.toString(), r["itemId"]!!.jsonPrimitive.content)
+            assertTrue(r["skipped"]!!.jsonPrimitive.boolean)
+            assertEquals("already terminal", r["skippedReason"]!!.jsonPrimitive.content)
+            assertNull(r["gateErrors"], "terminal root must NOT be gate-checked")
+
+            val summary = extractSummary(result)
+            assertEquals(0, summary["completed"]!!.jsonPrimitive.int)
+            assertEquals(1, summary["skipped"]!!.jsonPrimitive.int)
+            assertEquals(0, summary["gateFailures"]!!.jsonPrimitive.int)
+        }
+
+    // ──────────────────────────────────────────────
     // Test 6: Must provide either rootId or itemIds -> validation error otherwise
     // ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
`complete_tree` ran the completion gate against children **already in a terminal role** (including `statusLabel=cancelled`), returning `applied:false` + `gateErrors` instead of recording them as skipped — despite the tool's own docs stating "Items already in TERMINAL role are recorded as skipped."

Worse, because those terminal items registered as *failed* within the batch, a sibling with a dependency edge onto a cancelled child was then skipped with `skippedReason="dependency gate failed"` even though a terminal dependency is satisfied. The ready item had to be completed with a standalone `advance_item`.

## Fix
Short-circuit terminal-role items to `skipped("already terminal")` **before** the gate check and before `propagateSkip`, in both the descendants loop and the root-item path. A terminal item is done, so it is never gate-checked and never propagates a skip to its dependents.

## Tests
Three regression tests added to `CompleteTreeToolTest`:
- a terminal item with unfilled required notes is skipped, **not** gate-failed (and is never note-queried);
- the dependent of a terminal/cancelled blocker still **completes** (the core regression);
- an already-terminal root is skipped, not gate-failed.

Full `./gradlew build` green.

## Related
Surfaced by observation `821379ea` during a feature-completion run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)