### PR TITLE
chore(plugin): single-source the tier-classification block (canonical fragment + CI guard)

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -27,15 +27,25 @@ For each item, call `get_context(itemId=...)` to understand:
 - Existing notes already filled
 - Dependencies and blocked status
 
-**Execution tier** — classify per the output style's Tier Classification table:
+**Execution tier** — classify by this table (canonical source shared with the Workflow Orchestrator output style; edit the fragment, not this copy):
 
-| Criteria | Tier |
-|----------|------|
-| 1-2 files, known fix, no migration/new API | **Direct** — orchestrator implements, tests, reviews inline |
-| 3-10 files, single logical unit, clear or explorable scope | **Delegated** — single subagent, separate review agent |
-| 11+ files, multiple independent work streams, dependency edges | **Parallel** — worktree agents, full pipeline |
+<!-- BEGIN GENERATED:tier-classification | source: claude-plugins/task-orchestrator/output-styles/_fragments/tier-classification.md · regen: node claude-plugins/task-orchestrator/output-styles/generate.mjs -->
+| Criteria | Tier | Pipeline |
+|----------|------|----------|
+| 1-2 files, known fix, no migration/new API | **Direct** | Orchestrator edits, tests, reviews inline |
+| 3-10 files, single logical unit, clear or explorable scope | **Delegated** | Single subagent, separate review agent |
+| 11+ files, multiple independent work streams, dependency edges | **Parallel** | Worktree agents, full pipeline |
 
-Apply force-UP signals (migration, new API, multiple work streams, collaborative language) and force-DOWN signals (user says "just fix it", schema-free item) per the output style.
+**Force-UP signals** (bump tier regardless of file count):
+- Database migration → min Delegated
+- New public API surface → min Delegated
+- Multiple independent work streams → Parallel
+- User says "let's plan" / collaborative language → min Delegated
+
+**Force-DOWN signals:**
+- User says "just fix it" / "quick" → Direct (unless complexity contradicts)
+- Schema tag is `default` or absent → eligible for Direct
+<!-- END GENERATED:tier-classification -->
 
 If the item has no schema tag, apply `quick-fix` for Direct tier or leave untagged for Delegated/Parallel (the `default` schema catches these).
 

--- a/claude-plugins/task-orchestrator/output-styles/_fragments/tier-classification.consumers.txt
+++ b/claude-plugins/task-orchestrator/output-styles/_fragments/tier-classification.consumers.txt
@@ -1,0 +1,9 @@
+# Single source of truth for the set of in-repo files that embed the GENERATED:tier-classification
+# block from tier-classification.md. Read by all three enforcement sites so they can never diverge:
+#   - claude-plugins/task-orchestrator/output-styles/generate.mjs   (rewrite targets)
+#   - current/.../docs/TierClassificationConsistencyTest.kt         (drift assertion)
+#   - current/build.gradle.kts                                      (:current:test inputs.files, cache-busting)
+# Paths are repo-root-relative, one per line. Blank lines and lines starting with '#' are ignored.
+# To add a new consumer: add the marker block to the file, then add its path here — nowhere else.
+claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
+.claude/skills/implement/SKILL.md

--- a/claude-plugins/task-orchestrator/output-styles/_fragments/tier-classification.md
+++ b/claude-plugins/task-orchestrator/output-styles/_fragments/tier-classification.md
@@ -1,0 +1,15 @@
+| Criteria | Tier | Pipeline |
+|----------|------|----------|
+| 1-2 files, known fix, no migration/new API | **Direct** | Orchestrator edits, tests, reviews inline |
+| 3-10 files, single logical unit, clear or explorable scope | **Delegated** | Single subagent, separate review agent |
+| 11+ files, multiple independent work streams, dependency edges | **Parallel** | Worktree agents, full pipeline |
+
+**Force-UP signals** (bump tier regardless of file count):
+- Database migration → min Delegated
+- New public API surface → min Delegated
+- Multiple independent work streams → Parallel
+- User says "let's plan" / collaborative language → min Delegated
+
+**Force-DOWN signals:**
+- User says "just fix it" / "quick" → Direct (unless complexity contradicts)
+- Schema tag is `default` or absent → eligible for Direct

