### PR TITLE
docs(config): global-vs-per-project config precedence + AGENT_CONFIG_DIR reframe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ private fun getConfigPath(): Path {
 - In Docker: `-e AGENT_CONFIG_DIR=/project` (where config is mounted)
 - In local dev: not needed (uses working directory)
 - Currently used by: `YamlWorkItemSchemaService`
+- **This is the GLOBAL/fallback config.** `AGENT_CONFIG_DIR` locates the single, server-wide `.taskorchestrator/config.yaml`, read once at startup (restart to reload). Per-**project** config is stored per-root in the DB — pushed via `manage_project_config` or `PUT /api/v1/roots/{rootId}/config`, synced from the workspace file by the `config-sync` SessionStart hook — and hot-reloads without a restart, layering over this global file per item `rootId`. See `claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md` → "Global vs Per-Project Config".
 
 ## Adding New Components
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
@@ -366,6 +366,23 @@ work_item_schemas:
 
 ---
 
+## Global vs Per-Project Config
+
+Config resolves in **two layers**, chosen per work item by its `rootId`:
+
+| Layer | Where it lives | Reload | Scope |
+|-------|----------------|--------|-------|
+| **Global** | the `AGENT_CONFIG_DIR/.taskorchestrator/config.yaml` file | read once at server startup (restart to reload) | one per server — the **fallback/default** |
+| **Per-root** | pushed into the DB per project-root UUID (via `manage_project_config` or `PUT /api/v1/roots/{rootId}/config`) | **hot-reloaded** on every schema-resolving read — no restart | one per project root |
+
+For an item with a `rootId`, every schema / tag / trait lookup consults that root's per-root config **first** and falls back to the global file on a miss. An item with no `rootId` uses the global file only. Behavior is byte-identical to a single-file setup when no per-root config has been pushed.
+
+**Precedence — the workspace file is canonical; the per-root DB row is a synced replica.** The `config-sync.mjs` SessionStart hook (and the `manage-schemas` / `quick-start` push steps) copy the local `.taskorchestrator/config.yaml` into the per-root store whenever it changes. Durable edits belong in the **file**: a runtime `manage_project_config` push that isn't reflected in the file is overwritten at the next session's sync. A byte-identical file is a no-op (fingerprints match).
+
+**Global-only settings.** `note_limits` and `actor_authentication` are **not** part of the per-root layer — the resolver reads them only from the global file. A per-root document may carry them, but they are ignored; keep them in the global config.
+
+---
+
 ## Note Body Length Limits
 
 Top-level `note_limits.mode` (`warn`, default, or `reject`) governs what happens when a note body exceeds its schema `maxLength`, checked at `manage_notes` upsert time against the resolved body (inline `body` or file-read via `bodyFromFile`): `warn` accepts the note with a `warning` field on its result; `reject` fails that note with `code: NOTE_BODY_TOO_LONG`.


### PR DESCRIPTION
## Summary
**Phase 3** (final) of per-project config auto-sync (feature `89ebee43`) — documentation.

- **`config-format.md`** — new *Global vs Per-Project Config* section: the two resolution layers (global file = fallback, restart-to-reload; per-root DB config = hot-reloaded), the **precedence rule** (the workspace file is canonical, the per-root DB row is a synced replica, the file wins at session boundaries), and the **global-only settings** (`note_limits`, `actor_authentication` stay global).
- **`CLAUDE.md`** — reframes `AGENT_CONFIG_DIR` as the *global/fallback* config, pointing at the per-root DB layer and the `config-sync` hook.

## Note
A precedence sentence was trialed in the `manage_project_config` tool description but **reverted** — it exceeded the per-tool tools-list token budget (`ToolTokenBudgetTest`), and the token-efficiency policy keeps descriptions lean. The precedence rule lives in the human/contributor docs instead. `api-rest.md` (endpoint mechanics already documented in #234) and `quick-start.md` (single-user; sync is an opt-in fleet feature) were deferred as covered-elsewhere.

Docs-only; `ktlintCheck` + `:current:test` green.

## MCP
Feature: `89ebee43` · Phase 3: `8bbe7154`

🤖 Generated with [Claude Code](https://claude.com/claude-code)