### PR TITLE
feat(plugin): configure-server skill + recommend HTTP+REST+config-sync default

### DIFF
--- a/.claude/commands/deploy_to_docker.md
+++ b/.claude/commands/deploy_to_docker.md
@@ -156,16 +156,10 @@ docker run -d --name mcp-task-orchestrator-http --restart unless-stopped \
   -p 127.0.0.1:3001:3001 <image-tag>
 ```
 
-| Choice | Fragment |
-|--------|----------|
-| REST off | `-e API_ENABLED=false` |
-| REST unauthenticated | `-e API_ENABLED=true -e API_AUTH_MODE=none -e API_ALLOW_UNAUTHENTICATED=true` |
-| REST bearer | `-e API_ENABLED=true -e API_AUTH_MODE=bearer -e API_TOKENS_PATH=/run/secrets/api-tokens.yaml -v <TOKENS_HOST_PATH>:/run/secrets/api-tokens.yaml:ro` |
-| Config mount = project | `-v "<pwd>/.taskorchestrator:/project/.taskorchestrator:ro" -e AGENT_CONFIG_DIR=/project` |
-| Config mount = none | *(omit)* |
-| Debug on | `-e LOG_LEVEL=DEBUG -e DATABASE_SHOW_SQL=true` |
-
-> **Windows:** run the `docker run` (and the STDIO variant) via **PowerShell** using `${PWD}` for the volume path — the Bash/MSYS shell rewrites the leading slash in `-e AGENT_CONFIG_DIR=/project` and in `:/app/data` / `:/project/...` mounts, breaking the container. Bash is fine for `docker build`, `docker inspect`, `docker logs`, `docker stop/rm`.
+The exact fragments for each choice (REST off/unauthenticated/bearer, config mount, debug), the
+loopback-safety rationale, and the Windows/MSYS path caveat are single-sourced in
+`claude-plugins/task-orchestrator/skills/configure-server/references/runtime-config.md` — use that
+catalog to compose the command above rather than re-deriving the flags here.
 
 Verify running:
 ```bash
@@ -186,7 +180,7 @@ If **unauthenticated** REST was selected, repeat the loopback-only SECURITY cave
 
 ## Notes
 - **Reuse is the default:** detection reads the live container (`docker inspect`) first, then `${HOME}/.taskorchestrator/deploy.env`, then built-in defaults — so a redeploy keeps your last REST mode / mounts unless you Reconfigure.
-- **REST API + config-sync:** the `config-sync` SessionStart hook needs the REST API **on** (`Unauthenticated` locally, or `Bearer`). With REST `off`, only `/mcp` is served and config-sync no-ops.
+- **REST API + config-sync:** the `config-sync` SessionStart hook needs the REST API **on** (`Unauthenticated` locally, or `Bearer`) **and** the client-side `TASK_ORCHESTRATOR_API_URL` env var — see the "config-sync" section of `runtime-config.md` (cited above) for the full requirement and the silent-no-op failure mode. With REST `off`, only `/mcp` is served and config-sync no-ops regardless.
 - **No local build needed:** the Dockerfile runs `./gradlew :current:jar` in a builder stage.
 - **Persistence:** `mcp-task-data` volume persists the DB across runs.
 - **HTTP:** detached (`-d`), `/mcp` served, container `mcp-task-orchestrator-http`, published loopback-only by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **REST per-root config write endpoint.** `GET`/`PUT`/`DELETE /api/v1/roots/{rootId}/config`,
