### PR TITLE
refactor(plugin): make delegation-metadata opt-in via a delegated trait

### DIFF
--- a/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
+++ b/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
@@ -82,16 +82,7 @@ Delegation prompts must include entity IDs and full context — subagents start 
 
 **Notes are the report.** Subagents write findings into their work item's notes; their final message back is 1-2 lines (item ID, outcome, note keys filled). Never ask agents to restate note content in replies.
 
-## Delegation Metadata
-
-**Required for every Parallel and Delegated tier dispatch.** After a subagent returns, the orchestrator fills a `delegation-metadata` note on the work item via `manage_notes(operation="upsert")`. Direct tier skips this — there is no delegation to record.
-
-- **key:** `delegation-metadata`, **role:** `work`
-- **body:** Model used (`haiku` / `sonnet` / `opus`); isolation mode (`inline` or `worktree:<path>`); one-line rationale (why this model for this work); one-line outcome (success / partial / failure plus key result).
-
-The orchestrator fills this — not the subagent — because the orchestrator alone has accurate dispatch metadata (the subagent doesn't know which model it ran on, why it was chosen, or how its return compared to expectation). Fill in the same response that processes the subagent's return, batched alongside other note writes for that item where possible.
-
-Without these notes, `/session-retrospective` loses cross-session signal on whether model assignments matched task complexity.
+**Delegation metadata (opt-in).** If your project defines a `delegated` trait (see your schema config), apply it to Delegated/Parallel items and, after each subagent returns, fill its `delegation-metadata` work note — model · isolation · one-line rationale · one-line outcome. The orchestrator fills this, not the subagent (only the orchestrator knows the dispatch details). It feeds `/session-retrospective`'s delegation-alignment scoring; projects that don't define the trait simply skip it.
 
 ## Action Items
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/example-schemas.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/example-schemas.md
@@ -151,6 +151,14 @@ traits:
         required: true
         description: "Security review of auth, data handling, and access control."
         guidance: "Evaluate input validation, injection risks, access control, data handling. Flag OWASP Top 10 concerns."
+
+  delegated:
+    notes:
+      - key: delegation-metadata
+        role: work
+        required: false
+        description: "Model, isolation, rationale, and outcome for a delegated dispatch (orchestrator-filled)."
+        guidance: "Filled by the orchestrator AFTER a subagent returns (the subagent doesn't know which model it ran on). Record model (haiku/sonnet/opus), isolation (inline or worktree:<path>), a one-line rationale, and a one-line outcome. Optional — feeds /session-retrospective delegation-alignment scoring; absent is tolerated."
 ```
 
 Apply traits at item creation: `manage_items(create, items=[{..., traits: "needs-migration-review"}])` or via schema-level `default_traits`.

--- a/current/docs/integration-guides/self-improving-workflow.md
+++ b/current/docs/integration-guides/self-improving-workflow.md
@@ -121,7 +121,7 @@ work_item_schemas:
 
 ### `delegation-metadata` (optional) — model alignment data
 
-When the orchestrator dispatches a subagent, it can record the model used and isolation mode as a `delegation-metadata` note on the work item:
+When the orchestrator dispatches a subagent, it can record the model used and isolation mode as a `delegation-metadata` note on the work item. Projects that want this consistently can define a `delegated` trait (see the `/manage-schemas` reference) and apply it to delegated items:
 
 ```
 manage_notes(operation="upsert", notes=[{


### PR DESCRIPTION
## Summary
Move 2 of the `3602165b` refactor (item `1e2a3ef4`). The shipped `workflow-orchestrator.md` **hard-required** a `delegation-metadata` note after every Delegated/Parallel dispatch — imposing this project's `/session-retrospective` bookkeeping on every plugin consumer.

- **`workflow-orchestrator.md`** — removed the `## Delegation Metadata` section; replaced it with a short **opt-in pointer** under `## Delegation`. Projects define a `delegated` trait to keep the behavior; others simply skip it.
- **`example-schemas.md`** — documented the `delegated` trait (note `delegation-metadata`, role `work`, **`required: false`** so it never becomes a hard advance gate).
- **`self-improving-workflow.md`** — noted the metadata can be formalized as a `delegated` trait.

`/session-retrospective` already treats the note as optional ("if none exist, skip scoring"), so nothing there changes.

## Not in this PR (by design)
The trait *definition* lives in per-workspace `.taskorchestrator/config.yaml`, which is **gitignored** (runtime config is per-workspace; nothing ships). So this PR is the shipped-artifact half — removing the imposed requirement + documenting the opt-in. This repo's own workspace config gets the trait separately (takes effect on MCP restart — config is cached at startup).

## Verification
- No dangling references to the removed section (grep across `claude-plugins`)
- `node generate.mjs --check` → exit 0 (tier-classification block untouched)
- Diff is 3 markdown files; no code/test impact

## MCP
Item: `1e2a3ef4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)