### PR TITLE
feat(api): REST per-root config write endpoint + shared ProjectConfigPushService

### DIFF
--- a/current/docs/api-rest.md
+++ b/current/docs/api-rest.md
@@ -26,12 +26,13 @@ This document describes the HTTP REST API layer (v1) added alongside the MCP tra
 14. [Endpoints — Transitions (Audit)](#14-endpoints--transitions-audit)
 15. [Endpoints — Search](#15-endpoints--search)
 16. [Endpoints — Config / Schema Discovery](#16-endpoints--config--schema-discovery)
-17. [Endpoints — Service Meta](#17-endpoints--service-meta)
-18. [Server-Sent Events (SSE)](#18-server-sent-events-sse)
-19. [Audit Model](#19-audit-model)
-20. [Merge Patch Semantics](#20-merge-patch-semantics)
-21. [Status-Graph Caveat](#21-status-graph-caveat)
-22. [Known Limitations](#22-known-limitations)
+17. [Endpoints — Project Config (Per-Root)](#17-endpoints--project-config-per-root)
+18. [Endpoints — Service Meta](#18-endpoints--service-meta)
+19. [Server-Sent Events (SSE)](#19-server-sent-events-sse)
+20. [Audit Model](#20-audit-model)
+21. [Merge Patch Semantics](#21-merge-patch-semantics)
+22. [Status-Graph Caveat](#22-status-graph-caveat)
+23. [Known Limitations](#23-known-limitations)
 
 ---
 
@@ -116,6 +117,7 @@ Each token grants a set of additive capabilities:
 | `WRITE_NOTES` | `write-notes` | `PUT /items/{id}/notes/{key}`, `DELETE /items/{id}/notes/{key}` |
 | `ADVANCE` | `advance` | `POST /items/{id}/advance` |
 | `MANAGE_DEPENDENCIES` | `manage-dependencies` | `POST /dependencies`, `DELETE /dependencies/{id}` |
+| `WRITE_CONFIG` | `write-config` | `PUT /roots/{rootId}/config`, `DELETE /roots/{rootId}/config` |
 | `ADMIN` | `admin` | Implies all of the above; unlocks attribution fields in responses |
 
 **`ADMIN` unlocks:** When a caller has `ADMIN`, note and transition `actor`/`verification` fields are included in responses (subject to `API_REDACT_*` env flags). Non-admin callers always receive `null` for these fields.
@@ -158,6 +160,11 @@ Config/schema endpoints (`/config`, `/config/schemas`, etc.) use a fingerprint-b
 - Stable across reads when the config has not changed
 - `If-None-Match` → `304` when fingerprint matches
 
+The per-root project config endpoints (§17, `/roots/{rootId}/config`) use the SAME `"cfg-<fingerprint>"`
+format, but the fingerprint is a SHA-256 over the stored `configYaml`'s raw UTF-8 bytes (see
+`SQLiteProjectConfigRepository.computeFingerprint`) rather than the global config file. `PUT` additionally
+accepts `If-Match` for optimistic-concurrency writes (see §17).
+
 ---
 
 ## 5. Idempotency
@@ -197,7 +204,7 @@ All error responses use:
 | `scope_forbidden` | 403 | Item exists but is outside the caller's scope |
 | `field_not_patchable` | 400 | PATCH attempted on a server-owned field |
 | `cycle_detected` | 400 | Dependency would create a cycle |
-| `unsupported_media_type` | 415 | Wrong `Content-Type` for PATCH (see §20) |
+| `unsupported_media_type` | 415 | Wrong `Content-Type` for PATCH (see §21) |
 | `etag_mismatch` | 412 | `If-Match` header does not match current ETag |
 | `unauthenticated` | 401 | No authenticated principal (missing/invalid token) |
 | `verification_failed` | 401 | JWKS verification failed under `reject` policy |
@@ -441,6 +448,19 @@ Note: `"<previousRole>"` is a literal sentinel string — dashboards must resolv
 }
 ```
 
+**ProjectConfigResponseDto** (see §17):
+```json
+{
+  "rootItemId": "550e8400-e29b-41d4-a716-446655440000",
+  "fingerprint": "e3b0c44298fc1c14...",
+  "updatedAt": "2026-07-15T19:00:00Z",
+  "configYaml": "work_item_schemas:\n  ...",
+  "warning": "string|null"
+}
+```
+`configYaml` is populated on `GET` only (omitted on `PUT`). `warning` is populated only when the
+root's `type` is not `"project"` (non-fatal — the push still succeeds).
+
 ### SSE / ApiEvent
 
 ```json
@@ -574,7 +594,7 @@ Supports `Idempotency-Key` header.
 
 JSON Merge Patch update. Requires `WRITE_ITEMS`, `If-Match`, and `Content-Type: application/merge-patch+json` (or `application/json`).
 
-**Request body:** A partial JSON object following RFC 7396 merge-patch semantics (see §20).
+**Request body:** A partial JSON object following RFC 7396 merge-patch semantics (see §21).
 
 **Tags deviation:** In PATCH, `tags` must be a comma-separated **string** (not a JSON array). Example: `"tags": "feature,auth"`. Sending a JSON array in PATCH → `400 validation_error`.
 
@@ -884,11 +904,66 @@ Structural role-transition graph across all schema types.
 
 **Response:** `200 OK` → `StatusGraphDto`
 
-See §21 for the important caveat about what the status graph does and does not reflect.
+See §22 for the important caveat about what the status graph does and does not reflect.
 
 ---
 
-## 17. Endpoints — Service Meta
+## 17. Endpoints — Project Config (Per-Root)
+
+Per-root config YAML documents pushed by a client (or the fail-open SessionStart config-sync hook,
+in a later phase) and layered over the global `.taskorchestrator/config.yaml` on every
+schema-resolving read — see [`ProjectConfigPushService`](../src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushService.kt)
+and the MCP `manage_project_config` tool, which share the exact same validate-then-persist
+pipeline as these routes (both converge on identical DB state for the same payload).
+
+All three verbs additionally require `ApiScope.rootIds` (when scoped) to contain `{rootId}` —
+`403 scope_forbidden` otherwise. `{rootId}` must be a depth-0 WorkItem UUID.
+
+### PUT /roots/{rootId}/config
+
+Validates and stores raw `configYaml` for `{rootId}`. Requires `WRITE_CONFIG`.
+
+**Request body:** raw YAML text (`Content-Type: application/yaml` or `text/plain`); max 128 KiB.
+
+**Validation pipeline (in order, stops at first failure — nothing is written on failure):**
+1. Body size ≤ 128 KiB
+2. `{rootId}` resolves to an existing WorkItem
+3. That WorkItem is depth-0 (configs anchor to project roots only)
+4. `configYaml` parses under a `SafeConstructor` YAML load (rejects `!!`-tagged arbitrary Java
+   type construction — CWE-502 — as well as ordinary syntax errors)
+5. Optional `If-Match` (see below), evaluated against the CURRENT stored fingerprint
+
+**Responses:**
+- `200 OK` → `ProjectConfigResponseDto` (no `configYaml` field on this verb); `ETag: "cfg-<fingerprint>"`
+- `404 not_found` — `{rootId}` does not resolve to an existing WorkItem
+- `422 validation_error` — `{rootId}` is not depth-0
+- `422 parse_error` — `configYaml` failed SafeConstructor parse-validation
+- `412 etag_mismatch` — `If-Match` supplied and mismatched against an EXISTING row's ETag (a
+  first push to a root with no prior row ignores `If-Match` — there is nothing to match yet)
+- `413 payload_too_large` — body exceeds 128 KiB
+- `403 scope_forbidden` — capability present but `{rootId}` outside token scope
+
+### GET /roots/{rootId}/config
+
+Reads back the stored config for `{rootId}`. Requires `READ`.
+
+**Responses:**
+- `200 OK` → `ProjectConfigResponseDto` (includes `configYaml`); `ETag: "cfg-<fingerprint>"`
+- `304 Not Modified` — `If-None-Match` matches the current fingerprint ETag
+- `404 not_found` — no config has ever been pushed for `{rootId}` (the WorkItem itself is not
+  validated to exist — mirrors the MCP tool's `get` semantics)
+
+### DELETE /roots/{rootId}/config
+
+Removes the stored config row for `{rootId}`. Requires `WRITE_CONFIG`.
+
+**Responses:**
+- `204 No Content` — deleted
+- `404 not_found` — no config row existed for `{rootId}`
+
+---
+
+## 18. Endpoints — Service Meta
 
 ### GET /api/v1/info
 
@@ -930,7 +1005,7 @@ Requires `READ`. Returns server metadata and the caller's resolved capabilities.
 
 ---
 
-## 18. Server-Sent Events (SSE)
+## 19. Server-Sent Events (SSE)
 
 ### GET /api/v1/events
 
@@ -978,7 +1053,7 @@ Ktor's `sse {}` handler runs inside the response-body phase — after the HTTP 2
 
 ---
 
-## 19. Audit Model
+## 20. Audit Model
 
 All write endpoints (POST, PATCH, PUT, DELETE) synthesize an actor server-side from the authenticated principal. Client-supplied `actor.*` fields in the request body are **silently dropped** — callers cannot override audit attribution.
 
@@ -999,7 +1074,7 @@ All write endpoints (POST, PATCH, PUT, DELETE) synthesize an actor server-side f
 
 ---
 
-## 20. Merge Patch Semantics
+## 21. Merge Patch Semantics
 
 `PATCH /items/{id}` implements [RFC 7396 JSON Merge Patch](https://datatracker.ietf.org/doc/html/rfc7396).
 
@@ -1019,7 +1094,7 @@ All write endpoints (POST, PATCH, PUT, DELETE) synthesize an actor server-side f
 
 ---
 
-## 21. Status-Graph Caveat
+## 22. Status-Graph Caveat
 
 `GET /config/status-graph` returns the **structural** (schema-defined) transition graph — which triggers are valid for each role per type.
 
@@ -1035,7 +1110,7 @@ The `"<previousRole>"` sentinel in `blocked.resume` is a literal string — reso
 
 ---
 
-## 22. Known Limitations
+## 23. Known Limitations
 
 **SSE dependency-event scoping depends on a warm ancestor cache.** Live root-filtering and `Last-Event-ID` replay are both correctly root-scoped — ring-buffer entries carry `affectedRoots` metadata and the replay path applies the same root-intersection filter as the live fan-out. One residual caveat remains for dependency events: `dependency.added` / `dependency.removed` resolve their affected roots from an in-memory ancestor cache populated by prior item create/update writes. On a cache miss (e.g., a dependency change with no preceding item write on that subtree during the connection's lifetime), the event falls back to an unscoped broadcast. This is a deliberate tradeoff; root-scoped subscribers that require exact dependency-event scoping should re-fetch state rather than relying solely on the event stream.
 

--- a/current/docs/api/openapi.yaml
+++ b/current/docs/api/openapi.yaml
@@ -671,6 +671,28 @@ components:
         dbReachable:
           type: boolean
 
+    ProjectConfigResponseDto:
+      type: object
+      required: [rootItemId, fingerprint, updatedAt]
+      properties:
+        rootItemId:
+          type: string
+          format: uuid
+        fingerprint:
+          type: string
+          description: SHA-256 hex digest of the stored configYaml's UTF-8 bytes
+        updatedAt:
+          type: string
+          format: date-time
+        configYaml:
+          type: string
+          nullable: true
+          description: Raw stored YAML text; present on GET only (omitted on PUT)
+        warning:
+          type: string
+          nullable: true
+          description: Non-fatal notice when the root's `type` is not "project"
+
   responses:
     Unauthorized:
       description: Missing or invalid bearer token
@@ -1654,6 +1676,138 @@ paths:
           description: Not modified
         "401":
           $ref: "#/components/responses/Unauthorized"
+
+  /roots/{rootId}/config:
+    parameters:
+      - name: rootId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      summary: Read back the stored per-root config
+      operationId: getProjectConfig
+      tags: [project-config]
+      description: |
+        Requires READ + scope (rootId must be within the token's rootIds when scoped). Mirrors
+        the MCP manage_project_config tool's get operation — does not validate that the WorkItem
+        itself exists, only that a config row has been pushed.
+      parameters:
+        - name: If-None-Match
+          in: header
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Stored config
+          headers:
+            ETag:
+              schema:
+                type: string
+                description: '"cfg-<fingerprint>"'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectConfigResponseDto"
+        "304":
+          description: Not modified
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: No config has been pushed for this root
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorDto"
+
+    put:
+      summary: Validate and store raw config YAML for a root
+      operationId: putProjectConfig
+      tags: [project-config]
+      description: |
+        Requires WRITE_CONFIG + scope. Delegates the full validate-then-persist pipeline
+        (size cap -> root exists -> root is depth-0 -> SafeConstructor parse-validate -> upsert)
+        to ProjectConfigPushService — the SAME service the MCP manage_project_config tool's push
+        operation calls, so both surfaces converge on identical DB state for the same payload.
+      parameters:
+        - name: If-Match
+          in: header
+          schema:
+            type: string
+          description: >-
+            Optional; validated against the CURRENT stored fingerprint's ETag when a row already
+            exists. Ignored on a first push (no prior row to match).
+      requestBody:
+        required: true
+        content:
+          application/yaml:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        "200":
+          description: Config validated and stored
+          headers:
+            ETag:
+              schema:
+                type: string
+                description: '"cfg-<fingerprint>"'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectConfigResponseDto"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: rootId does not resolve to an existing WorkItem
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorDto"
+        "412":
+          description: If-Match mismatch against the current fingerprint
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorDto"
+        "413":
+          description: configYaml exceeds the 128 KiB cap
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorDto"
+        "422":
+          description: rootId is not depth-0, or configYaml failed parse-validation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorDto"
+
+    delete:
+      summary: Delete the stored per-root config
+      operationId: deleteProjectConfig
+      tags: [project-config]
+      description: Requires WRITE_CONFIG + scope.
+      responses:
+        "204":
+          description: Deleted
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: No config row existed for this root
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorDto"
 
   /info:
     get:

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushService.kt
@@ -1,0 +1,166 @@
+package io.github.jpicklyk.mcptask.current.application.service
+
+import io.github.jpicklyk.mcptask.current.domain.model.ProjectConfig
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlSchemaParser
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
+import org.yaml.snakeyaml.LoaderOptions
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Transport-agnostic validation + persist pipeline for per-root config YAML pushes.
+ *
+ * Extracted from [io.github.jpicklyk.mcptask.current.application.tools.config.ManageProjectConfigTool]
+ * (the MCP `manage_project_config` `push` operation) so the exact SAME pipeline can be driven by
+ * both the MCP tool and the REST `PUT /api/v1/roots/{rootId}/config` route
+ * ([io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.projectConfigRoutes]) — both callers
+ * must converge on identical DB state for the same payload.
+ *
+ * Pipeline, in order: size cap -> root exists -> root is depth-0 -> [SafeConstructor]
+ * parse-validate -> [io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository.upsert].
+ * The pipeline stops at the first failing step; nothing is written on failure.
+ */
+class ProjectConfigPushService(
+    private val repositoryProvider: RepositoryProvider,
+) {
+    /**
+     * Validates and persists [configYaml] for [rootItemId]. See [ProjectConfigPushResult] for the
+     * possible outcomes.
+     */
+    suspend fun push(
+        rootItemId: UUID,
+        configYaml: String,
+    ): ProjectConfigPushResult {
+        val sizeBytes = configYaml.toByteArray(Charsets.UTF_8).size
+        if (sizeBytes > MAX_CONFIG_YAML_BYTES) {
+            return ProjectConfigPushResult.TooLarge(sizeBytes, MAX_CONFIG_YAML_BYTES)
+        }
+
+        val item =
+            when (val itemResult = repositoryProvider.workItemRepository().getById(rootItemId)) {
+                is Result.Success -> itemResult.data
+                is Result.Error -> return ProjectConfigPushResult.NotFound(rootItemId)
+            }
+
+        if (item.depth != 0) {
+            return ProjectConfigPushResult.NotDepthZero(rootItemId, item.depth)
+        }
+
+        val typeWarning =
+            if (item.type != "project") {
+                "Root item type is '${item.type ?: "null"}', not 'project' — config pushed anyway " +
+                    "(a naming convention, not an enforced constraint)"
+            } else {
+                null
+            }
+
+        val parseError = validateYaml(configYaml)
+        if (parseError != null) {
+            return ProjectConfigPushResult.ParseError(parseError)
+        }
+
+        return when (val result = repositoryProvider.projectConfigRepository().upsert(rootItemId, configYaml)) {
+            is Result.Success ->
+                ProjectConfigPushResult.Success(
+                    rootItemId = result.data.rootItemId,
+                    fingerprint = result.data.fingerprint,
+                    updatedAt = result.data.updatedAt,
+                    warning = typeWarning,
+                )
+            is Result.Error -> ProjectConfigPushResult.RepositoryError(result.error.message)
+        }
+    }
+
+    /** Reads back the stored config for [rootItemId], or a null payload when no row exists. */
+    suspend fun get(rootItemId: UUID): Result<ProjectConfig?> = repositoryProvider.projectConfigRepository().get(rootItemId)
+
+    /** Deletes the stored config row for [rootItemId]. Returns true when a row was deleted. */
+    suspend fun delete(rootItemId: UUID): Result<Boolean> = repositoryProvider.projectConfigRepository().delete(rootItemId)
+
+    /**
+     * Parses [configYaml] the same way [io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService]
+     * will on every subsequent read (via the shared [YamlSchemaParser]), but BEFORE storing — a
+     * stored-but-unparseable config would otherwise silently fall through to the global schema on
+     * every future read, a confusing failure mode discovered only much later. Returns the parse
+     * failure message, or null when [configYaml] parses cleanly.
+     *
+     * Uses [SafeConstructor] rather than SnakeYAML's default `Constructor` — `configYaml` is
+     * attacker-reachable input (pushed over MCP or REST, not read from a trusted local file), and
+     * the default `Constructor` will happily instantiate an arbitrary Java type named by a
+     * `!!`-tag (the SnakeYAML deserialization-RCE gadget class, CWE-502). `SafeConstructor` only
+     * ever builds plain maps/lists/scalars, which is all a config document legitimately needs; any
+     * `!!`-tagged custom type throws [org.yaml.snakeyaml.constructor.ConstructorException] before
+     * anything is instantiated, and that exception is caught below like any other parse failure.
+     *
+     * Soft validation warnings collected by [YamlSchemaParser.parseRoot] (e.g. a note entry
+     * missing `key`, an invalid `lifecycle` value) are NOT treated as rejection here — only a hard
+     * YAML syntax/shape failure (invalid syntax, or a non-map document) is. Those soft warnings
+     * mirror the global config loader's existing behavior: skip the offending entry, keep going.
+     */
+    private fun validateYaml(configYaml: String): String? =
+        try {
+            @Suppress("UNCHECKED_CAST")
+            val root = Yaml(SafeConstructor(LoaderOptions())).load<Map<String, Any>>(configYaml)
+            if (root != null) {
+                YamlSchemaParser.parseRoot(root, warnOnMissingSchemas = false)
+            }
+            null
+        } catch (
+            @Suppress("TooGenericExceptionCaught") e: Exception
+        ) {
+            e.message ?: e.javaClass.simpleName
+        }
+
+    companion object {
+        /** `configYaml` size limit for `push`, in KiB — see [MAX_CONFIG_YAML_BYTES]. */
+        private const val MAX_CONFIG_YAML_KIB = 128
+
+        /**
+         * Hard cap on a pushed `configYaml` document's UTF-8 byte size (CWE-770: uncontrolled
+         * resource consumption). Enforced before any parse attempt, well above any legitimate
+         * config document, and small enough to bound parse cost against a hostile payload.
+         */
+        const val MAX_CONFIG_YAML_BYTES = MAX_CONFIG_YAML_KIB * 1024
+    }
+}
+
+/** Outcome of [ProjectConfigPushService.push]. */
+sealed class ProjectConfigPushResult {
+    /** [warning] is non-null when the root's `type` is not `"project"` (non-fatal, push still succeeds). */
+    data class Success(
+        val rootItemId: UUID,
+        val fingerprint: String,
+        val updatedAt: Instant,
+        val warning: String? = null,
+    ) : ProjectConfigPushResult()
+
+    /** No WorkItem exists for [rootItemId]. */
+    data class NotFound(
+        val rootItemId: UUID
+    ) : ProjectConfigPushResult()
+
+    /** [rootItemId] resolved to a WorkItem, but it is not depth-0 (configs anchor to project roots only). */
+    data class NotDepthZero(
+        val rootItemId: UUID,
+        val depth: Int
+    ) : ProjectConfigPushResult()
+
+    /** `configYaml` exceeded [ProjectConfigPushService.MAX_CONFIG_YAML_BYTES]; rejected before any parse attempt. */
+    data class TooLarge(
+        val sizeBytes: Int,
+        val maxBytes: Int
+    ) : ProjectConfigPushResult()
+
+    /** `configYaml` failed SafeConstructor parse-validation; [detail] is the parse failure message. */
+    data class ParseError(
+        val detail: String
+    ) : ProjectConfigPushResult()
+
+    /** The upsert itself failed at the repository layer. */
+    data class RepositoryError(
+        val message: String
+    ) : ProjectConfigPushResult()
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigTool.kt
@@ -1,14 +1,12 @@
 package io.github.jpicklyk.mcptask.current.application.tools.config
 
+import io.github.jpicklyk.mcptask.current.application.service.ProjectConfigPushResult
+import io.github.jpicklyk.mcptask.current.application.service.ProjectConfigPushService
 import io.github.jpicklyk.mcptask.current.application.tools.*
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
-import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlSchemaParser
 import io.modelcontextprotocol.kotlin.sdk.types.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.*
-import org.yaml.snakeyaml.LoaderOptions
-import org.yaml.snakeyaml.Yaml
-import org.yaml.snakeyaml.constructor.SafeConstructor
 
 /**
  * MCP tool for pushing and reading back per-root config YAML — the transport-agnostic sync path
@@ -149,64 +147,42 @@ not-found error when no config has been pushed for it.
         if (idError != null) return idError
         val configYaml = requireString(params, "configYaml")
 
-        val sizeBytes = configYaml.toByteArray(Charsets.UTF_8).size
-        if (sizeBytes > MAX_CONFIG_YAML_BYTES) {
-            return errorResponse(
-                "configYaml is $sizeBytes bytes, exceeds the $MAX_CONFIG_YAML_BYTES byte " +
-                    "($MAX_CONFIG_YAML_KIB KiB) limit",
-                ErrorCodes.VALIDATION_ERROR
-            )
-        }
-
-        val itemResult = context.workItemRepository().getById(rootItemId!!)
-        val item =
-            when (itemResult) {
-                is Result.Success -> itemResult.data
-                is Result.Error -> return errorResponse(
-                    "Root WorkItem not found: $rootItemId",
-                    ErrorCodes.RESOURCE_NOT_FOUND
-                )
-            }
-
-        if (item.depth != 0) {
-            return errorResponse(
-                "rootItemId must reference a depth-0 (root) WorkItem; '$rootItemId' has depth ${item.depth}",
-                ErrorCodes.VALIDATION_ERROR
-            )
-        }
-
-        val typeWarning =
-            if (item.type != "project") {
-                "Root item type is '${item.type ?: "null"}', not 'project' — config pushed anyway " +
-                    "(a naming convention, not an enforced constraint)"
-            } else {
-                null
-            }
-
-        val parseError = validateYaml(configYaml)
-        if (parseError != null) {
-            return errorResponse(
-                "configYaml failed to parse: $parseError",
-                ErrorCodes.VALIDATION_ERROR,
-                details = parseError
-            )
-        }
-
-        return when (val result = context.projectConfigRepository().upsert(rootItemId, configYaml)) {
-            is Result.Success -> {
-                val config = result.data
+        val service = ProjectConfigPushService(context.repositoryProvider)
+        return when (val result = service.push(rootItemId!!, configYaml)) {
+            is ProjectConfigPushResult.Success ->
                 successResponse(
                     buildJsonObject {
-                        put("rootItemId", JsonPrimitive(config.rootItemId.toString()))
-                        put("fingerprint", JsonPrimitive(config.fingerprint))
-                        put("updatedAt", JsonPrimitive(config.updatedAt.toString()))
-                        typeWarning?.let { put("warning", JsonPrimitive(it)) }
+                        put("rootItemId", JsonPrimitive(result.rootItemId.toString()))
+                        put("fingerprint", JsonPrimitive(result.fingerprint))
+                        put("updatedAt", JsonPrimitive(result.updatedAt.toString()))
+                        result.warning?.let { put("warning", JsonPrimitive(it)) }
                     }
                 )
-            }
-            is Result.Error ->
+            is ProjectConfigPushResult.NotFound ->
                 errorResponse(
-                    "Failed to store project config: ${result.error.message}",
+                    "Root WorkItem not found: ${result.rootItemId}",
+                    ErrorCodes.RESOURCE_NOT_FOUND
+                )
+            is ProjectConfigPushResult.NotDepthZero ->
+                errorResponse(
+                    "rootItemId must reference a depth-0 (root) WorkItem; '${result.rootItemId}' has depth ${result.depth}",
+                    ErrorCodes.VALIDATION_ERROR
+                )
+            is ProjectConfigPushResult.TooLarge ->
+                errorResponse(
+                    "configYaml is ${result.sizeBytes} bytes, exceeds the ${result.maxBytes} byte " +
+                        "(${result.maxBytes / 1024} KiB) limit",
+                    ErrorCodes.VALIDATION_ERROR
+                )
+            is ProjectConfigPushResult.ParseError ->
+                errorResponse(
+                    "configYaml failed to parse: ${result.detail}",
+                    ErrorCodes.VALIDATION_ERROR,
+                    details = result.detail
+                )
+            is ProjectConfigPushResult.RepositoryError ->
+                errorResponse(
+                    "Failed to store project config: ${result.message}",
                     ErrorCodes.DATABASE_ERROR
                 )
         }
@@ -223,7 +199,8 @@ not-found error when no config has been pushed for it.
         val (rootItemId, idError) = resolveItemId(params, "rootItemId", context)
         if (idError != null) return idError
 
-        return when (val result = context.projectConfigRepository().get(rootItemId!!)) {
+        val service = ProjectConfigPushService(context.repositoryProvider)
+        return when (val result = service.get(rootItemId!!)) {
             is Result.Success -> {
                 val config =
                     result.data ?: return errorResponse(
@@ -247,53 +224,13 @@ not-found error when no config has been pushed for it.
         }
     }
 
-    // ──────────────────────────────────────────────
-    // YAML parse-validation
-    // ──────────────────────────────────────────────
-
-    /**
-     * Parses [configYaml] the same way [io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService]
-     * will on every subsequent read (via the shared [YamlSchemaParser]), but BEFORE storing — a
-     * stored-but-unparseable config would otherwise silently fall through to the global schema on
-     * every future read, a confusing failure mode discovered only much later. Returns the parse
-     * failure message, or null when [configYaml] parses cleanly.
-     *
-     * Uses [SafeConstructor] rather than SnakeYAML's default `Constructor` — `configYaml` is
-     * attacker-reachable input (pushed over the MCP protocol by a caller, not read from a trusted
-     * local file), and the default `Constructor` will happily instantiate an arbitrary Java type
-     * named by a `!!`-tag (the SnakeYAML deserialization-RCE gadget class, CWE-502). `SafeConstructor`
-     * only ever builds plain maps/lists/scalars, which is all a config document legitimately needs;
-     * any `!!`-tagged custom type throws [org.yaml.snakeyaml.constructor.ConstructorException] before
-     * anything is instantiated, and that exception is caught below like any other parse failure.
-     *
-     * Soft validation warnings collected by [YamlSchemaParser.parseRoot] (e.g. a note entry
-     * missing `key`, an invalid `lifecycle` value) are NOT treated as rejection here — only a hard
-     * YAML syntax/shape failure (invalid syntax, or a non-map document) is. Those soft warnings
-     * mirror the global config loader's existing behavior: skip the offending entry, keep going.
-     */
-    private fun validateYaml(configYaml: String): String? =
-        try {
-            @Suppress("UNCHECKED_CAST")
-            val root = Yaml(SafeConstructor(LoaderOptions())).load<Map<String, Any>>(configYaml)
-            if (root != null) {
-                YamlSchemaParser.parseRoot(root, warnOnMissingSchemas = false)
-            }
-            null
-        } catch (
-            @Suppress("TooGenericExceptionCaught") e: Exception
-        ) {
-            e.message ?: e.javaClass.simpleName
-        }
-
     companion object {
-        /** `configYaml` size limit for `push`, in KiB — see [MAX_CONFIG_YAML_BYTES]. */
-        private const val MAX_CONFIG_YAML_KIB = 128
-
         /**
-         * Hard cap on a pushed `configYaml` document's UTF-8 byte size (CWE-770: uncontrolled
-         * resource consumption). Enforced before any parse attempt, well above any legitimate
-         * config document, and small enough to bound parse cost against a hostile payload.
+         * `configYaml` size limit for `push`, in bytes — delegates to
+         * [ProjectConfigPushService.MAX_CONFIG_YAML_BYTES], the single source of truth now that the
+         * validate+persist pipeline lives in the service. Kept as a public alias here for backward
+         * compatibility (existing callers/tests reference `ManageProjectConfigTool.MAX_CONFIG_YAML_BYTES`).
          */
-        const val MAX_CONFIG_YAML_BYTES = MAX_CONFIG_YAML_KIB * 1024
+        const val MAX_CONFIG_YAML_BYTES = ProjectConfigPushService.MAX_CONFIG_YAML_BYTES
     }
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/auth/ApiPrincipal.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/auth/ApiPrincipal.kt
@@ -65,6 +65,9 @@ enum class ApiCapability {
     /** POST/DELETE on dependency endpoints. */
     MANAGE_DEPENDENCIES,
 
+    /** PUT/DELETE on the per-root project config endpoint. */
+    WRITE_CONFIG,
+
     /** Future: any operator-only endpoint; also implies all of the above. */
     ADMIN,
     ;
@@ -73,7 +76,7 @@ enum class ApiCapability {
         /**
          * Parses a capability from its canonical string form as used in the secret file
          * and JWT claims.  Values use kebab-case to match the YAML convention:
-         * `read`, `write-notes`, `write-items`, `advance`, `manage-dependencies`, `admin`.
+         * `read`, `write-notes`, `write-items`, `advance`, `manage-dependencies`, `write-config`, `admin`.
          *
          * @throws IllegalArgumentException for unknown values.
          */
@@ -84,10 +87,11 @@ enum class ApiCapability {
                 "write-items" -> WRITE_ITEMS
                 "advance" -> ADVANCE
                 "manage-dependencies" -> MANAGE_DEPENDENCIES
+                "write-config" -> WRITE_CONFIG
                 "admin" -> ADMIN
                 else -> throw IllegalArgumentException(
                     "Unknown capability '$value'. Valid values: read, write-notes, write-items, " +
-                        "advance, manage-dependencies, admin",
+                        "advance, manage-dependencies, write-config, admin",
                 )
             }
     }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/dto/Dtos.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/dto/Dtos.kt
@@ -438,3 +438,21 @@ data class SearchHitDto(
     val score: Double,
     val noteKey: String? = null,
 )
+
+/**
+ * Response DTO for `PUT /api/v1/roots/{rootId}/config` and `GET /api/v1/roots/{rootId}/config`.
+ *
+ * Mirrors the `data` payload of the MCP `manage_project_config` tool's `push`/`get` operations
+ * (see [io.github.jpicklyk.mcptask.current.application.service.ProjectConfigPushResult.Success]) —
+ * both surfaces converge on the same [io.github.jpicklyk.mcptask.current.application.service.ProjectConfigPushService].
+ * `configYaml` is included only on GET (omitted on PUT, which already echoed the caller's own body).
+ * `warning` carries the non-fatal "root type is not 'project'" notice, when applicable.
+ */
+@Serializable
+data class ProjectConfigResponseDto(
+    val rootItemId: String,
+    val fingerprint: String,
+    val updatedAt: String,
+    val configYaml: String? = null,
+    val warning: String? = null,
+)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutes.kt
@@ -1,0 +1,255 @@
+package io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes
+
+import io.github.jpicklyk.mcptask.current.application.service.ProjectConfigPushResult
+import io.github.jpicklyk.mcptask.current.application.service.ProjectConfigPushService
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiCapability
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.enforceScopeForItem
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.requireCapability
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.ErrorDto
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.ProjectConfigResponseDto
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.header
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+private val projectConfigLogger = LoggerFactory.getLogger("ProjectConfigRoutes")
+
+/**
+ * ETag format for a stored per-root config, derived from its content fingerprint:
+ * `"cfg-<fingerprint>"` (quoted per RFC 7232). Distinct from [io.github.jpicklyk.mcptask.current.interfaces.api.v1.etag.etagFor]
+ * (which is timestamp-derived, `"v1-<epochMillis>"`) — config rows use a content hash instead of a
+ * timestamp because [io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository.upsert]
+ * already computes one (needed for hot-reload change-detection) and reusing it keeps a
+ * byte-identical re-push naturally idempotent under `If-Match`.
+ */
+private fun configEtag(fingerprint: String): String = "\"cfg-$fingerprint\""
+
+/**
+ * Registers the per-root config read/write/delete routes under `/api/v1/roots/{rootId}/config`.
+ *
+ * Endpoints:
+ * - `GET    /roots/{rootId}/config` — read back the stored config ([ApiCapability.READ] + scope);
+ *   `If-None-Match` → 304 when unchanged; 404 when no config has been pushed for the root.
+ * - `PUT    /roots/{rootId}/config` — validate + upsert raw YAML body ([ApiCapability.WRITE_CONFIG] +
+ *   scope); delegates the FULL validate-then-persist pipeline to [ProjectConfigPushService] — the
+ *   SAME service the MCP `manage_project_config` tool's `push` operation calls, so both surfaces
+ *   converge on identical DB state for the same payload. Body must not exceed
+ *   [ProjectConfigPushService.MAX_CONFIG_YAML_BYTES] (413); malformed/unsafe YAML is rejected before
+ *   storing (422); optional `If-Match` against the current fingerprint-derived ETag (412 on mismatch,
+ *   ignored when no row exists yet — a first push is a create).
+ * - `DELETE /roots/{rootId}/config` — remove the stored config row ([ApiCapability.WRITE_CONFIG] +
+ *   scope); 404 when no row exists.
+ *
+ * **Scope:** all three verbs enforce [enforceScopeForItem] against `{rootId}` itself (a root has no
+ * ancestors, so this reduces to "the token's `rootIds` must contain this exact root") — a per-project
+ * token can only read/push/delete its own root's config.
+ *
+ * **REST-only:** this route is registered on the authenticated `/api/v1` pipeline only (see
+ * [io.github.jpicklyk.mcptask.current.interfaces.mcp.installRestApiRoutes]) and is never reachable on
+ * the unauthenticated `/mcp` transport.
+ */
+fun Route.projectConfigRoutes(repositoryProvider: RepositoryProvider) {
+    val workItemRepo = repositoryProvider.workItemRepository()
+    val projectConfigRepo = repositoryProvider.projectConfigRepository()
+    val service = ProjectConfigPushService(repositoryProvider)
+
+    route("/roots/{rootId}/config") {
+        // ─── GET /roots/{rootId}/config ──────────────────────────────────────
+        requireCapability(ApiCapability.READ) {
+            get {
+                val rootId = call.parseRootId() ?: return@get
+
+                if (!enforceScopeForItem(call, rootId, workItemRepo)) {
+                    call.respond(HttpStatusCode.Forbidden, ErrorDto("scope_forbidden", "Access denied for root $rootId"))
+                    return@get
+                }
+
+                when (val result = projectConfigRepo.get(rootId)) {
+                    is Result.Success -> {
+                        val config =
+                            result.data ?: run {
+                                call.respond(
+                                    HttpStatusCode.NotFound,
+                                    ErrorDto("not_found", "No project config found for root $rootId"),
+                                )
+                                return@get
+                            }
+
+                        val etag = configEtag(config.fingerprint)
+                        val ifNoneMatch = call.request.headers[HttpHeaders.IfNoneMatch]?.trim()
+                        if (ifNoneMatch != null && ifNoneMatch == etag) {
+                            call.response.header(HttpHeaders.ETag, etag)
+                            call.respond(HttpStatusCode.NotModified)
+                            return@get
+                        }
+
+                        call.response.header(HttpHeaders.ETag, etag)
+                        call.respond(
+                            HttpStatusCode.OK,
+                            ProjectConfigResponseDto(
+                                rootItemId = config.rootItemId.toString(),
+                                fingerprint = config.fingerprint,
+                                updatedAt = config.updatedAt.toString(),
+                                configYaml = config.configYaml,
+                            ),
+                        )
+                    }
+                    is Result.Error -> {
+                        projectConfigLogger.warn("GET /roots/{}/config DB error: {}", rootId, result.error.message)
+                        call.respond(HttpStatusCode.InternalServerError, ErrorDto("db_error", "Failed to read project config"))
+                    }
+                }
+            }
+        }
+
+        // ─── PUT /roots/{rootId}/config ──────────────────────────────────────
+        requireCapability(ApiCapability.WRITE_CONFIG) {
+            put {
+                val rootId = call.parseRootId() ?: return@put
+
+                if (!enforceScopeForItem(call, rootId, workItemRepo)) {
+                    call.respond(HttpStatusCode.Forbidden, ErrorDto("scope_forbidden", "Access denied for root $rootId"))
+                    return@put
+                }
+
+                val configYaml = call.receiveText()
+                val sizeBytes = configYaml.toByteArray(Charsets.UTF_8).size
+                if (sizeBytes > ProjectConfigPushService.MAX_CONFIG_YAML_BYTES) {
+                    call.respond(
+                        HttpStatusCode.PayloadTooLarge,
+                        ErrorDto(
+                            "payload_too_large",
+                            "configYaml is $sizeBytes bytes, exceeds the " +
+                                "${ProjectConfigPushService.MAX_CONFIG_YAML_BYTES} byte limit",
+                        ),
+                    )
+                    return@put
+                }
+
+                // If-Match is only enforced against an EXISTING row — mirrors NoteWriteRoutes' PUT
+                // upsert semantics: a first push is a create with no prior ETag to match, so a
+                // stray If-Match on a not-yet-existing root is ignored rather than 412'd.
+                val ifMatch = call.request.headers[HttpHeaders.IfMatch]?.trim()
+                if (ifMatch != null) {
+                    val existingFingerprint =
+                        when (val fpResult = projectConfigRepo.getFingerprint(rootId)) {
+                            is Result.Success -> fpResult.data
+                            is Result.Error -> null
+                        }
+                    if (existingFingerprint != null) {
+                        val currentEtag = configEtag(existingFingerprint)
+                        if (ifMatch != currentEtag) {
+                            call.response.header(HttpHeaders.ETag, currentEtag)
+                            call.respond(
+                                HttpStatusCode.PreconditionFailed,
+                                ErrorDto("etag_mismatch", "ETag mismatch; current ETag is $currentEtag"),
+                            )
+                            return@put
+                        }
+                    }
+                }
+
+                when (val result = service.push(rootId, configYaml)) {
+                    is ProjectConfigPushResult.Success -> {
+                        val etag = configEtag(result.fingerprint)
+                        call.response.header(HttpHeaders.ETag, etag)
+                        call.respond(
+                            HttpStatusCode.OK,
+                            ProjectConfigResponseDto(
+                                rootItemId = result.rootItemId.toString(),
+                                fingerprint = result.fingerprint,
+                                updatedAt = result.updatedAt.toString(),
+                                warning = result.warning,
+                            ),
+                        )
+                    }
+                    is ProjectConfigPushResult.NotFound ->
+                        call.respond(
+                            HttpStatusCode.NotFound,
+                            ErrorDto("not_found", "Root WorkItem not found: ${result.rootItemId}"),
+                        )
+                    is ProjectConfigPushResult.NotDepthZero ->
+                        call.respond(
+                            HttpStatusCode.UnprocessableEntity,
+                            ErrorDto(
+                                "validation_error",
+                                "rootId must reference a depth-0 (root) WorkItem; '${result.rootItemId}' has depth ${result.depth}",
+                            ),
+                        )
+                    is ProjectConfigPushResult.TooLarge ->
+                        // Defensive — the pre-check above already covers this in practice.
+                        call.respond(
+                            HttpStatusCode.PayloadTooLarge,
+                            ErrorDto(
+                                "payload_too_large",
+                                "configYaml is ${result.sizeBytes} bytes, exceeds the ${result.maxBytes} byte limit",
+                            ),
+                        )
+                    is ProjectConfigPushResult.ParseError ->
+                        call.respond(
+                            HttpStatusCode.UnprocessableEntity,
+                            ErrorDto("parse_error", "configYaml failed to parse: ${result.detail}"),
+                        )
+                    is ProjectConfigPushResult.RepositoryError -> {
+                        projectConfigLogger.warn("PUT /roots/{}/config DB error: {}", rootId, result.message)
+                        call.respond(HttpStatusCode.InternalServerError, ErrorDto("db_error", "Failed to store project config"))
+                    }
+                }
+            }
+        }
+
+        // ─── DELETE /roots/{rootId}/config ───────────────────────────────────
+        requireCapability(ApiCapability.WRITE_CONFIG) {
+            delete {
+                val rootId = call.parseRootId() ?: return@delete
+
+                if (!enforceScopeForItem(call, rootId, workItemRepo)) {
+                    call.respond(HttpStatusCode.Forbidden, ErrorDto("scope_forbidden", "Access denied for root $rootId"))
+                    return@delete
+                }
+
+                when (val result = projectConfigRepo.delete(rootId)) {
+                    is Result.Success -> {
+                        if (!result.data) {
+                            call.respond(
+                                HttpStatusCode.NotFound,
+                                ErrorDto("not_found", "No project config found for root $rootId"),
+                            )
+                            return@delete
+                        }
+                        call.respond(HttpStatusCode.NoContent)
+                    }
+                    is Result.Error -> {
+                        projectConfigLogger.warn("DELETE /roots/{}/config DB error: {}", rootId, result.error.message)
+                        call.respond(HttpStatusCode.InternalServerError, ErrorDto("db_error", "Failed to delete project config"))
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Parses the `{rootId}` path parameter as a UUID; responds 400 and returns null on failure. */
+private suspend fun ApplicationCall.parseRootId(): UUID? {
+    val rawId =
+        parameters["rootId"] ?: run {
+            respond(HttpStatusCode.BadRequest, ErrorDto("bad_request", "Missing rootId"))
+            return null
+        }
+    return runCatching { UUID.fromString(rawId) }.getOrNull() ?: run {
+        respond(HttpStatusCode.BadRequest, ErrorDto("bad_request", "Invalid UUID: $rawId"))
+        null
+    }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
@@ -38,6 +38,7 @@ import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.itemRoutes
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.itemWriteRoutes
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.noteRoutes
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.noteWriteRoutes
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.projectConfigRoutes
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.searchRoutes
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.serviceRoutes
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.transitionRoutes
@@ -497,6 +498,9 @@ internal fun Application.installRestApiRoutes(
             )
             noteWriteRoutes(effectiveProvider, degradedModePolicy, idempotencyCache)
             dependencyWriteRoutes(effectiveProvider, degradedModePolicy)
+            // Phase 1 (project-config-rest-endpoint): per-root config read/write/delete —
+            // converges on the same ProjectConfigPushService the manage_project_config MCP tool uses.
+            projectConfigRoutes(effectiveProvider)
         }
         // Phase 6: real-time SSE event stream — registered OUTSIDE the ApiBearerAuth block (as a
         // sibling `route("/api/v1/events")`) so the ApiBearerAuth plugin does NOT intercept it. The

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ApiTestHelper.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ApiTestHelper.kt
@@ -35,7 +35,7 @@ const val ADMIN_TOKEN_ID = "test-admin-principal"
 
 /**
  * Write-capable token for Phase 5 write-route tests. Granted READ + all write capabilities
- * (WRITE_ITEMS, WRITE_NOTES, ADVANCE, MANAGE_DEPENDENCIES) but NOT admin.
+ * (WRITE_ITEMS, WRITE_NOTES, ADVANCE, MANAGE_DEPENDENCIES, WRITE_CONFIG) but NOT admin.
  */
 const val WRITE_TOKEN = "integration-write-token-w0987"
 const val WRITE_TOKEN_ID = "test-write-principal"
@@ -131,6 +131,7 @@ fun makeWriteAuthConfig(scopeRootIds: Set<UUID>? = null): ApiAuthConfig.Bearer {
                     ApiCapability.WRITE_NOTES,
                     ApiCapability.ADVANCE,
                     ApiCapability.MANAGE_DEPENDENCIES,
+                    ApiCapability.WRITE_CONFIG,
                 ),
             authMode = ApiAuthMode.BEARER,
         )

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/FullApiWiringSmokeTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/FullApiWiringSmokeTest.kt
@@ -12,7 +12,9 @@ import io.github.jpicklyk.mcptask.current.interfaces.api.v1.events.EventPublishi
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
+import io.ktor.client.request.put
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
@@ -79,6 +81,8 @@ class FullApiWiringSmokeTest {
                 itemWriteRoutes(decorated, DegradedModePolicy.ACCEPT_CACHED, IdempotencyCache(), NoOpNoteSchemaService)
                 noteWriteRoutes(decorated, DegradedModePolicy.ACCEPT_CACHED, IdempotencyCache())
                 dependencyWriteRoutes(decorated, DegradedModePolicy.ACCEPT_CACHED)
+                // Phase 1 (project-config-rest-endpoint): per-root config read/write/delete
+                projectConfigRoutes(decorated)
             }
             // Phase 6 SSE — registered OUTSIDE the ApiBearerAuth block (sibling /api/v1 route)
             // so the header-only ApiBearerAuth plugin does not intercept it; the SSE route does
@@ -152,5 +156,34 @@ class FullApiWiringSmokeTest {
                 client.get("/api/v1/events").status,
                 "events route is wired and its inline auth rejects unauthenticated requests",
             )
+
+            // Phase 1 (project-config-rest-endpoint): proves projectConfigRoutes wired without a
+            // requireCapability collision — it installs a SEPARATE READ group (GET) alongside a
+            // SEPARATE WRITE_CONFIG group (PUT/DELETE) on the same /roots/{rootId}/config path.
+            val configCreated =
+                client.post("/api/v1/items") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"title":"smoke-config-root"}""")
+                }
+            assertEquals(HttpStatusCode.Created, configCreated.status)
+            val rootId = Regex(""""id":"([0-9a-fA-F-]{36})"""").find(configCreated.bodyAsText())!!.groupValues[1]
+
+            // READ token can reach the GET route (capability gate wired); no config was ever
+            // pushed for this root, so the expected outcome is 404 — the route IS reachable.
+            assertEquals(
+                HttpStatusCode.NotFound,
+                client.get("/api/v1/roots/$rootId/config") { header("Authorization", "Bearer $TEST_TOKEN") }.status,
+                "GET config route reachable with READ token (404 = no config pushed, not a wiring failure)",
+            )
+
+            // WRITE_CONFIG token can PUT to the same path (separate capability group, same path).
+            val configPut =
+                client.put("/api/v1/roots/$rootId/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Text.Plain)
+                    setBody("work_item_schemas: {}")
+                }
+            assertEquals(HttpStatusCode.OK, configPut.status, "PUT config route reachable with WRITE_CONFIG token")
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutesTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutesTest.kt
@@ -176,6 +176,26 @@ class ProjectConfigPutRouteTest {
         }
 
     @Test
+    fun `PUT roots rootId config with a YAML type tag (CWE-502) is rejected with 422 and stores nothing`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+
+            // A !!-tagged non-standard type — SafeConstructor must refuse to instantiate it (CWE-502).
+            val response =
+                client.put("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Text.Plain)
+                    setBody("work_item_schemas: !!java.net.URL [\"http://evil.example\"]")
+                }
+
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+            val persisted = runBlocking { repo.projectConfigRepository().get(root.id) }
+            assertTrue((persisted as Result.Success).data == null, "A type-tagged payload must never be stored")
+        }
+
+    @Test
     fun `PUT roots rootId config over the size cap returns 413`(): Unit =
         testApplication {
             val repo = buildH2RepositoryProvider()
@@ -320,6 +340,22 @@ class ProjectConfigGetRouteTest {
         }
 
     @Test
+    fun `GET roots rootId config with token scope lacking the root returns 403`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            val otherRoot = createRoot(repo, title = "Other Root")
+            application { configureProjectConfigTestApp(repo, authConfig = makeWriteAuthConfig(scopeRootIds = setOf(otherRoot.id))) }
+
+            val response =
+                client.get("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $PROJECT_CONFIG_READ_ONLY_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
     fun `GET roots rootId config for a root with no pushed config returns 404`(): Unit =
         testApplication {
             val repo = buildH2RepositoryProvider()
@@ -357,6 +393,37 @@ class ProjectConfigDeleteRouteTest {
             assertEquals(HttpStatusCode.NoContent, response.status)
             val persisted = runBlocking { repo.projectConfigRepository().get(root.id) }
             assertTrue((persisted as Result.Success).data == null, "Config row should be deleted")
+        }
+
+    @Test
+    fun `DELETE roots rootId config with token scope lacking the root returns 403`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            val otherRoot = createRoot(repo, title = "Other Root")
+            application { configureProjectConfigTestApp(repo, authConfig = makeWriteAuthConfig(scopeRootIds = setOf(otherRoot.id))) }
+
+            val response =
+                client.delete("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+        }
+
+    @Test
+    fun `DELETE roots rootId config for a root with no pushed config returns 404`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+
+            val response =
+                client.delete("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
         }
 }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutesTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutesTest.kt
@@ -1,0 +1,409 @@
+package io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes
+
+import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
+import io.github.jpicklyk.mcptask.current.application.tools.config.ManageProjectConfigTool
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiAuthConfig
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiBearerAuth
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.BearerTokenStore
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.server.sse.SSE
+import io.ktor.server.testing.testApplication
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Exercises the REST `PUT/GET/DELETE /api/v1/roots/{rootId}/config` routes registered by
+ * [projectConfigRoutes]. Reuses [WRITE_TOKEN] (granted [io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiCapability.WRITE_CONFIG]
+ * — see [ApiTestHelper.makeWriteAuthConfig]) and [READ_ONLY_TOKEN] from [WriteRoutesTest] for the
+ * capability-denial cases.
+ */
+private const val PROJECT_CONFIG_READ_ONLY_TOKEN = TEST_TOKEN
+
+private val VALID_YAML =
+    """
+    work_item_schemas:
+      feature-task:
+        notes:
+          - key: spec
+            role: queue
+            required: true
+    """.trimIndent()
+
+/** Configures a test Ktor application with only [projectConfigRoutes] registered. */
+fun Application.configureProjectConfigTestApp(
+    repo: DefaultRepositoryProvider,
+    authConfig: ApiAuthConfig.Bearer = makeWriteAuthConfig(),
+) {
+    install(ContentNegotiation) { json(McpJson) }
+    install(SSE)
+    routing {
+        route("/api/v1") {
+            install(ApiBearerAuth) {
+                this.authConfig = authConfig
+                tokenEntries =
+                    authConfig.tokens.mapValues { (_, p) ->
+                        BearerTokenStore.TokenEntry(p, expiresAt = null)
+                    }
+            }
+            projectConfigRoutes(repo)
+        }
+    }
+}
+
+private fun createRoot(
+    repo: DefaultRepositoryProvider,
+    title: String = "Project Root",
+    type: String? = "project",
+): WorkItem =
+    runBlocking {
+        (repo.workItemRepository().create(WorkItem(title = title, type = type, depth = 0)) as Result.Success).data
+    }
+
+class ProjectConfigPutRouteTest {
+    @Test
+    fun `PUT roots rootId config happy path returns 200 with ETag and persists the row`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+
+            val response =
+                client.put("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.parse("application/yaml"))
+                    setBody(VALID_YAML)
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains(root.id.toString()), "Response should echo rootItemId: $body")
+            val etag = response.headers[HttpHeaders.ETag]
+            assertNotNull(etag, "ETag header should be present")
+            assertTrue(etag.startsWith("\"cfg-"), "ETag should use the cfg- prefix: $etag")
+
+            val persisted = runBlocking { repo.projectConfigRepository().get(root.id) }
+            assertTrue(persisted is Result.Success)
+            val config = (persisted as Result.Success).data
+            assertNotNull(config, "Config should be persisted")
+            assertEquals(VALID_YAML, config!!.configYaml)
+        }
+
+    @Test
+    fun `PUT roots rootId config without WRITE_CONFIG capability returns 403`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+
+            val response =
+                client.put("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $PROJECT_CONFIG_READ_ONLY_TOKEN")
+                    contentType(ContentType.Text.Plain)
+                    setBody(VALID_YAML)
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+            val persisted = runBlocking { repo.projectConfigRepository().get(root.id) }
+            assertTrue((persisted as Result.Success).data == null, "Config should NOT be created")
+        }
+
+    @Test
+    fun `PUT roots rootId config with token scope lacking the root returns 403`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            val otherRoot = createRoot(repo, title = "Other Root")
+            // WRITE_TOKEN scoped to a DIFFERENT root than the one we're pushing to.
+            application { configureProjectConfigTestApp(repo, authConfig = makeWriteAuthConfig(scopeRootIds = setOf(otherRoot.id))) }
+
+            val response =
+                client.put("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Text.Plain)
+                    setBody(VALID_YAML)
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+            val persisted = runBlocking { repo.projectConfigRepository().get(root.id) }
+            assertTrue((persisted as Result.Success).data == null, "Config should NOT be created outside token scope")
+        }
+
+    @Test
+    fun `PUT roots rootId config with malformed YAML returns 422 and stores nothing`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+
+            val response =
+                client.put("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Text.Plain)
+                    setBody("work_item_schemas: [this is not, a valid: map")
+                }
+
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("parse_error") || body.contains("failed to parse"), "Should report a parse error: $body")
+
+            val persisted = runBlocking { repo.projectConfigRepository().get(root.id) }
+            assertTrue((persisted as Result.Success).data == null, "Malformed YAML must never be stored")
+        }
+
+    @Test
+    fun `PUT roots rootId config over the size cap returns 413`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+
+            val oversized = "x".repeat(131_073) // MAX_CONFIG_YAML_BYTES (131072) + 1
+            val response =
+                client.put("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Text.Plain)
+                    setBody(oversized)
+                }
+
+            assertEquals(HttpStatusCode.PayloadTooLarge, response.status)
+            val persisted = runBlocking { repo.projectConfigRepository().get(root.id) }
+            assertTrue((persisted as Result.Success).data == null, "Oversized payload must never be stored")
+        }
+
+    @Test
+    fun `PUT roots rootId config with stale If-Match returns 412`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+
+            // First push creates the row.
+            client.put("/api/v1/roots/${root.id}/config") {
+                header("Authorization", "Bearer $WRITE_TOKEN")
+                contentType(ContentType.Text.Plain)
+                setBody(VALID_YAML)
+            }
+
+            val response =
+                client.put("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    header(HttpHeaders.IfMatch, "\"cfg-0000000000000000000000000000000000000000000000000000000000000000\"")
+                    contentType(ContentType.Text.Plain)
+                    setBody(VALID_YAML + "\n")
+                }
+
+            assertEquals(HttpStatusCode.PreconditionFailed, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("etag_mismatch"), "Should report etag_mismatch: $body")
+        }
+
+    @Test
+    fun `PUT roots rootId config to unknown root returns 404`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            application { configureProjectConfigTestApp(repo) }
+
+            val response =
+                client.put("/api/v1/roots/${UUID.randomUUID()}/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Text.Plain)
+                    setBody(VALID_YAML)
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `PUT roots rootId config to a non-depth-0 root returns 422`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val parent = createRoot(repo, title = "Parent")
+            val child =
+                runBlocking {
+                    (
+                        repo.workItemRepository().create(
+                            WorkItem(title = "Child", parentId = parent.id, depth = 1),
+                        ) as Result.Success
+                    ).data
+                }
+            application { configureProjectConfigTestApp(repo) }
+
+            val response =
+                client.put("/api/v1/roots/${child.id}/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Text.Plain)
+                    setBody(VALID_YAML)
+                }
+
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("depth-0"), "Should name the depth-0 constraint: $body")
+        }
+}
+
+class ProjectConfigGetRouteTest {
+    @Test
+    fun `GET roots rootId config returns stored config`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+
+            client.put("/api/v1/roots/${root.id}/config") {
+                header("Authorization", "Bearer $WRITE_TOKEN")
+                contentType(ContentType.Text.Plain)
+                setBody(VALID_YAML)
+            }
+
+            val response =
+                client.get("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $PROJECT_CONFIG_READ_ONLY_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains(root.id.toString()))
+        }
+
+    @Test
+    fun `GET roots rootId config with matching If-None-Match returns 304`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+
+            client.put("/api/v1/roots/${root.id}/config") {
+                header("Authorization", "Bearer $WRITE_TOKEN")
+                contentType(ContentType.Text.Plain)
+                setBody(VALID_YAML)
+            }
+
+            val firstGet =
+                client.get("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $PROJECT_CONFIG_READ_ONLY_TOKEN")
+                }
+            val etag = firstGet.headers[HttpHeaders.ETag]
+            assertNotNull(etag)
+
+            val response =
+                client.get("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $PROJECT_CONFIG_READ_ONLY_TOKEN")
+                    header(HttpHeaders.IfNoneMatch, etag)
+                }
+
+            assertEquals(HttpStatusCode.NotModified, response.status)
+        }
+
+    @Test
+    fun `GET roots rootId config for a root with no pushed config returns 404`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+
+            val response =
+                client.get("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $PROJECT_CONFIG_READ_ONLY_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+}
+
+class ProjectConfigDeleteRouteTest {
+    @Test
+    fun `DELETE roots rootId config removes the row and returns 204`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+
+            client.put("/api/v1/roots/${root.id}/config") {
+                header("Authorization", "Bearer $WRITE_TOKEN")
+                contentType(ContentType.Text.Plain)
+                setBody(VALID_YAML)
+            }
+
+            val response =
+                client.delete("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.NoContent, response.status)
+            val persisted = runBlocking { repo.projectConfigRepository().get(root.id) }
+            assertTrue((persisted as Result.Success).data == null, "Config row should be deleted")
+        }
+}
+
+/**
+ * Convergence test (task-scope acceptance criterion): the MCP `manage_project_config` tool's
+ * `push` operation and the REST `PUT /api/v1/roots/{rootId}/config` route both delegate to
+ * [io.github.jpicklyk.mcptask.current.application.service.ProjectConfigPushService] — pushing the
+ * SAME payload through each surface (to two different depth-0 roots) must produce identical
+ * fingerprint + stored bytes.
+ */
+class ProjectConfigConvergenceTest {
+    @Test
+    fun `MCP tool push and REST PUT converge on identical DB state for the same payload`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val rootViaTool = createRoot(repo, title = "Root Via Tool")
+            val rootViaRest = createRoot(repo, title = "Root Via REST")
+
+            // Push via the MCP tool.
+            val tool = ManageProjectConfigTool()
+            val context = ToolExecutionContext(repo)
+            runBlocking {
+                tool.execute(
+                    buildJsonObject {
+                        put("operation", JsonPrimitive("push"))
+                        put("rootItemId", JsonPrimitive(rootViaTool.id.toString()))
+                        put("configYaml", JsonPrimitive(VALID_YAML))
+                    },
+                    context,
+                )
+            }
+
+            // Push the SAME content via the REST route.
+            application { configureProjectConfigTestApp(repo) }
+            val response =
+                client.put("/api/v1/roots/${rootViaRest.id}/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Text.Plain)
+                    setBody(VALID_YAML)
+                }
+            assertEquals(HttpStatusCode.OK, response.status)
+
+            val configViaTool = (runBlocking { repo.projectConfigRepository().get(rootViaTool.id) } as Result.Success).data
+            val configViaRest = (runBlocking { repo.projectConfigRepository().get(rootViaRest.id) } as Result.Success).data
+            assertNotNull(configViaTool)
+            assertNotNull(configViaRest)
+            assertEquals(configViaTool!!.fingerprint, configViaRest!!.fingerprint, "Fingerprints must match for identical content")
+            assertEquals(configViaTool.configYaml, configViaRest.configYaml, "Stored YAML bytes must match")
+        }
+}


### PR DESCRIPTION
## Summary
**Phase 1** of per-project config auto-sync (feature `89ebee43`). Adds an authenticated REST write path for per-root config so a client can push a project's config over HTTP, and converges it with the existing MCP `manage_project_config` tool.

- **`PUT/GET/DELETE /api/v1/roots/{rootId}/config`** (new `ProjectConfigRoutes.kt`) behind a new **`ApiCapability.WRITE_CONFIG`** (ADMIN implies it), with **per-root scope enforcement** on every verb — a token can only touch its own root's config. Raw YAML body, 128 KiB cap → 413, malformed/unsafe YAML → 422, `If-Match`/ETag (`"cfg-<fingerprint>"`) → 412, GET `If-None-Match` → 304.
- **`ProjectConfigPushService`** (new) — the validation+persist pipeline (size → root-exists → depth-0 → SafeConstructor parse → upsert) extracted from `ManageProjectConfigTool`; the tool now calls it, so **both surfaces converge on identical DB state** (proven by a convergence test).
- REST-only: registered on the authenticated `/api/v1` pipeline, **never reachable on the unauthenticated `/mcp` transport**.

## Review
Independent security-focused review (separate agent): **PASS WITH OBSERVATIONS**. Scope/IDOR, capability gating, `/mcp` isolation, YAML safety (SafeConstructor + pre-parse size cap), and MCP-tool convergence all verified clear. Follow-ups:
- Review-flagged **test gaps closed in this PR** (commit `0797d90`): scope-403 on GET/DELETE, DELETE-404, CWE-502 `!!`-tag rejection.
- **Deferred:** a low-severity DoS (`receiveText()` buffers before the size check) — pre-existing across the write routes, tracked as `e941c2c7`.
- 415/Content-Type non-enforcement accepted (size-capped + SafeConstructor regardless).

## Test Results
Full `:current:test` green (2541 tests, 0 failures); 17 tests for this endpoint (13 original + 4 review additions); `ManageProjectConfigToolTest` passes unchanged (convergence). `ktlintCheck` green. OpenAPI + `api-rest.md` updated.

## MCP
Feature: `89ebee43` · Phase 1: `d8c9a21c` · follow-up: `e941c2c7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)