### PR TITLE
refactor(config): drop redundant schemas map from ParsedConfig

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigService.kt
@@ -135,7 +135,7 @@ class PerRootConfigService(
             @Suppress("UNCHECKED_CAST")
             val root = Yaml(SafeConstructor(LoaderOptions())).load<Map<String, Any>>(configYaml)
             if (root == null) {
-                YamlSchemaParser.ParsedConfig(emptyMap(), emptyMap(), emptyMap(), emptyList())
+                YamlSchemaParser.ParsedConfig(emptyMap(), emptyMap(), emptyList())
             } else {
                 YamlSchemaParser.parseRoot(root, warnOnMissingSchemas = false)
             }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt
@@ -58,21 +58,19 @@ class YamlWorkItemSchemaService(
     /** Lazily loaded schema cache and warnings. Initialized once on first access. */
     private val loadResult: YamlSchemaParser.ParsedConfig by lazy { loadSchemas() }
 
-    /** Lazily loaded tag→entries schema cache. */
-    private val schemas: Map<String, List<NoteSchemaEntry>> get() = loadResult.schemas
-
-    /** Lazily loaded type→WorkItemSchema cache. */
+    /** Lazily loaded type→WorkItemSchema cache. Note lists per tag are read via `[tag]?.notes`. */
     private val workItemSchemas: Map<String, WorkItemSchema> get() = loadResult.workItemSchemas
 
     /** Lazily loaded trait definitions. */
     private val traitDefs: Map<String, List<NoteSchemaEntry>> get() = loadResult.traits
 
     override fun getSchemaForTags(tags: List<String>): List<NoteSchemaEntry>? {
+        // First matching tag wins; fall back to the "default" schema only after every tag misses.
         for (tag in tags) {
-            val schema = schemas[tag]
-            if (schema != null) return schema
+            val schema = workItemSchemas[tag]
+            if (schema != null) return schema.notes
         }
-        return schemas["default"]
+        return workItemSchemas["default"]?.notes
     }
 
     override fun getSchemaForType(type: String?): WorkItemSchema? {
@@ -138,7 +136,7 @@ class YamlWorkItemSchemaService(
     private fun loadSchemas(): YamlSchemaParser.ParsedConfig {
         if (!configPath.toFile().exists()) {
             logger.debug("No config file found at {}; running in schema-free mode", configPath)
-            return YamlSchemaParser.ParsedConfig(emptyMap(), emptyMap(), emptyMap(), emptyList())
+            return YamlSchemaParser.ParsedConfig(emptyMap(), emptyMap(), emptyList())
         }
 
         return try {
@@ -147,7 +145,7 @@ class YamlWorkItemSchemaService(
                 @Suppress("UNCHECKED_CAST")
                 val root = yaml.load<Map<String, Any>>(reader)
                 if (root == null) {
-                    YamlSchemaParser.ParsedConfig(emptyMap(), emptyMap(), emptyMap(), emptyList())
+                    YamlSchemaParser.ParsedConfig(emptyMap(), emptyMap(), emptyList())
                 } else {
                     YamlSchemaParser.parseRoot(root)
                 }
@@ -155,13 +153,13 @@ class YamlWorkItemSchemaService(
         } catch (e: Exception) {
             val msg = "Failed to load note schemas from '$configPath': ${e.message}"
             logger.warn(msg)
-            YamlSchemaParser.ParsedConfig(emptyMap(), emptyMap(), emptyMap(), listOf(msg))
+            YamlSchemaParser.ParsedConfig(emptyMap(), emptyMap(), listOf(msg))
         }.also { result ->
             result.warnings.forEach { w -> logger.warn(w) }
-            val totalEntries = result.schemas.values.sumOf { it.size }
+            val totalEntries = result.workItemSchemas.values.sumOf { it.notes.size }
             logger.info(
                 "Loaded {} schemas ({} entries, {} warnings)",
-                result.schemas.size,
+                result.workItemSchemas.size,
                 totalEntries,
                 result.warnings.size
             )

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlSchemaParser.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlSchemaParser.kt
@@ -38,9 +38,13 @@ internal object YamlSchemaParser {
     /** Recognized `note_limits.mode` values. */
     private val VALID_NOTE_LIMITS_MODES = setOf("warn", "reject")
 
-    /** Result of parsing a config root map: schemas, traits, warnings, and the note-limits mode. */
+    /**
+     * Result of parsing a config root map: schemas (keyed by type/tag), traits, warnings, and the
+     * note-limits mode. Per-tag note lists are read via `workItemSchemas[tag]?.notes` — there is no
+     * separate tag→entries map, since it would be a redundant view of the same `NoteSchemaEntry`
+     * lists already held inside each [WorkItemSchema].
+     */
     data class ParsedConfig(
-        val schemas: Map<String, List<NoteSchemaEntry>>,
         val workItemSchemas: Map<String, WorkItemSchema>,
         val traits: Map<String, List<NoteSchemaEntry>>,
         val warnings: List<String>,
@@ -75,7 +79,7 @@ internal object YamlSchemaParser {
                     if (warnOnMissingSchemas) {
                         warnings.add("Config file is missing 'note_schemas' key; no schemas loaded")
                     }
-                    ParsedConfig(emptyMap(), emptyMap(), emptyMap(), warnings)
+                    ParsedConfig(emptyMap(), emptyMap(), warnings)
                 }
             }
 
@@ -89,9 +93,8 @@ internal object YamlSchemaParser {
     ): ParsedConfig {
         val rawSchemas =
             root["work_item_schemas"] as? Map<String, Any>
-                ?: return ParsedConfig(emptyMap(), emptyMap(), emptyMap(), warnings)
+                ?: return ParsedConfig(emptyMap(), emptyMap(), warnings)
 
-        val schemasMap = mutableMapOf<String, List<NoteSchemaEntry>>()
         val workItemSchemasMap = mutableMapOf<String, WorkItemSchema>()
 
         for ((schemaName, rawValue) in rawSchemas) {
@@ -122,7 +125,6 @@ internal object YamlSchemaParser {
                     parseEntry(raw, schemaName, index, warnings)
                 }
 
-            schemasMap[schemaName] = entries
             workItemSchemasMap[schemaName] =
                 WorkItemSchema(
                     type = schemaName,
@@ -132,7 +134,7 @@ internal object YamlSchemaParser {
                 )
         }
 
-        return ParsedConfig(schemasMap, workItemSchemasMap, emptyMap(), warnings)
+        return ParsedConfig(workItemSchemasMap, emptyMap(), warnings)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -142,9 +144,8 @@ internal object YamlSchemaParser {
     ): ParsedConfig {
         val noteSchemas =
             root["note_schemas"] as? Map<String, Any>
-                ?: return ParsedConfig(emptyMap(), emptyMap(), emptyMap(), warnings)
+                ?: return ParsedConfig(emptyMap(), emptyMap(), warnings)
 
-        val schemasMap = mutableMapOf<String, List<NoteSchemaEntry>>()
         val workItemSchemasMap = mutableMapOf<String, WorkItemSchema>()
 
         for ((schemaName, rawEntries) in noteSchemas) {
@@ -153,7 +154,6 @@ internal object YamlSchemaParser {
                 entryList.mapIndexedNotNull { index, raw ->
                     parseEntry(raw, schemaName, index, warnings)
                 }
-            schemasMap[schemaName] = entries
             // Wrap into WorkItemSchema with AUTO lifecycle for backward compat
             workItemSchemasMap[schemaName] =
                 WorkItemSchema(
@@ -163,7 +163,7 @@ internal object YamlSchemaParser {
                 )
         }
 
-        return ParsedConfig(schemasMap, workItemSchemasMap, emptyMap(), warnings)
+        return ParsedConfig(workItemSchemasMap, emptyMap(), warnings)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaServiceTest.kt
@@ -348,6 +348,40 @@ note_schemas:
     }
 
     @Test
+    fun `later matching tag wins over default when earlier tag misses`() {
+        // Regression guard: getSchemaForTags must scan ALL tags before falling back to "default".
+        // A per-tag `workItemSchemas[tag]?.notes ?: default` collapse would wrongly return the
+        // default on the first (missing) tag instead of the schema of a later matching tag.
+        val tempDir = createTempConfigDir()
+        writeConfig(
+            tempDir,
+            """
+note_schemas:
+  my-schema:
+    - key: acceptance-criteria
+      role: queue
+      required: true
+      description: "Acceptance criteria"
+  default:
+    - key: implementation-notes
+      role: work
+      required: true
+      description: "Implementation notes"
+            """.trimIndent()
+        )
+
+        val configPath = tempDir.toPath().resolve(".taskorchestrator/config.yaml")
+        val service = YamlNoteSchemaService(configPath)
+
+        // First tag misses; second tag matches a named schema — the named schema must win,
+        // NOT the default.
+        val schema = service.getSchemaForTags(listOf("unknown-tag", "my-schema"))
+        assertNotNull(schema)
+        assertEquals(1, schema.size)
+        assertEquals("acceptance-criteria", schema[0].key)
+    }
+
+    @Test
     fun `empty tags list returns default schema`() {
         val tempDir = createTempConfigDir()
         writeConfig(


### PR DESCRIPTION
## Summary

Removes a redundant map from `YamlSchemaParser.ParsedConfig`. The parsed-config result carried **both**:

- `workItemSchemas: Map<String, WorkItemSchema>`
- `schemas: Map<String, List<NoteSchemaEntry>>` — populated in lockstep in both parse paths, where `schemas[tag]` was the **same list reference** as `workItemSchemas[tag].notes`.

The `schemas` field is dropped. `getSchemaForTags` now reads `workItemSchemas[tag]?.notes`.

## Correctness note (the one real risk)

The fallback ordering is preserved: iterate **all** tags, and fall back to the `"default"` schema **only after every tag misses** (loop-then-default). A naive per-tag collapse —

```kotlin
workItemSchemas[tag]?.notes ?: workItemSchemas["default"]?.notes   // WRONG inside the loop
```

— would return the default on the *first* missing tag instead of a later matching tag (e.g. `["unknown", "feature-task"]` with a `default` configured would yield `default`, not `feature-task`). A regression test (`later matching tag wins over default when earlier tag misses`) guards this.

## Blast radius

- `YamlSchemaParser.kt` — field removed; `schemasMap` population dropped from `parseWorkItemSchemas`/`parseLegacyNoteSchemas`; construction sites updated
- `YamlNoteSchemaService.kt` — `getSchemaForTags` rewrite + load-summary log line now derives counts from `workItemSchemas`
- `PerRootConfigService.kt` — one construction-site fixup
- `PerRootConfigService` / `ProjectConfigPushService` are behaviorally unaffected (they read only `workItemSchemas`/`traits`)

Behavior-preserving: **no interface, API, or migration change.**

## Testing

- Added regression test for loop-then-default tag ordering
- `./gradlew test` (full suite) — green

Closes the tracked cleanup item `68100966`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
