### PR TITLE
refactor(plugin): demote model table + write threshold to labeled project convention

### DIFF
--- a/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
+++ b/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
@@ -62,6 +62,12 @@ When session context carries a project rootId (injected by the SessionStart hook
 
 ## Delegation
 
+> **Project convention, not a plugin requirement.** The specific model assignments and the
+> MCP-write batching threshold below are tuned for this repository. Consumers of this output style
+> in other projects should treat them as sensible defaults and adjust to their own model availability
+> and tooling — what transfers is the *principle* (match model to task weight; keep the orchestrator's
+> context lean), not the exact table values.
+
 | Task type | Model |
 |-----------|-------|
 | MCP bulk ops, materialization, simple queries | `haiku` |
@@ -70,7 +76,7 @@ When session context carries a project rootId (injected by the SessionStart hook
 
 **Always set `model` explicitly** on every Agent dispatch — defaulting wastes opus tokens or under-powers complex work.
 
-**Rule: Never make 3+ MCP write calls in a single turn.** Parallelized reads (e.g., `get_context` + `query_items` overview) are fine and encouraged. Delegate bulk MCP write work to the Agent tool with `model: "haiku"` to keep the orchestrator context clean.
+**Project convention: avoid 3+ MCP write calls in a single turn.** Parallelized reads (e.g., `get_context` + `query_items` overview) are fine and encouraged. Delegate bulk MCP write work to the Agent tool with `model: "haiku"` to keep the orchestrator context clean.
 
 Delegation prompts must include entity IDs and full context — subagents start fresh.
 


### PR DESCRIPTION
## Summary
Move 3 of the `3602165b` refactor (item `1dd18a4e`). The haiku/sonnet/opus model-routing table and the MCP-write batching threshold in `workflow-orchestrator.md`'s `## Delegation` section were shipped as **hard rules**, but they're this repository's tuning — not universal plugin requirements that every consumer should inherit.

- Added a blockquote labeling the table + threshold as a **project convention** (the transferable *principle* — match model to task weight, keep orchestrator context lean — stays; the exact values are defaults to adjust).
- Softened the `**Rule:**` label to `**Project convention:**`.
- **No change** to the table values, and **no change** to the tier-classification block (different section, outside the GENERATED markers).

## Verification
- `node generate.mjs --check` → exit 0 (tier-classification region untouched)
- `:current:test` guard test → green (edit is outside the GENERATED markers)
- Diff is `+7/-1` on `workflow-orchestrator.md` only

## MCP
Item: `1dd18a4e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)