### PR TITLE
feat(api): opt-in unauthenticated REST mode (API_AUTH_MODE=none) for localhost

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,8 @@ Add to `gradle/libs.versions.toml` (`[versions]` + `[libraries]`), then referenc
 
 **REST API environment variables** (see also `current/docs/fleet-deployment.md`):
 - `API_ENABLED` — master API switch (default: `false`; set `true` to opt into the REST API, which then requires `API_AUTH_MODE`)
-- `API_AUTH_MODE` — `bearer` or `jwks`; required when API enabled; no `none` mode
+- `API_AUTH_MODE` — `bearer` or `jwks`; required when API enabled. Also accepts `none` when `API_ALLOW_UNAUTHENTICATED=true` (opt-in unauthenticated mode, loopback-only — see `current/docs/api-rest.md` §1)
+- `API_ALLOW_UNAUTHENTICATED` — confirm flag required alongside `API_AUTH_MODE=none` (default: `false`); ignored with `bearer`/`jwks`
 - `API_TOKENS_PATH` — bearer token YAML file path (default: `/run/secrets/api-tokens.yaml`)
 - `API_JWKS_URL` — JWKS endpoint URL (jwks mode, required)
 - `API_JWKS_ISSUER` — expected JWT `iss` claim (jwks mode, required)

--- a/claude-plugins/task-orchestrator/hooks/config-sync.mjs
+++ b/claude-plugins/task-orchestrator/hooks/config-sync.mjs
@@ -10,7 +10,10 @@
 //
 // Requires (all optional — absent = no-op):
 //   TASK_ORCHESTRATOR_API_URL    base URL of the REST API, e.g. http://localhost:3001
