### PR TITLE
test(plugin): tier-classification guard coverage + generate.mjs nits

### DIFF
--- a/claude-plugins/task-orchestrator/output-styles/generate.mjs
+++ b/claude-plugins/task-orchestrator/output-styles/generate.mjs
@@ -34,26 +34,29 @@ const manifestTargets = norm(readFileSync(manifestPath, 'utf8'))
   .split('\n')
   .map((line) => line.trim())
   .filter((line) => line && !line.startsWith('#'))
-  .map((rel) => ({ path: resolve(repoRoot, rel), required: true }));
+  .map((rel) => resolve(repoRoot, rel));
 const targets = [
   ...manifestTargets,
   // Out-of-repo copies (e.g. a personal ~/.claude/output-styles/workflow-analyst.md) are not in the
   // manifest — pass them as CLI args to sync them: `node generate.mjs <path-to-style>`.
-  ...extra.map((p) => ({ path: resolve(p), required: true })),
+  ...extra.map((p) => resolve(p)),
 ];
 
 let failures = 0;
 let changed = 0;
-for (const { path, required } of targets) {
+for (const path of targets) {
   if (!existsSync(path)) {
-    if (required) { console.error(`ERROR: required consumer missing: ${path}`); failures++; }
+    console.error(`ERROR: consumer missing: ${path}`);
+    failures++;
     continue;
   }
-  const text = norm(readFileSync(path, 'utf8'));
+  const raw = readFileSync(path, 'utf8');
+  const text = norm(raw);
   const bi = text.indexOf(BEGIN);
   const ei = text.indexOf(END);
   if (bi === -1 || ei === -1) {
-    if (required) { console.error(`ERROR: markers not found in ${path}`); failures++; }
+    console.error(`ERROR: markers not found in ${path}`);
+    failures++;
     continue;
   }
   const beginLineEnd = text.indexOf('\n', bi);
@@ -68,7 +71,10 @@ for (const { path, required } of targets) {
     console.error(`OUT OF SYNC: ${path} — run: node claude-plugins/task-orchestrator/output-styles/generate.mjs`);
     failures++;
   } else {
-    writeFileSync(path, rebuilt);
+    // Preserve the file's original line-ending style — only the marked region changed, so a
+    // regen on a CRLF checkout must not flip the whole file to LF.
+    const eol = raw.includes('\r\n') ? '\r\n' : '\n';
+    writeFileSync(path, eol === '\n' ? rebuilt : rebuilt.replace(/\n/g, eol));
     console.log(`updated: ${path}`);
     changed++;
   }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/docs/TierClassificationConsistencyTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/docs/TierClassificationConsistencyTest.kt
@@ -5,6 +5,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
@@ -35,11 +36,14 @@ class TierClassificationConsistencyTest {
     @Test
     fun `every in-repo consumer mirrors the canonical fragment`() {
         val root = repoRoot()
+        // Mirror generate.mjs's canonical form: CRLF-normalized, exactly one trailing newline
+        // (the generator does `.replace(/\n*$/, '\n')`), so the test and generator stay byte-aligned.
         val fragment =
             root
                 .resolve("claude-plugins/task-orchestrator/output-styles/_fragments/tier-classification.md")
                 .let { Files.readString(it) }
                 .normalize()
+                .trimEnd('\n') + "\n"
 
         val consumers = readManifest(root)
         assertTrue(
@@ -50,13 +54,34 @@ class TierClassificationConsistencyTest {
         for (relativePath in consumers) {
             val text = Files.readString(root.resolve(relativePath)).normalize()
             val region = regionBetweenMarkers(text, relativePath)
+            // Byte-exact (only CRLF normalized) — matches generate.mjs's exact-string check so that
+            // whitespace-only drift inside the markers is caught, not silently trimmed away.
             assertEquals(
-                fragment.trim(),
-                region.trim(),
+                fragment,
+                region,
                 "tier-classification block in $relativePath drifted from the canonical fragment. " +
                     "Run: node claude-plugins/task-orchestrator/output-styles/generate.mjs",
             )
         }
+    }
+
+    @Test
+    fun `regionBetweenMarkers extracts the block between well-formed markers`() {
+        val text = "intro\n$beginPrefix | note -->\nBODY 1\nBODY 2\n$endPrefix -->\noutro\n"
+        assertEquals("BODY 1\nBODY 2\n", regionBetweenMarkers(text, "well-formed"))
+    }
+
+    @Test
+    fun `regionBetweenMarkers fails cleanly when markers are missing`() {
+        val ex = assertFailsWith<AssertionError> { regionBetweenMarkers("no markers here\n", "missing") }
+        assertTrue(ex.message!!.contains("markers not found"))
+    }
+
+    @Test
+    fun `regionBetweenMarkers fails cleanly when END precedes BEGIN`() {
+        val text = "$endPrefix -->\nbody\n$beginPrefix -->\n"
+        val ex = assertFailsWith<AssertionError> { regionBetweenMarkers(text, "reversed") }
+        assertTrue(ex.message!!.contains("malformed"))
     }
 
     private fun regionBetweenMarkers(


### PR DESCRIPTION
## Summary
Follow-up hardening from the two independent reviews on #229 (item `4bfd4b5d`).

- **`generate.mjs`** — removed the dead post-manifest `required` field and its unreachable guards; the generator now **preserves each file's original line endings** on write (detects CRLF from the raw read and re-applies), so a regen on a CRLF checkout no longer flips the whole file to LF.
- **`TierClassificationConsistencyTest`** — the drift assertion is now **byte-exact** (dropped `.trim()`), aligned with `generate.mjs`'s exact-string check; the fragment is normalized to the generator's canonical form (exactly one trailing newline) so the test and generator can't accept/reject differently. Added **negative-case unit tests** for `regionBetweenMarkers`: happy path, missing markers, and END-before-BEGIN (both fail cleanly).

**Intentionally omitted:** a JS-level unit test for `generate.mjs` — the repo has no JS test harness and CI (`test.yml`) installs no Node, so a node-invoking JVM test would fail in CI. The generator's output is guarded by the Kotlin consistency test instead (asserts committed files == fragment, which is what the generator produces).

## Test Results
- `:current:test` (`TierClassificationConsistencyTest`, 4 tests) — green
- `:current:ktlintCheck` — green
- `node generate.mjs --check` — exit 0
- CRLF preservation empirically verified via a throwaway CRLF target (`cat -A` confirmed all lines, including injected fragment lines, kept `^M$`)

## MCP
Item: `4bfd4b5d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)