+  gated by a new `WRITE_CONFIG` capability, backed by a shared `ProjectConfigPushService` so the
+  MCP `manage_project_config` tool and the REST path converge on identical validation and DB state
+  (#234).
+- **`config-sync` SessionStart hook.** Opt-in, fail-open plugin hook that fingerprints the
+  workspace's `.taskorchestrator/config.yaml` at session start and, if it differs from the
+  server's stored per-root config, pushes it via the new REST endpoint — so a shared HTTP server
+  picks up per-project schemas/traits without a restart. No-ops silently unless
+  `TASK_ORCHESTRATOR_API_URL` (and, for bearer mode, `TASK_ORCHESTRATOR_API_TOKEN`) is set in the
+  client environment (#235).
+- **Opt-in unauthenticated REST mode.** `API_AUTH_MODE=none` (plus the required confirm flag
+  `API_ALLOW_UNAUTHENTICATED=true`) attaches a synthetic `ADMIN`/unrestricted principal to every
+  `/api/v1/*` request, skipping bearer/JWKS auth entirely. Intended for a loopback-bound local
+  server only — see `current/docs/api-rest.md` §1 and the loopback-footgun guidance in the new
+  `configure-server` skill below (#237).
+- **New plugin skill `/configure-server`.** End-user decision flow for how the server runs and is
+  reached — transport (HTTP vs STDIO), REST API mode, port publishing, config mount, and
+  config-sync — plus a companion `references/runtime-config.md` rendering catalog shared with
+  `/deploy_to_docker`. Establishes a new **recommended default for new installs**: localhost +
+  HTTP + REST enabled + unauthenticated (loopback-bound), which enables config-sync out of the box
+  for a single developer working across multiple projects. **Image/server defaults are unchanged**
+  — still STDIO, REST off, `MCP_HTTP_HOST=0.0.0.0` — the new posture is delivered entirely by the
+  skill's render, the reframed README/quick-start recipes, and an additive `http-rest`
+  `docker-compose.yml` profile (the existing `http` profile stays REST-off).
+- **`/deploy_to_docker` reuse-on-redeploy.** Every redeploy now detects the existing container's
+  settings via `docker inspect` before removing it and defaults to reusing them, via a
+  Reuse/Reconfigure chooser; Reconfigure adds a REST-mode chooser (Off / Unauthenticated-local /
+  Bearer+token-file) and a config-mount chooser (this-project fallback / none for multi-project).
+  Resolved settings persist to `~/.taskorchestrator/deploy.env` so they survive a full container
+  removal (#238).
+
+### Documentation
+
+- Documented global-vs-per-project config precedence (workspace file is canonical; the per-root DB
+  row is a hot-reloaded synced replica; the file wins at session boundaries) and reframed
+  `AGENT_CONFIG_DIR` in `CLAUDE.md` as the global/fallback config layer, with a pointer to the
+  per-root DB layer and the `config-sync` hook (#236).
+
 ## [3.11.0] - 2026-07-15
 
 ### Added
@@ -101,6 +143,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The REST API is off by default.** `API_ENABLED` defaults to `false`, so the stock container
   (stdio or MCP-over-HTTP) starts with no API configuration; enable the API explicitly with
   `API_ENABLED=true` (which then requires `API_AUTH_MODE`).
+
+> **Correction (added 2026-07-15):** the "binds to loopback by default" clause above was inaccurate
+> both then and now — `MCP_HTTP_HOST` has always defaulted to `0.0.0.0` (verified at the `v3.9.0` tag
+> and unchanged since; see `AppConfig.kt`). For Docker deployments, host-level exposure has always
+> been controlled by the `-p` port-publish mapping (e.g. `-p 127.0.0.1:3001:3001`), not by the
+> server's internal bind address. See `current/docs/quick-start.md` "HTTP transport security" and
+> `SECURITY.md` for the accurate guidance.
 
 ## [3.8.0] - 2026-05-22 (Plugin v3.2.2)
 

--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ export TASK_ORCHESTRATOR_API_URL=http://localhost:3001
 > access. This is only safe because the port is published **loopback-only** (`-p 127.0.0.1:3001:3001`).
 > Never publish it on `0.0.0.0` or a wider interface.
 
-Once running, `/plugin install task-orchestrator@task-orchestrator-marketplace` then
-`/configure-server` walks you through this (and bearer-token or STDIO alternatives) interactively.
+Prefer not to wire this up by hand? Install the plugin and run `/configure-server` — it renders
+all of the above (plus the bearer-token and STDIO alternatives) interactively.
 
 ### Simpler alternative: STDIO, no config-sync
 

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Agent: advance_item(trigger="start", itemId="a3f2",
 Clean Architecture (Domain > Application > Infrastructure > Interface) with comprehensive test coverage.
 
 Key capabilities added in recent versions:
-- **REST API** — an HTTP REST layer (`API_ENABLED=true`) exposes items, notes, dependencies, transitions, config, and real-time SSE events to dashboards, CI systems, and operators. Supports static bearer tokens and JWKS JWT auth. See [`current/docs/api-rest.md`](current/docs/api-rest.md) for the full endpoint reference.
+- **REST API** — an HTTP REST layer (`API_ENABLED=true`) exposes items, notes, dependencies, transitions, config, and real-time SSE events to dashboards, CI systems, and operators. Supports static bearer tokens, JWKS JWT auth, and an opt-in unauthenticated loopback mode (`API_AUTH_MODE=none`) for single-developer local setups — see [Quick Start](#quick-start) above and `/configure-server`. See [`current/docs/api-rest.md`](current/docs/api-rest.md) for the full endpoint reference.
 - **Full-text search** — search work items and notes by keyword with ranked results (see [Full-Text Search](#full-text-search) above)
 - **Unbounded hierarchy depth** — item trees are not capped at depth 3; cycle protection is enforced at the database level via a trigger
 - **Backlinks** — `query_dependencies(operation="backlinks")` finds all items that reference a given item (reverse-direction edge lookup)

--- a/README.md
+++ b/README.md
@@ -183,15 +183,56 @@ Task Orchestrator enforces workflow structure without imposing methodology. The 
 
 **Prerequisite**: [Docker](https://www.docker.com/products/docker-desktop/) installed and running.
 
-### 1. Pull the image
+If you work across multiple projects, **set up once and every project you open just works**: run
+one persistent server with the REST API on, and each project's `.taskorchestrator/config.yaml` syncs
+into it automatically via `config-sync` — no per-project container, no manual config mounting.
+
+### Recommended: HTTP + REST enabled, localhost-only
+
+Pull the image, then run the plugin's `/configure-server` skill (or use the equivalent manual setup
+below) to stand up a persistent local server:
 
 ```bash
 docker pull ghcr.io/jpicklyk/task-orchestrator:latest
+
+docker run -d --name mcp-task-orchestrator-http --restart unless-stopped \
+  -v mcp-task-data:/app/data \
+  -e MCP_TRANSPORT=http -e API_ENABLED=true -e API_AUTH_MODE=none -e API_ALLOW_UNAUTHENTICATED=true \
+  -p 127.0.0.1:3001:3001 \
+  ghcr.io/jpicklyk/task-orchestrator:latest
 ```
 
-### 2. Register with your MCP client
+Register it in `.mcp.json` (HTTP shape — not an args array):
 
-**Claude Code (recommended):**
+```json
+{
+  "mcpServers": {
+    "mcp-task-orchestrator": {
+      "type": "http",
+      "url": "http://localhost:3001/mcp"
+    }
+  }
+}
+```
+
+And export the client-side env so `config-sync` can find the server (without this, config-sync
+silently no-ops):
+
+```bash
+export TASK_ORCHESTRATOR_API_URL=http://localhost:3001
+```
+
+> **SECURITY:** unauthenticated REST means anyone who can reach the port has full read/write/delete
+> access. This is only safe because the port is published **loopback-only** (`-p 127.0.0.1:3001:3001`).
+> Never publish it on `0.0.0.0` or a wider interface.
+
+Once running, `/plugin install task-orchestrator@task-orchestrator-marketplace` then
+`/configure-server` walks you through this (and bearer-token or STDIO alternatives) interactively.
+
+### Simpler alternative: STDIO, no config-sync
+
+If you don't want a persistent daemon and are fine hand-mounting each project's config, STDIO is the
+simpler no-setup option — a per-session container, no port, no REST API:
 
 ```bash
 claude mcp add-json mcp-task-orchestrator '{
@@ -204,7 +245,7 @@ claude mcp add-json mcp-task-orchestrator '{
 }'
 ```
 
-**Any MCP client** — add to `.mcp.json` in your project root:
+Or add the same shape to `.mcp.json`:
 
 ```json
 {
@@ -223,9 +264,8 @@ claude mcp add-json mcp-task-orchestrator '{
 
 Restart your client. The server auto-initializes on first run — no setup required.
 
-### 3. Enable workflow schemas (optional)
-
-Mount your project's config to activate gate enforcement:
+To activate workflow schema gates on STDIO, mount the project's config directly instead of relying on
+config-sync:
 
 ```json
 {
@@ -263,7 +303,7 @@ The plugin adds workflow automation on top of the MCP server — skills, hooks, 
 
 | Layer | What it does |
 |-------|-------------|
-| **Skills** | Slash commands for common workflows — `/task-orchestrator:create-item`, `/task-orchestrator:manage-schemas`, `/task-orchestrator:quick-start` |
+| **Skills** | Slash commands for common workflows — `/task-orchestrator:create-item`, `/task-orchestrator:manage-schemas`, `/task-orchestrator:quick-start`, `/task-orchestrator:configure-server` |
 | **Hooks** | Automatic context injection at session start, plan mode integration, sub-agent context handoff, actor attribution enforcement |
 | **Output style** | Workflow Orchestrator mode — Claude plans, delegates to sub-agents, and tracks progress without writing code directly |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,6 +76,22 @@ All 14 MCP tools are available to any connected client without identification. T
 
 **This is intentional.** Within a cooperating fleet, access control between agents adds friction without meaningful security benefit — the agents are working toward the same goals. Tenant isolation is achieved at the infrastructure level (separate databases), not the application level.
 
+### REST API Authentication
+
+The above applies to the **MCP tool surface** (`/mcp`). The optional REST API (`/api/v1/*`, opt-in via `API_ENABLED=true`) is a separate surface with its own authentication layer, selected by `API_AUTH_MODE`. Full semantics: [`current/docs/api-rest.md`](current/docs/api-rest.md) §1.
+
+| Mode | Identity | Capability model |
+|------|----------|-------------------|
+| `bearer` | Static token, hashed (SHA-256) at rest in a YAML file | Per-token `capabilities` (`read`, `write-items`, `write-notes`, `advance`, `manage-dependencies`, `admin`) and optional `scope.root_ids` |
+| `jwks` | JWT verified against a JWKS endpoint (or `did:web` document) | Same capability model, driven by JWT claims |
+| `none` (opt-in, requires `API_ALLOW_UNAUTHENTICATED=true` in addition) | None — every request is attached a synthetic `ADMIN` principal | Unrestricted: full read/write/delete access to every item, note, and per-root config, with no scope restriction |
+
+**The unauthenticated mode's threat boundary is the network, not the application.** `API_AUTH_MODE=none` deliberately grants unconditional `ADMIN` access — there is no capability check to bypass because there is no capability restriction at all. This mode is safe **only** when the port is unreachable from anyone but the operator's own machine. That containment comes entirely from how the port is published, not from anything the server enforces:
+
+- **The safety mechanism is `-p 127.0.0.1:3001:3001`** (Docker's port-publish mapping to loopback), not `MCP_HTTP_HOST`. Publishing wider (e.g. `-p 3001:3001` or `-p 0.0.0.0:3001:3001`) while `API_AUTH_MODE=none` exposes an unauthenticated read/write/delete API to the entire reachable network.
+- **`MCP_HTTP_HOST` must stay `0.0.0.0`.** The container binds all interfaces *inside its own network namespace* by design — this is required for Docker's port-publish mechanism to reach the process at all. Setting `MCP_HTTP_HOST=127.0.0.1` to "harden" it instead binds loopback inside the container's namespace, which breaks the docker-proxy path from the host and can make the server unreachable even via `127.0.0.1:3001` on the host.
+- Operators who need unauthenticated REST reachable from more than one host should use `bearer` or `jwks` mode instead — the unauthenticated mode is scoped to single-operator, loopback-only, local use (see [`claude-plugins/task-orchestrator/skills/configure-server/references/runtime-config.md`](claude-plugins/task-orchestrator/skills/configure-server/references/runtime-config.md), and [`current/docs/fleet-deployment.md`](current/docs/fleet-deployment.md) for multi-caller topologies).
+
 ### Actor Attribution and Verification
 
 Actor attribution has two layers — **presence enforcement** (is an actor claim provided?) and **authenticity verification** (is the claim cryptographically valid?). These are implemented in different places:
@@ -214,9 +230,12 @@ This means that in deployments where non-Claude-Code clients connect to the serv
 | Transport | Built-in security | Operator responsibility |
 |-----------|------------------|----------------------|
 | **STDIO** | Process-level isolation (client spawns server) | Ensure the host environment is trusted |
-| **HTTP** | None — no TLS, no auth headers, no CORS | Deploy behind a reverse proxy with TLS and authentication, or restrict network access |
+| **HTTP — `/mcp`** | None — no TLS, no auth headers, no CORS | Deploy behind a reverse proxy with TLS and authentication, or restrict network access |
+| **HTTP — `/api/v1/*`** (REST, opt-in) | `API_AUTH_MODE` gates every request (`bearer`, `jwks`, or opt-in `none`) — see "REST API Authentication" above | Same network exposure responsibility as `/mcp`; `none` mode additionally depends on loopback-only port publishing |
 
-**For HTTP deployments in production:** Do not expose the server directly to untrusted networks. Use a reverse proxy (nginx, Caddy, Traefik) with TLS termination and client authentication. The server's `MCP_HTTP_HOST` and `MCP_HTTP_PORT` variables control the bind address — restrict to `127.0.0.1` or a private network interface when possible.
+**Enabling the REST API does not add auth to `/mcp`.** Bearer/JWKS auth on `/api/v1/*` is a separate gate from the MCP transport — `/mcp` stays open by design (MCP clients send no REST token) even when `API_AUTH_MODE=bearer` or `jwks`. Treat `/mcp` and `/api/v1/*` as two endpoints on the same port with independent (or, for `none` mode, absent) authentication.
+
+**For HTTP deployments in production:** Do not expose the server directly to untrusted networks. Use a reverse proxy (nginx, Caddy, Traefik) with TLS termination and client authentication. The server's `MCP_HTTP_HOST` and `MCP_HTTP_PORT` variables control the bind address inside the container's network namespace — for Docker deployments, host-level exposure is controlled by the `-p` port-publish mapping instead (see "REST API Authentication" above); for a direct non-Docker JAR run, restrict `MCP_HTTP_HOST` to `127.0.0.1` or a private network interface when possible.
 
 ### Data Security
 

--- a/claude-plugins/task-orchestrator/skills/configure-server/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/configure-server/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: configure-server
+description: "Configures how the MCP Task Orchestrator SERVER runs and is reached — transport (HTTP vs STDIO), the REST API, port publishing, config mounts, and config-sync. Use when a user says: run the server, register the image, set up the Docker container, enable the REST API, set up config-sync, reconfigure the server, change transport, expose the API, or reconnect to a different endpoint. NOT for first-time onboarding (that's quick-start) and NOT for note schemas / gates / traits / actor_authentication policy (that's manage-schemas) — this skill only decides how the container is launched and reached."
+argument-hint: "[optional: 'recommended', 'http', 'stdio', 'bearer', or a change request e.g. 'enable REST']"
+---
+
+# Configure Server — Runtime & Transport Setup
+
+Decides **how the MCP Task Orchestrator container is launched and reached**: transport, REST API mode,
+port publishing, config mount, and config-sync. This is a runtime/deployment concern, distinct from
+`quick-start` (first-time onboarding narrative) and `manage-schemas` (workflow gates/traits/
+`actor_authentication` content inside `.taskorchestrator/config.yaml`). If the user wants schema or
+gate changes, redirect to `/manage-schemas` instead of proceeding here.
+
+The full fragment catalog (exact env tuples, loopback caveat, Windows/MSYS caveat, `.mcp.json` shapes)
+lives in `references/runtime-config.md` — this skill's job is the **decision flow** and **rendering**,
+not re-deriving that catalog. Read it before rendering any command.
+
+---
+
+## Step 1 — Offer the recommended default first
+
+Before walking the full decision tree, offer the one-tap recommended path via `AskUserQuestion`:
+
+```
+AskUserQuestion(questions: [{
+  question: "How do you want to run the server?",
+  header: "Server setup",
+  multiSelect: false,
+  options: [
+    { label: "Recommended default", description: "HTTP + REST API enabled, unauthenticated, loopback-bound (127.0.0.1). Enables config-sync out of the box. Best for a single developer working across multiple projects." },
+    { label: "Customize", description: "Walk through transport, REST mode, config mount, and debug logging one at a time." }
+  ]
+}])
+```
+
+**Recommended default** → skip straight to Step 5 (Render — HTTP) with: REST = unauthenticated,
+config mount = none, debug = off. **Customize** → Step 2.
+
+Why this is the default: it is the majority deployment shape for a single developer who wants
+`config-sync` (per-project config that hot-reloads without a restart) to just work across every
+project they open, without hand-managing tokens. The image itself still ships conservative (STDIO,
+REST off, `0.0.0.0` bind) — this posture is entirely rendered by this skill, never an image change.
+
+---
+
+## Step 2 — Transport
+
+```
+AskUserQuestion(questions: [{
+  question: "Which transport?", header: "Transport", multiSelect: false,
+  options: [
+    { label: "HTTP (Recommended)", description: "Detached daemon, serves /mcp on a published port. Required for REST API and config-sync." },
+    { label: "STDIO", description: "Per-session process, no port, no REST API, no config-sync. Simpler, no persistent daemon." }
+  ]
+}])
+```
+
+**STDIO ⊥ REST — hard constraint:** if the user picks STDIO, skip Steps 3-4 entirely (REST mode and
+port are incoherent for a `--rm -i` per-session process) and go straight to Step 5 (Render — STDIO).
+Tell the user plainly: *"STDIO has no REST API and no config-sync — those require a persistent HTTP
+daemon. If you want config-sync later, re-run this skill and choose HTTP."*
+
+HTTP → Step 3.
+
+---
+
+## Step 3 — REST API mode (HTTP only)
+
+```
+AskUserQuestion(questions: [{
+  question: "REST API mode?", header: "REST API", multiSelect: false,
+  options: [
+    { label: "Unauthenticated (Recommended)", description: "No token needed. Loopback-bound only. Enables config-sync with zero extra setup." },
+    { label: "Bearer token", description: "Token-authenticated. For shared/multi-user setups." },
+    { label: "Off", description: "MCP only, no REST, no config-sync." }
+  ]
+}])
+```
+
+- **Unauthenticated** → always render the loopback SECURITY caveat from `references/runtime-config.md`
+  ("Loopback footgun") before the command, and force `-p 127.0.0.1:3001:3001` in the render — never a
+  wider publish.
+- **Bearer** → ask for the host path to the token YAML (free-text/"Other" answer), e.g.
+  `~/.taskorchestrator-secrets/api-tokens.yaml`. If the file doesn't exist yet, point at
+  `current/docs/api-rest.md` §1 for the token-generation snippet — this skill does not generate tokens.
+- **Off** → REST fragment is just `-e API_ENABLED=false`; config-sync will no-op (tell the user).
+
+---
+
+## Step 4 — Config mount and debug (HTTP only)
+
+```
+AskUserQuestion(questions: [{
+  question: "Mount this project's config as the server's global/fallback config?", header: "Config mount", multiSelect: false,
+  options: [
+    { label: "This project (fallback)", description: "Mount ./.taskorchestrator read-only as AGENT_CONFIG_DIR — good for a single-project server." },
+    { label: "None (multi-project)", description: "No mount. Per-project config flows in via config-sync into the DB per root — good for one server shared across projects." }
+  ]
+}])
+```
+
+Then ask Yes/No for debug logging (`LOG_LEVEL=DEBUG` + `DATABASE_SHOW_SQL=true`).
+
+---
+
+## Step 5 — Render
+
+Look up the exact fragments in `references/runtime-config.md` — do not improvise env values.
+
+### STDIO
+
+Render the `.mcp.json` **args array** shape (see reference doc, "`.mcp.json` shapes"):
+
+```json
+{
+  "mcpServers": {
+    "mcp-task-orchestrator": {
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "-v", "mcp-task-data:/app/data", "ghcr.io/jpicklyk/task-orchestrator:latest"]
+    }
+  }
+}
+```
+
+Add the config-mount fragment (as `args` entries, not env flags) if the user wants a project mount.
+No REST, no port, no config-sync — say so.
+
+### HTTP — three coordinated pieces (all required, this is the default path now)
+
+1. **The detached docker run command** — compose the recommended-default tuple (or the customized
+   equivalent) from `references/runtime-config.md`:
+
+   ```
+   docker run -d --name mcp-task-orchestrator-http --restart unless-stopped \
+     -v mcp-task-data:/app/data \
+     -e MCP_TRANSPORT=http -e API_ENABLED=true -e API_AUTH_MODE=none -e API_ALLOW_UNAUTHENTICATED=true \
+     -p 127.0.0.1:3001:3001 \
+     ghcr.io/jpicklyk/task-orchestrator:latest
+   ```
+
+   (Substitute the REST-off or bearer fragment, and add the config-mount / debug fragments, per the
+   user's Step 3-4 answers.) On Windows, run this via **PowerShell** with `${PWD}` for volume paths —
+   see "Windows / MSYS path caveat" in the reference doc.
+
+2. **The `.mcp.json` HTTP entry** (NOT an args array):
+
+   ```json
+   {
+     "mcpServers": {
+       "mcp-task-orchestrator": {
+         "type": "http",
+         "url": "http://localhost:3001/mcp"
+       }
+     }
+   }
+   ```
+
+3. **Client-side config-sync env** — export in the user's own shell/profile, not the container:
+
+   ```
+   TASK_ORCHESTRATOR_API_URL=http://localhost:3001
+   ```
+
+   Add `TASK_ORCHESTRATOR_API_TOKEN=<token>` only for bearer mode. **Omitting this env var is the
+   single most common way config-sync silently no-ops** (verified `config-sync.mjs:84-92`) — always
+   render it, never treat it as optional polish.
+
+If REST mode is **unauthenticated**, always print the SECURITY caveat (verbatim from
+`references/runtime-config.md` → "Loopback footgun") immediately before or after the docker run block.
+
+---
+
+## Step 6 — HTTP lifecycle (verify it's actually working)
+
+For any HTTP render, walk through:
+
+1. **Run** the docker command from Step 5.
+2. **Verify the container is up:**
+   ```bash
+   docker ps --filter name=mcp-task-orchestrator-http --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+   docker logs --since 20s mcp-task-orchestrator-http
+   ```
+3. **Reconnect the client:** update `.mcp.json` (Step 5, piece 2) if not already in place, then run
+   `/mcp` in Claude Code — confirm `mcp-task-orchestrator` shows connected with all tools listed.
+4. If REST is enabled, sanity-check it: `curl http://localhost:3001/api/v1/health` should return `200`.
+
+---
+
+## Reconfiguring later
+
+Re-running this skill is safe — it always renders a fresh command from the current answers; it does
+not read or depend on any previously-rendered state. To change an existing container's settings,
+stop/remove it first (`docker stop mcp-task-orchestrator-http && docker rm mcp-task-orchestrator-http`),
+then re-render and run the new command. (Maintainers building the image from source have a dedicated
+detect-and-reuse flow in `/deploy_to_docker` — not needed for the published-image path this skill covers.)

--- a/claude-plugins/task-orchestrator/skills/configure-server/references/runtime-config.md
+++ b/claude-plugins/task-orchestrator/skills/configure-server/references/runtime-config.md
@@ -1,0 +1,156 @@
+# Runtime Config Catalog
+
+This is the **rendering catalog** for `/configure-server` (and the fragment source `deploy_to_docker`
+cites): the exact env fragments, tuples, and caveats to render for each runtime choice. It is not a
+tutorial and not a security explainer — for env *semantics* (what each flag does, auth model details,
+capability model) this doc defers to:
+
+- [`current/docs/api-rest.md`](../../../../../current/docs/api-rest.md) §1 (Authentication) — authoritative for REST auth modes
+- [`current/docs/fleet-deployment.md`](../../../../../current/docs/fleet-deployment.md) — authoritative for fleet/security posture
+
+If this catalog and either of those docs ever disagree, those docs win — fix this file to match.
+
+> **Anti-drift note:** this file is cited by `configure-server/SKILL.md`,
+> `.claude/commands/deploy_to_docker.md`, and a comment in `docker-compose.yml`'s `http-rest`
+> profile. If this file is renamed or moved, update all of those citations — grep the repo root for
+> `runtime-config.md` and fix every hit (aside from this file's own self-reference).
+
+---
+
+## The recommended default tuple (new installs)
+
+Localhost + HTTP + REST enabled + no auth. This is the tuple `/configure-server` renders as the
+one-tap default:
+
+```
+-e MCP_TRANSPORT=http -e API_ENABLED=true -e API_AUTH_MODE=none -e API_ALLOW_UNAUTHENTICATED=true -p 127.0.0.1:3001:3001
+```
+
+Plus, on the client side (required — see "Loopback footgun" and "config-sync" below):
+
+```
+TASK_ORCHESTRATOR_API_URL=http://localhost:3001
+```
+
+`MCP_HTTP_HOST` is **not** part of this tuple — it stays at its image default (`0.0.0.0`). See below.
+
+---
+
+## Env-fragment table (compose into a `docker run` command)
+
+| Choice | Fragment |
+|--------|----------|
+| Transport: HTTP | `-e MCP_TRANSPORT=http -e MCP_HTTP_HOST=0.0.0.0 -e MCP_HTTP_PORT=3001` |
+| Transport: STDIO | *(no HTTP env — use `docker run --rm -i`, no `-p`, no REST)* |
+| REST off | `-e API_ENABLED=false` |
+| REST unauthenticated (recommended) | `-e API_ENABLED=true -e API_AUTH_MODE=none -e API_ALLOW_UNAUTHENTICATED=true` |
+| REST bearer | `-e API_ENABLED=true -e API_AUTH_MODE=bearer -e API_TOKENS_PATH=/run/secrets/api-tokens.yaml -v <TOKENS_HOST_PATH>:/run/secrets/api-tokens.yaml:ro` |
+| Config mount = project (fallback) | `-v "<pwd>/.taskorchestrator:/project/.taskorchestrator:ro" -e AGENT_CONFIG_DIR=/project` |
+| Config mount = none (multi-project via config-sync) | *(omit)* |
+| Debug on | `-e LOG_LEVEL=DEBUG -e DATABASE_SHOW_SQL=true` |
+| Port publish (loopback only) | `-p 127.0.0.1:3001:3001` |
+
+## REST-mode env tuples (full, copy-paste)
+
+**Off** (MCP only, no REST):
+```
+-e API_ENABLED=false
+```
+
+**Unauthenticated (recommended for single-developer local use):**
+```
+-e API_ENABLED=true -e API_AUTH_MODE=none -e API_ALLOW_UNAUTHENTICATED=true
+```
+Both keys are required together — `api-rest.md` §1 "Unauthenticated Mode" — `API_AUTH_MODE=none` alone
+still fails startup; `API_ALLOW_UNAUTHENTICATED=true` alone (with `bearer`/`jwks`) is silently ignored.
+
+**Bearer (token file):**
+```
+-e API_ENABLED=true -e API_AUTH_MODE=bearer -e API_TOKENS_PATH=/run/secrets/api-tokens.yaml \
+-v <host-path-to-api-tokens.yaml>:/run/secrets/api-tokens.yaml:ro
+```
+See `api-rest.md` §1 for the token file format and hash generation.
+
+---
+
+## Loopback footgun (must always be rendered alongside unauthenticated REST)
+
+> **SECURITY:** unauthenticated REST means anyone who can reach the port has full read/write/delete
+> access to every item, note, and per-root config — identical to the existing `/mcp` exposure. This
+> is only safe when the port is **published loopback-only**.
+
+**The safety mechanism is the Docker port-publish mapping, not the server bind:**
+
+- Render `-p 127.0.0.1:3001:3001` — this is what makes the port unreachable from outside the host.
+- **Leave `MCP_HTTP_HOST=0.0.0.0` alone.** The container must bind all interfaces *inside* its own
+  network namespace for Docker's port-publish mechanism to reach it at all — that bind is internal to
+  the container and is not the same thing as host-network exposure. Setting `MCP_HTTP_HOST=127.0.0.1`
+  binds loopback *inside the container's own namespace*, which breaks the docker-proxy path from the
+  host and makes the server unreachable even via `127.0.0.1:3001` on the host. This has bitten people
+  who "hardened" the wrong knob — don't repeat it.
+- Never publish with `-p 3001:3001` (all interfaces) when REST is unauthenticated.
+
+This mirrors the existing `/mcp` guidance already documented in `current/docs/quick-start.md` (Step 9,
+HTTP transport security) and `current/docs/fleet-deployment.md` — both already establish that host
+exposure is controlled by the `-p` mapping, not `MCP_HTTP_HOST`, for Docker deployments.
+
+---
+
+## config-sync — the easy way to silently no-op it
+
+`config-sync` (the SessionStart hook, `config-sync.mjs`) pushes this workspace's
+`.taskorchestrator/config.yaml` into the server's per-root config store over the REST API. It requires,
+on the **client side** (the environment the Claude Code session itself runs in — not the container):
+
+```
+TASK_ORCHESTRATOR_API_URL=http://localhost:3001
+TASK_ORCHESTRATOR_API_TOKEN=<token>   # bearer mode only; omit entirely for unauthenticated mode
+```
+
+Verified in `config-sync.mjs:84-92`: if `TASK_ORCHESTRATOR_API_URL` is unset, the hook returns
+immediately with no error and no log — it silently no-ops. There is no visible symptom other than
+per-project config never showing up server-side. **Always render this env var alongside the HTTP+REST
+docker run command** — it is easy to forget because it's set outside the container, not inside it.
+
+config-sync also requires the workspace's `.taskorchestrator/config.yaml` to carry a `project:` block
+with a `rootId` (project-scoping) — without it, the hook has no root to push to and no-ops even with
+the API URL set. See `manage-schemas/references/config-format.md` → "Project Scoping" (owned by
+`manage-schemas`, out of scope here — mention only, don't duplicate).
+
+---
+
+## Windows / MSYS path caveat
+
+Run the `docker run` command (HTTP or STDIO) via **PowerShell**, using `${PWD}` for volume paths — not
+the Bash tool / Git Bash. MSYS rewrites a leading slash in arguments like `-e AGENT_CONFIG_DIR=/project`
+and in mount specs (`:/app/data`, `:/project/...`), silently breaking the container's env/mounts. This
+does not affect `docker build`, `docker inspect`, `docker logs`, or `docker stop`/`rm` — only `docker run`
+invocations that pass `/`-rooted values as `-e`/`-v` arguments.
+
+---
+
+## `.mcp.json` shapes (do not conflate)
+
+**STDIO** — args array:
+```json
+{
+  "mcpServers": {
+    "mcp-task-orchestrator": {
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "-v", "mcp-task-data:/app/data", "ghcr.io/jpicklyk/task-orchestrator:latest"]
+    }
+  }
+}
+```
+
+**HTTP** — `type: http` entry, no args array:
+```json
+{
+  "mcpServers": {
+    "mcp-task-orchestrator": {
+      "type": "http",
+      "url": "http://localhost:3001/mcp"
+    }
+  }
+}
+```

--- a/claude-plugins/task-orchestrator/skills/quick-start/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/quick-start/SKILL.md
@@ -227,6 +227,7 @@ Present this capabilities table:
 | Build custom workflow schemas | `/manage-schemas` | Create, view, edit, delete, and validate note schemas |
 | See project health dashboard | `/work-summary` | Active work, blockers, next actions at a glance |
 | Advance an item through gates | `/status-progression` | Shows current role, gate status, correct trigger |
+| Change how the server runs (HTTP, REST API, config-sync) | `/configure-server` | Transport, REST API mode, port publishing, config mount |
 
 **Offer cleanup:** Ask via `AskUserQuestion` whether to keep the tutorial items for reference or delete them. If delete, use the container UUID returned in Step 4 above:
 

--- a/current/docs/Home.md
+++ b/current/docs/Home.md
@@ -21,7 +21,49 @@ MCP Task Orchestrator is an open-source MCP server that gives AI agents persiste
 
 ## Quick Install
 
-Run this once in your terminal to register the server with Claude Code:
+If you work across multiple projects, the recommended setup is a persistent local server with the
+REST API enabled (unauthenticated, loopback-only) — every project's `.taskorchestrator/config.yaml`
+then syncs into it automatically via `config-sync`, with no per-project container or manual config
+mounting:
+
+```bash
+docker pull ghcr.io/jpicklyk/task-orchestrator:latest
+
+docker run -d --name mcp-task-orchestrator-http --restart unless-stopped \
+  -v mcp-task-data:/app/data \
+  -e MCP_TRANSPORT=http -e API_ENABLED=true -e API_AUTH_MODE=none -e API_ALLOW_UNAUTHENTICATED=true \
+  -p 127.0.0.1:3001:3001 \
+  ghcr.io/jpicklyk/task-orchestrator:latest
+```
+
+Register it in `.mcp.json` (HTTP shape — not an args array):
+
+```json
+{
+  "mcpServers": {
+    "mcp-task-orchestrator": {
+      "type": "http",
+      "url": "http://localhost:3001/mcp"
+    }
+  }
+}
+```
+
+And export the client-side env so `config-sync` can find the server (without this it silently no-ops):
+
+```bash
+export TASK_ORCHESTRATOR_API_URL=http://localhost:3001
+```
+
+> **SECURITY:** unauthenticated REST means anyone who can reach the port has full read/write/delete
+> access. This is only safe because the port is published **loopback-only** (`-p 127.0.0.1:3001:3001`).
+> Never publish it on `0.0.0.0` or a wider interface.
+
+Once the plugin is installed, run `/task-orchestrator:configure-server` to walk through this (and
+bearer-token or STDIO alternatives) interactively.
+
+**Simpler alternative — STDIO, no config-sync.** If you don't want a persistent daemon, run this once
+in your terminal to register a per-session container instead:
 
 ```bash
 claude mcp add-json mcp-task-orchestrator '{

--- a/current/docs/_Sidebar.md
+++ b/current/docs/_Sidebar.md
@@ -15,6 +15,7 @@
 
 **Reference**
 - [API Reference](api-reference.md)
+- [REST API Reference](api-rest.md)
 - [Workflow Guide](workflow-guide.md)
 
 **Operations**

--- a/current/docs/integration-guides/bare-mcp.md
+++ b/current/docs/integration-guides/bare-mcp.md
@@ -37,6 +37,9 @@ For non-Claude-Code MCP clients, the server configuration follows the standard M
 
 The `mcp-task-data` Docker volume persists the SQLite database across container restarts.
 
+For a persistent HTTP server shared across multiple projects (instead of this per-session `--rm -i`
+container), see `/task-orchestrator:configure-server`.
+
 ## Core Workflow
 
 ### Creating Work Items

--- a/current/docs/integration-guides/note-schemas.md
+++ b/current/docs/integration-guides/note-schemas.md
@@ -85,7 +85,9 @@ claude mcp add-json mcp-task-orchestrator '{
 
 Only the `.taskorchestrator/` folder is exposed — the server has no access to the rest of your project.
 
-See [Quick Start](../quick-start.md) Step 8 for the full Docker mount example.
+See [Quick Start](../quick-start.md) Step 8 for the full Docker mount example. If you work across
+multiple projects, `/task-orchestrator:configure-server` sets up `config-sync` instead, which
+hot-reloads each project's config without a read-only mount or a restart.
 
 ### Cache Invalidation
 

--- a/current/docs/quick-start.md
+++ b/current/docs/quick-start.md
@@ -594,6 +594,8 @@ If the API is enabled but the token file is missing, empty, or malformed, the se
 
 ### 4. Test it
 
+> Running **unauthenticated** (the loopback option above)? Omit the `-H "Authorization: Bearer …"` header from the item calls below — there is no token. The health check needs no auth in either mode.
+
 ```bash
 # Health — no auth required
 curl http://localhost:3001/api/v1/health

--- a/current/docs/quick-start.md
+++ b/current/docs/quick-start.md
@@ -2,6 +2,15 @@
 
 MCP Task Orchestrator gives AI agents persistent, structured task tracking that survives across sessions. Instead of loading your entire project state into context on every prompt, agents read and write a shared graph of `WorkItem` entities — keeping context lean and work visible.
 
+> **Working across multiple projects?** Set up one persistent server with the REST API enabled, and
+> every project you open picks up its own `.taskorchestrator/config.yaml` automatically via
+> `config-sync` — no per-project container, no manual config mounting. The recommended posture is
+> **localhost + HTTP + REST enabled + no auth** (safe because the port is published loopback-only).
+> Once the plugin is installed (Step 4 below), run `/task-orchestrator:configure-server` to set this
+> up interactively — it also covers STDIO and bearer-token alternatives. The steps below default to
+> the simpler **stdio** transport, which stays the right choice if you only ever work in one project
+> and don't need config-sync.
+
 ---
 
 ## Prerequisites
@@ -111,6 +120,7 @@ Skills are invoked as slash commands in any Claude Code session:
 | `/task-orchestrator:work-summary` | Insight-driven dashboard: active work, blockers, and next actions |
 | `/task-orchestrator:create-item` | Create a tracked work item from the current conversation context |
 | `/task-orchestrator:quick-start` | Interactive onboarding — teaches by doing, adapts to empty or populated workspaces |
+| `/task-orchestrator:configure-server` | Configure server transport, REST API mode, port publishing, config mount, and config-sync |
 | `/task-orchestrator:manage-schemas` | Create, view, edit, delete, and validate note schemas in config |
 | `/task-orchestrator:status-progression` | Navigate role transitions; shows current gate status and the correct trigger |
 | `/task-orchestrator:dependency-manager` | Visualize, create, and diagnose dependencies between work items |
@@ -399,6 +409,10 @@ After adding or editing this file, reconnect the MCP server:
 ---
 
 ## Step 9: Running MCP over HTTP (optional)
+
+> If the plugin is installed, `/task-orchestrator:configure-server` walks Steps 9-10 interactively —
+> transport, REST mode, port, config mount, and the client-side config-sync env — and renders the
+> exact commands for you. The manual steps below are the same setup done by hand.
 
 By default the server speaks the **stdio** transport (Step 2). To serve MCP over **HTTP** instead — for remote clients, container-to-container access, or a shared long-running server — set `MCP_TRANSPORT=http`. The MCP endpoint is mounted at `/mcp` using the Streamable HTTP transport.
 

--- a/current/docs/quick-start.md
+++ b/current/docs/quick-start.md
@@ -462,7 +462,7 @@ Restart Claude Code and run `/mcp` to confirm the connection and all 14 tools. O
 
 > **Schema config works identically over HTTP.** `.taskorchestrator/config.yaml` is loaded via `AGENT_CONFIG_DIR` regardless of transport — the `-v ...:/project/.taskorchestrator:ro` mount above gives the HTTP server the same schemas it would have over stdio. (An HTTP server resolves a single project's config; run one server per project.)
 
-The `docker compose --profile http up` service in `docker-compose.yml` is pre-configured this way.
+The `docker compose --profile http up` service in `docker-compose.yml` is pre-configured this way. If you want the recommended REST-enabled, unauthenticated, loopback-only posture as copy-paste compose instead, use the additive `http-rest` profile (`docker compose --profile http-rest up`) — it layers `API_ENABLED=true`, `API_AUTH_MODE=none`, and `API_ALLOW_UNAUTHENTICATED=true` onto the same HTTP service without changing the `http` profile's REST-off default.
 
 ### HTTP transport security
 
@@ -480,7 +480,24 @@ The Streamable HTTP transport follows the [MCP transport security requirements](
 
 The REST API adds HTTP endpoints under `/api/v1` for dashboards, CI systems, and operators who want to read or write work items without an MCP client. It runs on the **same** HTTP server as the MCP transport (Step 9) — `/mcp` keeps serving MCP clients while `/api/v1/*` serves REST. So you enable it on top of an `MCP_TRANSPORT=http` container.
 
-The API is **off by default**, and when enabled it **always requires authentication** (there is no unauthenticated mode). This walkthrough uses **bearer-token** auth — the simplest option for local use. For JWT/JWKS, see [api-rest.md](api-rest.md).
+The API is **off by default** (`API_ENABLED=false`). When you opt in, there are two supported postures:
+
+- **Unauthenticated, loopback-only (recommended default for a single developer).** No token to manage — `API_AUTH_MODE=none` plus the confirm flag `API_ALLOW_UNAUTHENTICATED=true`, published only on `127.0.0.1`. This is what enables `config-sync` out of the box (see the callout at the top of this doc) and is the tuple `/task-orchestrator:configure-server` renders by default. Safety comes entirely from the `-p 127.0.0.1:3001:3001` publish mapping — never widen that publish while running unauthenticated, and never set `MCP_HTTP_HOST=127.0.0.1` to "harden" it (that binds loopback *inside* the container's network namespace and breaks host→container reachability; leave `MCP_HTTP_HOST=0.0.0.0`).
+- **Bearer-token auth**, for shared or multi-user setups where you want per-caller credentials. This is the walkthrough below. For JWT/JWKS, see [api-rest.md](api-rest.md) §1.
+
+To go the unauthenticated route instead of following steps 1-3 below, start the container with:
+
+```bash
+docker run -d --name mcp-task-orchestrator-http --restart unless-stopped \
+  -v mcp-task-data:/app/data \
+  -e MCP_TRANSPORT=http -e API_ENABLED=true -e API_AUTH_MODE=none -e API_ALLOW_UNAUTHENTICATED=true \
+  -p 127.0.0.1:3001:3001 \
+  ghcr.io/jpicklyk/task-orchestrator:latest
+```
+
+and skip to [Step 4: Test it](#4-test-it) (omit the `Authorization` header — there's no token). See [api-rest.md](api-rest.md) §1 for the full unauthenticated-mode semantics.
+
+The rest of this section walks through the **bearer-token** path.
 
 > **You never store your plaintext token.** The server only keeps its **SHA-256 hash**. You generate a token once, keep the plaintext somewhere safe (e.g. a password manager), and put only the hash in `api-tokens.yaml`. You send the plaintext in each request.
 
@@ -599,7 +616,7 @@ Expected: `/api/v1/health` → `200`; the authenticated calls **without** the he
 - **`401` on every authenticated call** almost always means the hash in `api-tokens.yaml` doesn't match your token — re-run step 1 (usually the trailing-newline gotcha).
 - **The `/mcp` endpoint stays open** even with the API enabled (MCP clients don't send the REST token). Keep the server on a trusted boundary — the `127.0.0.1` binding above does this.
 - **Rotating a token:** generate a new one (step 1), replace `token_sha256`, then restart the container (`docker restart task-orchestrator-http`). Tokens are read once at startup.
-- **Docker Compose alternative:** the `http` profile in `docker-compose.yml` runs an MCP-only HTTP server; to enable the REST API there, add the same `API_ENABLED`/`API_AUTH_MODE`/`API_TOKENS_PATH` env vars and the `api-tokens.yaml` mount to that service.
+- **Docker Compose alternative:** the `http` profile in `docker-compose.yml` runs an MCP-only HTTP server; to enable the REST API there in bearer mode, add the same `API_ENABLED`/`API_AUTH_MODE`/`API_TOKENS_PATH` env vars and the `api-tokens.yaml` mount to that service. For the unauthenticated posture instead, use the additive `http-rest` profile, which already ships `API_ENABLED=true`/`API_AUTH_MODE=none`/`API_ALLOW_UNAUTHENTICATED=true`.
 
 See [api-rest.md](api-rest.md) for full endpoint documentation, capabilities and scopes, JWKS mode, DTOs, merge-patch semantics, ETag/idempotency, SSE, and the complete env-var reference.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,53 @@ services:
     cpu_shares: 256
     stop_grace_period: 10s
 
+  mcp-task-orchestrator-http-rest:
+    build:
+      context: .
+      target: runtime-current
+    container_name: mcp-task-orchestrator-http-rest
+    profiles:
+      - http-rest
+    user: "1001:1001"
+    labels:
+      mcp.client: claude-desktop
+    volumes:
+      - mcp-task-data:/app/data
+      - .:/project:ro
+    environment:
+      DATABASE_PATH: /app/data/current-tasks.db
+      MCP_TRANSPORT: http
+      # Bind stays 0.0.0.0 inside the container by design — Docker's port-publish mechanism
+      # requires it. Loopback safety comes from the `ports:` mapping below, NOT this value.
+      # Do not change this to 127.0.0.1 — see runtime-config.md "Loopback footgun".
+      MCP_HTTP_HOST: 0.0.0.0
+      MCP_HTTP_PORT: "3001"
+      LOG_LEVEL: INFO
+      USE_FLYWAY: "true"
+      AGENT_CONFIG_DIR: /project
+      MCP_SERVER_NAME: mcp-task-orchestrator
+      # Recommended single-developer posture: REST API on, unauthenticated, loopback-bound.
+      # See claude-plugins/task-orchestrator/skills/configure-server/references/runtime-config.md
+      # and current/docs/api-rest.md §1 for the auth-mode rationale.
+      API_ENABLED: "true"
+      API_AUTH_MODE: none
+      API_ALLOW_UNAUTHENTICATED: "true"
+    ports:
+      # Loopback only — this is what makes the unauthenticated REST API safe. Never change
+      # to "3001:3001" (all interfaces) while API_AUTH_MODE=none.
+      - "127.0.0.1:3001:3001"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    restart: unless-stopped
+    mem_limit: 512m
+    mem_reservation: 256m
+    cpus: 1.0
+    cpu_shares: 256
+    stop_grace_period: 10s
+
 volumes:
   mcp-task-data:
     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,10 @@ services:
       MCP_HTTP_PORT: "3001"
       LOG_LEVEL: INFO
       USE_FLYWAY: "true"
+      # Single-repo convenience: this compose file runs from one project dir, so it mounts that
+      # repo's .taskorchestrator config as the global fallback (AGENT_CONFIG_DIR). The MULTI-project
+      # recommended default (per /configure-server) uses NO config mount and relies on config-sync
+      # to push each repo's config into the per-root DB store instead.
       AGENT_CONFIG_DIR: /project
       MCP_SERVER_NAME: mcp-task-orchestrator
       # Recommended single-developer posture: REST API on, unauthenticated, loopback-bound.


### PR DESCRIPTION
## Summary

Extracts server/runtime configuration out of the dev-only `deploy_to_docker` command into a new **user-facing plugin skill `configure-server`**, and establishes a recommended new-install default of **localhost + HTTP + REST API + no-auth (unauthenticated, loopback-bound)** — the posture that makes cross-project **config-sync** work out of the box, which is a primary single-developer benefit (one server, many repos, per-project config hot-reloaded per `rootId`, no restart).

The runtime-config knowledge previously lived only in maintainer tooling; end users pulling `ghcr.io/jpicklyk/task-orchestrator:latest` had no tool for it and no out-of-box config-sync.

## Key design guarantee: image defaults are unchanged

The recommended posture is delivered **entirely by the skill's rendered config + docs + an additive compose profile** — **not** by changing image/server defaults. The shipped image stays conservative:

- `MCP_TRANSPORT=stdio`, `API_ENABLED=false`, `MCP_HTTP_HOST=0.0.0.0` — all unchanged (no Dockerfile/Kotlin diffs).
- Unauthenticated REST still requires two explicit opt-ins (`API_AUTH_MODE=none` + `API_ALLOW_UNAUTHENTICATED=true`).
- **Loopback safety = the `-p 127.0.0.1:3001:3001` publish mapping**, never `MCP_HTTP_HOST=127.0.0.1` (which would break host→container reachability). This footgun is documented in the shared catalog.

## What's in it

**New skill + single-source catalog**
- `skills/configure-server/SKILL.md` — user-invocable; decision flow (recommended default → transport → REST mode → mount → debug), STDIO⊥REST enforced, renders `.mcp.json`/`docker run` for the pulled image, emits the loopback SECURITY caveat + HTTP lifecycle.
- `skills/configure-server/references/runtime-config.md` — the rendering catalog (fragment table, REST tuples, footgun, config-sync no-op traps, Windows/MSYS caveat), citing `api-rest.md`/`fleet-deployment.md` as the semantic authorities rather than duplicating them.
- `.claude/commands/deploy_to_docker.md` — now cites the shared catalog instead of holding its own fragment table (no drift); keeps its detection/reuse/lifecycle/prompts.
- `docker-compose.yml` — additive `http-rest` profile shipping the recommended posture (existing `stdio` / `http` services untouched).

**Documentation coherence pass** (cross-reference audit)
- `quick-start.md` — Step 10 rewritten to lead with the unauthenticated/loopback flow, fixing a **false "there is no unauthenticated mode" claim** that predated PR #237.
- `Home.md` — Quick Install updated in lockstep with README.
- `README.md` — REST capabilities bullet notes the unauthenticated/loopback mode.
- `SECURITY.md` — new subsection documenting the REST auth layer (bearer/jwks/none) and the unauthenticated-mode threat boundary.
- `CHANGELOG.md` — backfills #234–#238 + this skill; corrects the 3.9.0 "loopback by default" note (default bind has always been `0.0.0.0`).
- `_Sidebar.md`, `integration-guides/{note-schemas,bare-mcp}.md` — nav link + cross-links.

## Process

Built with the orchestrator pipeline: Fable design review → single-dev positioning → verified Docker-config reality → implementation subagent → parallel documentation cross-reference sweep → independent review agent (`review-checklist` + `plugin-impact`, **APPROVED**, 3 non-blocking polish items applied). Tracked as MCP item `f9b736e3` (terminal).

No code, no tests changed (markdown/YAML only); `docker compose config -q` validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
