### PR TITLE
feat(plugin): config-sync SessionStart hook — sync workspace config to per-root store

### DIFF
--- a/claude-plugins/task-orchestrator/hooks/config-sync.mjs
+++ b/claude-plugins/task-orchestrator/hooks/config-sync.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// SessionStart hook — syncs this workspace's .taskorchestrator/config.yaml into the
+// per-root config store over the REST API, so a shared HTTP-transport server picks up
+// this project's schemas/traits without a restart.
+//
+// Fail-open by design: ANY error, missing env, or unreachable API results in exit 0 with
+// (at most) a one-line note — it must never block session start. It no-ops entirely for
+// stdio/local setups (no API env vars set) where the global config file already serves the
+// workspace directly.
+//
+// Requires (all optional — absent = no-op):
+//   TASK_ORCHESTRATOR_API_URL    base URL of the REST API, e.g. http://localhost:3001
+//   TASK_ORCHESTRATOR_API_TOKEN  bearer token with the WRITE_CONFIG capability, scoped to this root
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { createHash } from 'crypto';
+
+const REQUEST_TIMEOUT_MS = 2000;
+
+/** Locate .taskorchestrator/config.yaml (AGENT_CONFIG_DIR, then walk up from cwd) and return its RAW bytes. */
+function findConfigBytes() {
+  const candidates = [];
+  if (process.env.AGENT_CONFIG_DIR) {
+    candidates.push(resolve(process.env.AGENT_CONFIG_DIR, '.taskorchestrator', 'config.yaml'));
+  }
+  let dir = process.cwd();
+  const fsRoot = resolve(dir, '/');
+  while (dir !== fsRoot) {
+    candidates.push(resolve(dir, '.taskorchestrator', 'config.yaml'));
+    dir = resolve(dir, '..');
+  }
+  for (const candidate of candidates) {
+    try {
+      return readFileSync(candidate); // Buffer — hash and PUT the SAME bytes so the fingerprint matches the server's
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+/** Extract project.rootId from the config text (mirrors session-start.mjs's parser). */
+function parseRootId(text) {
+  let inProject = false;
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (/^project\s*:\s*$/.test(trimmed)) {
+      inProject = true;
+      continue;
+    }
+    if (inProject && /^\S/.test(line)) inProject = false;
+    if (inProject) {
+      const m = trimmed.match(/^rootId\s*:\s*["']?([^"'#]+?)["']?\s*(#.*)?$/);
+      if (m) return m[1].trim();
+    }
+  }
+  return null;
+}
+
+function emit(line) {
+  process.stdout.write(
+    JSON.stringify({ hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: line } }),
+  );
+}
+
+function fetchWithTimeout(url, opts) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  return fetch(url, { ...opts, signal: controller.signal }).finally(() => clearTimeout(timer));
+}
+
+async function main() {
+  if (typeof fetch !== 'function') return; // node < 18 — no global fetch; nothing we can do, stay silent
+
+  const bytes = findConfigBytes();
+  if (!bytes) return; // no config file → nothing to sync
+  const rootId = parseRootId(bytes.toString('utf-8'));
+  if (!rootId) return; // not project-scoped → nothing to sync
+
+  const apiUrl = process.env.TASK_ORCHESTRATOR_API_URL;
+  const token = process.env.TASK_ORCHESTRATOR_API_TOKEN;
+  if (!apiUrl || !token) return; // stdio/local: the global config file already serves this workspace
+
+  const localEtag = `"cfg-${createHash('sha256').update(bytes).digest('hex')}"`;
+  const endpoint = `${apiUrl.replace(/\/+$/, '')}/api/v1/roots/${rootId}/config`;
+  const authHeader = { Authorization: `Bearer ${token}` };
+
+  // 1) Read the server's current fingerprint to decide whether a push is needed.
+  let currentEtag = null;
+  try {
+    const res = await fetchWithTimeout(endpoint, { headers: authHeader });
+    if (res.status === 200) {
+      currentEtag = res.headers.get('etag');
+      if (currentEtag && currentEtag === localEtag) {
+        emit(`Task Orchestrator: project config already in sync for root ${rootId}.`);
+        return;
+      }
+    } else if (res.status === 404) {
+      currentEtag = null; // no row yet — first push is a create
+    } else {
+      emit(`Task Orchestrator: config sync skipped — GET returned HTTP ${res.status}.`);
+      return;
+    }
+  } catch (err) {
+    emit(`Task Orchestrator: config sync skipped — API unreachable (${err?.message ?? err}).`);
+    return;
+  }
+
+  // 2) Push the exact bytes; If-Match guards against a concurrent update when a row exists.
+  try {
+    const headers = { ...authHeader, 'Content-Type': 'application/yaml' };
+    if (currentEtag) headers['If-Match'] = currentEtag;
+    const res = await fetchWithTimeout(endpoint, { method: 'PUT', headers, body: bytes });
+    if (res.status === 200) {
+      emit(`Task Orchestrator: synced project config to root ${rootId} — per-project schemas/traits are now live.`);
+    } else if (res.status === 412) {
+      emit(`Task Orchestrator: config sync deferred — root ${rootId} was updated concurrently (412); will retry next session.`);
+    } else {
+      emit(`Task Orchestrator: config sync failed — PUT returned HTTP ${res.status}.`);
+    }
+  } catch (err) {
+    emit(`Task Orchestrator: config sync failed — ${err?.message ?? err}.`);
+  }
+}
+
+// Fail-open: swallow every error so the hook always exits 0 and never blocks session start.
+main().catch(() => {});

--- a/claude-plugins/task-orchestrator/hooks/hooks-config.json
+++ b/claude-plugins/task-orchestrator/hooks/hooks-config.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.mjs",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/config-sync.mjs",
+            "timeout": 5
           }
         ]
       }