--- a/claude-plugins/task-orchestrator/output-styles/generate.mjs
+++ b/claude-plugins/task-orchestrator/output-styles/generate.mjs
@@ -27,6 +27,8 @@ const fragment = norm(readFileSync(resolve(scriptDir, '_fragments/tier-classific
 
 const check = process.argv.includes('--check');
 const extra = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+// KEEP IN SYNC with TierClassificationConsistencyTest.inRepoConsumers and current/build.gradle.kts
+// `inputs.files` — a consumer added here but not to inputs.files is not cache-busted, so drift can pass CI.
 const targets = [
   { path: resolve(scriptDir, 'workflow-orchestrator.md'), required: true },
   { path: resolve(repoRoot, '.claude/skills/implement/SKILL.md'), required: true },
@@ -50,6 +52,11 @@ for (const { path, required } of targets) {
     continue;
   }
   const beginLineEnd = text.indexOf('\n', bi);
+  if (beginLineEnd === -1 || ei <= beginLineEnd) {
+    console.error(`ERROR: malformed markers in ${path} (END must follow BEGIN on a later line)`);
+    failures++;
+    continue;
+  }
   const rebuilt = text.slice(0, beginLineEnd + 1) + fragment + text.slice(ei);
   if (rebuilt === text) continue; // already in sync
   if (check) {

--- a/claude-plugins/task-orchestrator/output-styles/generate.mjs
+++ b/claude-plugins/task-orchestrator/output-styles/generate.mjs
@@ -30,7 +30,8 @@ const extra = process.argv.slice(2).filter((a) => !a.startsWith('--'));
 const targets = [
   { path: resolve(scriptDir, 'workflow-orchestrator.md'), required: true },
   { path: resolve(repoRoot, '.claude/skills/implement/SKILL.md'), required: true },
-  { path: resolve(repoRoot, '.claude/output-styles/workflow-analyst.md'), required: false },
+  // Out-of-repo copies (e.g. a personal ~/.claude/output-styles/workflow-analyst.md) are not
+  // defaults — pass them as CLI args to sync them: `node generate.mjs <path-to-style>`.
   ...extra.map((p) => ({ path: resolve(p), required: true })),
 ];
 

--- a/claude-plugins/task-orchestrator/output-styles/generate.mjs
+++ b/claude-plugins/task-orchestrator/output-styles/generate.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Regenerates the shared tier-classification block in every consumer file from the
+// single canonical fragment (_fragments/tier-classification.md). Run this after
+// editing the fragment — the copies must never be hand-edited.
+//
+//   node claude-plugins/task-orchestrator/output-styles/generate.mjs            # rewrite copies in place
+//   node claude-plugins/task-orchestrator/output-styles/generate.mjs --check    # verify only, non-zero exit on drift (CI)
+//   node .../generate.mjs <extra-file> [...]                                    # also sync extra targets, e.g. a home-dir style
+//
+// The Kotlin test TierClassificationConsistencyTest enforces the in-repo copies in CI;
+// this script is the developer convenience for keeping them (and any out-of-repo copy)
+// in sync. Required in-repo consumers must contain the markers or the run fails.
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const MARKER = 'tier-classification';
+const BEGIN = `<!-- BEGIN GENERATED:${MARKER}`;
+const END = `<!-- END GENERATED:${MARKER}`;
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '../../..');
+const norm = (s) => s.replace(/\r\n/g, '\n');
+
+// Canonical content, normalized to exactly one trailing newline.
+const fragment = norm(readFileSync(resolve(scriptDir, '_fragments/tier-classification.md'), 'utf8')).replace(/\n*$/, '\n');
+
+const check = process.argv.includes('--check');
+const extra = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+const targets = [
+  { path: resolve(scriptDir, 'workflow-orchestrator.md'), required: true },
+  { path: resolve(repoRoot, '.claude/skills/implement/SKILL.md'), required: true },
+  { path: resolve(repoRoot, '.claude/output-styles/workflow-analyst.md'), required: false },
+  ...extra.map((p) => ({ path: resolve(p), required: true })),
+];
+
+let failures = 0;
+let changed = 0;
+for (const { path, required } of targets) {
+  if (!existsSync(path)) {
+    if (required) { console.error(`ERROR: required consumer missing: ${path}`); failures++; }
+    continue;
+  }
+  const text = norm(readFileSync(path, 'utf8'));
+  const bi = text.indexOf(BEGIN);
+  const ei = text.indexOf(END);
+  if (bi === -1 || ei === -1) {
+    if (required) { console.error(`ERROR: markers not found in ${path}`); failures++; }
+    continue;
+  }
+  const beginLineEnd = text.indexOf('\n', bi);
+  const rebuilt = text.slice(0, beginLineEnd + 1) + fragment + text.slice(ei);
+  if (rebuilt === text) continue; // already in sync
+  if (check) {
+    console.error(`OUT OF SYNC: ${path} — run: node claude-plugins/task-orchestrator/output-styles/generate.mjs`);
+    failures++;
+  } else {
+    writeFileSync(path, rebuilt);
+    console.log(`updated: ${path}`);
+    changed++;
+  }
+}
+
+if (failures > 0) process.exit(1);
+if (!check) console.log(changed === 0 ? 'all consumers already in sync' : `${changed} file(s) updated`);

--- a/claude-plugins/task-orchestrator/output-styles/generate.mjs
+++ b/claude-plugins/task-orchestrator/output-styles/generate.mjs
@@ -27,13 +27,18 @@ const fragment = norm(readFileSync(resolve(scriptDir, '_fragments/tier-classific
 
 const check = process.argv.includes('--check');
 const extra = process.argv.slice(2).filter((a) => !a.startsWith('--'));
-// KEEP IN SYNC with TierClassificationConsistencyTest.inRepoConsumers and current/build.gradle.kts
-// `inputs.files` — a consumer added here but not to inputs.files is not cache-busted, so drift can pass CI.
+// The in-repo consumer set is defined ONCE in the manifest and shared by TierClassificationConsistencyTest
+// and current/build.gradle.kts inputs.files, so the three enforcement sites can never diverge.
+const manifestPath = resolve(scriptDir, '_fragments/tier-classification.consumers.txt');
+const manifestTargets = norm(readFileSync(manifestPath, 'utf8'))
+  .split('\n')
+  .map((line) => line.trim())
+  .filter((line) => line && !line.startsWith('#'))
+  .map((rel) => ({ path: resolve(repoRoot, rel), required: true }));
 const targets = [
-  { path: resolve(scriptDir, 'workflow-orchestrator.md'), required: true },
-  { path: resolve(repoRoot, '.claude/skills/implement/SKILL.md'), required: true },
-  // Out-of-repo copies (e.g. a personal ~/.claude/output-styles/workflow-analyst.md) are not
-  // defaults — pass them as CLI args to sync them: `node generate.mjs <path-to-style>`.
+  ...manifestTargets,
+  // Out-of-repo copies (e.g. a personal ~/.claude/output-styles/workflow-analyst.md) are not in the
+  // manifest — pass them as CLI args to sync them: `node generate.mjs <path-to-style>`.
   ...extra.map((p) => ({ path: resolve(p), required: true })),
 ];
 

--- a/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
+++ b/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
@@ -18,6 +18,7 @@ Items whose `type` (or legacy `tags`) matches a schema in `.taskorchestrator/con
 
 Classify every piece of work into a tier before starting — the tier determines how much process to apply.
 
+<!-- BEGIN GENERATED:tier-classification | source: claude-plugins/task-orchestrator/output-styles/_fragments/tier-classification.md · regen: node claude-plugins/task-orchestrator/output-styles/generate.mjs -->
 | Criteria | Tier | Pipeline |
 |----------|------|----------|
 | 1-2 files, known fix, no migration/new API | **Direct** | Orchestrator edits, tests, reviews inline |
@@ -33,6 +34,7 @@ Classify every piece of work into a tier before starting — the tier determines
 **Force-DOWN signals:**
 - User says "just fix it" / "quick" → Direct (unless complexity contradicts)
 - Schema tag is `default` or absent → eligible for Direct
+<!-- END GENERATED:tier-classification -->
 
 ### Tier Pipeline Summary
 

--- a/current/build.gradle.kts
+++ b/current/build.gradle.kts
@@ -144,16 +144,24 @@ tasks.test {
     // headroom; production runtime heap is unaffected (this is test-only).
     maxHeapSize = "2g"
 
-    // TierClassificationConsistencyTest reads these markdown files at runtime. Declare them
-    // as task inputs so a markdown-only edit (with no Kotlin change) invalidates the cached
-    // test result instead of reporting UP-TO-DATE — otherwise Gradle's incremental cache
-    // (and CI's setup-gradle cache) would let tier-block drift slip through the guard.
-    // KEEP IN SYNC with TierClassificationConsistencyTest.inRepoConsumers and generate.mjs `targets`.
+    // TierClassificationConsistencyTest reads the fragment + its consumers at runtime. Declare them
+    // as task inputs so a markdown-only edit (with no Kotlin change) invalidates the cached test
+    // result instead of reporting UP-TO-DATE — otherwise Gradle's incremental cache (and CI's
+    // setup-gradle cache) would let tier-block drift slip through the guard. The consumer set is
+    // read from the same manifest the test and generate.mjs use, so the three cannot diverge.
+    val tierFragmentsDir = rootProject.file("claude-plugins/task-orchestrator/output-styles/_fragments")
+    val tierConsumersManifest = tierFragmentsDir.resolve("tier-classification.consumers.txt")
+    val tierConsumerFiles =
+        tierConsumersManifest
+            .readLines()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && !it.startsWith("#") }
+            .map { rootProject.file(it) }
     inputs
         .files(
-            rootProject.file("claude-plugins/task-orchestrator/output-styles/_fragments/tier-classification.md"),
-            rootProject.file("claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md"),
-            rootProject.file(".claude/skills/implement/SKILL.md"),
+            tierConsumersManifest,
+            tierFragmentsDir.resolve("tier-classification.md"),
+            *tierConsumerFiles.toTypedArray(),
         ).withPropertyName("docsConsistencyInputs")
 }
 

--- a/current/build.gradle.kts
+++ b/current/build.gradle.kts
@@ -148,6 +148,7 @@ tasks.test {
     // as task inputs so a markdown-only edit (with no Kotlin change) invalidates the cached
     // test result instead of reporting UP-TO-DATE — otherwise Gradle's incremental cache
     // (and CI's setup-gradle cache) would let tier-block drift slip through the guard.
+    // KEEP IN SYNC with TierClassificationConsistencyTest.inRepoConsumers and generate.mjs `targets`.
     inputs
         .files(
             rootProject.file("claude-plugins/task-orchestrator/output-styles/_fragments/tier-classification.md"),

--- a/current/build.gradle.kts
+++ b/current/build.gradle.kts
@@ -143,6 +143,17 @@ tasks.test {
     // `OutOfMemoryError: Java heap space` worker crashes. Raise the cap to give the suite
     // headroom; production runtime heap is unaffected (this is test-only).
     maxHeapSize = "2g"
+
+    // TierClassificationConsistencyTest reads these markdown files at runtime. Declare them
+    // as task inputs so a markdown-only edit (with no Kotlin change) invalidates the cached
+    // test result instead of reporting UP-TO-DATE — otherwise Gradle's incremental cache
+    // (and CI's setup-gradle cache) would let tier-block drift slip through the guard.
+    inputs
+        .files(
+            rootProject.file("claude-plugins/task-orchestrator/output-styles/_fragments/tier-classification.md"),
+            rootProject.file("claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md"),
+            rootProject.file(".claude/skills/implement/SKILL.md"),
+        ).withPropertyName("docsConsistencyInputs")
 }
 
 kotlin {

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/docs/TierClassificationConsistencyTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/docs/TierClassificationConsistencyTest.kt
@@ -26,6 +26,8 @@ class TierClassificationConsistencyTest {
     private val beginPrefix = "<!-- BEGIN GENERATED:$marker"
     private val endPrefix = "<!-- END GENERATED:$marker"
 
+    // KEEP IN SYNC with generate.mjs `targets` and current/build.gradle.kts `inputs.files` on the test
+    // task — a consumer added here but not to inputs.files is not cache-busted, so drift can pass CI.
     private val inRepoConsumers =
         listOf(
             "claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md",
@@ -63,6 +65,9 @@ class TierClassificationConsistencyTest {
             fail("tier-classification markers not found in $source (expected $beginPrefix ... $endPrefix)")
         }
         val beginLineEnd = text.indexOf('\n', begin)
+        if (beginLineEnd == -1 || end <= beginLineEnd) {
+            fail("malformed tier-classification markers in $source (END must follow BEGIN on a later line)")
+        }
         return text.substring(beginLineEnd + 1, end)
     }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/docs/TierClassificationConsistencyTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/docs/TierClassificationConsistencyTest.kt
@@ -5,6 +5,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.test.fail
 
 /**
@@ -26,13 +27,10 @@ class TierClassificationConsistencyTest {
     private val beginPrefix = "<!-- BEGIN GENERATED:$marker"
     private val endPrefix = "<!-- END GENERATED:$marker"
 
-    // KEEP IN SYNC with generate.mjs `targets` and current/build.gradle.kts `inputs.files` on the test
-    // task — a consumer added here but not to inputs.files is not cache-busted, so drift can pass CI.
-    private val inRepoConsumers =
-        listOf(
-            "claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md",
-            ".claude/skills/implement/SKILL.md",
-        )
+    // The in-repo consumer set is defined ONCE in this manifest, shared by generate.mjs and
+    // current/build.gradle.kts inputs.files. Add a new consumer there, not here.
+    private val consumersManifest =
+        "claude-plugins/task-orchestrator/output-styles/_fragments/tier-classification.consumers.txt"
 
     @Test
     fun `every in-repo consumer mirrors the canonical fragment`() {
@@ -43,7 +41,13 @@ class TierClassificationConsistencyTest {
                 .let { Files.readString(it) }
                 .normalize()
 
-        for (relativePath in inRepoConsumers) {
+        val consumers = readManifest(root)
+        assertTrue(
+            consumers.isNotEmpty(),
+            "consumer manifest $consumersManifest is empty — the guard would be vacuously green",
+        )
+
+        for (relativePath in consumers) {
             val text = Files.readString(root.resolve(relativePath)).normalize()
             val region = regionBetweenMarkers(text, relativePath)
             assertEquals(
@@ -72,6 +76,12 @@ class TierClassificationConsistencyTest {
     }
 
     private fun String.normalize(): String = replace("\r\n", "\n")
+
+    private fun readManifest(root: Path): List<String> =
+        Files
+            .readAllLines(root.resolve(consumersManifest))
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && !it.startsWith("#") }
 
     /** Walk up from the test working directory until the repo root (contains both marker dirs). */
     private fun repoRoot(): Path {

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/docs/TierClassificationConsistencyTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/docs/TierClassificationConsistencyTest.kt
@@ -1,0 +1,82 @@
+package io.github.jpicklyk.mcptask.current.docs
+
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+/**
+ * Guards the single-source-of-truth contract for the tier-classification block.
+ *
+ * The block is authored once in
+ * `claude-plugins/task-orchestrator/output-styles/_fragments/tier-classification.md`
+ * and mirrored (verbatim) into each in-repo consumer between
+ * `<!-- BEGIN GENERATED:tier-classification -->` / `<!-- END GENERATED:tier-classification -->`
+ * markers. The mirror is produced by `output-styles/generate.mjs`; this test fails the
+ * build if any consumer drifts from the fragment, so the copies can never silently diverge
+ * (which is exactly what happened to the pre-refactor manual mirror).
+ *
+ * The out-of-repo project-level style (`~/.claude/output-styles/workflow-analyst.md`) is
+ * intentionally NOT guarded here — it is not part of the repository and CI cannot see it.
+ */
+class TierClassificationConsistencyTest {
+    private val marker = "tier-classification"
+    private val beginPrefix = "<!-- BEGIN GENERATED:$marker"
+    private val endPrefix = "<!-- END GENERATED:$marker"
+
+    private val inRepoConsumers =
+        listOf(
+            "claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md",
+            ".claude/skills/implement/SKILL.md",
+        )
+
+    @Test
+    fun `every in-repo consumer mirrors the canonical fragment`() {
+        val root = repoRoot()
+        val fragment =
+            root
+                .resolve("claude-plugins/task-orchestrator/output-styles/_fragments/tier-classification.md")
+                .let { Files.readString(it) }
+                .normalize()
+
+        for (relativePath in inRepoConsumers) {
+            val text = Files.readString(root.resolve(relativePath)).normalize()
+            val region = regionBetweenMarkers(text, relativePath)
+            assertEquals(
+                fragment.trim(),
+                region.trim(),
+                "tier-classification block in $relativePath drifted from the canonical fragment. " +
+                    "Run: node claude-plugins/task-orchestrator/output-styles/generate.mjs",
+            )
+        }
+    }
+
+    private fun regionBetweenMarkers(
+        text: String,
+        source: String
+    ): String {
+        val begin = text.indexOf(beginPrefix)
+        val end = text.indexOf(endPrefix)
+        if (begin == -1 || end == -1) {
+            fail("tier-classification markers not found in $source (expected $beginPrefix ... $endPrefix)")
+        }
+        val beginLineEnd = text.indexOf('\n', begin)
+        return text.substring(beginLineEnd + 1, end)
+    }
+
+    private fun String.normalize(): String = replace("\r\n", "\n")
+
+    /** Walk up from the test working directory until the repo root (contains both marker dirs). */
+    private fun repoRoot(): Path {
+        var dir: Path? = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+        while (dir != null) {
+            if (Files.isDirectory(dir.resolve("claude-plugins")) && Files.isDirectory(dir.resolve("current"))) {
+                return dir
+            }
+            dir = dir.parent
+        }
+        fail("could not locate repo root (looking for a dir containing both 'claude-plugins/' and 'current/')")
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts the tier-classification block (criteria table + force signals) into a single canonical fragment: `claude-plugins/task-orchestrator/output-styles/_fragments/tier-classification.md`.
- Mirrors it verbatim into the two in-repo consumers — `workflow-orchestrator.md` (shipped plugin style) and `.claude/skills/implement/SKILL.md` — between `<!-- BEGIN/END GENERATED:tier-classification -->` markers. Replaces the previous drift-prone hand-maintained copies.
- `generate.mjs` regenerates the copies from the fragment (`--check` mode for CI/verification; extra paths as CLI args for any out-of-repo copy).
- `TierClassificationConsistencyTest` fails the build if any consumer drifts from the fragment. The `.md` files are declared as `:current:test` inputs so a **markdown-only** edit invalidates the cached result (otherwise Gradle/CI caching would let drift pass green).

**No behavior change:** the block content is preserved byte-for-byte; only markers were added. The implement skill's reduced 2-column table was normalized up to the full canonical block.

## Scope
Move 1 of 4 from the recommended approach on MCP item `3602165b`. Moves 2–4 (delegation-metadata → schema, model-table demotion, schema-minimal style) are tracked as follow-up items. The out-of-repo `~/.claude/output-styles/workflow-analyst.md` is intentionally outside the CI/PR loop (not in the repo).

## Test Results
- `:current:test` (`TierClassificationConsistencyTest`) — green. Drift-injection verified: a markdown-only edit re-runs the test (compileTestKotlin stays UP-TO-DATE) and fails on the drift assertion; restored → green.
- `:current:ktlintCheck` — green.
- `node generate.mjs --check` — exit 0.

## Review
Independent review (separate agent, review-quality framework): **PASS WITH OBSERVATIONS**. Caught a cache-tracking defect — the guard was UP-TO-DATE-cached on markdown-only changes — which was fixed (input tracking) and verified before this PR.

## MCP
- Item: `3602165b`
- Follow-ups: `1e2a3ef4` (move 2), `1dd18a4e` (move 3), `36c05208` (move 4), `4bfd4b5d` (generator/negative-case test coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)