-//   TASK_ORCHESTRATOR_API_TOKEN  bearer token with the WRITE_CONFIG capability, scoped to this root
+//   TASK_ORCHESTRATOR_API_TOKEN  bearer token with the WRITE_CONFIG capability, scoped to this root.
+//                                Optional: an unauthenticated server (API_AUTH_MODE=none +
+//                                API_ALLOW_UNAUTHENTICATED=true) needs no token at all — when
+//                                absent, requests are sent with no Authorization header.
 
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
@@ -79,12 +82,15 @@ async function main() {
   if (!rootId) return; // not project-scoped → nothing to sync
 
   const apiUrl = process.env.TASK_ORCHESTRATOR_API_URL;
+  if (!apiUrl) return; // stdio/local: the global config file already serves this workspace
+
+  // Token is optional — an unauthenticated server (API_AUTH_MODE=none +
+  // API_ALLOW_UNAUTHENTICATED=true) needs no Authorization header at all.
   const token = process.env.TASK_ORCHESTRATOR_API_TOKEN;
-  if (!apiUrl || !token) return; // stdio/local: the global config file already serves this workspace
 
   const localEtag = `"cfg-${createHash('sha256').update(bytes).digest('hex')}"`;
   const endpoint = `${apiUrl.replace(/\/+$/, '')}/api/v1/roots/${rootId}/config`;
-  const authHeader = { Authorization: `Bearer ${token}` };
+  const authHeader = token ? { Authorization: `Bearer ${token}` } : {};
 
   // 1) Read the server's current fingerprint to decide whether a push is needed.
   let currentEtag = null;

--- a/current/docs/api-rest.md
+++ b/current/docs/api-rest.md
@@ -38,7 +38,7 @@ This document describes the HTTP REST API layer (v1) added alongside the MCP tra
 
 ## 1. Authentication
 
-All `/api/v1/*` endpoints require authentication. The API supports two modes, selected by `API_AUTH_MODE`:
+All `/api/v1/*` endpoints require authentication by default. The API supports three modes, selected by `API_AUTH_MODE`:
 
 ### Bearer Mode (`API_AUTH_MODE=bearer`)
 
@@ -103,6 +103,21 @@ Capabilities and scope are derived from the JWT's `sub` claim (mapped to a princ
 - `403 Forbidden` — token valid but lacks required capability
 
 **`degradedModePolicy` interaction (JWKS mode):** When `DEGRADED_MODE_POLICY=reject` and JWKS verification fails, write endpoints return `401` with error `verification_failed`. Read endpoints and the bearer mode are unaffected (bearer auth has no JWKS chain).
+
+### Unauthenticated Mode (`API_AUTH_MODE=none`, opt-in)
+
+**Two signals are required together** — this is a deliberate two-key opt-in, not a single flag:
+
+```
+API_AUTH_MODE=none
+API_ALLOW_UNAUTHENTICATED=true
+```
+
+Setting `API_AUTH_MODE=none` alone still fails startup with an error naming the confirm flag. Setting `API_ALLOW_UNAUTHENTICATED=true` alone (with `bearer`/`jwks`) is silently ignored — it only takes effect combined with `none`.
+
+When both are set, every request — with or without an `Authorization` header — is attached a synthetic principal with `ADMIN` capability (implies all others) and unrestricted scope (`root_ids: null`). No token is required or checked. Audit records attribute writes to the actor `api:local-unauth`.
+
+> **SECURITY — loopback only.** This mode has NO authentication whatsoever: anyone who can reach the port has full read/write/delete access to every item, note, and per-root config, identical to the existing `/mcp` exposure. Use it only on a server bound to `127.0.0.1` (or otherwise network-fenced) for a single-user local setup — e.g. the config-sync hook talking to a local HTTP-transport server. Never set both keys on a server reachable from an untrusted network. The server logs a loud `SECURITY:` warning at startup when this mode is active.
 
 ---
 

--- a/current/docs/api/openapi.yaml
+++ b/current/docs/api/openapi.yaml
@@ -25,6 +25,8 @@ components:
       description: |
         Static bearer token (API_AUTH_MODE=bearer) or JWT (API_AUTH_MODE=jwks).
         For SSE, use Authorization header or opt-in ?token= query param.
+        Optional opt-in unauthenticated mode (API_AUTH_MODE=none + API_ALLOW_UNAUTHENTICATED=true)
+        accepts requests with no Authorization header at all — loopback-only, see api-rest.md §1.
 
   parameters:
     itemId:

--- a/current/docs/fleet-deployment.md
+++ b/current/docs/fleet-deployment.md
@@ -64,12 +64,20 @@ API_JWKS_ALGORITHMS=RS256,EdDSA
 API_JWKS_CACHE_TTL_SECONDS=300   # optional, default 300
 ```
 
+```bash
+# Unauthenticated mode — opt-in, loopback-only (see "Unauthenticated mode" below)
+API_ENABLED=true
+API_AUTH_MODE=none
+API_ALLOW_UNAUTHENTICATED=true
+```
+
 ### REST API env vars
 
 | Variable | Required when | Default | Description |
 |----------|--------------|---------|-------------|
 | `API_ENABLED` | optional | `false` | Master API switch. Unset or `false` skips all `/api/v1/*` route registration; set `true` to opt in. |
-| `API_AUTH_MODE` | API enabled | — | `bearer` or `jwks`. Required; no `none` mode. |
+| `API_AUTH_MODE` | API enabled | — | `bearer` or `jwks`. Also accepts `none` when `API_ALLOW_UNAUTHENTICATED=true` (see below). Required. |
+| `API_ALLOW_UNAUTHENTICATED` | opting into `none` | `false` | Confirm flag required alongside `API_AUTH_MODE=none`. Ignored with `bearer`/`jwks`. |
 | `API_TOKENS_PATH` | bearer mode | `/run/secrets/api-tokens.yaml` | Path to bearer token YAML secret file. |
 | `API_JWKS_URL` | jwks mode | — | JWKS endpoint URL (fully-qualified HTTP/HTTPS). |
 | `API_JWKS_ISSUER` | jwks mode | — | Expected `iss` claim value in JWTs. |
@@ -97,6 +105,12 @@ See [api-rest.md §1](api-rest.md#1-authentication) for the full YAML format. Ke
 - Token rotation requires a server restart (no live reload)
 - `admin` capability unlocks attribution fields in responses (subject to `API_REDACT_*` env flags)
 
+### Unauthenticated mode
+
+`API_AUTH_MODE=none` + `API_ALLOW_UNAUTHENTICATED=true` (both required — see the env var table above) disables authentication on `/api/v1/*` entirely: every request, with or without an `Authorization` header, is attached a synthetic `ADMIN`/unrestricted-scope principal. This exists for a **single-user, loopback-bound local server** — e.g. so the `config-sync.mjs` hook (below) can push per-project config without minting a bearer token, the same friction-free posture the `/mcp` endpoint already has.
+
+**This mode carries the same fence requirement as `/mcp`:** bind the HTTP transport to `127.0.0.1` (`MCP_HTTP_HOST=127.0.0.1`), or otherwise ensure the port is unreachable from any untrusted network, before setting both keys. Do not combine this mode with a `0.0.0.0` bind or a port published outside a trusted host. The server logs a `SECURITY:` WARN at startup whenever this mode is active, mirroring the existing `/mcp`-is-unauthenticated warning.
+
 ### `degradedModePolicy` and the REST API
 
 When `API_AUTH_MODE=jwks` and `DEGRADED_MODE_POLICY=reject`, write endpoints (`POST`, `PATCH`, `PUT`, `DELETE`, advance) return `401 verification_failed` if JWKS verification fails. **Bearer mode is always trusted** — the REST API bearer token was validated at the HTTP layer and has no JWKS verification chain.
@@ -107,14 +121,14 @@ This is different from the MCP actor `reject` policy, which governs MCP tool cal
 
 In a shared HTTP deployment, per-project config lives in the DB per root (hot-reloaded, no restart), while the mounted global `.taskorchestrator/config.yaml` is only a fallback. The plugin's `config-sync.mjs` SessionStart hook keeps a project's DB config in sync with its workspace file: on session start it fingerprints the local file and, if it differs from the server's stored config, PUTs it to `PUT /api/v1/roots/{rootId}/config`. **The file is the source of truth; the DB row is a synced replica** (a byte-identical file is a no-op via `If-Match`/fingerprint).
 
-The hook is **fail-open and opt-in** — it no-ops silently (exit 0) unless BOTH client env vars below are set, so stdio/local deployments (which read the file directly) are unaffected:
+The hook is **fail-open and opt-in** — it no-ops silently (exit 0) unless `TASK_ORCHESTRATOR_API_URL` is set, so stdio/local deployments (which read the file directly) are unaffected:
 
 | Variable | Required for sync | Description |
 |----------|-------------------|-------------|
 | `TASK_ORCHESTRATOR_API_URL` | yes | Base URL of the REST API, e.g. `http://orchestrator.internal:3001` (the hook appends `/api/v1/roots/{rootId}/config`). |
-| `TASK_ORCHESTRATOR_API_TOKEN` | yes | Bearer token with the `write-config` capability, scoped (`scope.root_ids`) to this workspace's project root. |
+| `TASK_ORCHESTRATOR_API_TOKEN` | no | Bearer token with the `write-config` capability, scoped (`scope.root_ids`) to this workspace's project root. **Optional** — omit it entirely when the server runs in [unauthenticated mode](#unauthenticated-mode); the hook then sends the request with no `Authorization` header at all. |
 
-Set these per-workspace (e.g. in `.claude/settings.json`'s `env` block, or the shell environment). The token needs only `write-config` for its own root — not `admin` — and the server must have `API_ENABLED=true`. If the API is unreachable or returns an error, the hook logs a one-line note and continues; it never blocks session start.
+Set these per-workspace (e.g. in `.claude/settings.json`'s `env` block, or the shell environment). Against a bearer/jwks server the token needs only `write-config` for its own root — not `admin`. Against an unauthenticated server, no token is needed at all. Either way the server must have `API_ENABLED=true`. If the API is unreachable or returns an error, the hook logs a one-line note and continues; it never blocks session start.
 
 ---
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/ApiAuthConfigLoader.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/ApiAuthConfigLoader.kt
@@ -14,7 +14,8 @@ import java.net.URL
  * | Variable | Required when | Default | Description |
  * |----------|--------------|---------|-------------|
  * | `API_ENABLED` | optional | `false` | Master API switch. Unset or `false` → [ApiAuthConfig.Disabled]. `true` opts in (then `API_AUTH_MODE` is required). |
- * | `API_AUTH_MODE` | `API_ENABLED=true` | — | `bearer` or `jwks`. Unset / `none` / invalid → startup failure. |
+ * | `API_AUTH_MODE` | `API_ENABLED=true` | — | `bearer` or `jwks`. Also accepts `none` when `API_ALLOW_UNAUTHENTICATED=true` (see below) → [ApiAuthConfig.Unauthenticated]. Unset / invalid / `none` without the confirm flag → startup failure. |
+ * | `API_ALLOW_UNAUTHENTICATED` | optional | `false` | Confirm flag required alongside `API_AUTH_MODE=none` to opt into [ApiAuthConfig.Unauthenticated]. Parsed like `API_ENABLED`. Ignored when `API_AUTH_MODE` is not `none`. |
  * | `API_TOKENS_PATH` | bearer mode | `/run/secrets/api-tokens.yaml` | Path to the bearer token secret file. |
  * | `API_JWKS_URL` | jwks mode | — | JWKS endpoint URL. Required; startup fails if absent. |
  * | `API_JWKS_ISSUER` | jwks mode | — | Expected `iss` claim. Required. |
@@ -48,10 +49,18 @@ class ApiAuthConfigLoader(
             return ApiAuthConfig.Disabled
         }
 
-        val authMode = resolveAuthMode()
+        val allowUnauthenticated = resolveApiAllowUnauthenticated()
+        val authMode = resolveAuthMode(allowUnauthenticated)
         return when (authMode) {
             "bearer" -> loadBearer()
             "jwks" -> loadJwks()
+            "none" -> {
+                logger.warn(
+                    "API_AUTH_MODE=none with API_ALLOW_UNAUTHENTICATED=true: the REST API will run " +
+                        "UNAUTHENTICATED. This must only be used on a loopback-bound local server.",
+                )
+                ApiAuthConfig.Unauthenticated
+            }
             else -> throw IllegalArgumentException(
                 "API_AUTH_MODE='$authMode' is not supported. Valid values: bearer, jwks.",
             )
@@ -77,25 +86,44 @@ class ApiAuthConfigLoader(
         }
     }
 
-    private fun resolveAuthMode(): String {
+    private fun resolveApiAllowUnauthenticated(): Boolean {
+        // Confirm flag for API_AUTH_MODE=none — parsed exactly like resolveApiEnabled. Two
+        // independent keys must both be set to reach Unauthenticated: this key alone (with any
+        // other API_AUTH_MODE) is a no-op, and API_AUTH_MODE=none alone (without this key) still
+        // fails fast in resolveAuthMode below.
+        val raw = envResolver("API_ALLOW_UNAUTHENTICATED") ?: return false
+        return when (raw.lowercase().trim()) {
+            "true", "1", "yes" -> true
+            "false", "0", "no" -> false
+            else -> throw IllegalArgumentException(
+                "API_ALLOW_UNAUTHENTICATED has invalid value '$raw'. Expected: true or false.",
+            )
+        }
+    }
+
+    private fun resolveAuthMode(allowUnauthenticated: Boolean): String {
         val raw = envResolver("API_AUTH_MODE")
         if (raw.isNullOrBlank()) {
             throw IllegalArgumentException(
                 "API_AUTH_MODE is required when API_ENABLED=true. " +
-                    "Valid values: bearer, jwks. " +
-                    "There is no 'none' mode — the API always requires authentication.",
+                    "Valid values: bearer, jwks (or none, with API_ALLOW_UNAUTHENTICATED=true).",
             )
         }
         val normalised = raw.lowercase().trim()
         if (normalised == "none") {
-            throw IllegalArgumentException(
-                "API_AUTH_MODE=none is not allowed. The API always requires authentication. " +
-                    "Valid values: bearer, jwks.",
-            )
+            if (!allowUnauthenticated) {
+                throw IllegalArgumentException(
+                    "API_AUTH_MODE=none requires API_ALLOW_UNAUTHENTICATED=true to confirm this opt-in " +
+                        "(the REST API would otherwise run unauthenticated). Valid values: bearer, jwks, " +
+                        "or none with API_ALLOW_UNAUTHENTICATED=true.",
+                )
+            }
+            return normalised
         }
         if (normalised !in listOf("bearer", "jwks")) {
             throw IllegalArgumentException(
-                "API_AUTH_MODE='$raw' is not valid. Valid values: bearer, jwks.",
+                "API_AUTH_MODE='$raw' is not valid. Valid values: bearer, jwks, none " +
+                    "(requires API_ALLOW_UNAUTHENTICATED=true).",
             )
         }
         return normalised

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/audit/ApiAuditBridge.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/audit/ApiAuditBridge.kt
@@ -77,6 +77,12 @@ object ApiAuditBridge {
                     verifier = "api-jwks",
                     reason = null,
                 )
+            ApiAuthMode.UNAUTHENTICATED ->
+                VerificationResult(
+                    status = VerificationStatus.UNCHECKED,
+                    verifier = "api-unauthenticated",
+                    reason = null,
+                )
         }
 
     /**
@@ -90,13 +96,18 @@ object ApiAuditBridge {
      * no JWKS verification chain. The spec says: "API_AUTH_MODE=bearer is unaffected — bearer
      * auth has no verification chain." Bearer tokens are validated by the auth plugin before
      * any route handler runs; if a route handler sees a principal, the bearer token was valid.
+     *
+     * **Unauthenticated mode is likewise always trusted** — like bearer, there is no JWKS
+     * verification chain to run; the synthetic [io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.LOCAL_UNAUTH_PRINCIPAL]
+     * is attached unconditionally by the auth plugin.
      */
     fun resolveTrustedActorIdOrNull(
         principal: ApiPrincipal,
         degradedModePolicy: DegradedModePolicy,
     ): String? {
-        // Bearer mode: always trusted — no JWKS chain, auth was validated at plugin level
-        if (principal.authMode == ApiAuthMode.BEARER) {
+        // Bearer and Unauthenticated modes: always trusted — no JWKS chain, auth was validated
+        // (or synthesized) at plugin level.
+        if (principal.authMode == ApiAuthMode.BEARER || principal.authMode == ApiAuthMode.UNAUTHENTICATED) {
             return "api:${principal.tokenId}"
         }
         // JWKS mode: run through the standard policy resolution

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/auth/ApiAuthConfig.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/auth/ApiAuthConfig.kt
@@ -33,6 +33,12 @@ sealed class ApiAuthConfig {
         val algorithms: List<String>,
         val cacheTtlSeconds: Long,
     ) : ApiAuthConfig()
+
+    // Opt-in unauthenticated mode (API_AUTH_MODE=none + API_ALLOW_UNAUTHENTICATED=true).
+    // Every request is attached the synthetic ApiPrincipal.LOCAL_UNAUTH_PRINCIPAL (ADMIN,
+    // unrestricted scope) with NO credential check at all. Intended only for a loopback-bound
+    // single-user local server -- see the SECURITY warn logged at startup in CurrentMcpServer.
+    data object Unauthenticated : ApiAuthConfig()
 }
 
 // Wrapper around a SHA-256 digest ByteArray that provides the structural equality

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/auth/ApiPrincipal.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/auth/ApiPrincipal.kt
@@ -23,6 +23,24 @@ data class ApiPrincipal(
 )
 
 /**
+ * Synthetic principal attached to every request when [ApiAuthConfig.Unauthenticated] is active.
+ *
+ * Granted [ApiCapability.ADMIN] (implies all other capabilities via the existing
+ * `hasCapability`/`requireCapability` logic) and an unrestricted [ApiScope] (`rootIds = null`),
+ * so `requireCapability` and `enforceScopeForItem` pass unchanged for every route -- no
+ * authorization-layer special-casing is needed for this mode.
+ *
+ * Audited as actor `api:local-unauth` via the existing [ApiAuditBridge] (tokenId-derived).
+ */
+val LOCAL_UNAUTH_PRINCIPAL =
+    ApiPrincipal(
+        tokenId = "local-unauth",
+        scope = ApiScope(rootIds = null, tagsInclude = emptySet()),
+        capabilities = setOf(ApiCapability.ADMIN),
+        authMode = ApiAuthMode.UNAUTHENTICATED,
+    )
+
+/**
  * Structural scope filter attached to an authenticated principal.
  *
  * Scope enforcement walks the item's ancestor chain.  A null [rootIds] means the
@@ -104,4 +122,7 @@ enum class ApiAuthMode {
 
     /** JWT validated against a JWKS endpoint. */
     JWKS,
+
+    /** No credential at all -- [ApiAuthConfig.Unauthenticated] mode's synthetic principal. */
+    UNAUTHENTICATED,
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/auth/AuthenticationPlugin.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/auth/AuthenticationPlugin.kt
@@ -86,6 +86,10 @@ class ApiAuthPluginConfig {
  *
  * When [ApiAuthConfig.Disabled] is configured, the plugin is a no-op (every call passes through
  * without a principal — routes must not call [apiPrincipal] in this case).
+ *
+ * When [ApiAuthConfig.Unauthenticated] is configured (opt-in: `API_AUTH_MODE=none` +
+ * `API_ALLOW_UNAUTHENTICATED=true`), every call is attached [LOCAL_UNAUTH_PRINCIPAL] with no
+ * credential check at all — see [LOCAL_UNAUTH_PRINCIPAL] for the ADMIN/unrestricted rationale.
  */
 val ApiBearerAuth =
     createApplicationPlugin(
@@ -100,6 +104,14 @@ val ApiBearerAuth =
 
             // When API is disabled, skip authentication entirely.
             if (authConfig is ApiAuthConfig.Disabled) return@onCall
+
+            // Opt-in unauthenticated mode (API_AUTH_MODE=none + API_ALLOW_UNAUTHENTICATED=true):
+            // attach the synthetic ADMIN/unrestricted principal and skip the Authorization-header
+            // check entirely -- this MUST run before that check so a token-less request isn't 401'd.
+            if (authConfig is ApiAuthConfig.Unauthenticated) {
+                call.attributes.put(ApiPrincipalKey, LOCAL_UNAUTH_PRINCIPAL)
+                return@onCall
+            }
 
             // Skip authentication for public endpoints (health, well-known discovery, etc.)
             val uri = call.request.local.uri
@@ -158,6 +170,7 @@ val ApiBearerAuth =
                     }
 
                     is ApiAuthConfig.Disabled -> null // unreachable due to guard above
+                    is ApiAuthConfig.Unauthenticated -> null // unreachable due to guard above
                 }
 
             if (principal == null) {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
@@ -265,6 +265,18 @@ class CurrentMcpServer(
                     "The /mcp endpoint remains unauthenticated regardless of the REST API auth mode.",
             )
         }
+        if (apiWiring.apiConfig is ApiAuthConfig.Unauthenticated) {
+            logger.warn(
+                "SECURITY: API_AUTH_MODE=none + API_ALLOW_UNAUTHENTICATED=true — the /api/v1 REST " +
+                    "API is UNAUTHENTICATED. Anyone who can reach {}:{} has full read/write/delete " +
+                    "access to all config and data via the REST API (same exposure as /mcp above). " +
+                    "This MUST be fronted by a reverse proxy / mTLS / private network, or bound to " +
+                    "127.0.0.1 for a loopback-only local run — do NOT expose this port to untrusted " +
+                    "callers.",
+                host,
+                port,
+            )
+        }
         if (host == "0.0.0.0") {
             logger.warn(
                 "SECURITY: MCP HTTP transport is bound to 0.0.0.0 (all interfaces). If this is not a " +

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/ApiAuthConfigLoaderTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/ApiAuthConfigLoaderTest.kt
@@ -247,7 +247,7 @@ class ApiAuthConfigLoaderTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `API_AUTH_MODE=none throws with explicit message`() {
+    fun `API_AUTH_MODE=none without the confirm flag throws naming API_ALLOW_UNAUTHENTICATED`() {
         val loader =
             ApiAuthConfigLoader(
                 envResolver =
@@ -257,7 +257,73 @@ class ApiAuthConfigLoaderTest {
                     ),
             )
         val ex = assertThrows<IllegalArgumentException> { loader.load() }
-        assertTrue(ex.message!!.contains("none") || ex.message!!.contains("not allowed"), "Error: ${ex.message}")
+        assertTrue(ex.message!!.contains("API_ALLOW_UNAUTHENTICATED"), "Error: ${ex.message}")
+    }
+
+    // -------------------------------------------------------------------------
+    // Unauthenticated mode (API_AUTH_MODE=none + API_ALLOW_UNAUTHENTICATED=true)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `API_AUTH_MODE=none with API_ALLOW_UNAUTHENTICATED=true returns Unauthenticated`() {
+        val loader =
+            ApiAuthConfigLoader(
+                envResolver =
+                    env(
+                        "API_ENABLED" to "true",
+                        "API_AUTH_MODE" to "none",
+                        "API_ALLOW_UNAUTHENTICATED" to "true",
+                    ),
+            )
+        val config = loader.load()
+        assertInstanceOf(ApiAuthConfig.Unauthenticated::class.java, config)
+    }
+
+    @Test
+    fun `API_AUTH_MODE=none with API_ALLOW_UNAUTHENTICATED=false still throws`() {
+        val loader =
+            ApiAuthConfigLoader(
+                envResolver =
+                    env(
+                        "API_ENABLED" to "true",
+                        "API_AUTH_MODE" to "none",
+                        "API_ALLOW_UNAUTHENTICATED" to "false",
+                    ),
+            )
+        val ex = assertThrows<IllegalArgumentException> { loader.load() }
+        assertTrue(ex.message!!.contains("API_ALLOW_UNAUTHENTICATED"), "Error: ${ex.message}")
+    }
+
+    @Test
+    fun `API_ALLOW_UNAUTHENTICATED=true alone with bearer mode is ignored — normal Bearer config`() {
+        val tokensPath = writeTokenFile(validBearerTokenYaml())
+        val loader =
+            ApiAuthConfigLoader(
+                envResolver =
+                    env(
+                        "API_ENABLED" to "true",
+                        "API_AUTH_MODE" to "bearer",
+                        "API_TOKENS_PATH" to tokensPath,
+                        "API_ALLOW_UNAUTHENTICATED" to "true",
+                    ),
+            )
+        val config = loader.load()
+        assertInstanceOf(ApiAuthConfig.Bearer::class.java, config)
+    }
+
+    @Test
+    fun `API_ALLOW_UNAUTHENTICATED with invalid value throws`() {
+        val loader =
+            ApiAuthConfigLoader(
+                envResolver =
+                    env(
+                        "API_ENABLED" to "true",
+                        "API_AUTH_MODE" to "none",
+                        "API_ALLOW_UNAUTHENTICATED" to "maybe",
+                    ),
+            )
+        val ex = assertThrows<IllegalArgumentException> { loader.load() }
+        assertTrue(ex.message!!.contains("API_ALLOW_UNAUTHENTICATED"), "Error: ${ex.message}")
     }
 
     @Test

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ApiTestHelper.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ApiTestHelper.kt
@@ -145,11 +145,13 @@ fun makeWriteAuthConfig(scopeRootIds: Set<UUID>? = null): ApiAuthConfig.Bearer {
  *
  * Installs [ContentNegotiation], [SSE], [ApiBearerAuth], and registers routes via [routeBlock].
  *
- * @param authConfig The auth config to install on `/api/v1`.
+ * @param authConfig The auth config to install on `/api/v1`. Accepts any [ApiAuthConfig] variant
+ *   (e.g. [ApiAuthConfig.Unauthenticated] for opt-in unauth-mode tests) — token entries are only
+ *   populated when it is [ApiAuthConfig.Bearer].
  * @param routeBlock Route registration block called inside `route("/api/v1") { ... }`.
  */
 fun Application.configureTestApp(
-    authConfig: ApiAuthConfig.Bearer = makeTestAuthConfig(),
+    authConfig: ApiAuthConfig = makeTestAuthConfig(),
     routeBlock: io.ktor.server.routing.Route.() -> Unit,
 ) {
     install(ContentNegotiation) { json(McpJson) }
@@ -159,9 +161,9 @@ fun Application.configureTestApp(
             install(ApiBearerAuth) {
                 this.authConfig = authConfig
                 tokenEntries =
-                    authConfig.tokens.mapValues { (_, p) ->
+                    (authConfig as? ApiAuthConfig.Bearer)?.tokens?.mapValues { (_, p) ->
                         BearerTokenStore.TokenEntry(p, expiresAt = null)
-                    }
+                    } ?: emptyMap()
             }
             routeBlock()
         }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemRoutesTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemRoutesTest.kt
@@ -4,6 +4,7 @@ import io.github.jpicklyk.mcptask.current.domain.model.Priority
 import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.WorkItemsTable
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiAuthConfig
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
@@ -246,6 +247,30 @@ class ItemRoutesTest {
                     header("Authorization", "Bearer $TEST_TOKEN")
                 }
             assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+    /**
+     * Opt-in unauthenticated mode ([ApiAuthConfig.Unauthenticated]): a request with NO
+     * Authorization header at all is attached the synthetic ADMIN/unrestricted principal and
+     * must reach this capability-gated (`requireCapability(READ)`), scope-checked
+     * (`enforceScopeForItem`) route successfully — proving both checks pass unchanged for the
+     * synthetic principal.
+     */
+    @Test
+    fun `GET items id succeeds with no Authorization header in unauthenticated mode`() =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root =
+                runBlocking {
+                    repo.workItemRepository().create(WorkItem(title = "Unauth Item", depth = 0)).getOrNull()!!
+                }
+            application {
+                configureTestApp(ApiAuthConfig.Unauthenticated) { itemRoutes(repo) }
+            }
+            val response = client.get("/api/v1/items/${root.id}")
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("Unauth Item"), "Expected item title in response: $body")
         }
 
     // ─── Pagination ──────────────────────────────────────────────────────────

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutesTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutesTest.kt
@@ -54,10 +54,16 @@ private val VALID_YAML =
             required: true
     """.trimIndent()
 
-/** Configures a test Ktor application with only [projectConfigRoutes] registered. */
+/**
+ * Configures a test Ktor application with only [projectConfigRoutes] registered.
+ *
+ * [authConfig] accepts any [ApiAuthConfig] variant — e.g. [ApiAuthConfig.Unauthenticated] for
+ * opt-in unauth-mode tests (see [ProjectConfigUnauthenticatedModeTest]). Token entries are only
+ * populated when it is [ApiAuthConfig.Bearer].
+ */
 fun Application.configureProjectConfigTestApp(
     repo: DefaultRepositoryProvider,
-    authConfig: ApiAuthConfig.Bearer = makeWriteAuthConfig(),
+    authConfig: ApiAuthConfig = makeWriteAuthConfig(),
 ) {
     install(ContentNegotiation) { json(McpJson) }
     install(SSE)
@@ -66,9 +72,9 @@ fun Application.configureProjectConfigTestApp(
             install(ApiBearerAuth) {
                 this.authConfig = authConfig
                 tokenEntries =
-                    authConfig.tokens.mapValues { (_, p) ->
+                    (authConfig as? ApiAuthConfig.Bearer)?.tokens?.mapValues { (_, p) ->
                         BearerTokenStore.TokenEntry(p, expiresAt = null)
-                    }
+                    } ?: emptyMap()
             }
             projectConfigRoutes(repo)
         }
@@ -424,6 +430,56 @@ class ProjectConfigDeleteRouteTest {
                 }
 
             assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+}
+
+/**
+ * Opt-in unauthenticated REST mode (`API_AUTH_MODE=none` + `API_ALLOW_UNAUTHENTICATED=true`).
+ * With [ApiAuthConfig.Unauthenticated] installed, every request — including one with NO
+ * Authorization header at all — is attached the synthetic ADMIN/unrestricted principal and must
+ * reach this WRITE_CONFIG-gated, scope-checked route successfully. This is the config-sync hook's
+ * exact use case: a token-less PUT against a local unauthenticated server.
+ */
+class ProjectConfigUnauthenticatedModeTest {
+    @Test
+    fun `PUT roots rootId config with no Authorization header succeeds in unauthenticated mode`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo, authConfig = ApiAuthConfig.Unauthenticated) }
+
+            val response =
+                client.put("/api/v1/roots/${root.id}/config") {
+                    // Deliberately no Authorization header.
+                    contentType(ContentType.Text.Plain)
+                    setBody(VALID_YAML)
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val persisted = runBlocking { repo.projectConfigRepository().get(root.id) }
+            assertTrue(persisted is Result.Success)
+            val config = (persisted as Result.Success).data
+            assertNotNull(config, "Config should be persisted even with no token")
+            assertEquals(VALID_YAML, config!!.configYaml)
+        }
+
+    @Test
+    fun `GET roots rootId config with no Authorization header succeeds in unauthenticated mode`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo, authConfig = ApiAuthConfig.Unauthenticated) }
+
+            client.put("/api/v1/roots/${root.id}/config") {
+                contentType(ContentType.Text.Plain)
+                setBody(VALID_YAML)
+            }
+
+            val response = client.get("/api/v1/roots/${root.id}/config")
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains(root.id.toString()))
         }
 }
 


### PR DESCRIPTION
## Summary
Adds a **two-signal opt-in** unauthenticated mode to the `/api/v1` REST layer, so config-sync (and the rest of the REST API) works token-free on a single-user, loopback-bound local server — matching the posture `/mcp` already has (the same per-root config write is already reachable unauthenticated via `manage_project_config` on `/mcp`).

- **`ApiAuthConfig.Unauthenticated`** — accepted **only** when `API_AUTH_MODE=none` **and** `API_ALLOW_UNAUTHENTICATED=true`. `none` alone still fails fast; the flag alone is inert; bearer/jwks/disabled are byte-unchanged.
- **Synthetic principal** — in that mode the `ApiBearerAuth` plugin attaches `LOCAL_UNAUTH_PRINCIPAL` (ADMIN + unrestricted scope) *before* the header/401 path, so `requireCapability`/`enforceScopeForItem` pass with **no changes to the authorization checks or routes**.
- **Loud `SECURITY:` startup WARN** in unauth mode (mirrors the `/mcp` one — bind loopback / fence the network).
- **`config-sync.mjs` token now optional** — syncs on `TASK_ORCHESTRATOR_API_URL` alone and omits `Authorization` when there's no token, so URL-only config-sync works against an unauth local server. Authed path unchanged.
- **Not auto-detected** from bind address (unreliable under Docker NAT / `0.0.0.0`) — explicit opt-in only.

## Security review
Independent security-focused review (separate agent): **PASS WITH OBSERVATIONS**, no blocking findings. Core property **verified**: the unauthenticated mode is unreachable without *both* keys, no other mode can obtain the synthetic principal, `/mcp` bypass and bearer/jwks 401 paths are untouched. Redaction-bypass of the ADMIN principal is intentional/documented. Non-blocking follow-ups (secondary tests verified-by-read, a doc nit) tracked as `9c23b53c`.

## Test Results
`:current:test` green (2552 tests, 0 failures); `ktlintCheck` green. New/updated tests in `ApiAuthConfigLoaderTest`, `ProjectConfigRoutesTest`, `ItemRoutesTest`, `ApiTestHelper`. Hook token-optional path smoke-verified (URL-only triggers sync; no-URL stays no-op).

## MCP
Item: `dfca3967` · follow-up: `9c23b53c`

🤖 Generated with [Claude Code](https://claude.com/claude-code)