--- a/current/docs/fleet-deployment.md
+++ b/current/docs/fleet-deployment.md
@@ -92,7 +92,7 @@ API_JWKS_CACHE_TTL_SECONDS=300   # optional, default 300
 
 See [api-rest.md §1](api-rest.md#1-authentication) for the full YAML format. Key points:
 - `token_sha256` must be a 64-char lowercase hex SHA-256 digest of the plaintext token
-- `capabilities` grant specific operations: `read`, `write-notes`, `write-items`, `advance`, `manage-dependencies`, `admin`
+- `capabilities` grant specific operations: `read`, `write-notes`, `write-items`, `advance`, `manage-dependencies`, `write-config`, `admin`
 - `scope.root_ids` restricts access to specific subtrees (null/empty = unrestricted)
 - Token rotation requires a server restart (no live reload)
 - `admin` capability unlocks attribution fields in responses (subject to `API_REDACT_*` env flags)
@@ -102,6 +102,19 @@ See [api-rest.md §1](api-rest.md#1-authentication) for the full YAML format. Ke
 When `API_AUTH_MODE=jwks` and `DEGRADED_MODE_POLICY=reject`, write endpoints (`POST`, `PATCH`, `PUT`, `DELETE`, advance) return `401 verification_failed` if JWKS verification fails. **Bearer mode is always trusted** — the REST API bearer token was validated at the HTTP layer and has no JWKS verification chain.
 
 This is different from the MCP actor `reject` policy, which governs MCP tool calls (`claim_item`, `advance_item`). Both layers share the same `DEGRADED_MODE_POLICY` env var but apply it independently.
+
+### Client-side config sync (SessionStart hook)
+
+In a shared HTTP deployment, per-project config lives in the DB per root (hot-reloaded, no restart), while the mounted global `.taskorchestrator/config.yaml` is only a fallback. The plugin's `config-sync.mjs` SessionStart hook keeps a project's DB config in sync with its workspace file: on session start it fingerprints the local file and, if it differs from the server's stored config, PUTs it to `PUT /api/v1/roots/{rootId}/config`. **The file is the source of truth; the DB row is a synced replica** (a byte-identical file is a no-op via `If-Match`/fingerprint).
+
+The hook is **fail-open and opt-in** — it no-ops silently (exit 0) unless BOTH client env vars below are set, so stdio/local deployments (which read the file directly) are unaffected:
+
+| Variable | Required for sync | Description |
+|----------|-------------------|-------------|
+| `TASK_ORCHESTRATOR_API_URL` | yes | Base URL of the REST API, e.g. `http://orchestrator.internal:3001` (the hook appends `/api/v1/roots/{rootId}/config`). |
+| `TASK_ORCHESTRATOR_API_TOKEN` | yes | Bearer token with the `write-config` capability, scoped (`scope.root_ids`) to this workspace's project root. |
+
+Set these per-workspace (e.g. in `.claude/settings.json`'s `env` block, or the shell environment). The token needs only `write-config` for its own root — not `admin` — and the server must have `API_ENABLED=true`. If the API is unreachable or returns an error, the hook logs a one-line note and continues; it never blocks session start.
 
 ---
 


### PR DESCRIPTION
## Summary
**Phase 2** of per-project config auto-sync (feature `89ebee43`). Adds `hooks/config-sync.mjs`, a SessionStart hook that keeps a project's per-root DB config in sync with its workspace `.taskorchestrator/config.yaml`:

- On session start: fingerprint the local file (SHA-256 over raw bytes) → GET the server's current fingerprint → if unchanged, no-op; if changed or absent, `PUT /api/v1/roots/{rootId}/config` with the exact bytes (`If-Match` when a row exists, omitted on first create).
- **Fail-open & opt-in:** no-ops silently (exit 0) unless `TASK_ORCHESTRATOR_API_URL` + `TASK_ORCHESTRATOR_API_TOKEN` are set — so stdio/local deployments are untouched. Any error → one log line, never blocks session start.
- Wired as a **second** SessionStart hook (`session-start.mjs` untouched). Client env vars + the `write-config` capability documented in `fleet-deployment.md`.

## Fingerprint parity (the flagged risk)
The hook hashes and PUTs the **same raw buffer**, so its fingerprint matches the server's `computeFingerprint` (SHA-256 hex over UTF-8 bytes) regardless of CRLF. Proven end-to-end with a mock server: in-sync detection makes **no PUT**, and the create path PUTs **byte-identical** content.

## Verification
- Smoke: no env → silent exit 0; unreachable API → fail-open `unreachable` line + valid JSON hookSpecificOutput.
- Mock server: in-sync (server ETag == local hash) → no PUT; 404 → PUT with byte-identical body and no `If-Match`.
- `hooks-config.json` validated as JSON.

## Dependency
Consumes the Phase 1 endpoint (#234) at runtime; harmlessly no-ops until that's merged and a server with the endpoint is deployed.

## MCP
Feature: `89ebee43` · Phase 2: `7df8f95f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)