### PR TITLE
feat(config): config-sync hardening — cross-project & multi-session correctness

### DIFF
--- a/claude-plugins/task-orchestrator/hooks/config-sync.mjs
+++ b/claude-plugins/task-orchestrator/hooks/config-sync.mjs
@@ -73,6 +73,26 @@ function fetchWithTimeout(url, opts) {
   return fetch(url, { ...opts, signal: controller.signal }).finally(() => clearTimeout(timer));
 }
 
+/**
+ * Decides what to do with the GET response's `relation` field (fast-forward guard — see
+ * ProjectConfigRoutes.kt's `?fingerprint=` handling). Pure function, kept separate from `main` so
+ * the branch logic is unit-inspectable without a JS test harness (this repo has none for the
+ * plugin hooks).
+ *
+ * - "current": already in sync, no push needed.
+ * - "superseded": this checkout's config.yaml is known-old (a later push happened elsewhere) —
+ *   skip the push rather than silently reverting that later change.
+ * - "unknown", or the field absent entirely (an older server that predates this guard): degrade to
+ *   the existing etag-compare-then-push behavior — never block on an ambiguous relation.
+ *
+ * Returns one of: "already-in-sync" | "skip-superseded" | "push".
+ */
+function decideSyncAction(relation, updatedAt) {
+  if (relation === 'current') return { action: 'already-in-sync' };
+  if (relation === 'superseded') return { action: 'skip-superseded', updatedAt };
+  return { action: 'push' }; // 'unknown' or absent (older server) — fall back to etag-compare push
+}
+
 async function main() {
   if (typeof fetch !== 'function') return; // node < 18 — no global fetch; nothing we can do, stay silent
 
@@ -88,20 +108,47 @@ async function main() {
   // API_ALLOW_UNAUTHENTICATED=true) needs no Authorization header at all.
   const token = process.env.TASK_ORCHESTRATOR_API_TOKEN;
 
-  const localEtag = `"cfg-${createHash('sha256').update(bytes).digest('hex')}"`;
+  const localFingerprint = createHash('sha256').update(bytes).digest('hex');
+  const localEtag = `"cfg-${localFingerprint}"`;
   const endpoint = `${apiUrl.replace(/\/+$/, '')}/api/v1/roots/${rootId}/config`;
   const authHeader = token ? { Authorization: `Bearer ${token}` } : {};
 
-  // 1) Read the server's current fingerprint to decide whether a push is needed.
+  // 1) Read the server's current fingerprint — and, via ?fingerprint=, how our local fingerprint
+  //    relates to its history (fast-forward guard) — to decide whether a push is needed.
   let currentEtag = null;
   try {
-    const res = await fetchWithTimeout(endpoint, { headers: authHeader });
+    const res = await fetchWithTimeout(`${endpoint}?fingerprint=${localFingerprint}`, { headers: authHeader });
     if (res.status === 200) {
       currentEtag = res.headers.get('etag');
       if (currentEtag && currentEtag === localEtag) {
         emit(`Task Orchestrator: project config already in sync for root ${rootId}.`);
         return;
       }
+
+      let relation;
+      let updatedAt;
+      try {
+        const body = await res.json();
+        relation = body?.relation;
+        updatedAt = body?.updatedAt;
+      } catch {
+        relation = undefined; // unparseable body — degrade like an absent relation field
+      }
+
+      const decision = decideSyncAction(relation, updatedAt);
+      if (decision.action === 'already-in-sync') {
+        emit(`Task Orchestrator: project config already in sync for root ${rootId}.`);
+        return;
+      }
+      if (decision.action === 'skip-superseded') {
+        emit(
+          `Task Orchestrator: config sync skipped — your checkout's config.yaml is older than the ` +
+            `server's (updated ${decision.updatedAt ?? 'unknown'}); pull or copy back before editing.`,
+        );
+        return;
+      }
+      // decision.action === 'push' ('unknown' relation, or an older server with no relation field
+      // at all) — fall through to step 2, same as today's etag-compare-then-push behavior.
     } else if (res.status === 404) {
       currentEtag = null; // no row yet — first push is a create
     } else {

--- a/claude-plugins/task-orchestrator/hooks/config-sync.mjs
+++ b/claude-plugins/task-orchestrator/hooks/config-sync.mjs
@@ -79,18 +79,22 @@ function fetchWithTimeout(url, opts) {
  * the branch logic is unit-inspectable without a JS test harness (this repo has none for the
  * plugin hooks).
  *
+ * `relation` is the SOLE authority whenever present — callers must NOT also consult the
+ * etag-compare result in that case (see `main`'s call site). Only when `relation` is absent
+ * entirely (an older server that predates this guard) does the caller fall back to comparing
+ * etags itself.
+ *
  * - "current": already in sync, no push needed.
  * - "superseded": this checkout's config.yaml is known-old (a later push happened elsewhere) —
  *   skip the push rather than silently reverting that later change.
- * - "unknown", or the field absent entirely (an older server that predates this guard): degrade to
- *   the existing etag-compare-then-push behavior — never block on an ambiguous relation.
+ * - "unknown": divergent edit (or no server-side history yet) — push.
  *
  * Returns one of: "already-in-sync" | "skip-superseded" | "push".
  */
 function decideSyncAction(relation, updatedAt) {
   if (relation === 'current') return { action: 'already-in-sync' };
   if (relation === 'superseded') return { action: 'skip-superseded', updatedAt };
-  return { action: 'push' }; // 'unknown' or absent (older server) — fall back to etag-compare push
+  return { action: 'push' }; // 'unknown' relation — a divergent edit, or no history yet — push.
 }
 
 async function main() {
@@ -120,10 +124,6 @@ async function main() {
     const res = await fetchWithTimeout(`${endpoint}?fingerprint=${localFingerprint}`, { headers: authHeader });
     if (res.status === 200) {
       currentEtag = res.headers.get('etag');
-      if (currentEtag && currentEtag === localEtag) {
-        emit(`Task Orchestrator: project config already in sync for root ${rootId}.`);
-        return;
-      }
 
       let relation;
       let updatedAt;
@@ -135,20 +135,29 @@ async function main() {
         relation = undefined; // unparseable body — degrade like an absent relation field
       }
 
-      const decision = decideSyncAction(relation, updatedAt);
-      if (decision.action === 'already-in-sync') {
+      if (relation !== undefined) {
+        // relation is the sole authority when the server provides it — the client-side etag
+        // compare below is only ever consulted as the degrade path for an older server that
+        // predates this field (see the `else if` branch).
+        const decision = decideSyncAction(relation, updatedAt);
+        if (decision.action === 'already-in-sync') {
+          emit(`Task Orchestrator: project config already in sync for root ${rootId}.`);
+          return;
+        }
+        if (decision.action === 'skip-superseded') {
+          emit(
+            `Task Orchestrator: config sync skipped — your checkout's config.yaml is older than the ` +
+              `server's (updated ${decision.updatedAt ?? 'unknown'}); pull or copy back before editing.`,
+          );
+          return;
+        }
+        // decision.action === 'push' ('unknown' relation) — fall through to step 2.
+      } else if (currentEtag && currentEtag === localEtag) {
+        // Degrade path: an older server with no `relation` field at all — fall back to the
+        // client-side etag compare instead of blocking on an ambiguous relation.
         emit(`Task Orchestrator: project config already in sync for root ${rootId}.`);
         return;
       }
-      if (decision.action === 'skip-superseded') {
-        emit(
-          `Task Orchestrator: config sync skipped — your checkout's config.yaml is older than the ` +
-            `server's (updated ${decision.updatedAt ?? 'unknown'}); pull or copy back before editing.`,
-        );
-        return;
-      }
-      // decision.action === 'push' ('unknown' relation, or an older server with no relation field
-      // at all) — fall through to step 2, same as today's etag-compare-then-push behavior.
     } else if (res.status === 404) {
       currentEtag = null; // no row yet — first push is a create
     } else {

--- a/claude-plugins/task-orchestrator/skills/configure-server/references/runtime-config.md
+++ b/claude-plugins/task-orchestrator/skills/configure-server/references/runtime-config.md
@@ -107,7 +107,7 @@ TASK_ORCHESTRATOR_API_URL=http://localhost:3001
 TASK_ORCHESTRATOR_API_TOKEN=<token>   # bearer mode only; omit entirely for unauthenticated mode
 ```
 
-Verified in `config-sync.mjs:84-92`: if `TASK_ORCHESTRATOR_API_URL` is unset, the hook returns
+Verified in `config-sync.mjs` (the `TASK_ORCHESTRATOR_API_URL` guard in `main()`): if `TASK_ORCHESTRATOR_API_URL` is unset, the hook returns
 immediately with no error and no log — it silently no-ops. There is no visible symptom other than
 per-project config never showing up server-side. **Always render this env var alongside the HTTP+REST
 docker run command** — it is easy to forget because it's set outside the container, not inside it.

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
@@ -135,6 +135,7 @@ For detailed workflow, see `references/validate-workflow.md` in this skill folde
   ```
   - Success → report the returned `fingerprint`. Re-pushing identical content later returns the same fingerprint (idempotent) — safe to call after every write without pre-checking.
   - `VALIDATION_ERROR` → the server rejected the YAML (e.g. a construct its parser can't accept). The local file is already saved — tell the user the parse error from the response and to fix `.taskorchestrator/config.yaml`, then re-run VALIDATE and retry the push.
+  - `CONFLICT_ERROR` (superseded) → the pushed content is provably older than the server's (its fingerprint is in the server's history but not current). Tell the user to pull/copy the server's config back before editing (`manage_project_config(operation="get", ...)` shows it), or pass `force: true` on the push if overwriting the server's newer config is intentional.
   - A `warning` field on a successful response → relay it to the user as-is (non-fatal — e.g. the root item's `type` isn't `"project"`).
 - Remind: **MCP reconnect required** (`/mcp`) for schema changes to take effect on the *global* config path — the server caches `.taskorchestrator/config.yaml` on first access. A successful per-root push above takes effect immediately for items scoped to that root, without needing reconnect.
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
@@ -375,11 +375,52 @@ Config resolves in **two layers**, chosen per work item by its `rootId`:
 | **Global** | the `AGENT_CONFIG_DIR/.taskorchestrator/config.yaml` file | read once at server startup (restart to reload) | one per server — the **fallback/default** |
 | **Per-root** | pushed into the DB per project-root UUID (via `manage_project_config` or `PUT /api/v1/roots/{rootId}/config`) | **hot-reloaded** on every schema-resolving read — no restart | one per project root |
 
-For an item with a `rootId`, every schema / tag / trait lookup consults that root's per-root config **first** and falls back to the global file on a miss. An item with no `rootId` uses the global file only. Behavior is byte-identical to a single-file setup when no per-root config has been pushed.
+For an item with a `rootId`, every schema / tag / trait lookup is **whole-algorithm-first**: the
+entire per-root resolution runs to completion before the global layer is consulted at all. For the
+type lookup, that precedence is:
+
+1. Per-root exact match on `item.type`
+2. Per-root `default` schema
+3. Global exact match on `item.type`
+4. Global `default` schema
+
+The tag lookup follows the same shape (per-root first-matching-tag, then per-root `default`,
+*then* the equivalent global steps). This means a per-root `default` schema wins over a **global
+exact type match** — once a root has pushed its own config, that config is treated as the root's
+complete self-description, not a patch layered on top of the global floor. An item with no
+`rootId` uses the global file only. Behavior is byte-identical to a single-file setup when no
+per-root config has been pushed.
+
+**Layer roles:** global = server-wide floor; per-root = the project's complete self-description,
+which can lower the floor to zero via the empty default (see below).
 
 **Precedence — the workspace file is canonical; the per-root DB row is a synced replica.** The `config-sync.mjs` SessionStart hook (and the `manage-schemas` / `quick-start` push steps) copy the local `.taskorchestrator/config.yaml` into the per-root store whenever it changes. Durable edits belong in the **file**: a runtime `manage_project_config` push that isn't reflected in the file is overwritten at the next session's sync. A byte-identical file is a no-op (fingerprints match).
 
 **Global-only settings.** `note_limits` and `actor_authentication` are **not** part of the per-root layer — the resolver reads them only from the global file. A per-root document may carry them, but they are ignored; keep them in the global config.
+
+### Schema-free / non-dev / business-workflow projects
+
+A project that has no notion of "notes to fill" — non-dev workflows, business-process tracking,
+or anything using Task Orchestrator purely for status/dependency tracking — can push a per-root
+config with an **empty default schema** to fence off the global config entirely:
+
+```yaml
+work_item_schemas:
+  default:
+    lifecycle: auto   # or manual / permanent for workflow-style projects
+    notes: []
+```
+
+Because per-root resolution is whole-algorithm-first, this `default` entry resolves for every item
+type in this root (no exact type match needed) with zero required notes — every gate passes
+automatically, regardless of what the global config requires for the same type elsewhere. The
+global config is never consulted for this root once this per-root default resolves.
+
+**Why the global default still matters even with per-root fencing available:** stdio mode (no
+per-root DB row exists at all — items resolve via `rootId == null`), the bootstrap window before a
+workspace's first `manage_project_config` push, legacy items with a null `rootId` predating the
+root-backfill, and process-global containers that intentionally sit outside any single project
+root. The global default is the floor these cases fall back to.
 
 ---
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
@@ -396,6 +396,18 @@ which can lower the floor to zero via the empty default (see below).
 
 **Precedence — the workspace file is canonical; the per-root DB row is a synced replica.** The `config-sync.mjs` SessionStart hook (and the `manage-schemas` / `quick-start` push steps) copy the local `.taskorchestrator/config.yaml` into the per-root store whenever it changes. Durable edits belong in the **file**: a runtime `manage_project_config` push that isn't reflected in the file is overwritten at the next session's sync. A byte-identical file is a no-op (fingerprints match).
 
+**Fast-forward guarded.** The server keeps a per-root fingerprint history (newest first, pruned to
+20), so file-canonical precedence is enforced, not just assumed. A push whose fingerprint is
+**known-old** — present in that history but not the root's current fingerprint (e.g. a stale
+checkout that missed a later push made from another machine) — is rejected server-side (REST `409
+superseded`; MCP tool `CONFLICT_ERROR`) instead of silently reverting the later change.
+`config-sync.mjs` checks this on every session start via `GET .../config?fingerprint=<local-sha256>`:
+a `superseded` relation skips the push and surfaces a message telling the agent to pull or copy the
+server's config back before editing, rather than pushing over it. `current` (already in sync) and
+`unknown` (brand-new content, or an older server that predates this guard — no `relation` field
+returned) both proceed as before. `force: true` (or `?force=true`) bypasses the guard when a
+deliberate revert or overwrite is intended.
+
 **Global-only settings.** `note_limits` and `actor_authentication` are **not** part of the per-root layer — the resolver reads them only from the global file. A per-root document may carry them, but they are ignored; keep them in the global config.
 
 ### Schema-free / non-dev / business-workflow projects

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
@@ -408,7 +408,19 @@ server's config back before editing, rather than pushing over it. `current` (alr
 returned) both proceed as before. `force: true` (or `?force=true`) bypasses the guard when a
 deliberate revert or overwrite is intended.
 
-**Global-only settings.** `note_limits` and `actor_authentication` are **not** part of the per-root layer — the resolver reads them only from the global file. A per-root document may carry them, but they are ignored; keep them in the global config.
+**Per-root honorable settings.** `note_limits` and `status_labels` are layered the same way as
+schemas/traits: a per-root document that **explicitly** sets `note_limits.mode` or a trigger under
+`status_labels` wins for that root; a per-root document that **omits the key entirely** falls
+through to the global value, unchanged. `status_labels` falls through **per trigger** — a per-root
+map that only overrides `start` still defers to the global config for `complete`, `block`, etc.
+(and a trigger explicitly mapped to `null` in the per-root doc means "no label for this trigger",
+which is different from the trigger being absent). A pushed document's response (`manage_project_config`
+push, or `PUT /roots/{rootId}/config`) reports which top-level keys it contains that are NOT honored
+per-root in an additive `ignoredSections` field.
+
+**Global-only settings.** `actor_authentication` is **not** part of the per-root layer — the
+resolver reads it only from the global file. A per-root document may carry it, but it is ignored
+(and reported in `ignoredSections`); keep it in the global config.
 
 ### Schema-free / non-dev / business-workflow projects
 
@@ -444,6 +456,10 @@ Top-level `note_limits.mode` (`warn`, default, or `reject`) governs what happens
 note_limits:
   mode: warn   # warn | reject
 ```
+
+This mode is per-root honorable (see "Global vs Per-Project Config" above): a project root that
+pushes its own `note_limits.mode` overrides the global mode for that root's items only; a per-root
+document with no `note_limits` section at all defers to the global mode unchanged.
 
 Notes are a compression boundary: keep bodies distilled prose, and route verbatim artifacts (test output, diffs, logs) through `bodyFromFile` rather than pasting them inline.
 

--- a/claude-plugins/task-orchestrator/skills/quick-start/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/quick-start/SKILL.md
@@ -52,6 +52,7 @@ If the user accepts:
    ```
    - Success → the returned `fingerprint` confirms the push landed; re-pushing identical content later returns the same fingerprint (idempotent).
    - `VALIDATION_ERROR` → surface the parse error to the user; the config.yaml write from step 3 is already saved locally, so nothing is lost — tell them to fix the file and retry the push (or run `/manage-schemas validate`).
+   - `CONFLICT_ERROR` (superseded) → the local file is older than the server's stored config (rare during onboarding — usually means another checkout already synced a newer version). Fetch the server's copy with `manage_project_config(operation="get", ...)` and reconcile, or pass `force: true` if overwriting is intentional.
    - A `warning` field → relay it to the user (non-fatal).
 
    If the tool isn't available, note this and skip — the config.yaml write from step 3 is authoritative on its own; the server will pick it up on its normal config read path.

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -612,7 +612,7 @@ Providing both `ids` and `itemId` in the same delete call is an error — the se
 | `bodyFromFile` | string | No | Server-side file path read in place of `body`. Resolved strictly relative to the agent config root (`AGENT_CONFIG_DIR`, falling back to the server's working directory) — absolute paths, `..` escapes, and symlink escapes are rejected. File must exist and be ≤65536 bytes. CRLF line endings are normalized to LF on read. |
 | `actor` | object | No | Optional actor claim — see Actor Attribution section |
 
-**Note body length limits.** When the resolved schema declares `maxLength` for a note's `key`, the resolved body (from `body` or `bodyFromFile`) is checked against it after resolution. The top-level config `note_limits.mode` controls enforcement: `warn` (default) accepts the note and adds a `warning` field to that note's result naming the limit and actual size; `reject` fails that note with a structured error: `{ "code": "NOTE_BODY_TOO_LONG", "key": "...", "maxLength": N, "actualLength": N }` in its `failures` entry.
+**Note body length limits.** When the resolved schema declares `maxLength` for a note's `key`, the resolved body (from `body` or `bodyFromFile`) is checked against it after resolution. The top-level config `note_limits.mode` controls enforcement: `warn` (default) accepts the note and adds a `warning` field to that note's result naming the limit and actual size; `reject` fails that note with a structured error: `{ "code": "NOTE_BODY_TOO_LONG", "key": "...", "maxLength": N, "actualLength": N }` in its `failures` entry. `note_limits` is layered per-root: a per-root `manage_project_config` push that explicitly sets `note_limits.mode` wins for that root's items; a per-root document that omits `note_limits` entirely falls through to the global mode unchanged — see [`config-format.md`](../../claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md).
 
 Each upsert note element may include an optional `actor` object:
 - `id` (required string): Identifier for the actor writing this note
@@ -1102,7 +1102,7 @@ All cascade types are recorded in `cascadeEvents`.
 }
 ```
 
-`previousRole` and `trigger` are omitted from successful results — the caller supplied the trigger, and `newRole` is the outcome. Both remain present on `cascadeEvents` entries and on failed results (see below). `cascadeEvents` and `unblockedItems` are omitted entirely when empty (there is no top-level `allUnblockedItems` aggregate — sum `unblockedItems` across `results` if you need a batch total). `expectedNotes` is always present (`[]` when no schema matches the item's tags) and is keys-only: `key`, `role`, `required`, `exists` (`filled` appears only in `get_context`'s item-mode `schema` entries, not here). `statusLabel` (string, optional) is present when the transition set a status label (config-driven via `status_labels`; defaults: `"in-progress"` for `start`, `"done"` for `complete`, `"blocked"` for `block`, `"cancelled"` for `cancel`; `resume`/`reopen` set none). `summary` (string, optional) echoes the transition's input annotation when one was supplied.
+`previousRole` and `trigger` are omitted from successful results — the caller supplied the trigger, and `newRole` is the outcome. Both remain present on `cascadeEvents` entries and on failed results (see below). `cascadeEvents` and `unblockedItems` are omitted entirely when empty (there is no top-level `allUnblockedItems` aggregate — sum `unblockedItems` across `results` if you need a batch total). `expectedNotes` is always present (`[]` when no schema matches the item's tags) and is keys-only: `key`, `role`, `required`, `exists` (`filled` appears only in `get_context`'s item-mode `schema` entries, not here). `statusLabel` (string, optional) is present when the transition set a status label (config-driven via `status_labels`; defaults: `"in-progress"` for `start`, `"done"` for `complete`, `"blocked"` for `block`, `"cancelled"` for `cancel`; `resume`/`reopen` set none). `status_labels` is layered per-root: a per-root `manage_project_config` push resolves a label for a given trigger from that root's `status_labels` map first, falling through to the global config PER TRIGGER when the root's map doesn't mention that trigger (or has no `status_labels` section at all). `summary` (string, optional) echoes the transition's input annotation when one was supplied.
 
 `guidanceKey` (string, optional) names the first unfilled required note with guidance for the **new** role; omitted when no schema matches, no required notes exist for the new role, or all required notes are already filled. Resolve the full guidance text via `query_items(operation="schema", itemId=...)`.
 
@@ -1767,6 +1767,21 @@ On success, stores the document and returns its fingerprint. Pushing byte-identi
 naturally idempotent: the fingerprint returned is unchanged, so a caller can `get` first and skip
 the push when fingerprints already match — no separate idempotency-key machinery is needed.
 
+**Which sections are honored per-root.** Only a subset of top-level `configYaml` keys are resolved
+per-root; everything else stays global-only and is reported back via `ignoredSections` (see below)
+so a push is never silently partial:
+
+| Top-level key | Honored per-root? | Layered by |
+|---|---|---|
+| `work_item_schemas` | Yes | `PerRootConfigService` / `ToolExecutionContext.resolveSchema()` |
+| `note_schemas` (legacy) | Yes | `PerRootConfigService` / `ToolExecutionContext.resolveSchema()` |
+| `traits` | Yes | `PerRootConfigService` / `ToolExecutionContext.resolveSchema()` |
+| `project` | Yes | `ProjectConfigPushService` (embedded `project.rootId` guard only) |
+| `note_limits` | Yes | `ToolExecutionContext.resolveNoteLimitsMode()` |
+| `status_labels` | Yes | `ToolExecutionContext.resolveStatusLabel()` |
+| `actor_authentication` | No — global-only | n/a |
+| any other key | No | n/a |
+
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `operation` | string (`"push"` \| `"get"`) | Yes | Selects the operation |
@@ -1808,11 +1823,14 @@ config bytes are parsed (`PerRootConfigService`, on every schema-resolving read)
   "rootItemId": "3f9c2b10-...",
   "fingerprint": "a94a8fe5cc...",
   "updatedAt": "2026-07-14T18:40:00Z",
-  "warning": "Root item type is 'null', not 'project' — config pushed anyway (a naming convention, not an enforced constraint)"
+  "warning": "Root item type is 'null', not 'project' — config pushed anyway (a naming convention, not an enforced constraint)",
+  "ignoredSections": ["actor_authentication"]
 }
 ```
 
-`warning` is only present when the root's `type` is not `"project"`.
+`warning` is only present when the root's `type` is not `"project"`. `ignoredSections` is only
+present (and non-empty) when the pushed document contains top-level keys outside the honored
+allowlist above — e.g. `actor_authentication`.
 
 **Error cases.**
 

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -243,7 +243,8 @@ snippets, filtered list search, or hierarchical overview.
 |---|---|---|---|
 | `operation` | string | Yes | `"schema"` |
 | `type` | string | Exactly one of `type`/`itemId` | Schema type identifier — direct lookup in `work_item_schemas` |
-| `itemId` | string (UUID or 4+ char prefix) | Exactly one of `type`/`itemId` | Resolves the item's schema via the standard type-first/tag-fallback/trait-merge logic |
+| `itemId` | string (UUID or 4+ char prefix) | Exactly one of `type`/`itemId` | Resolves the item's schema via the standard type-first/tag-fallback/trait-merge logic, layered per-root-then-global using the item's own `rootId` |
+| `rootId` | string (UUID or 4+ char prefix) | No | Only used with `type`. Resolves `type` against this root's per-root pushed config first (per-root exact type -> per-root `"default"` -> global exact type -> global `"default"`), falling back to global-only behavior when the root has no pushed config. Ignored when `itemId` is used instead — the item's own `rootId` is applied automatically. |
 
 **Response (schema).**
 
@@ -251,6 +252,7 @@ snippets, filtered list search, or hierarchical overview.
 {
   "type": "feature-implementation",
   "configFingerprint": "a1b2c3d4",
+  "configSource": "global",
   "notes": [
     { "key": "specification", "role": "queue", "required": true, "description": "...", "guidance": "...", "skill": "spec-quality", "maxLength": 4000 },
     { "key": "implementation-notes", "role": "work", "required": true, "description": "..." }
@@ -258,7 +260,7 @@ snippets, filtered list search, or hierarchical overview.
 }
 ```
 
-This is the **only** place that returns full note text (`description`, `guidance`, `skill`, `maxLength`) in one shot for an entire schema. Use it to resolve the keys-only `expectedNotes` and the reference-only `guidanceKey`/`skillPointer` fields returned elsewhere. `guidance`, `skill`, and `maxLength` are omitted per-entry when unset. `configFingerprint` is `null` when unavailable; cache schema responses per fingerprint to avoid re-fetching unchanged config. Errors with `RESOURCE_NOT_FOUND` when no schema matches the given `type` or the item is schema-free.
+This is the **only** place that returns full note text (`description`, `guidance`, `skill`, `maxLength`) in one shot for an entire schema. Use it to resolve the keys-only `expectedNotes` and the reference-only `guidanceKey`/`skillPointer` fields returned elsewhere. `guidance`, `skill`, and `maxLength` are omitted per-entry when unset. `configFingerprint` reports the fingerprint of whichever config layer actually supplied the schema (per-root or global) and is `null` when unavailable; cache schema responses per fingerprint to avoid re-fetching unchanged config. `configSource` is `"per-root"` when a per-root pushed config supplied the schema (via `rootId` on the `type` path, or the item's own `rootId` on the `itemId` path) and `"global"` otherwise. Errors with `RESOURCE_NOT_FOUND` when no schema matches the given `type` or the item is schema-free.
 
 **Examples.**
 

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1757,6 +1757,11 @@ Validates, in order:
 6. If the parsed document embeds a top-level `project.rootId` that parses as a UUID and differs
    from `rootItemId`, the push is rejected as a `rootId` mismatch (see **rootId mismatch guard**
    below) — unless `force: true` is passed.
+7. If the incoming document's fingerprint is **superseded** — it appears in the root's fingerprint
+   history but is not the current fingerprint (i.e. the server has already moved past this exact
+   content) — the push is rejected as stale (see **Fast-forward guard** below) — unless
+   `force: true` is passed. A fingerprint the server has never seen (`unknown`) pushes normally;
+   the current fingerprint (`current`) is the idempotent re-push.
 
 On success, stores the document and returns its fingerprint. Pushing byte-identical content is
 naturally idempotent: the fingerprint returned is unchanged, so a caller can `get` first and skip
@@ -1767,7 +1772,7 @@ the push when fingerprints already match — no separate idempotency-key machine
 | `operation` | string (`"push"` \| `"get"`) | Yes | Selects the operation |
 | `rootItemId` | string (UUID or 4+ char hex prefix) | Yes | Project root WorkItem — must be depth 0 for `push` |
 | `configYaml` | string | Yes (push only) | Raw config.yaml text to store for this root; max 128 KiB |
-| `force` | boolean | No (push only, default `false`) | Bypass push guards — currently skips the embedded `project.rootId` mismatch check |
+| `force` | boolean | No (push only, default `false`) | Bypass push guards — skips both the embedded `project.rootId` mismatch check and the superseded (fast-forward) staleness check |
 
 **rootId mismatch guard.** A pushed `configYaml` document may embed its own root id at top-level
 `project.rootId`. If present and it parses as a UUID that differs from the `rootItemId` argument,
@@ -1818,7 +1823,20 @@ config bytes are parsed (`PerRootConfigService`, on every schema-resolving read)
 | Root WorkItem has `depth != 0` | `VALIDATION_ERROR` |
 | `configYaml` fails to parse (invalid/unsafe YAML syntax or shape, including `!!`-tagged custom types — see **Parse safety** above) | `VALIDATION_ERROR` (message includes the parse detail) |
 | `configYaml` embeds a `project.rootId` that differs from `rootItemId` (and `force` was not `true`) | `VALIDATION_ERROR` (message names both ids) |
+| `configYaml`'s fingerprint is superseded — in the root's history but not current (and `force` was not `true`) | `VALIDATION_ERROR` (message: local config is older than the server's, with the server row's `updatedAt`) |
 | Storage failure | `DATABASE_ERROR` |
+
+**Fast-forward guard.** Every successful push appends the *previous* current fingerprint to a
+per-root history (newest first, pruned to the last 20; stored in `project_config.fingerprint_history`,
+added in migration V11). An incoming push whose fingerprint appears in that history but is not the
+current fingerprint is provably *older content the server has already moved past* — the classic
+stale-checkout case (old branch, unsynced worktree, second machine) — and is rejected so a session
+starting from an outdated file cannot silently revert the project's live config. Content the server
+has never seen (`unknown`) is accepted — true divergence remains last-writer-wins by design. Rows
+created before V11 have no history and classify every non-current fingerprint as `unknown`
+(pre-guard behavior) until history accumulates. The `config-sync` SessionStart hook performs the
+same check client-side via `get` + `fingerprint` (below) and skips the push with a warning instead
+of hitting the rejection.
 
 #### `get`
 
@@ -1828,6 +1846,7 @@ Reads back the stored config for a root.
 |---|---|---|---|
 | `operation` | string (`"push"` \| `"get"`) | Yes | Selects the operation |
 | `rootItemId` | string (UUID or 4+ char hex prefix) | Yes | Project root WorkItem to read the config for |
+| `fingerprint` | string (hex SHA-256) | No (get only) | A local document fingerprint to classify against this root's stored config; adds `relation` to the response |
 
 **Response (success).**
 
@@ -1836,9 +1855,16 @@ Reads back the stored config for a root.
   "rootItemId": "3f9c2b10-...",
   "configYaml": "work_item_schemas:\n  ...\n",
   "fingerprint": "a94a8fe5cc...",
-  "updatedAt": "2026-07-14T18:40:00Z"
+  "updatedAt": "2026-07-14T18:40:00Z",
+  "relation": "superseded"
 }
 ```
+
+`relation` is only present when a `fingerprint` argument was supplied: `"current"` (matches the
+stored fingerprint), `"superseded"` (in this root's fingerprint history but not current — the
+supplied content is older than the server's), or `"unknown"` (never seen — new content, or a
+pre-V11 row with no history). Callers deciding whether to push should treat `superseded` as
+"do not push without `force`" — this is exactly what the `config-sync` hook does.
 
 **Response (no config pushed for this root).** `error.code` is `RESOURCE_NOT_FOUND`.
 

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1752,6 +1752,9 @@ Validates, in order:
    below). Unparseable or unsafe YAML is rejected here — nothing is stored — so a broken or
    malicious config can never silently exist server-side and fall through to the global schema on
    a later read.
+6. If the parsed document embeds a top-level `project.rootId` that parses as a UUID and differs
+   from `rootItemId`, the push is rejected as a `rootId` mismatch (see **rootId mismatch guard**
+   below) — unless `force: true` is passed.
 
 On success, stores the document and returns its fingerprint. Pushing byte-identical content is
 naturally idempotent: the fingerprint returned is unchanged, so a caller can `get` first and skip
@@ -1762,6 +1765,14 @@ the push when fingerprints already match — no separate idempotency-key machine
 | `operation` | string (`"push"` \| `"get"`) | Yes | Selects the operation |
 | `rootItemId` | string (UUID or 4+ char hex prefix) | Yes | Project root WorkItem — must be depth 0 for `push` |
 | `configYaml` | string | Yes (push only) | Raw config.yaml text to store for this root; max 128 KiB |
+| `force` | boolean | No (push only, default `false`) | Bypass push guards — currently skips the embedded `project.rootId` mismatch check |
+
+**rootId mismatch guard.** A pushed `configYaml` document may embed its own root id at top-level
+`project.rootId`. If present and it parses as a UUID that differs from the `rootItemId` argument,
+the push is rejected before any write — this catches a config document synced or copy-pasted
+against the wrong project root before it silently overwrites the target root's gates. An absent or
+non-UUID `project.rootId` is not an error; the push proceeds as if it were absent. Pass
+`force: true` to push anyway.
 
 **Parse safety.** `configYaml` is parsed with SnakeYAML's `SafeConstructor` rather than its default
 `Constructor`. The default constructor will instantiate an arbitrary Java type named by a YAML
@@ -1804,6 +1815,7 @@ config bytes are parsed (`PerRootConfigService`, on every schema-resolving read)
 | `rootItemId` does not resolve to an existing WorkItem | `RESOURCE_NOT_FOUND` |
 | Root WorkItem has `depth != 0` | `VALIDATION_ERROR` |
 | `configYaml` fails to parse (invalid/unsafe YAML syntax or shape, including `!!`-tagged custom types — see **Parse safety** above) | `VALIDATION_ERROR` (message includes the parse detail) |
+| `configYaml` embeds a `project.rootId` that differs from `rootItemId` (and `force` was not `true`) | `VALIDATION_ERROR` (message names both ids) |
 | Storage failure | `DATABASE_ERROR` |
 
 #### `get`

--- a/current/docs/api-rest.md
+++ b/current/docs/api-rest.md
@@ -940,19 +940,27 @@ Validates and stores raw `configYaml` for `{rootId}`. Requires `WRITE_CONFIG`.
 
 **Request body:** raw YAML text (`Content-Type: application/yaml` or `text/plain`); max 128 KiB.
 
+**Query parameter:** `force` (boolean, default `false`) — set `?force=true` to bypass push guards;
+currently skips the embedded `project.rootId` mismatch check (guard 5 below).
+
 **Validation pipeline (in order, stops at first failure — nothing is written on failure):**
 1. Body size ≤ 128 KiB
 2. `{rootId}` resolves to an existing WorkItem
 3. That WorkItem is depth-0 (configs anchor to project roots only)
 4. `configYaml` parses under a `SafeConstructor` YAML load (rejects `!!`-tagged arbitrary Java
    type construction — CWE-502 — as well as ordinary syntax errors)
-5. Optional `If-Match` (see below), evaluated against the CURRENT stored fingerprint
+5. Unless `?force=true`: if the parsed document embeds a top-level `project.rootId` that parses as
+   a UUID and differs from `{rootId}`, the push is rejected (an absent or non-UUID `project.rootId`
+   is not an error — the push proceeds as if it were absent)
+6. Optional `If-Match` (see below), evaluated against the CURRENT stored fingerprint
 
 **Responses:**
 - `200 OK` → `ProjectConfigResponseDto` (no `configYaml` field on this verb); `ETag: "cfg-<fingerprint>"`
 - `404 not_found` — `{rootId}` does not resolve to an existing WorkItem
 - `422 validation_error` — `{rootId}` is not depth-0
 - `422 parse_error` — `configYaml` failed SafeConstructor parse-validation
+- `422 rootid_mismatch` — `configYaml` embeds a `project.rootId` differing from `{rootId}` (message
+  names both ids); retry with `?force=true` to bypass
 - `412 etag_mismatch` — `If-Match` supplied and mismatched against an EXISTING row's ETag (a
   first push to a root with no prior row ignores `If-Match` — there is nothing to match yet)
 - `413 payload_too_large` — body exceeds 128 KiB

--- a/current/docs/api-rest.md
+++ b/current/docs/api-rest.md
@@ -470,11 +470,13 @@ Note: `"<previousRole>"` is a literal sentinel string — dashboards must resolv
   "fingerprint": "e3b0c44298fc1c14...",
   "updatedAt": "2026-07-15T19:00:00Z",
   "configYaml": "work_item_schemas:\n  ...",
-  "warning": "string|null"
+  "warning": "string|null",
+  "relation": "current|superseded|unknown|null"
 }
 ```
 `configYaml` is populated on `GET` only (omitted on `PUT`). `warning` is populated only when the
-root's `type` is not `"project"` (non-fatal — the push still succeeds).
+root's `type` is not `"project"` (non-fatal — the push still succeeds). `relation` is populated on
+`GET` only, and only when `?fingerprint=` was supplied — see §17.
 
 ### SSE / ApiEvent
 
@@ -941,7 +943,8 @@ Validates and stores raw `configYaml` for `{rootId}`. Requires `WRITE_CONFIG`.
 **Request body:** raw YAML text (`Content-Type: application/yaml` or `text/plain`); max 128 KiB.
 
 **Query parameter:** `force` (boolean, default `false`) — set `?force=true` to bypass push guards;
-currently skips the embedded `project.rootId` mismatch check (guard 5 below).
+skips both the embedded `project.rootId` mismatch check (guard 5 below) and the fast-forward
+fingerprint guard (guard 6 below).
 
 **Validation pipeline (in order, stops at first failure — nothing is written on failure):**
 1. Body size ≤ 128 KiB
@@ -952,7 +955,12 @@ currently skips the embedded `project.rootId` mismatch check (guard 5 below).
 5. Unless `?force=true`: if the parsed document embeds a top-level `project.rootId` that parses as
    a UUID and differs from `{rootId}`, the push is rejected (an absent or non-UUID `project.rootId`
    is not an error — the push proceeds as if it were absent)
-6. Optional `If-Match` (see below), evaluated against the CURRENT stored fingerprint
+6. Unless `?force=true`: the incoming `configYaml`'s fingerprint is classified against `{rootId}`'s
+   stored fingerprint history — a fast-forward (known-old) guard. A fingerprint that is
+   **superseded** (present in history but not current) is rejected, since writing it would silently
+   revert a later push made from elsewhere. **current** (idempotent re-push) and **unknown**
+   (divergent edit, or no row/history yet) both proceed normally.
+7. Optional `If-Match` (see below), evaluated against the CURRENT stored fingerprint
 
 **Responses:**
 - `200 OK` → `ProjectConfigResponseDto` (no `configYaml` field on this verb); `ETag: "cfg-<fingerprint>"`
@@ -961,6 +969,9 @@ currently skips the embedded `project.rootId` mismatch check (guard 5 below).
 - `422 parse_error` — `configYaml` failed SafeConstructor parse-validation
 - `422 rootid_mismatch` — `configYaml` embeds a `project.rootId` differing from `{rootId}` (message
   names both ids); retry with `?force=true` to bypass
+- `409 superseded` — `configYaml`'s fingerprint is known-old (guard 6 above); message names the
+  server's current `updatedAt`; retry with `?force=true` to overwrite anyway. Distinct from
+  `412 etag_mismatch` below — this is a known-old-**content** guard, not a concurrent-write guard.
 - `412 etag_mismatch` — `If-Match` supplied and mismatched against an EXISTING row's ETag (a
   first push to a root with no prior row ignores `If-Match` — there is nothing to match yet)
 - `413 payload_too_large` — body exceeds 128 KiB
@@ -969,6 +980,11 @@ currently skips the embedded `project.rootId` mismatch check (guard 5 below).
 ### GET /roots/{rootId}/config
 
 Reads back the stored config for `{rootId}`. Requires `READ`.
+
+**Query parameter:** `fingerprint` (optional, SHA-256 hex digest) — when supplied, classifies it
+against `{rootId}`'s stored fingerprint history and adds a `relation` field
+(`"current"|"superseded"|"unknown"`) to the response body. Omitted entirely when the query
+parameter is absent.
 
 **Responses:**
 - `200 OK` → `ProjectConfigResponseDto` (includes `configYaml`); `ETag: "cfg-<fingerprint>"`

--- a/current/docs/api-rest.md
+++ b/current/docs/api-rest.md
@@ -471,12 +471,16 @@ Note: `"<previousRole>"` is a literal sentinel string — dashboards must resolv
   "updatedAt": "2026-07-15T19:00:00Z",
   "configYaml": "work_item_schemas:\n  ...",
   "warning": "string|null",
-  "relation": "current|superseded|unknown|null"
+  "relation": "current|superseded|unknown|null",
+  "ignoredSections": ["actor_authentication"]
 }
 ```
 `configYaml` is populated on `GET` only (omitted on `PUT`). `warning` is populated only when the
 root's `type` is not `"project"` (non-fatal — the push still succeeds). `relation` is populated on
-`GET` only, and only when `?fingerprint=` was supplied — see §17.
+`GET` only, and only when `?fingerprint=` was supplied — see §17. `ignoredSections` is populated on
+`PUT` only, and only when the pushed document contains top-level keys the per-root resolution layer
+does not honor (e.g. `actor_authentication`, which stays global-only) — omitted entirely when empty.
+See §17 for the full list of honored per-root keys.
 
 ### SSE / ApiEvent
 
@@ -962,8 +966,15 @@ fingerprint guard (guard 6 below).
    (divergent edit, or no row/history yet) both proceed normally.
 7. Optional `If-Match` (see below), evaluated against the CURRENT stored fingerprint
 
+On success, the parsed document's top-level keys are checked against the honored allowlist —
+`work_item_schemas`, `note_schemas`, `traits`, `project`, `note_limits`, `status_labels` — and any
+other key present (e.g. `actor_authentication`, which stays global-only — see
+[`config-format.md`](../../claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md))
+is reported in the response's `ignoredSections` array so a push is never silently partial.
+
 **Responses:**
-- `200 OK` → `ProjectConfigResponseDto` (no `configYaml` field on this verb); `ETag: "cfg-<fingerprint>"`
+- `200 OK` → `ProjectConfigResponseDto` (no `configYaml` field on this verb; `ignoredSections`
+  present only when non-empty); `ETag: "cfg-<fingerprint>"`
 - `404 not_found` — `{rootId}` does not resolve to an existing WorkItem
 - `422 validation_error` — `{rootId}` is not depth-0
 - `422 parse_error` — `configYaml` failed SafeConstructor parse-validation

--- a/current/docs/api/openapi.yaml
+++ b/current/docs/api/openapi.yaml
@@ -701,6 +701,16 @@ components:
           description: >-
             Present on GET only, and only when ?fingerprint= was supplied — classifies that
             fingerprint against the root's stored fingerprint history.
+        ignoredSections:
+          type: array
+          nullable: true
+          items:
+            type: string
+          description: >-
+            Present on PUT only, and only when the pushed document has top-level keys not honored
+            by the per-root resolution layer (e.g. actor_authentication, which stays global-only).
+            Honored keys: work_item_schemas, note_schemas, traits, project, note_limits,
+            status_labels. Omitted entirely when empty.
 
   responses:
     Unauthorized:
@@ -1761,6 +1771,11 @@ paths:
         etag_mismatch, which is a concurrent-write guard rather than a known-old-content guard —
         unless ?force=true is set. current (idempotent re-push) and unknown (divergent edit, or
         no row/history yet) both proceed normally.
+
+        On success, top-level keys in the parsed document not honored by the per-root resolution
+        layer (work_item_schemas, note_schemas, traits, project, note_limits, status_labels) are
+        reported in the response's ignoredSections array — e.g. actor_authentication, which stays
+        global-only.
       parameters:
         - name: If-Match
           in: header

--- a/current/docs/api/openapi.yaml
+++ b/current/docs/api/openapi.yaml
@@ -694,6 +694,13 @@ components:
           type: string
           nullable: true
           description: Non-fatal notice when the root's `type` is not "project"
+        relation:
+          type: string
+          nullable: true
+          enum: [current, superseded, unknown]
+          description: >-
+            Present on GET only, and only when ?fingerprint= was supplied — classifies that
+            fingerprint against the root's stored fingerprint history.
 
   responses:
     Unauthorized:
@@ -1700,6 +1707,14 @@ paths:
           in: header
           schema:
             type: string
+        - name: fingerprint
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional SHA-256 hex digest; when supplied, adds a `relation` field
+            ("current"/"superseded"/"unknown") to the response, classifying it against the
+            root's stored fingerprint history.
       responses:
         "200":
           description: Stored config
@@ -1732,13 +1747,20 @@ paths:
       description: |
         Requires WRITE_CONFIG + scope. Delegates the full validate-then-persist pipeline
         (size cap -> root exists -> root is depth-0 -> SafeConstructor parse-validate ->
-        embedded-rootId guard -> upsert) to ProjectConfigPushService — the SAME service the MCP
-        manage_project_config tool's push operation calls, so both surfaces converge on identical
-        DB state for the same payload.
+        embedded-rootId guard -> fast-forward fingerprint guard -> upsert) to
+        ProjectConfigPushService — the SAME service the MCP manage_project_config tool's push
+        operation calls, so both surfaces converge on identical DB state for the same payload.
 
         The embedded-rootId guard: if the parsed document has a top-level project.rootId that
         parses as a UUID and differs from {rootId}, the push is rejected as 422 rootid_mismatch
         unless ?force=true is set. An absent or non-UUID project.rootId is not an error.
+
+        The fast-forward (known-old) guard: the incoming configYaml's fingerprint is classified
+        against {rootId}'s stored fingerprint history. A fingerprint that is superseded (present
+        in history but not current) is rejected as 409 superseded — distinct from 412
+        etag_mismatch, which is a concurrent-write guard rather than a known-old-content guard —
+        unless ?force=true is set. current (idempotent re-push) and unknown (divergent edit, or
+        no row/history yet) both proceed normally.
       parameters:
         - name: If-Match
           in: header
@@ -1753,7 +1775,8 @@ paths:
             type: boolean
             default: false
           description: >-
-            Bypass push guards — currently skips the embedded project.rootId mismatch check.
+            Bypass push guards — skips both the embedded project.rootId mismatch check and the
+            fast-forward fingerprint guard.
       requestBody:
         required: true
         content:
@@ -1781,6 +1804,14 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           description: rootId does not resolve to an existing WorkItem
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorDto"
+        "409":
+          description: >-
+            configYaml's fingerprint is known-old (superseded) — present in the root's
+            fingerprint history but not current; retry with ?force=true to overwrite anyway
           content:
             application/json:
               schema:

--- a/current/docs/api/openapi.yaml
+++ b/current/docs/api/openapi.yaml
@@ -1731,9 +1731,14 @@ paths:
       tags: [project-config]
       description: |
         Requires WRITE_CONFIG + scope. Delegates the full validate-then-persist pipeline
-        (size cap -> root exists -> root is depth-0 -> SafeConstructor parse-validate -> upsert)
-        to ProjectConfigPushService — the SAME service the MCP manage_project_config tool's push
-        operation calls, so both surfaces converge on identical DB state for the same payload.
+        (size cap -> root exists -> root is depth-0 -> SafeConstructor parse-validate ->
+        embedded-rootId guard -> upsert) to ProjectConfigPushService — the SAME service the MCP
+        manage_project_config tool's push operation calls, so both surfaces converge on identical
+        DB state for the same payload.
+
+        The embedded-rootId guard: if the parsed document has a top-level project.rootId that
+        parses as a UUID and differs from {rootId}, the push is rejected as 422 rootid_mismatch
+        unless ?force=true is set. An absent or non-UUID project.rootId is not an error.
       parameters:
         - name: If-Match
           in: header
@@ -1742,6 +1747,13 @@ paths:
           description: >-
             Optional; validated against the CURRENT stored fingerprint's ETag when a row already
             exists. Ignored on a first push (no prior row to match).
+        - name: force
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: >-
+            Bypass push guards — currently skips the embedded project.rootId mismatch check.
       requestBody:
         required: true
         content:
@@ -1786,7 +1798,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorDto"
         "422":
-          description: rootId is not depth-0, or configYaml failed parse-validation
+          description: >-
+            rootId is not depth-0, configYaml failed parse-validation, or configYaml embeds a
+            mismatched project.rootId (rootid_mismatch)
           content:
             application/json:
               schema:

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushService.kt
@@ -1,5 +1,6 @@
 package io.github.jpicklyk.mcptask.current.application.service
 
+import io.github.jpicklyk.mcptask.current.domain.model.FingerprintRelation
 import io.github.jpicklyk.mcptask.current.domain.model.ProjectConfig
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlSchemaParser
@@ -36,9 +37,18 @@ class ProjectConfigPushService(
      * differs from [rootItemId], the push is rejected as [ProjectConfigPushResult.RootIdMismatch]
      * instead of being upserted — this catches a config document copy-pasted or synced against the
      * wrong project root before it silently overwrites the target root's gates. An absent or
-     * non-UUID embedded `project.rootId` is not an error; the push proceeds unchanged. Passing
-     * `force: true` skips this guard (bypasses push guards generally — a later guard shares this
-     * same flag).
+     * non-UUID embedded `project.rootId` is not an error; the push proceeds unchanged.
+     *
+     * A second guard runs right after: the fast-forward (known-old) guard. The incoming
+     * `configYaml`'s fingerprint is classified against the root's stored fingerprint history (see
+     * [io.github.jpicklyk.mcptask.current.domain.model.FingerprintRelation]) — a fingerprint that is
+     * [FingerprintRelation.SUPERSEDED] (known-old: present in history but not current) is rejected as
+     * [ProjectConfigPushResult.Superseded], since writing it would silently revert a later push made
+     * from elsewhere. [FingerprintRelation.CURRENT] (idempotent re-push) and
+     * [FingerprintRelation.UNKNOWN] (divergent edit, or no row/history yet) both proceed normally.
+     *
+     * Passing `force: true` skips BOTH guards (bypasses push guards generally — this single flag is
+     * shared across guards).
      */
     suspend fun push(
         rootItemId: UUID,
@@ -81,7 +91,26 @@ class ProjectConfigPushService(
             }
         }
 
-        return when (val result = repositoryProvider.projectConfigRepository().upsert(rootItemId, configYaml)) {
+        val projectConfigRepository = repositoryProvider.projectConfigRepository()
+
+        if (!force) {
+            val incomingFingerprint = projectConfigRepository.computeFingerprint(configYaml)
+            val relation =
+                when (val relationResult = projectConfigRepository.classifyFingerprint(rootItemId, incomingFingerprint)) {
+                    is Result.Success -> relationResult.data
+                    is Result.Error -> return ProjectConfigPushResult.RepositoryError(relationResult.error.message)
+                }
+            if (relation == FingerprintRelation.SUPERSEDED) {
+                val currentUpdatedAt =
+                    when (val currentResult = projectConfigRepository.get(rootItemId)) {
+                        is Result.Success -> currentResult.data?.updatedAt
+                        is Result.Error -> null
+                    } ?: Instant.now()
+                return ProjectConfigPushResult.Superseded(rootItemId, currentUpdatedAt)
+            }
+        }
+
+        return when (val result = projectConfigRepository.upsert(rootItemId, configYaml)) {
             is Result.Success ->
                 ProjectConfigPushResult.Success(
                     rootItemId = result.data.rootItemId,
@@ -212,6 +241,20 @@ sealed class ProjectConfigPushResult {
     data class RootIdMismatch(
         val targetRootId: UUID,
         val embeddedRootId: UUID
+    ) : ProjectConfigPushResult()
+
+    /**
+     * The incoming `configYaml`'s fingerprint classified as
+     * [io.github.jpicklyk.mcptask.current.domain.model.FingerprintRelation.SUPERSEDED] — known-old:
+     * present in [rootItemId]'s fingerprint history but not its current fingerprint. Rejected before
+     * any write, since persisting it would silently revert a later push made from elsewhere, unless
+     * the caller passed `force: true` to [ProjectConfigPushService.push]. [currentUpdatedAt] is the
+     * server's current row's `updatedAt`, for a caller-facing "local config is older than the
+     * server's (updated ...)" message.
+     */
+    data class Superseded(
+        val rootItemId: UUID,
+        val currentUpdatedAt: Instant
     ) : ProjectConfigPushResult()
 
     /** The upsert itself failed at the repository layer. */

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushService.kt
@@ -137,6 +137,28 @@ class ProjectConfigPushService(
     /** Reads back the stored config for [rootItemId], or a null payload when no row exists. */
     suspend fun get(rootItemId: UUID): Result<ProjectConfig?> = repositoryProvider.projectConfigRepository().get(rootItemId)
 
+    /**
+     * Classifies [fingerprint] against [rootItemId]'s stored fingerprint (+ history) and returns
+     * the lowercase [FingerprintRelation] name (`"current"` / `"superseded"` / `"unknown"`), or
+     * null on a repository error.
+     *
+     * Centralizes the `when (classifyFingerprint(...)) { Success -> name.lowercase(); Error -> null }`
+     * mapping shared by [io.github.jpicklyk.mcptask.current.application.tools.config.ManageProjectConfigTool]'s
+     * `get` operation and [io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.projectConfigRoutes]'s
+     * `GET` route — both need the exact same "unclassifiable = absent from the response, not an
+     * error surfaced to the caller" policy, which is why a repository error swallows to null here
+     * rather than propagating a [Result.Error]: an unclassifiable fingerprint is deliberately
+     * treated as if the caller simply hadn't supplied one.
+     */
+    suspend fun classifyRelation(
+        rootItemId: UUID,
+        fingerprint: String,
+    ): String? =
+        when (val result = repositoryProvider.projectConfigRepository().classifyFingerprint(rootItemId, fingerprint)) {
+            is Result.Success -> result.data.name.lowercase()
+            is Result.Error -> null
+        }
+
     /** Deletes the stored config row for [rootItemId]. Returns true when a row was deleted. */
     suspend fun delete(rootItemId: UUID): Result<Boolean> = repositoryProvider.projectConfigRepository().delete(rootItemId)
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushService.kt
@@ -20,7 +20,8 @@ import java.util.UUID
  * must converge on identical DB state for the same payload.
  *
  * Pipeline, in order: size cap -> root exists -> root is depth-0 -> [SafeConstructor]
- * parse-validate -> [io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository.upsert].
+ * parse-validate -> embedded-rootId guard (skipped when `force: true`) ->
+ * [io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository.upsert].
  * The pipeline stops at the first failing step; nothing is written on failure.
  */
 class ProjectConfigPushService(
@@ -29,10 +30,20 @@ class ProjectConfigPushService(
     /**
      * Validates and persists [configYaml] for [rootItemId]. See [ProjectConfigPushResult] for the
      * possible outcomes.
+     *
+     * When [force] is `false` (the default), a rootId guard runs after parse-validation: if the
+     * document embeds its own root id at top-level `project.rootId` and it parses as a UUID that
+     * differs from [rootItemId], the push is rejected as [ProjectConfigPushResult.RootIdMismatch]
+     * instead of being upserted — this catches a config document copy-pasted or synced against the
+     * wrong project root before it silently overwrites the target root's gates. An absent or
+     * non-UUID embedded `project.rootId` is not an error; the push proceeds unchanged. Passing
+     * `force: true` skips this guard (bypasses push guards generally — a later guard shares this
+     * same flag).
      */
     suspend fun push(
         rootItemId: UUID,
         configYaml: String,
+        force: Boolean = false,
     ): ProjectConfigPushResult {
         val sizeBytes = configYaml.toByteArray(Charsets.UTF_8).size
         if (sizeBytes > MAX_CONFIG_YAML_BYTES) {
@@ -57,9 +68,17 @@ class ProjectConfigPushService(
                 null
             }
 
-        val parseError = validateYaml(configYaml)
-        if (parseError != null) {
-            return ProjectConfigPushResult.ParseError(parseError)
+        val parsedRoot =
+            when (val outcome = parseAndValidateYaml(configYaml)) {
+                is YamlParseOutcome.Failure -> return ProjectConfigPushResult.ParseError(outcome.detail)
+                is YamlParseOutcome.Success -> outcome.root
+            }
+
+        if (!force && parsedRoot != null) {
+            val embeddedRootId = extractEmbeddedRootId(parsedRoot)
+            if (embeddedRootId != null && embeddedRootId != rootItemId) {
+                return ProjectConfigPushResult.RootIdMismatch(rootItemId, embeddedRootId)
+            }
         }
 
         return when (val result = repositoryProvider.projectConfigRepository().upsert(rootItemId, configYaml)) {
@@ -84,8 +103,9 @@ class ProjectConfigPushService(
      * Parses [configYaml] the same way [io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService]
      * will on every subsequent read (via the shared [YamlSchemaParser]), but BEFORE storing — a
      * stored-but-unparseable config would otherwise silently fall through to the global schema on
-     * every future read, a confusing failure mode discovered only much later. Returns the parse
-     * failure message, or null when [configYaml] parses cleanly.
+     * every future read, a confusing failure mode discovered only much later. Parses ONCE: the
+     * returned [YamlParseOutcome.Success.root] is reused by [push]'s embedded-rootId guard so the
+     * document is never parsed twice for one push.
      *
      * Uses [SafeConstructor] rather than SnakeYAML's default `Constructor` — `configYaml` is
      * attacker-reachable input (pushed over MCP or REST, not read from a trusted local file), and
@@ -100,19 +120,44 @@ class ProjectConfigPushService(
      * YAML syntax/shape failure (invalid syntax, or a non-map document) is. Those soft warnings
      * mirror the global config loader's existing behavior: skip the offending entry, keep going.
      */
-    private fun validateYaml(configYaml: String): String? =
+    private fun parseAndValidateYaml(configYaml: String): YamlParseOutcome =
         try {
             @Suppress("UNCHECKED_CAST")
             val root = Yaml(SafeConstructor(LoaderOptions())).load<Map<String, Any>>(configYaml)
             if (root != null) {
                 YamlSchemaParser.parseRoot(root, warnOnMissingSchemas = false)
             }
-            null
+            YamlParseOutcome.Success(root)
         } catch (
             @Suppress("TooGenericExceptionCaught") e: Exception
         ) {
-            e.message ?: e.javaClass.simpleName
+            YamlParseOutcome.Failure(e.message ?: e.javaClass.simpleName)
         }
+
+    /**
+     * Reads a top-level `project.rootId` string from an already-[SafeConstructor]-parsed document
+     * root and parses it as a UUID. Returns null when the `project` map, the `rootId` key, or a
+     * valid UUID shape is absent — all three are treated as "no embedded rootId" by [push], not as
+     * errors.
+     */
+    private fun extractEmbeddedRootId(root: Map<String, Any>): UUID? {
+        val project = root["project"] as? Map<*, *> ?: return null
+        val rawRootId = project["rootId"] as? String ?: return null
+        return runCatching { UUID.fromString(rawRootId) }.getOrNull()
+    }
+
+    /** Outcome of a single [Yaml.load] + [YamlSchemaParser.parseRoot] pass over `configYaml`. */
+    private sealed class YamlParseOutcome {
+        /** [root] is the SafeConstructor-parsed document root, or null for an empty/blank document. */
+        data class Success(
+            val root: Map<String, Any>?
+        ) : YamlParseOutcome()
+
+        /** [detail] is the parse failure message. */
+        data class Failure(
+            val detail: String
+        ) : YamlParseOutcome()
+    }
 
     companion object {
         /** `configYaml` size limit for `push`, in KiB — see [MAX_CONFIG_YAML_BYTES]. */
@@ -157,6 +202,16 @@ sealed class ProjectConfigPushResult {
     /** `configYaml` failed SafeConstructor parse-validation; [detail] is the parse failure message. */
     data class ParseError(
         val detail: String
+    ) : ProjectConfigPushResult()
+
+    /**
+     * `configYaml` embeds a top-level `project.rootId` that parses as a UUID but differs from
+     * [targetRootId] — the push target the caller supplied. Rejected before any write, unless the
+     * caller passed `force: true` to [ProjectConfigPushService.push].
+     */
+    data class RootIdMismatch(
+        val targetRootId: UUID,
+        val embeddedRootId: UUID
     ) : ProjectConfigPushResult()
 
     /** The upsert itself failed at the repository layer. */

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushService.kt
@@ -117,10 +117,22 @@ class ProjectConfigPushService(
                     fingerprint = result.data.fingerprint,
                     updatedAt = result.data.updatedAt,
                     warning = typeWarning,
+                    ignoredSections = computeIgnoredSections(parsedRoot),
                 )
             is Result.Error -> ProjectConfigPushResult.RepositoryError(result.error.message)
         }
     }
+
+    /**
+     * Returns the top-level keys of [parsedRoot] that are NOT honored by any per-root resolution
+     * layer ([PerRootConfigService][io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService]
+     * and [io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext]'s layered
+     * resolvers) — e.g. `actor_authentication`, which stays global-only (see `config-format.md`).
+     * A pushed document that only contains keys from [HONORED_TOP_LEVEL_SECTIONS] returns an empty
+     * list, which callers omit from their response entirely rather than surfacing an empty array.
+     */
+    private fun computeIgnoredSections(parsedRoot: Map<String, Any>?): List<String> =
+        parsedRoot?.keys?.filterNot { it in HONORED_TOP_LEVEL_SECTIONS } ?: emptyList()
 
     /** Reads back the stored config for [rootItemId], or a null payload when no row exists. */
     suspend fun get(rootItemId: UUID): Result<ProjectConfig?> = repositoryProvider.projectConfigRepository().get(rootItemId)
@@ -198,17 +210,35 @@ class ProjectConfigPushService(
          * config document, and small enough to bound parse cost against a hostile payload.
          */
         const val MAX_CONFIG_YAML_BYTES = MAX_CONFIG_YAML_KIB * 1024
+
+        /**
+         * Top-level `configYaml` keys honored by the per-root resolution layer (schema/trait
+         * lookup via [io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService],
+         * note-limits/status-label layering via
+         * [io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext]). Any other
+         * top-level key in a pushed document (e.g. `actor_authentication`, which is intentionally
+         * global-only — see `config-format.md`) is reported via [ProjectConfigPushResult.Success.ignoredSections]
+         * so a push is never silently partial.
+         */
+        private val HONORED_TOP_LEVEL_SECTIONS =
+            setOf("work_item_schemas", "note_schemas", "traits", "project", "note_limits", "status_labels")
     }
 }
 
 /** Outcome of [ProjectConfigPushService.push]. */
 sealed class ProjectConfigPushResult {
-    /** [warning] is non-null when the root's `type` is not `"project"` (non-fatal, push still succeeds). */
+    /**
+     * [warning] is non-null when the root's `type` is not `"project"` (non-fatal, push still
+     * succeeds). [ignoredSections] lists top-level `configYaml` keys not honored by any per-root
+     * resolution layer (see [ProjectConfigPushService.HONORED_TOP_LEVEL_SECTIONS]); empty when the
+     * document only used honored keys.
+     */
     data class Success(
         val rootItemId: UUID,
         val fingerprint: String,
         val updatedAt: Instant,
         val warning: String? = null,
+        val ignoredSections: List<String> = emptyList(),
     ) : ProjectConfigPushResult()
 
     /** No WorkItem exists for [rootItemId]. */

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
@@ -128,6 +128,46 @@ class ToolExecutionContext(
     }
 
     /**
+     * Same resolution as [resolveSchema], but also reports which config layer supplied the BASE
+     * schema (the type/tag lookup step — see [resolveBaseSchemaWithSource]) and that layer's
+     * config fingerprint. Trait notes are merged in identically to [resolveSchema] and may
+     * originate from a different layer than the base schema (see [mergeTraits]); [ResolvedSchema.source]
+     * and [ResolvedSchema.fingerprint] describe the base schema's provenance only — this is what
+     * `query_items`'s `schema` operation needs for its `configSource`/`configFingerprint` fields.
+     */
+    suspend fun resolveSchemaWithSource(item: WorkItem): ResolvedSchema? {
+        val service = noteSchemaService()
+        val (baseSchema, source) = resolveBaseSchemaWithSource(item, service) ?: return null
+        val merged = mergeTraits(item, baseSchema, service)
+        val fingerprint =
+            when (source) {
+                SchemaSource.PER_ROOT -> item.rootId?.let { perRootConfigService?.getFingerprint(it) }
+                SchemaSource.GLOBAL -> service.getConfigFingerprint()
+            }
+        return ResolvedSchema(merged, source, fingerprint)
+    }
+
+    /**
+     * Type-only counterpart to [resolveSchemaWithSource] for callers that have a type name but no
+     * [WorkItem] (e.g. `query_items(operation="schema", type=...)`). Mirrors [resolveTypeAgainstLayers]
+     * only — no tag fallback (there's no item to carry tags) and no trait merging (there's no item
+     * to carry `properties`). Returns null when neither layer defines [type].
+     */
+    suspend fun resolveTypeSchema(
+        type: String,
+        rootId: UUID?
+    ): ResolvedSchema? {
+        val service = noteSchemaService()
+        val (schema, source) = resolveTypeAgainstLayers(type, rootId, service) ?: return null
+        val fingerprint =
+            when (source) {
+                SchemaSource.PER_ROOT -> rootId?.let { perRootConfigService?.getFingerprint(it) }
+                SchemaSource.GLOBAL -> service.getConfigFingerprint()
+            }
+        return ResolvedSchema(schema, source, fingerprint)
+    }
+
+    /**
      * Returns true if the resolved (trait-merged) schema for [item] has a REVIEW phase.
      * Convenience wrapper around [resolveSchema] + [WorkItemSchema.hasReviewPhase].
      * Returns false when no schema matches (schema-free mode — skip REVIEW).
@@ -161,7 +201,19 @@ class ToolExecutionContext(
     private suspend fun resolveBaseSchema(
         item: WorkItem,
         service: NoteSchemaService
-    ): WorkItemSchema? {
+    ): WorkItemSchema? = resolveBaseSchemaWithSource(item, service)?.first
+
+    /**
+     * Same resolution as [resolveBaseSchema], but returns which layer ([SchemaSource]) supplied
+     * the result alongside the schema itself — the source-tracking variant used by
+     * [resolveSchemaWithSource]. Behavior is byte-identical to [resolveBaseSchema]; this is purely
+     * an additive return-shape change, factored out so [resolveBaseSchema] keeps its original
+     * public-facing behavior unchanged for every other caller of [resolveSchema].
+     */
+    private suspend fun resolveBaseSchemaWithSource(
+        item: WorkItem,
+        service: NoteSchemaService
+    ): Pair<WorkItemSchema, SchemaSource>? {
         val rootId = item.rootId
         val perRoot = perRootConfigService
 
@@ -171,13 +223,7 @@ class ToolExecutionContext(
         // neither the exact type nor "default" defined) do we fall through to the global lookup
         // (which has its own type -> "default" fallback — see class KDoc above).
         item.type?.let { type ->
-            val perRootMatch =
-                if (rootId != null && perRoot != null) {
-                    perRoot.getSchemaForType(rootId, type) ?: perRoot.getSchemaForType(rootId, "default")
-                } else {
-                    null
-                }
-            (perRootMatch ?: service.getSchemaForType(type))?.let { return it }
+            resolveTypeAgainstLayers(type, rootId, service)?.let { return it }
         }
 
         // Tag fallback: run the per-root schema map through the SAME first-tag-match/"default"
@@ -185,7 +231,7 @@ class ToolExecutionContext(
         // has no config row for this root, or no tag (nor "default") matches within it.
         val tags = item.tagList()
         if (rootId != null && perRoot != null) {
-            resolvePerRootTagMatch(rootId, tags, perRoot)?.let { return it }
+            resolvePerRootTagMatch(rootId, tags, perRoot)?.let { return it to SchemaSource.PER_ROOT }
         }
 
         // Tag fallback: find the matched tag, then look up the full WorkItemSchema
@@ -199,8 +245,28 @@ class ToolExecutionContext(
             }
         // Retrieve the full WorkItemSchema (with lifecycle/defaultTraits) if available.
         // Re-use tagNotes from above to avoid a redundant getSchemaForTags call in the fallback.
-        return service.getSchemaForType(matchedType)
-            ?: WorkItemSchema(type = matchedType, notes = tagNotes)
+        val resolved = service.getSchemaForType(matchedType) ?: WorkItemSchema(type = matchedType, notes = tagNotes)
+        return resolved to SchemaSource.GLOBAL
+    }
+
+    /**
+     * Runs the type-lookup step shared by [resolveBaseSchemaWithSource] and [resolveTypeSchema]:
+     * per-root exact type -> per-root `"default"` -> global exact type (which has its own internal
+     * `-> global "default"` fallback — see [resolveSchema]'s KDoc table). Whole-algorithm-first:
+     * the entire per-root probe runs to completion before the global layer is consulted at all.
+     * Returns null when neither layer defines [type].
+     */
+    private suspend fun resolveTypeAgainstLayers(
+        type: String,
+        rootId: UUID?,
+        service: NoteSchemaService
+    ): Pair<WorkItemSchema, SchemaSource>? {
+        val perRoot = perRootConfigService
+        if (rootId != null && perRoot != null) {
+            val perRootMatch = perRoot.getSchemaForType(rootId, type) ?: perRoot.getSchemaForType(rootId, "default")
+            if (perRootMatch != null) return perRootMatch to SchemaSource.PER_ROOT
+        }
+        return service.getSchemaForType(type)?.let { it to SchemaSource.GLOBAL }
     }
 
     /**
@@ -275,3 +341,18 @@ class ToolExecutionContext(
         private val logger = LoggerFactory.getLogger(ToolExecutionContext::class.java)
     }
 }
+
+/** Which config layer supplied a resolved schema — see [ToolExecutionContext.resolveSchemaWithSource]. */
+enum class SchemaSource { PER_ROOT, GLOBAL }
+
+/**
+ * A resolved [WorkItemSchema] together with which layer supplied its base schema and that layer's
+ * config fingerprint (null when the supplying layer has no fingerprint available, e.g. no global
+ * config loaded). Returned by [ToolExecutionContext.resolveSchemaWithSource] and
+ * [ToolExecutionContext.resolveTypeSchema].
+ */
+data class ResolvedSchema(
+    val schema: WorkItemSchema,
+    val source: SchemaSource,
+    val fingerprint: String?
+)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
@@ -175,6 +175,42 @@ class ToolExecutionContext(
     suspend fun resolveHasReviewPhase(item: WorkItem): Boolean = resolveSchema(item)?.hasReviewPhase() ?: false
 
     /**
+     * Layered `note_limits.mode` resolution: [rootId]'s per-root config wins when it explicitly
+     * configures `note_limits` (see [PerRootConfigService.getNoteLimitsMode] for the absent-vs-explicit
+     * distinction); otherwise falls back to the global [noteSchemaService]'s mode. A null [rootId] or
+     * no wired [perRootConfigService] skips the per-root layer entirely — byte-identical to the
+     * pre-layering global-only behavior.
+     */
+    suspend fun resolveNoteLimitsMode(rootId: UUID?): String {
+        val perRoot = perRootConfigService
+        val perRootMode = if (rootId != null && perRoot != null) perRoot.getNoteLimitsMode(rootId) else null
+        return perRootMode ?: noteSchemaService().getNoteLimitsMode()
+    }
+
+    /**
+     * Layered status-label resolution for a single [trigger]: [rootId]'s per-root `status_labels`
+     * map wins ONLY when it explicitly contains [trigger] as a key (its value may itself be null,
+     * meaning "this root explicitly clears the label for this trigger" — see
+     * [PerRootConfigService.getStatusLabels]); a trigger key absent from the per-root map (including
+     * when there is no per-root `status_labels` section at all) falls through to the global
+     * [statusLabelService]. A null [rootId] or no wired [perRootConfigService] skips the per-root
+     * layer entirely.
+     */
+    suspend fun resolveStatusLabel(
+        trigger: String,
+        rootId: UUID?
+    ): String? {
+        val perRoot = perRootConfigService
+        if (rootId != null && perRoot != null) {
+            val perRootLabels = perRoot.getStatusLabels(rootId)
+            if (perRootLabels != null && perRootLabels.containsKey(trigger)) {
+                return perRootLabels[trigger]
+            }
+        }
+        return statusLabelService().resolveLabel(trigger)
+    }
+
+    /**
      * Returns the union of trait names available for the given [rootIds], per-root traits first
      * (in [rootIds] iteration order), followed by the global trait list — deduplicated, preserving
      * first-seen order. Used by response hints (e.g. `availableTraits` on item creation) so callers

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
@@ -123,8 +123,9 @@ class ToolExecutionContext(
      */
     suspend fun resolveSchema(item: WorkItem): WorkItemSchema? {
         val service = noteSchemaService()
-        val baseSchema = resolveBaseSchema(item, service) ?: return null
-        return mergeTraits(item, baseSchema, service)
+        val snapshot = snapshotFor(item.rootId)
+        val baseSchema = resolveBaseSchemaWithSource(item, snapshot, service)?.first ?: return null
+        return mergeTraits(item, baseSchema, snapshot, service)
     }
 
     /**
@@ -137,14 +138,10 @@ class ToolExecutionContext(
      */
     suspend fun resolveSchemaWithSource(item: WorkItem): ResolvedSchema? {
         val service = noteSchemaService()
-        val (baseSchema, source) = resolveBaseSchemaWithSource(item, service) ?: return null
-        val merged = mergeTraits(item, baseSchema, service)
-        val fingerprint =
-            when (source) {
-                SchemaSource.PER_ROOT -> item.rootId?.let { perRootConfigService?.getFingerprint(it) }
-                SchemaSource.GLOBAL -> service.getConfigFingerprint()
-            }
-        return ResolvedSchema(merged, source, fingerprint)
+        val snapshot = snapshotFor(item.rootId)
+        val (baseSchema, source) = resolveBaseSchemaWithSource(item, snapshot, service) ?: return null
+        val merged = mergeTraits(item, baseSchema, snapshot, service)
+        return ResolvedSchema(merged, source, fingerprintFor(source, snapshot, service))
     }
 
     /**
@@ -158,13 +155,9 @@ class ToolExecutionContext(
         rootId: UUID?
     ): ResolvedSchema? {
         val service = noteSchemaService()
-        val (schema, source) = resolveTypeAgainstLayers(type, rootId, service) ?: return null
-        val fingerprint =
-            when (source) {
-                SchemaSource.PER_ROOT -> rootId?.let { perRootConfigService?.getFingerprint(it) }
-                SchemaSource.GLOBAL -> service.getConfigFingerprint()
-            }
-        return ResolvedSchema(schema, source, fingerprint)
+        val snapshot = snapshotFor(rootId)
+        val (schema, source) = resolveTypeAgainstLayers(type, snapshot, service) ?: return null
+        return ResolvedSchema(schema, source, fingerprintFor(source, snapshot, service))
     }
 
     /**
@@ -182,8 +175,7 @@ class ToolExecutionContext(
      * pre-layering global-only behavior.
      */
     suspend fun resolveNoteLimitsMode(rootId: UUID?): String {
-        val perRoot = perRootConfigService
-        val perRootMode = if (rootId != null && perRoot != null) perRoot.getNoteLimitsMode(rootId) else null
+        val perRootMode = snapshotFor(rootId)?.noteLimitsModeExplicit
         return perRootMode ?: noteSchemaService().getNoteLimitsMode()
     }
 
@@ -199,15 +191,32 @@ class ToolExecutionContext(
     suspend fun resolveStatusLabel(
         trigger: String,
         rootId: UUID?
-    ): String? {
-        val perRoot = perRootConfigService
-        if (rootId != null && perRoot != null) {
-            val perRootLabels = perRoot.getStatusLabels(rootId)
+    ): String? = resolveStatusLabels(listOf(trigger), rootId)[trigger]
+
+    /**
+     * Batched counterpart to [resolveStatusLabel]: resolves every trigger in [triggers] against
+     * [rootId]'s layered status-label config from a SINGLE per-root snapshot fetch instead of one
+     * fetch per trigger — callers resolving more than one trigger for the same item (e.g.
+     * `AdvanceItemTool`'s root-aware [StatusLabelService], which needs the primary trigger plus the
+     * system-internal "cascade" trigger) should call this once rather than [resolveStatusLabel] in
+     * a loop. Per-trigger precedence is identical to [resolveStatusLabel]: an explicit per-root key
+     * for that trigger wins (including an explicit `null` value — see
+     * [PerRootConfigService.getStatusLabels]); a trigger absent from the per-root map falls through
+     * to the global [statusLabelService].
+     */
+    suspend fun resolveStatusLabels(
+        triggers: Collection<String>,
+        rootId: UUID?
+    ): Map<String, String?> {
+        val perRootLabels = snapshotFor(rootId)?.statusLabels
+        val global = statusLabelService()
+        return triggers.associateWith { trigger ->
             if (perRootLabels != null && perRootLabels.containsKey(trigger)) {
-                return perRootLabels[trigger]
+                perRootLabels[trigger]
+            } else {
+                global.resolveLabel(trigger)
             }
         }
-        return statusLabelService().resolveLabel(trigger)
     }
 
     /**
@@ -223,7 +232,13 @@ class ToolExecutionContext(
         val perRoot = perRootConfigService
         val perRootTraits =
             if (perRoot != null) {
-                rootIds.flatMap { rootId -> perRoot.getAllTraits(rootId)?.keys.orEmpty() }
+                rootIds.flatMap { rootId ->
+                    perRoot
+                        .getSnapshot(rootId)
+                        ?.traits
+                        ?.keys
+                        .orEmpty()
+                }
             } else {
                 emptyList()
             }
@@ -231,43 +246,58 @@ class ToolExecutionContext(
     }
 
     /**
-     * Resolves the base schema without trait merging. Type-first lookup with tag fallback, each
-     * layered per-root-then-global — see [resolveSchema]'s KDoc for the full fallback table.
+     * Fetches [rootId]'s [PerRootConfigService.Snapshot] in ONE call, or null when [rootId] is
+     * null, no [perRootConfigService] is wired, or the root has no per-root config (no row, or a
+     * row that fails to parse). Every per-root-aware resolver below (schema/tag/trait lookup,
+     * note-limits mode, status labels, fingerprint) takes this ALREADY-fetched snapshot as a
+     * parameter instead of independently calling the single-facet accessors on
+     * [PerRootConfigService] — each of those would otherwise re-invoke [PerRootConfigService.resolve]
+     * on its own, costing a redundant fingerprint-read per facet even when the cache is warm.
      */
-    private suspend fun resolveBaseSchema(
-        item: WorkItem,
-        service: NoteSchemaService
-    ): WorkItemSchema? = resolveBaseSchemaWithSource(item, service)?.first
+    private suspend fun snapshotFor(rootId: UUID?): PerRootConfigService.Snapshot? = rootId?.let { perRootConfigService?.getSnapshot(it) }
 
     /**
-     * Same resolution as [resolveBaseSchema], but returns which layer ([SchemaSource]) supplied
-     * the result alongside the schema itself — the source-tracking variant used by
-     * [resolveSchemaWithSource]. Behavior is byte-identical to [resolveBaseSchema]; this is purely
-     * an additive return-shape change, factored out so [resolveBaseSchema] keeps its original
-     * public-facing behavior unchanged for every other caller of [resolveSchema].
+     * Returns the fingerprint associated with a resolved schema's [source], from the SAME
+     * [snapshot] used to resolve it (PER_ROOT) or from the global loader (GLOBAL) — the tiny shared
+     * helper behind [resolveSchemaWithSource] and [resolveTypeSchema], replacing what used to be a
+     * duplicated 4-line `when (source)` expression in each.
      */
-    private suspend fun resolveBaseSchemaWithSource(
+    private fun fingerprintFor(
+        source: SchemaSource,
+        snapshot: PerRootConfigService.Snapshot?,
+        service: NoteSchemaService
+    ): String? =
+        when (source) {
+            SchemaSource.PER_ROOT -> snapshot?.fingerprint
+            SchemaSource.GLOBAL -> service.getConfigFingerprint()
+        }
+
+    /**
+     * Resolves the base schema (no trait merging), returning which layer ([SchemaSource]) supplied
+     * it alongside the schema itself. Type-first lookup with tag fallback, each layered
+     * per-root-then-global against the ALREADY-fetched [snapshot] — see [resolveSchema]'s KDoc for
+     * the full fallback table.
+     */
+    private fun resolveBaseSchemaWithSource(
         item: WorkItem,
+        snapshot: PerRootConfigService.Snapshot?,
         service: NoteSchemaService
     ): Pair<WorkItemSchema, SchemaSource>? {
-        val rootId = item.rootId
-        val perRoot = perRootConfigService
-
         // Type-first lookup: whole-algorithm-first per layer. Run the ENTIRE per-root layer
         // (exact type match, then per-root "default") before ever consulting the global layer.
         // Only when neither per-root key matches (no config row for this root, or a row with
         // neither the exact type nor "default" defined) do we fall through to the global lookup
         // (which has its own type -> "default" fallback — see class KDoc above).
         item.type?.let { type ->
-            resolveTypeAgainstLayers(type, rootId, service)?.let { return it }
+            resolveTypeAgainstLayers(type, snapshot, service)?.let { return it }
         }
 
         // Tag fallback: run the per-root schema map through the SAME first-tag-match/"default"
         // algorithm first; only fall through to the global tag algorithm when the per-root layer
         // has no config row for this root, or no tag (nor "default") matches within it.
         val tags = item.tagList()
-        if (rootId != null && perRoot != null) {
-            resolvePerRootTagMatch(rootId, tags, perRoot)?.let { return it to SchemaSource.PER_ROOT }
+        if (snapshot != null) {
+            resolvePerRootTagMatch(tags, snapshot)?.let { return it to SchemaSource.PER_ROOT }
         }
 
         // Tag fallback: find the matched tag, then look up the full WorkItemSchema
@@ -288,59 +318,56 @@ class ToolExecutionContext(
     /**
      * Runs the type-lookup step shared by [resolveBaseSchemaWithSource] and [resolveTypeSchema]:
      * per-root exact type -> per-root `"default"` -> global exact type (which has its own internal
-     * `-> global "default"` fallback — see [resolveSchema]'s KDoc table). Whole-algorithm-first:
-     * the entire per-root probe runs to completion before the global layer is consulted at all.
-     * Returns null when neither layer defines [type].
+     * `-> global "default"` fallback — see [resolveSchema]'s KDoc table), against the
+     * ALREADY-fetched [snapshot]. Whole-algorithm-first: the entire per-root probe runs to
+     * completion before the global layer is consulted at all. Returns null when neither layer
+     * defines [type].
      */
-    private suspend fun resolveTypeAgainstLayers(
+    private fun resolveTypeAgainstLayers(
         type: String,
-        rootId: UUID?,
+        snapshot: PerRootConfigService.Snapshot?,
         service: NoteSchemaService
     ): Pair<WorkItemSchema, SchemaSource>? {
-        val perRoot = perRootConfigService
-        if (rootId != null && perRoot != null) {
-            val perRootMatch = perRoot.getSchemaForType(rootId, type) ?: perRoot.getSchemaForType(rootId, "default")
+        if (snapshot != null) {
+            val perRootMatch = snapshot.workItemSchemas[type] ?: snapshot.workItemSchemas["default"]
             if (perRootMatch != null) return perRootMatch to SchemaSource.PER_ROOT
         }
         return service.getSchemaForType(type)?.let { it to SchemaSource.GLOBAL }
     }
 
     /**
-     * Runs the same "first matching tag wins, else `default`" algorithm [resolveBaseSchema] uses
-     * against the global service, but against [rootId]'s per-root schema map instead. Per-root
-     * schema map keys (type/tag names) and their [WorkItemSchema] values come straight from
-     * [PerRootConfigService.getSchemas], which already carries lifecycle/defaultTraits — no
-     * separate "fetch notes, then re-fetch the full schema" step is needed here (unlike the global
-     * path, which has two parallel maps for historical reasons).
+     * Runs the same "first matching tag wins, else `default`" algorithm [resolveBaseSchemaWithSource]
+     * uses against the global service, but against the ALREADY-fetched [snapshot]'s per-root schema
+     * map instead. Per-root schema map keys (type/tag names) and their [WorkItemSchema] values come
+     * straight from [PerRootConfigService.Snapshot.workItemSchemas], which already carries
+     * lifecycle/defaultTraits — no separate "fetch notes, then re-fetch the full schema" step is
+     * needed here (unlike the global path, which has two parallel maps for historical reasons).
      *
-     * Returns null when there is no per-root config row for [rootId], or no tag (nor `"default"`)
-     * matches within it — either case means "defer to the global tag algorithm".
+     * Returns null when no tag (nor `"default"`) matches within [snapshot] — meaning "defer to the
+     * global tag algorithm".
      */
-    private suspend fun resolvePerRootTagMatch(
-        rootId: UUID,
+    private fun resolvePerRootTagMatch(
         tags: List<String>,
-        perRoot: PerRootConfigService
+        snapshot: PerRootConfigService.Snapshot
     ): WorkItemSchema? {
-        val schemas = perRoot.getSchemas(rootId) ?: return null
         for (tag in tags) {
-            schemas[tag]?.let { return it }
+            snapshot.workItemSchemas[tag]?.let { return it }
         }
-        return schemas["default"]
+        return snapshot.workItemSchemas["default"]
     }
 
     /**
      * Merges trait notes into the base schema. Collects default_traits from config +
-     * per-item traits from properties JSON, looks up notes for each (per-root config for
-     * [item]'s root taking precedence over the global trait definition — see [resolveSchema]'s
+     * per-item traits from properties JSON, looks up notes for each (the ALREADY-fetched [snapshot]
+     * for [item]'s root taking precedence over the global trait definition — see [resolveSchema]'s
      * KDoc), and appends to the base schema notes (base key wins on duplicates).
      */
-    private suspend fun mergeTraits(
+    private fun mergeTraits(
         item: WorkItem,
         baseSchema: WorkItemSchema,
+        snapshot: PerRootConfigService.Snapshot?,
         service: NoteSchemaService
     ): WorkItemSchema {
-        val rootId = item.rootId
-        val perRoot = perRootConfigService
         val defaultTraits = baseSchema.defaultTraits
         val itemTraits = PropertiesHelper.extractTraits(item.properties)
         val allTraits = (defaultTraits + itemTraits).distinct()
@@ -349,7 +376,7 @@ class ToolExecutionContext(
 
         val traitNotes = mutableListOf<NoteSchemaEntry>()
         for (traitName in allTraits) {
-            val perRootNotes = if (rootId != null && perRoot != null) perRoot.getTraitNotes(rootId, traitName) else null
+            val perRootNotes = snapshot?.traits?.get(traitName)
             val notes = perRootNotes ?: service.getTraitNotes(traitName)
             if (notes == null) {
                 logger.warn("Unknown trait '{}' on item '{}'; skipping", traitName, item.id)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
@@ -90,30 +90,29 @@ class ToolExecutionContext(
      * [perRootConfigService] wired) skips the per-root layer entirely — zero extra calls, behavior
      * byte-identical to before this layering was added.
      *
-     * Per-key fallback table (`?:` reads as "per-root miss defers to global"):
+     * Per-key fallback table — both the type step and the tag step are **whole-algorithm-first**:
+     * the entire per-root resolution (exact match, then per-root `"default"`) runs to completion
+     * before the global layer is consulted at all:
      *
-     * | Resolution step | Expression |
+     * | Resolution step | Precedence |
      * |---|---|
-     * | Type lookup | `perRoot.getSchemaForType(rootId, type) ?: global.getSchemaForType(type)` |
-     * | Tag lookup | whole-algorithm-first: run the existing first-tag-match/"default" match against the per-root schema map; only defer the WHOLE algorithm to global if the per-root layer has no config row or no match at all |
+     * | Type lookup | per-root exact type -> per-root `"default"` -> global exact type -> global `"default"` (the last step is [NoteSchemaService.getSchemaForType]'s own internal fallback) |
+     * | Tag lookup | per-root first-matching-tag -> per-root `"default"` -> global first-matching-tag -> global `"default"` (see [resolvePerRootTagMatch]) |
      * | Trait notes | `perRoot.getTraitNotes(rootId, name) ?: global.getTraitNotes(name)`, per trait name |
-     * | "default" schema | folded into the type/tag rules above — a per-root `default` entry wins over the global one wherever the surrounding rule would have used it |
      *
-     * **Known limitation:** [PerRootConfigService.getSchemaForType] has no internal `"default"`
-     * fallback (unlike [NoteSchemaService.getSchemaForType], which falls back to its own
-     * `workItemSchemas["default"]` when the exact type misses). So for the *type* lookup step, a
-     * per-root config that defines no exact match for `item.type` defers entirely to
-     * `global.getSchemaForType(type)` — which may itself resolve to the *global* default schema,
-     * bypassing any per-root default. Only an explicit per-root entry for `item.type` (or the tag
-     * path's own `default` handling) overrides the global result. This mirrors the resolution
-     * expression the per-root schema layering design specifies for the type step.
+     * This intentionally means a per-root `"default"` schema wins over a global *exact* type match:
+     * once a root has pushed its own config, that config is treated as the root's complete
+     * self-description for gate purposes, not a patch over the global floor. A project that wants
+     * zero required notes for every item type can push a per-root config with an empty default
+     * schema (`work_item_schemas: { default: { notes: [] } } }`) to fence off the global config
+     * entirely — see `config-format.md` for the schema-free / non-dev project pattern.
      *
      * Note length limits ([NoteSchemaService.getNoteLimitsMode]) and anything else not exposed by
      * [PerRootConfigService] stay global-only — [PerRootConfigService] does not expose them.
      *
      * Resolution order (unchanged from before layering, now with the per-root prefix above):
-     * 1. If the item has a `type`, look up the schema by type via [NoteSchemaService.getSchemaForType].
-     * 2. If no type or no type-based schema found, look up by tags via [NoteSchemaService.getSchemaForTags]
+     * 1. If the item has a `type`, look up the schema by type (per-root layer first, see table above).
+     * 2. If no type or no type-based schema found, look up by tags (per-root layer first, see table above)
      *    (first matching tag wins; falls back to default schema if no tag matches).
      * 3. Returns null if no schema matches (schema-free mode).
      *
@@ -136,6 +135,26 @@ class ToolExecutionContext(
     suspend fun resolveHasReviewPhase(item: WorkItem): Boolean = resolveSchema(item)?.hasReviewPhase() ?: false
 
     /**
+     * Returns the union of trait names available for the given [rootIds], per-root traits first
+     * (in [rootIds] iteration order), followed by the global trait list — deduplicated, preserving
+     * first-seen order. Used by response hints (e.g. `availableTraits` on item creation) so callers
+     * discover per-root traits alongside the global ones without a separate lookup.
+     *
+     * Roots with no pushed config (or no [perRootConfigService] wired at all) contribute nothing —
+     * this degrades to the plain global trait list, unchanged from before this method existed.
+     */
+    suspend fun availableTraits(rootIds: Collection<UUID>): List<String> {
+        val perRoot = perRootConfigService
+        val perRootTraits =
+            if (perRoot != null) {
+                rootIds.flatMap { rootId -> perRoot.getAllTraits(rootId)?.keys.orEmpty() }
+            } else {
+                emptyList()
+            }
+        return (perRootTraits + noteSchemaService().getAvailableTraits()).distinct()
+    }
+
+    /**
      * Resolves the base schema without trait merging. Type-first lookup with tag fallback, each
      * layered per-root-then-global — see [resolveSchema]'s KDoc for the full fallback table.
      */
@@ -146,10 +165,18 @@ class ToolExecutionContext(
         val rootId = item.rootId
         val perRoot = perRootConfigService
 
-        // Type-first lookup: an exact per-root type match wins; otherwise defer entirely to the
-        // global lookup (which has its own type -> "default" fallback — see class KDoc above).
+        // Type-first lookup: whole-algorithm-first per layer. Run the ENTIRE per-root layer
+        // (exact type match, then per-root "default") before ever consulting the global layer.
+        // Only when neither per-root key matches (no config row for this root, or a row with
+        // neither the exact type nor "default" defined) do we fall through to the global lookup
+        // (which has its own type -> "default" fallback — see class KDoc above).
         item.type?.let { type ->
-            val perRootMatch = if (rootId != null && perRoot != null) perRoot.getSchemaForType(rootId, type) else null
+            val perRootMatch =
+                if (rootId != null && perRoot != null) {
+                    perRoot.getSchemaForType(rootId, type) ?: perRoot.getSchemaForType(rootId, "default")
+                } else {
+                    null
+                }
             (perRootMatch ?: service.getSchemaForType(type))?.let { return it }
         }
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigTool.kt
@@ -93,6 +93,19 @@ not-found error when no config has been pushed for it.
                             )
                         }
                     )
+                    put(
+                        "force",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("boolean"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "push only, default false: bypass push guards — currently skips the " +
+                                        "embedded project.rootId mismatch check"
+                                )
+                            )
+                        }
+                    )
                 },
             required = listOf("operation", "rootItemId")
         )
@@ -146,9 +159,10 @@ not-found error when no config has been pushed for it.
         val (rootItemId, idError) = resolveItemId(params, "rootItemId", context)
         if (idError != null) return idError
         val configYaml = requireString(params, "configYaml")
+        val force = optionalBoolean(params, "force")
 
         val service = ProjectConfigPushService(context.repositoryProvider)
-        return when (val result = service.push(rootItemId!!, configYaml)) {
+        return when (val result = service.push(rootItemId!!, configYaml, force)) {
             is ProjectConfigPushResult.Success ->
                 successResponse(
                     buildJsonObject {
@@ -179,6 +193,13 @@ not-found error when no config has been pushed for it.
                     "configYaml failed to parse: ${result.detail}",
                     ErrorCodes.VALIDATION_ERROR,
                     details = result.detail
+                )
+            is ProjectConfigPushResult.RootIdMismatch ->
+                errorResponse(
+                    "configYaml embeds project.rootId '${result.embeddedRootId}', which differs from " +
+                        "the target rootItemId '${result.targetRootId}'; fix project.rootId in the " +
+                        "document or pass force: true to push anyway",
+                    ErrorCodes.VALIDATION_ERROR
                 )
             is ProjectConfigPushResult.RepositoryError ->
                 errorResponse(

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigTool.kt
@@ -260,16 +260,7 @@ the root's stored fingerprint history.
                         "No project config found for root: $rootItemId",
                         ErrorCodes.RESOURCE_NOT_FOUND
                     )
-                val relation =
-                    fingerprint?.let {
-                        when (
-                            val relationResult =
-                                context.repositoryProvider.projectConfigRepository().classifyFingerprint(rootItemId, it)
-                        ) {
-                            is Result.Success -> relationResult.data.name.lowercase()
-                            is Result.Error -> null
-                        }
-                    }
+                val relation = fingerprint?.let { service.classifyRelation(rootItemId, it) }
                 successResponse(
                     buildJsonObject {
                         put("rootItemId", JsonPrimitive(config.rootItemId.toString()))

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigTool.kt
@@ -43,7 +43,10 @@ known-old (present in the root's fingerprint history but not current) is rejecte
 `CONFLICT_ERROR` naming force as the override, unless `force: true` is passed — this guards against
 silently reverting a later push made from elsewhere. Pushing byte-identical content is naturally
 idempotent: the returned `fingerprint` is unchanged, so callers can `get` first and skip the push
-when fingerprints match.
+when fingerprints match. A pushed document may set `note_limits`/`status_labels` to override the
+global config for this root's items alongside `work_item_schemas`/`note_schemas`/`traits`/`project`;
+any other top-level key (e.g. `actor_authentication`, which stays global-only) is reported back in
+an additive `ignoredSections` array, present only when non-empty.
 
 **get** — returns the stored `configYaml` + `fingerprint` + `updatedAt` for a root, or a
 not-found error when no config has been pushed for it. When `fingerprint` is supplied, the response
@@ -189,6 +192,9 @@ the root's stored fingerprint history.
                         put("fingerprint", JsonPrimitive(result.fingerprint))
                         put("updatedAt", JsonPrimitive(result.updatedAt.toString()))
                         result.warning?.let { put("warning", JsonPrimitive(it)) }
+                        if (result.ignoredSections.isNotEmpty()) {
+                            put("ignoredSections", JsonArray(result.ignoredSections.map { JsonPrimitive(it) }))
+                        }
                     }
                 )
             is ProjectConfigPushResult.NotFound ->

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigTool.kt
@@ -38,12 +38,17 @@ otherwise); if the root's `type` is not "project", the response includes a non-f
 parse-validated BEFORE storing, using a safe YAML constructor that only builds plain maps/lists/
 scalars (arbitrary `!!`-tagged Java type construction is rejected, not silently ignored) —
 unparseable or unsafe YAML is rejected with the parse error and never written, so a broken or
-malicious config can never silently exist server-side. Pushing byte-identical content is naturally
+malicious config can never silently exist server-side. A `configYaml` whose fingerprint is
+known-old (present in the root's fingerprint history but not current) is rejected as a
+`CONFLICT_ERROR` naming force as the override, unless `force: true` is passed — this guards against
+silently reverting a later push made from elsewhere. Pushing byte-identical content is naturally
 idempotent: the returned `fingerprint` is unchanged, so callers can `get` first and skip the push
 when fingerprints match.
 
 **get** — returns the stored `configYaml` + `fingerprint` + `updatedAt` for a root, or a
-not-found error when no config has been pushed for it.
+not-found error when no config has been pushed for it. When `fingerprint` is supplied, the response
+also includes a `relation` field ("current"/"superseded"/"unknown") classifying that value against
+the root's stored fingerprint history.
         """.trimIndent()
 
     override val category = ToolCategory.SYSTEM
@@ -100,8 +105,22 @@ not-found error when no config has been pushed for it.
                             put(
                                 "description",
                                 JsonPrimitive(
-                                    "push only, default false: bypass push guards — currently skips the " +
-                                        "embedded project.rootId mismatch check"
+                                    "push only, default false: bypass push guards — skips the embedded " +
+                                        "project.rootId mismatch check and the known-old (fast-forward) " +
+                                        "fingerprint guard"
+                                )
+                            )
+                        }
+                    )
+                    put(
+                        "fingerprint",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "get only: SHA-256 hex digest to classify against the stored config's " +
+                                        "current fingerprint and history; adds a relation field to the response"
                                 )
                             )
                         }
@@ -201,6 +220,12 @@ not-found error when no config has been pushed for it.
                         "document or pass force: true to push anyway",
                     ErrorCodes.VALIDATION_ERROR
                 )
+            is ProjectConfigPushResult.Superseded ->
+                errorResponse(
+                    "local config is older than the server's (updated ${result.currentUpdatedAt}); " +
+                        "pull or copy back before editing, or pass force: true to overwrite anyway",
+                    ErrorCodes.CONFLICT_ERROR
+                )
             is ProjectConfigPushResult.RepositoryError ->
                 errorResponse(
                     "Failed to store project config: ${result.message}",
@@ -219,6 +244,7 @@ not-found error when no config has been pushed for it.
     ): JsonElement {
         val (rootItemId, idError) = resolveItemId(params, "rootItemId", context)
         if (idError != null) return idError
+        val fingerprint = optionalString(params, "fingerprint")
 
         val service = ProjectConfigPushService(context.repositoryProvider)
         return when (val result = service.get(rootItemId!!)) {
@@ -228,12 +254,23 @@ not-found error when no config has been pushed for it.
                         "No project config found for root: $rootItemId",
                         ErrorCodes.RESOURCE_NOT_FOUND
                     )
+                val relation =
+                    fingerprint?.let {
+                        when (
+                            val relationResult =
+                                context.repositoryProvider.projectConfigRepository().classifyFingerprint(rootItemId, it)
+                        ) {
+                            is Result.Success -> relationResult.data.name.lowercase()
+                            is Result.Error -> null
+                        }
+                    }
                 successResponse(
                     buildJsonObject {
                         put("rootItemId", JsonPrimitive(config.rootItemId.toString()))
                         put("configYaml", JsonPrimitive(config.configYaml))
                         put("fingerprint", JsonPrimitive(config.fingerprint))
                         put("updatedAt", JsonPrimitive(config.updatedAt.toString()))
+                        relation?.let { put("relation", JsonPrimitive(it)) }
                     }
                 )
             }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/CreateItemHandler.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/CreateItemHandler.kt
@@ -42,6 +42,7 @@ class CreateItemHandler(
 
         val createdItems = mutableListOf<JsonObject>()
         val failures = mutableListOf<JsonObject>()
+        val createdRootIds = mutableSetOf<UUID>()
 
         for ((index, element) in items.withIndex()) {
             try {
@@ -151,6 +152,7 @@ class CreateItemHandler(
 
                 when (val result = repo.create(workItem)) {
                     is Result.Success -> {
+                        result.data.rootId?.let { createdRootIds.add(it) }
                         val createdTags = result.data.tags
                         val resolvedSchema = context.resolveSchema(result.data)
                         val schemaFields = buildSchemaResponseFields(resolvedSchema)
@@ -198,7 +200,7 @@ class CreateItemHandler(
             }
         }
 
-        val availableTraits = context.noteSchemaService().getAvailableTraits()
+        val availableTraits = context.availableTraits(createdRootIds)
         val data =
             buildJsonObject {
                 put("items", JsonArray(createdItems))

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
@@ -6,7 +6,6 @@ import io.github.jpicklyk.mcptask.current.application.tools.*
 import io.github.jpicklyk.mcptask.current.domain.model.Priority
 import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
-import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteWorkItemRepository
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.SearchMatchMode
@@ -411,6 +410,22 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
                             put("enum", JsonArray(listOf("claimed", "unclaimed", "expired").map { JsonPrimitive(it) }))
                         }
                     )
+                    put(
+                        "rootId",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "schema operation with `type` only: project root WorkItem UUID or hex prefix " +
+                                        "(4+ chars). Resolves `type` against that root's per-root config first (per-root " +
+                                        "exact type -> per-root \"default\" -> global exact type -> global \"default\"), " +
+                                        "falling back to global-only behavior when the root has no pushed config. Ignored " +
+                                        "when `itemId` is used instead (the item's own rootId is applied automatically)."
+                                )
+                            )
+                        }
+                    )
                 },
             required = listOf("operation")
         )
@@ -462,6 +477,7 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
                 if (itemIdStr != null) {
                     validateIdOrPrefix(params, "itemId")
                 }
+                validateIdOrPrefix(params, "rootId", required = false)
             }
             else -> throw ToolValidationException("Invalid operation: $operation. Must be one of: get, search, overview, schema")
         }
@@ -586,12 +602,16 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
      * work-item type or a specific item. This is the reference target for the keys-only
      * `expectedNotes` and `guidanceKey` fields emitted elsewhere.
      *
-     * - `type`: direct lookup via [NoteSchemaService.getSchemaForType] (base schema as configured;
-     *   no per-item trait merging since there is no item).
+     * - `type` (+ optional `rootId`): resolved via [ToolExecutionContext.resolveTypeSchema] — when
+     *   `rootId` is given, that root's per-root config is consulted first (same precedence as the
+     *   `itemId` path), falling back to the global lookup; without `rootId`, behavior is unchanged
+     *   (global-only, no per-item trait merging since there is no item).
      * - `itemId`: resolves the item, then uses the standard resolution logic
-     *   ([ToolExecutionContext.resolveSchema]: type-first, tag fallback, trait merging).
+     *   ([ToolExecutionContext.resolveSchemaWithSource]: type-first, tag fallback, trait merging,
+     *   layered per-root-then-global using the item's own `rootId`).
      *
-     * Response: `{ type, configFingerprint, notes: [{key, role, required, description, guidance?, skill?, maxLength?}] }`.
+     * Response: `{ type, configFingerprint, configSource, notes: [{key, role, required, description, guidance?, skill?, maxLength?}] }`.
+     * `configSource` is `"per-root"` when the schema's base layer was the per-root config, `"global"` otherwise.
      */
     private suspend fun executeSchema(
         params: JsonElement,
@@ -599,9 +619,11 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
     ): JsonElement {
         val typeParam = optionalString(params, "type")
 
-        val schema: WorkItemSchema? =
+        val resolved: ResolvedSchema? =
             if (typeParam != null) {
-                context.noteSchemaService().getSchemaForType(typeParam)
+                val (rootId, rootIdError) = resolveItemId(params, "rootId", context, required = false)
+                if (rootIdError != null) return rootIdError
+                context.resolveTypeSchema(typeParam, rootId)
             } else {
                 val (resolvedId, idError) = resolveItemId(params, "itemId", context)
                 if (idError != null) return idError
@@ -613,19 +635,20 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
                             ErrorCodes.RESOURCE_NOT_FOUND
                         )
                     }
-                context.resolveSchema(item)
+                context.resolveSchemaWithSource(item)
             }
 
-        if (schema == null) {
+        if (resolved == null) {
             val subject = if (typeParam != null) "type '$typeParam'" else "item (schema-free mode)"
             return errorResponse("No schema found for $subject", ErrorCodes.RESOURCE_NOT_FOUND)
         }
 
-        val fingerprint = context.noteSchemaService().getConfigFingerprint()
+        val (schema, source, fingerprint) = resolved
         val data =
             buildJsonObject {
                 put("type", JsonPrimitive(schema.type))
                 put("configFingerprint", if (fingerprint != null) JsonPrimitive(fingerprint) else JsonNull)
+                put("configSource", JsonPrimitive(if (source == SchemaSource.PER_ROOT) "per-root" else "global"))
                 put("notes", buildFullSchemaEntriesJson(schema.notes))
             }
         return successResponse(data)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesTool.kt
@@ -355,7 +355,8 @@ field naming the limit and actual size; `mode: reject` fails that note with `cod
                         ?.maxLength
                 if (maxLength != null && body.length > maxLength) {
                     val detail = "body length ${body.length} exceeds maxLength $maxLength for key '$key'"
-                    if (context.noteSchemaService().getNoteLimitsMode() == "reject") {
+                    val effectiveNoteLimitsMode = context.resolveNoteLimitsMode(validatedItems.getValue(itemId).rootId)
+                    if (effectiveNoteLimitsMode == "reject") {
                         failures.add(
                             buildJsonObject {
                                 put("index", JsonPrimitive(index))

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -340,7 +340,7 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                     roleTransitionRepository = context.roleTransitionRepository(),
                     dependencyRepository = context.dependencyRepository(),
                     noteRepository = context.noteRepository(),
-                    statusLabelService = resolveRootAwareStatusLabelService(context, item.rootId),
+                    statusLabelService = resolveRootAwareStatusLabelService(context, item.rootId, trigger),
                     schemaResolver = { context.resolveSchema(it) }
                 )
 
@@ -550,24 +550,37 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                 )
         }
 
+    // Divergence note (pre-existing, tracked as backlog): REST transitions
+    // (ItemWriteRoutes' advance route) construct their AdvanceService with a NoOpStatusLabelService
+    // and do NOT apply status labels at all — including this per-root layer. Only the MCP path
+    // below resolves and applies status labels. Not addressed here; out of scope for this pass.
+
     /**
      * Builds a [StatusLabelService] bound to a single item's [rootId], for handing to [AdvanceService]
      * (whose constructor takes a plain, non-suspending [StatusLabelService] and has no rootId
      * awareness of its own — see `docs: AdvanceService.kt` is out of this task's scope). Since
      * [StatusLabelService.resolveLabel] is synchronous, the per-root layering
-     * ([ToolExecutionContext.resolveStatusLabel]) must run to completion for every trigger
-     * [AdvanceService] might ask about BEFORE this method returns; the resulting map is then served
-     * from a trivial synchronous lookup.
+     * ([ToolExecutionContext.resolveStatusLabels]) must run to completion BEFORE this method
+     * returns; the resulting map is then served from a trivial synchronous lookup.
      *
-     * Covers every [UserTrigger] plus the system-internal "cascade" trigger (used by
-     * [AdvanceService]'s cascade-apply paths, which are not reachable through the public
-     * `advance_item` trigger parameter — see [UserTrigger]'s KDoc).
+     * Resolves only the trigger set [AdvanceService.advance] can actually consult for a single
+     * advance call: the primary [trigger] itself (passed unconditionally to
+     * `statusLabelService.resolveLabel(trigger)` for the primary transition) plus the
+     * system-internal `"cascade"` trigger (consulted only when a cascade is detected and applied —
+     * see `AdvanceService.detectAndApplyTerminalCascades`/`applyCascadeEvents`). No other
+     * [UserTrigger] value is ever looked up during a single call, so precomputing the full 8-trigger
+     * set (every [UserTrigger] plus `"cascade"`) — as this used to do — resolved 6 triggers that
+     * could never be consulted. [ToolExecutionContext.resolveStatusLabels] additionally collapses
+     * this 2-element (or 1-element, when [trigger] happens to be `"cascade"`) resolution into a
+     * SINGLE per-root snapshot fetch rather than one per trigger.
      */
     private suspend fun resolveRootAwareStatusLabelService(
         context: ToolExecutionContext,
-        rootId: UUID?
+        rootId: UUID?,
+        trigger: String
     ): StatusLabelService {
-        val resolved = KNOWN_STATUS_LABEL_TRIGGERS.associateWith { trigger -> context.resolveStatusLabel(trigger, rootId) }
+        val consultedTriggers = setOf(trigger, "cascade")
+        val resolved = context.resolveStatusLabels(consultedTriggers, rootId)
         return object : StatusLabelService {
             override fun resolveLabel(trigger: String): String? = resolved[trigger]
         }
@@ -613,14 +626,4 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
             put("errorCode", JsonPrimitive(toolError.code))
             toolError.contendedItemId?.let { put("contendedItemId", JsonPrimitive(it.toString())) }
         }
-
-    companion object {
-        /**
-         * Every trigger [AdvanceService] may pass to [StatusLabelService.resolveLabel]: all public
-         * [UserTrigger] values, plus the system-internal "cascade" trigger used by cascade-apply
-         * paths. Used by [resolveRootAwareStatusLabelService] to precompute a complete per-item
-         * label map up front.
-         */
-        private val KNOWN_STATUS_LABEL_TRIGGERS = UserTrigger.entries.map { it.triggerString } + "cascade"
-    }
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -3,6 +3,7 @@ package io.github.jpicklyk.mcptask.current.application.tools.workflow
 import io.github.jpicklyk.mcptask.current.application.service.AdvanceFailure
 import io.github.jpicklyk.mcptask.current.application.service.AdvanceOutcome
 import io.github.jpicklyk.mcptask.current.application.service.AdvanceService
+import io.github.jpicklyk.mcptask.current.application.service.StatusLabelService
 import io.github.jpicklyk.mcptask.current.application.service.buildExpectedNotesJson
 import io.github.jpicklyk.mcptask.current.application.service.computePhaseNoteContext
 import io.github.jpicklyk.mcptask.current.application.tools.*
@@ -246,18 +247,6 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
         transitions: JsonArray,
         context: ToolExecutionContext
     ): JsonElement {
-        // Shared advance pipeline (ownership → resolve → validate → gate → apply → cascade → unblock).
-        // MCP enforces claim ownership (enforceOwnership = true); the REST route passes false.
-        val advanceService =
-            AdvanceService(
-                workItemRepository = context.workItemRepository(),
-                roleTransitionRepository = context.roleTransitionRepository(),
-                dependencyRepository = context.dependencyRepository(),
-                noteRepository = context.noteRepository(),
-                statusLabelService = context.statusLabelService(),
-                schemaResolver = { context.resolveSchema(it) }
-            )
-
         val resultsList = mutableListOf<JsonObject>()
         var successCount = 0
         var failCount = 0
@@ -340,8 +329,22 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                     }
                 }
 
-            // Delegate the full pipeline (ownership → resolve → validate → gate → apply → cascade →
-            // unblock) to the shared AdvanceService. MCP enforces claim ownership.
+            // Shared advance pipeline (ownership → resolve → validate → gate → apply → cascade →
+            // unblock). Built per-item (not once for the whole batch) because statusLabelService
+            // must be bound to THIS item's rootId — a batch can mix items from different roots, each
+            // with its own per-root status_labels override (see resolveRootAwareStatusLabelService).
+            // MCP enforces claim ownership (enforceOwnership = true); the REST route passes false.
+            val advanceService =
+                AdvanceService(
+                    workItemRepository = context.workItemRepository(),
+                    roleTransitionRepository = context.roleTransitionRepository(),
+                    dependencyRepository = context.dependencyRepository(),
+                    noteRepository = context.noteRepository(),
+                    statusLabelService = resolveRootAwareStatusLabelService(context, item.rootId),
+                    schemaResolver = { context.resolveSchema(it) }
+                )
+
+            // Delegate the full pipeline to the per-item AdvanceService above.
             val outcome =
                 advanceService.advance(
                     item = item,
@@ -547,6 +550,29 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                 )
         }
 
+    /**
+     * Builds a [StatusLabelService] bound to a single item's [rootId], for handing to [AdvanceService]
+     * (whose constructor takes a plain, non-suspending [StatusLabelService] and has no rootId
+     * awareness of its own — see `docs: AdvanceService.kt` is out of this task's scope). Since
+     * [StatusLabelService.resolveLabel] is synchronous, the per-root layering
+     * ([ToolExecutionContext.resolveStatusLabel]) must run to completion for every trigger
+     * [AdvanceService] might ask about BEFORE this method returns; the resulting map is then served
+     * from a trivial synchronous lookup.
+     *
+     * Covers every [UserTrigger] plus the system-internal "cascade" trigger (used by
+     * [AdvanceService]'s cascade-apply paths, which are not reachable through the public
+     * `advance_item` trigger parameter — see [UserTrigger]'s KDoc).
+     */
+    private suspend fun resolveRootAwareStatusLabelService(
+        context: ToolExecutionContext,
+        rootId: UUID?
+    ): StatusLabelService {
+        val resolved = KNOWN_STATUS_LABEL_TRIGGERS.associateWith { trigger -> context.resolveStatusLabel(trigger, rootId) }
+        return object : StatusLabelService {
+            override fun resolveLabel(trigger: String): String? = resolved[trigger]
+        }
+    }
+
     private fun buildErrorResult(
         itemId: UUID,
         trigger: String,
@@ -587,4 +613,14 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
             put("errorCode", JsonPrimitive(toolError.code))
             toolError.contendedItemId?.let { put("contendedItemId", JsonPrimitive(it.toString())) }
         }
+
+    companion object {
+        /**
+         * Every trigger [AdvanceService] may pass to [StatusLabelService.resolveLabel]: all public
+         * [UserTrigger] values, plus the system-internal "cascade" trigger used by cascade-apply
+         * paths. Used by [resolveRootAwareStatusLabelService] to precompute a complete per-item
+         * label map up front.
+         */
+        private val KNOWN_STATUS_LABEL_TRIGGERS = UserTrigger.entries.map { it.triggerString } + "cascade"
+    }
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/FingerprintRelation.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/FingerprintRelation.kt
@@ -1,0 +1,27 @@
+package io.github.jpicklyk.mcptask.current.domain.model
+
+/**
+ * Classifies a caller-supplied fingerprint against a root's stored [ProjectConfig] state — the
+ * fast-forward push guard's core signal. Computed by
+ * [io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository.classifyFingerprint]
+ * and consumed by [io.github.jpicklyk.mcptask.current.application.service.ProjectConfigPushService.push]
+ * (rejects a push classified [SUPERSEDED] unless `force: true`) and surfaced read-side by
+ * `GET /roots/{rootId}/config?fingerprint=...` and the MCP `manage_project_config` `get` operation.
+ */
+enum class FingerprintRelation {
+    /** Matches the root's current stored fingerprint — the caller's local copy is up to date. */
+    CURRENT,
+
+    /**
+     * Present in the root's fingerprint history but not current — the caller's local copy predates
+     * a later push made from elsewhere. Pushing it would silently revert that later change.
+     */
+    SUPERSEDED,
+
+    /**
+     * Neither current nor found in history: no config row exists yet for the root, the row's
+     * history is NULL (a pre-V11 row, or the root's very first push), or the fingerprint simply has
+     * no relation on record (e.g. a divergent edit). Treated as safe to push, not blocked.
+     */
+    UNKNOWN
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/ProjectConfigRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/ProjectConfigRepository.kt
@@ -1,5 +1,6 @@
 package io.github.jpicklyk.mcptask.current.domain.repository
 
+import io.github.jpicklyk.mcptask.current.domain.model.FingerprintRelation
 import io.github.jpicklyk.mcptask.current.domain.model.ProjectConfig
 import java.util.UUID
 
@@ -36,4 +37,25 @@ interface ProjectConfigRepository {
 
     /** Deletes the config row for [rootItemId], if any. Returns true if a row was deleted. */
     suspend fun delete(rootItemId: UUID): Result<Boolean>
+
+    /**
+     * Computes the SHA-256 fingerprint of [configYaml] — the exact algorithm [upsert] uses when
+     * persisting. Exposed as a pure, non-persisting method so callers (notably
+     * [io.github.jpicklyk.mcptask.current.application.service.ProjectConfigPushService.push]'s
+     * fast-forward guard) can classify an incoming payload's fingerprint against the stored state
+     * BEFORE deciding whether to write it, without duplicating the hash algorithm.
+     */
+    fun computeFingerprint(configYaml: String): String
+
+    /**
+     * Classifies [fingerprint] against [rootItemId]'s stored current fingerprint and fingerprint
+     * history — see [FingerprintRelation] for the three outcomes. A NULL/absent history (a
+     * pre-V11 row, or no row at all for [rootItemId]) classifies any non-current fingerprint as
+     * [FingerprintRelation.UNKNOWN] — identical to pre-history behavior until history accumulates
+     * on subsequent [upsert] calls.
+     */
+    suspend fun classifyFingerprint(
+        rootItemId: UUID,
+        fingerprint: String
+    ): Result<FingerprintRelation>
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigService.kt
@@ -77,6 +77,19 @@ class PerRootConfigService(
     suspend fun getAllTraits(rootItemId: UUID): Map<String, List<NoteSchemaEntry>>? = resolve(rootItemId)?.traits
 
     /**
+     * Returns the cached config fingerprint for [rootItemId], or null when no config row exists or
+     * it fails to parse. Goes through [resolve]'s normal fingerprint-check hot-reload path first
+     * (so this never returns a stale fingerprint after a concurrent push) — callers needing to
+     * report which config version supplied a resolved schema (e.g. `query_items`'s `schema`
+     * operation) should call this immediately after a [getSchemaForType]/[getSchemas] lookup that
+     * resolved from this root's per-root layer.
+     */
+    suspend fun getFingerprint(rootItemId: UUID): String? {
+        resolve(rootItemId) ?: return null
+        return cache[rootItemId]?.fingerprint
+    }
+
+    /**
      * Returns the parsed config for [rootItemId], reusing the cached parse when the DB
      * fingerprint hasn't changed since it was cached. Returns null when there is no config row
      * for this root, or the stored YAML fails to parse (see class doc — failures fall through to

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigService.kt
@@ -58,6 +58,42 @@ class PerRootConfigService(
     /** In-memory cache keyed by root item UUID. Populated lazily on first [resolve] per root. */
     private val cache = ConcurrentHashMap<UUID, CacheEntry>()
 
+    /**
+     * A single-pass, single-root view combining every per-root config facet a caller might need
+     * (schemas, traits, note-limits mode, status labels) plus the fingerprint it was resolved
+     * against — everything [resolve] already parses in one pass, bundled instead of split across
+     * the individual accessor methods below. Callers needing several of these facets for the same
+     * [rootItemId] (e.g. [io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext])
+     * should call [getSnapshot] once and read the fields locally, instead of calling the
+     * single-facet accessors once each — each of those independently re-invokes [resolve], which
+     * costs at least one fingerprint-only DB read apiece even when the cache is warm.
+     */
+    data class Snapshot(
+        val workItemSchemas: Map<String, WorkItemSchema>,
+        val traits: Map<String, List<NoteSchemaEntry>>,
+        val noteLimitsModeExplicit: String?,
+        val statusLabels: Map<String, String?>?,
+        val fingerprint: String
+    )
+
+    /**
+     * Returns a [Snapshot] of every per-root config facet for [rootItemId] from a SINGLE [resolve]
+     * pass, or null under the same conditions as every other accessor on this class: no config row
+     * for [rootItemId], or the stored YAML fails to parse (see class doc — failures fall through to
+     * the global loader rather than throwing).
+     */
+    suspend fun getSnapshot(rootItemId: UUID): Snapshot? {
+        val parsed = resolve(rootItemId) ?: return null
+        val fingerprint = cache[rootItemId]?.fingerprint ?: return null
+        return Snapshot(
+            workItemSchemas = parsed.workItemSchemas,
+            traits = parsed.traits,
+            noteLimitsModeExplicit = parsed.noteLimitsModeExplicit,
+            statusLabels = parsed.statusLabels,
+            fingerprint = fingerprint
+        )
+    }
+
     /** Returns the resolved `work_item_schemas` map for [rootItemId], or null when no config row exists or it fails to parse. */
     suspend fun getSchemas(rootItemId: UUID): Map<String, WorkItemSchema>? = resolve(rootItemId)?.workItemSchemas
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigService.kt
@@ -90,6 +90,26 @@ class PerRootConfigService(
     }
 
     /**
+     * Returns [rootItemId]'s explicitly-configured `note_limits.mode`, or null when there is no
+     * config row for this root, the row fails to parse, or the row's document has no top-level
+     * `note_limits` key at all — see [YamlSchemaParser.ParsedConfig.noteLimitsModeExplicit] for the
+     * absent-vs-explicit distinction this preserves. Callers (see
+     * [io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext.resolveNoteLimitsMode])
+     * treat a null return as "fall through to the global note-limits mode", not as "warn".
+     */
+    suspend fun getNoteLimitsMode(rootItemId: UUID): String? = resolve(rootItemId)?.noteLimitsModeExplicit
+
+    /**
+     * Returns [rootItemId]'s explicitly-configured `status_labels` trigger→label map, or null when
+     * there is no config row for this root, the row fails to parse, or the row's document has no
+     * top-level `status_labels` key at all. A non-null return may still be a PARTIAL map — see
+     * [YamlSchemaParser.ParsedConfig.statusLabels] — callers fall through to the global status label
+     * service on a per-trigger basis when a trigger key is absent from this map (see
+     * [io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext.resolveStatusLabel]).
+     */
+    suspend fun getStatusLabels(rootItemId: UUID): Map<String, String?>? = resolve(rootItemId)?.statusLabels
+
+    /**
      * Returns the parsed config for [rootItemId], reusing the cached parse when the DB
      * fingerprint hasn't changed since it was cached. Returns null when there is no config row
      * for this root, or the stored YAML fails to parse (see class doc — failures fall through to

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt
@@ -3,13 +3,13 @@ package io.github.jpicklyk.mcptask.current.infrastructure.config
 import io.github.jpicklyk.mcptask.current.application.service.WorkItemSchemaService
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
+import io.github.jpicklyk.mcptask.current.infrastructure.security.sha256Hex
 import org.slf4j.LoggerFactory
 import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.SafeConstructor
 import java.io.FileReader
 import java.nio.file.Paths
-import java.security.MessageDigest
 
 /**
  * YAML-backed implementation of [WorkItemSchemaService].
@@ -111,9 +111,7 @@ class YamlWorkItemSchemaService(
         val file = configPath.toFile()
         if (!file.exists()) return null
         return try {
-            val bytes = file.readBytes()
-            val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
-            digest.joinToString("") { "%02x".format(it) }
+            sha256Hex(file.readBytes())
         } catch (
             @Suppress("TooGenericExceptionCaught") e: Exception
         ) {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlSchemaParser.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlSchemaParser.kt
@@ -43,12 +43,28 @@ internal object YamlSchemaParser {
      * note-limits mode. Per-tag note lists are read via `workItemSchemas[tag]?.notes` — there is no
      * separate tag→entries map, since it would be a redundant view of the same `NoteSchemaEntry`
      * lists already held inside each [WorkItemSchema].
+     *
+     * @property noteLimitsMode always resolves to a mode ("warn" default) — unchanged behavior for
+     *   the global file-backed loader, which has no fallback layer beneath it.
+     * @property noteLimitsModeExplicit null when the document has no top-level `note_limits` key at
+     *   all; otherwise the resolved mode (same value as [noteLimitsMode]). Callers that layer this
+     *   config over another (e.g. [PerRootConfigService]) use this field to distinguish "this
+     *   document doesn't opine on note limits, fall through" from "this document explicitly
+     *   configures note limits" — a plain [noteLimitsMode] read can't make that distinction because
+     *   it always defaults to "warn" when the key is absent.
+     * @property statusLabels null when the document has no top-level `status_labels` key at all;
+     *   otherwise the parsed trigger→label map (values may themselves be null, mirroring
+     *   [io.github.jpicklyk.mcptask.current.infrastructure.config.YamlStatusLabelService]'s
+     *   "explicit null clears the label" semantics — only an ABSENT key in this map falls through to
+     *   another layer).
      */
     data class ParsedConfig(
         val workItemSchemas: Map<String, WorkItemSchema>,
         val traits: Map<String, List<NoteSchemaEntry>>,
         val warnings: List<String>,
-        val noteLimitsMode: String = DEFAULT_NOTE_LIMITS_MODE
+        val noteLimitsMode: String = DEFAULT_NOTE_LIMITS_MODE,
+        val noteLimitsModeExplicit: String? = null,
+        val statusLabels: Map<String, String?>? = null
     )
 
     /**
@@ -70,6 +86,8 @@ internal object YamlSchemaParser {
         val warnings = mutableListOf<String>()
         val parsedTraits = parseTraits(root, warnings)
         val parsedNoteLimitsMode = parseNoteLimitsMode(root, warnings)
+        val noteLimitsModeExplicit = if (root.containsKey("note_limits")) parsedNoteLimitsMode else null
+        val parsedStatusLabels = parseStatusLabels(root, warnings)
 
         val base =
             when {
@@ -83,7 +101,13 @@ internal object YamlSchemaParser {
                 }
             }
 
-        return base.copy(traits = parsedTraits, warnings = warnings, noteLimitsMode = parsedNoteLimitsMode)
+        return base.copy(
+            traits = parsedTraits,
+            warnings = warnings,
+            noteLimitsMode = parsedNoteLimitsMode,
+            noteLimitsModeExplicit = noteLimitsModeExplicit,
+            statusLabels = parsedStatusLabels
+        )
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -269,5 +293,29 @@ internal object YamlSchemaParser {
             return DEFAULT_NOTE_LIMITS_MODE
         }
         return modeRaw
+    }
+
+    /**
+     * Parses the top-level `status_labels` key into a trigger→label map, mirroring
+     * [io.github.jpicklyk.mcptask.current.infrastructure.config.YamlStatusLabelService]'s reading of
+     * the same key from the global file: each value is coerced to a string via `toString()` (YAML
+     * `null` survives as a Kotlin `null`, meaning "explicitly no label for this trigger").
+     *
+     * Returns null when the document has no `status_labels` key at all (see [ParsedConfig.statusLabels]
+     * for what callers do with that distinction), or when the key is present but not a map (a
+     * malformed section is treated the same as "absent", with a warning).
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun parseStatusLabels(
+        root: Map<String, Any>,
+        warnings: MutableList<String>
+    ): Map<String, String?>? {
+        if (!root.containsKey("status_labels")) return null
+        val raw = root["status_labels"] as? Map<String, Any?>
+        if (raw == null) {
+            warnings.add("status_labels section is not a map; ignoring")
+            return null
+        }
+        return raw.entries.associate { (trigger, label) -> trigger to label?.toString() }
     }
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/ProjectConfigTable.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/ProjectConfigTable.kt
@@ -19,6 +19,15 @@ object ProjectConfigTable : UUIDTable("project_config") {
     val fingerprint = text("fingerprint")
     val updatedAt = timestamp("updated_at")
 
+    /**
+     * JSON array of prior fingerprints for this root (newest first, pruned to 20 by
+     * [io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteProjectConfigRepository.upsert]).
+     * Nullable — pre-V11 rows and a root's first push both have no history yet; NULL is treated as
+     * "no known ancestors" by
+     * [io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteProjectConfigRepository.classifyFingerprint].
+     */
+    val fingerprintHistory = text("fingerprint_history").nullable()
+
     init {
         foreignKey(rootItemId to WorkItemsTable.id, onDelete = ReferenceOption.CASCADE)
         uniqueIndex(rootItemId)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteProjectConfigRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteProjectConfigRepository.kt
@@ -1,10 +1,12 @@
 package io.github.jpicklyk.mcptask.current.infrastructure.repository
 
+import io.github.jpicklyk.mcptask.current.domain.model.FingerprintRelation
 import io.github.jpicklyk.mcptask.current.domain.model.ProjectConfig
 import io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ProjectConfigTable
+import kotlinx.serialization.json.*
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
@@ -20,8 +22,12 @@ import java.util.UUID
  *
  * Upsert uses the same atomic `INSERT … ON CONFLICT DO UPDATE` pattern as
  * [SQLiteNoteRepository.upsertRow] (keyed on the unique `root_item_id` column here instead of
- * `(work_item_id, key)`) to avoid a SELECT-then-branch TOCTOU race between concurrent writers for
- * the same root.
+ * `(work_item_id, key)`) to avoid a SELECT-then-branch TOCTOU race between concurrent writers
+ * deciding row EXISTENCE. Computing the new `fingerprint_history` value, however, needs the row's
+ * prior `fingerprint`/`fingerprint_history` state, so [upsert] reads those two columns first,
+ * inside the same `suspendedTransaction` as the upsert itself. This table is one row per project
+ * root — tiny and low-write-frequency (config pushes, not hot-path reads) — so the extra read
+ * inside the transaction is not a meaningful bottleneck or race window in practice.
  */
 class SQLiteProjectConfigRepository(
     private val databaseManager: DatabaseManager
@@ -34,18 +40,39 @@ class SQLiteProjectConfigRepository(
             val fingerprint = computeFingerprint(configYaml)
             val now = Instant.now()
 
+            val existing =
+                ProjectConfigTable
+                    .select(ProjectConfigTable.fingerprint, ProjectConfigTable.fingerprintHistory)
+                    .where { ProjectConfigTable.rootItemId eq rootItemId }
+                    .singleOrNull()
+
+            // Unchanged-fingerprint re-push leaves history untouched; a changed fingerprint
+            // prepends the OUTGOING (previous current) fingerprint, newest first, pruned to 20.
+            val newFingerprintHistory =
+                when {
+                    existing == null -> null
+                    existing[ProjectConfigTable.fingerprint] == fingerprint -> existing[ProjectConfigTable.fingerprintHistory]
+                    else -> {
+                        val previousFingerprint = existing[ProjectConfigTable.fingerprint]
+                        val previousHistory = decodeHistory(existing[ProjectConfigTable.fingerprintHistory])
+                        encodeHistory((listOf(previousFingerprint) + previousHistory).take(MAX_HISTORY_SIZE))
+                    }
+                }
+
             ProjectConfigTable.upsert(
                 keys = arrayOf(ProjectConfigTable.rootItemId),
                 onUpdate = {
                     it[ProjectConfigTable.configYaml] = configYaml
                     it[ProjectConfigTable.fingerprint] = fingerprint
                     it[ProjectConfigTable.updatedAt] = now
+                    it[ProjectConfigTable.fingerprintHistory] = newFingerprintHistory
                 },
             ) {
                 it[ProjectConfigTable.rootItemId] = rootItemId
                 it[ProjectConfigTable.configYaml] = configYaml
                 it[ProjectConfigTable.fingerprint] = fingerprint
                 it[ProjectConfigTable.updatedAt] = now
+                it[ProjectConfigTable.fingerprintHistory] = newFingerprintHistory
             }
 
             Result.Success(
@@ -85,6 +112,32 @@ class SQLiteProjectConfigRepository(
             Result.Success(deletedCount > 0)
         }
 
+    override fun computeFingerprint(configYaml: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(configYaml.toByteArray(Charsets.UTF_8))
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+
+    override suspend fun classifyFingerprint(
+        rootItemId: UUID,
+        fingerprint: String
+    ): Result<FingerprintRelation> =
+        databaseManager.suspendedTransaction("Failed to classify ProjectConfig fingerprint") {
+            val row =
+                ProjectConfigTable
+                    .select(ProjectConfigTable.fingerprint, ProjectConfigTable.fingerprintHistory)
+                    .where { ProjectConfigTable.rootItemId eq rootItemId }
+                    .singleOrNull()
+
+            val relation =
+                when {
+                    row == null -> FingerprintRelation.UNKNOWN
+                    row[ProjectConfigTable.fingerprint] == fingerprint -> FingerprintRelation.CURRENT
+                    decodeHistory(row[ProjectConfigTable.fingerprintHistory]).contains(fingerprint) -> FingerprintRelation.SUPERSEDED
+                    else -> FingerprintRelation.UNKNOWN
+                }
+            Result.Success(relation)
+        }
+
     private fun mapRowToProjectConfig(row: ResultRow): ProjectConfig =
         ProjectConfig(
             rootItemId = row[ProjectConfigTable.rootItemId],
@@ -93,9 +146,23 @@ class SQLiteProjectConfigRepository(
             updatedAt = row[ProjectConfigTable.updatedAt]
         )
 
-    /** Mirrors [io.github.jpicklyk.mcptask.current.infrastructure.config.YamlWorkItemSchemaService.getConfigFingerprint]'s SHA-256 approach. */
-    private fun computeFingerprint(configYaml: String): String {
-        val digest = MessageDigest.getInstance("SHA-256").digest(configYaml.toByteArray(Charsets.UTF_8))
-        return digest.joinToString("") { "%02x".format(it) }
+    /** Serializes a fingerprint list (newest first) to the `fingerprint_history` TEXT column's JSON array shape. */
+    private fun encodeHistory(history: List<String>): String = buildJsonArray { history.forEach { add(JsonPrimitive(it)) } }.toString()
+
+    /** Parses the `fingerprint_history` TEXT column; null/blank/malformed JSON all decode to "no known ancestors". */
+    private fun decodeHistory(historyJson: String?): List<String> {
+        if (historyJson.isNullOrBlank()) return emptyList()
+        return try {
+            Json.parseToJsonElement(historyJson).jsonArray.mapNotNull { it.jsonPrimitive.contentOrNull }
+        } catch (
+            @Suppress("TooGenericExceptionCaught") _: Exception
+        ) {
+            emptyList()
+        }
+    }
+
+    companion object {
+        /** Fingerprint history is pruned to this many entries (newest first) on every changed-fingerprint upsert. */
+        private const val MAX_HISTORY_SIZE = 20
     }
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteProjectConfigRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteProjectConfigRepository.kt
@@ -6,6 +6,7 @@ import io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigReposit
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ProjectConfigTable
+import io.github.jpicklyk.mcptask.current.infrastructure.security.sha256Hex
 import kotlinx.serialization.json.*
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.eq
@@ -13,7 +14,6 @@ import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.upsert
-import java.security.MessageDigest
 import java.time.Instant
 import java.util.UUID
 
@@ -112,10 +112,7 @@ class SQLiteProjectConfigRepository(
             Result.Success(deletedCount > 0)
         }
 
-    override fun computeFingerprint(configYaml: String): String {
-        val digest = MessageDigest.getInstance("SHA-256").digest(configYaml.toByteArray(Charsets.UTF_8))
-        return digest.joinToString("") { "%02x".format(it) }
-    }
+    override fun computeFingerprint(configYaml: String): String = sha256Hex(configYaml.toByteArray(Charsets.UTF_8))
 
     override suspend fun classifyFingerprint(
         rootItemId: UUID,

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/security/Sha256Hex.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/security/Sha256Hex.kt
@@ -1,0 +1,22 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.security
+
+import java.security.MessageDigest
+
+/**
+ * Computes the SHA-256 digest of [bytes] and returns it as a lowercase hex string.
+ *
+ * This is the single server-side definition of the config-fingerprint hash: config fingerprints
+ * are compared for equality between the client (`config-sync.mjs`'s `createHash('sha256')...digest('hex')`)
+ * and the server ([io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteProjectConfigRepository.computeFingerprint]
+ * and [io.github.jpicklyk.mcptask.current.infrastructure.config.YamlWorkItemSchemaService.getConfigFingerprint]) —
+ * every server-side call site MUST route through this function so the two sides can never silently
+ * diverge (e.g. a stray uppercase-hex or different digest algorithm on one side only).
+ *
+ * Scoped to the config subsystem: other pre-existing SHA-256/hex call sites in this codebase
+ * (`BearerTokenStore`, `AuthenticationPlugin`, `EventRoutes`) are tracked separately and are not
+ * converted to this utility here.
+ */
+fun sha256Hex(bytes: ByteArray): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
+    return digest.joinToString("") { "%02x".format(it) }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/dto/Dtos.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/dto/Dtos.kt
@@ -455,4 +455,6 @@ data class ProjectConfigResponseDto(
     val updatedAt: String,
     val configYaml: String? = null,
     val warning: String? = null,
+    /** "current" | "superseded" | "unknown" — present only on GET when `?fingerprint=` was supplied. */
+    val relation: String? = null,
 )

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/dto/Dtos.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/dto/Dtos.kt
@@ -457,4 +457,6 @@ data class ProjectConfigResponseDto(
     val warning: String? = null,
     /** "current" | "superseded" | "unknown" — present only on GET when `?fingerprint=` was supplied. */
     val relation: String? = null,
+    /** Top-level `configYaml` keys not honored by any per-root layer (e.g. `actor_authentication`); present only on PUT, and only when non-empty. */
+    val ignoredSections: List<String>? = null,
 )

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutes.kt
@@ -56,7 +56,9 @@ private fun configEtag(fingerprint: String): String = "\"cfg-$fingerprint\""
  *   unless `?force=true` — distinct from the 412 `If-Match` case below, which is a concurrent-write
  *   guard rather than a known-old-content guard; optional `If-Match` against the current
  *   fingerprint-derived ETag (412 on mismatch, ignored when no row exists yet — a first push is a
- *   create).
+ *   create). On success, top-level `configYaml` keys not honored by the per-root resolution layer
+ *   (e.g. `actor_authentication`) are reported in an additive `ignoredSections` field, omitted when
+ *   empty.
  * - `DELETE /roots/{rootId}/config` — remove the stored config row ([ApiCapability.WRITE_CONFIG] +
  *   scope); 404 when no row exists.
  *
@@ -190,6 +192,7 @@ fun Route.projectConfigRoutes(repositoryProvider: RepositoryProvider) {
                                 fingerprint = result.fingerprint,
                                 updatedAt = result.updatedAt.toString(),
                                 warning = result.warning,
+                                ignoredSections = result.ignoredSections.ifEmpty { null },
                             ),
                         )
                     }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutes.kt
@@ -41,16 +41,22 @@ private fun configEtag(fingerprint: String): String = "\"cfg-$fingerprint\""
  *
  * Endpoints:
  * - `GET    /roots/{rootId}/config` — read back the stored config ([ApiCapability.READ] + scope);
- *   `If-None-Match` → 304 when unchanged; 404 when no config has been pushed for the root.
+ *   `If-None-Match` → 304 when unchanged; 404 when no config has been pushed for the root. Optional
+ *   `?fingerprint=<sha256>` classifies that value against the root's stored fingerprint
+ *   history and adds an additive `relation` field ("current"/"superseded"/"unknown") to the
+ *   response body — omitted entirely when the query param is absent.
  * - `PUT    /roots/{rootId}/config` — validate + upsert raw YAML body ([ApiCapability.WRITE_CONFIG] +
  *   scope); delegates the FULL validate-then-persist pipeline to [ProjectConfigPushService] — the
  *   SAME service the MCP `manage_project_config` tool's `push` operation calls, so both surfaces
  *   converge on identical DB state for the same payload. Body must not exceed
  *   [ProjectConfigPushService.MAX_CONFIG_YAML_BYTES] (413); malformed/unsafe YAML is rejected before
  *   storing (422); a `configYaml` embedding a mismatched top-level `project.rootId` is rejected as
- *   422 `rootid_mismatch` unless the `?force=true` query param is set; optional `If-Match` against
- *   the current fingerprint-derived ETag (412 on mismatch, ignored when no row exists yet — a first
- *   push is a create).
+ *   422 `rootid_mismatch` unless the `?force=true` query param is set; a `configYaml` whose
+ *   fingerprint is known-old (present in history but not current) is rejected as 409 `superseded`
+ *   unless `?force=true` — distinct from the 412 `If-Match` case below, which is a concurrent-write
+ *   guard rather than a known-old-content guard; optional `If-Match` against the current
+ *   fingerprint-derived ETag (412 on mismatch, ignored when no row exists yet — a first push is a
+ *   create).
  * - `DELETE /roots/{rootId}/config` — remove the stored config row ([ApiCapability.WRITE_CONFIG] +
  *   scope); 404 when no row exists.
  *
@@ -97,6 +103,14 @@ fun Route.projectConfigRoutes(repositoryProvider: RepositoryProvider) {
                             return@get
                         }
 
+                        val relation =
+                            call.request.queryParameters["fingerprint"]?.let { queriedFingerprint ->
+                                when (val relationResult = projectConfigRepo.classifyFingerprint(rootId, queriedFingerprint)) {
+                                    is Result.Success -> relationResult.data.name.lowercase()
+                                    is Result.Error -> null
+                                }
+                            }
+
                         call.response.header(HttpHeaders.ETag, etag)
                         call.respond(
                             HttpStatusCode.OK,
@@ -105,6 +119,7 @@ fun Route.projectConfigRoutes(repositoryProvider: RepositoryProvider) {
                                 fingerprint = config.fingerprint,
                                 updatedAt = config.updatedAt.toString(),
                                 configYaml = config.configYaml,
+                                relation = relation,
                             ),
                         )
                     }
@@ -213,6 +228,15 @@ fun Route.projectConfigRoutes(repositoryProvider: RepositoryProvider) {
                                 "configYaml embeds project.rootId '${result.embeddedRootId}', which differs " +
                                     "from the target rootId '${result.targetRootId}'; fix project.rootId in " +
                                     "the document or retry with ?force=true",
+                            ),
+                        )
+                    is ProjectConfigPushResult.Superseded ->
+                        call.respond(
+                            HttpStatusCode.Conflict,
+                            ErrorDto(
+                                "superseded",
+                                "local config is older than the server's (updated ${result.currentUpdatedAt}); " +
+                                    "pull or copy back before editing, or retry with ?force=true",
                             ),
                         )
                     is ProjectConfigPushResult.RepositoryError -> {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutes.kt
@@ -47,8 +47,10 @@ private fun configEtag(fingerprint: String): String = "\"cfg-$fingerprint\""
  *   SAME service the MCP `manage_project_config` tool's `push` operation calls, so both surfaces
  *   converge on identical DB state for the same payload. Body must not exceed
  *   [ProjectConfigPushService.MAX_CONFIG_YAML_BYTES] (413); malformed/unsafe YAML is rejected before
- *   storing (422); optional `If-Match` against the current fingerprint-derived ETag (412 on mismatch,
- *   ignored when no row exists yet — a first push is a create).
+ *   storing (422); a `configYaml` embedding a mismatched top-level `project.rootId` is rejected as
+ *   422 `rootid_mismatch` unless the `?force=true` query param is set; optional `If-Match` against
+ *   the current fingerprint-derived ETag (412 on mismatch, ignored when no row exists yet — a first
+ *   push is a create).
  * - `DELETE /roots/{rootId}/config` — remove the stored config row ([ApiCapability.WRITE_CONFIG] +
  *   scope); 404 when no row exists.
  *
@@ -124,6 +126,7 @@ fun Route.projectConfigRoutes(repositoryProvider: RepositoryProvider) {
                     return@put
                 }
 
+                val force = call.request.queryParameters["force"]?.toBooleanStrictOrNull() ?: false
                 val configYaml = call.receiveText()
                 val sizeBytes = configYaml.toByteArray(Charsets.UTF_8).size
                 if (sizeBytes > ProjectConfigPushService.MAX_CONFIG_YAML_BYTES) {
@@ -161,7 +164,7 @@ fun Route.projectConfigRoutes(repositoryProvider: RepositoryProvider) {
                     }
                 }
 
-                when (val result = service.push(rootId, configYaml)) {
+                when (val result = service.push(rootId, configYaml, force)) {
                     is ProjectConfigPushResult.Success -> {
                         val etag = configEtag(result.fingerprint)
                         call.response.header(HttpHeaders.ETag, etag)
@@ -201,6 +204,16 @@ fun Route.projectConfigRoutes(repositoryProvider: RepositoryProvider) {
                         call.respond(
                             HttpStatusCode.UnprocessableEntity,
                             ErrorDto("parse_error", "configYaml failed to parse: ${result.detail}"),
+                        )
+                    is ProjectConfigPushResult.RootIdMismatch ->
+                        call.respond(
+                            HttpStatusCode.UnprocessableEntity,
+                            ErrorDto(
+                                "rootid_mismatch",
+                                "configYaml embeds project.rootId '${result.embeddedRootId}', which differs " +
+                                    "from the target rootId '${result.targetRootId}'; fix project.rootId in " +
+                                    "the document or retry with ?force=true",
+                            ),
                         )
                     is ProjectConfigPushResult.RepositoryError -> {
                         projectConfigLogger.warn("PUT /roots/{}/config DB error: {}", rootId, result.message)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutes.kt
@@ -107,10 +107,7 @@ fun Route.projectConfigRoutes(repositoryProvider: RepositoryProvider) {
 
                         val relation =
                             call.request.queryParameters["fingerprint"]?.let { queriedFingerprint ->
-                                when (val relationResult = projectConfigRepo.classifyFingerprint(rootId, queriedFingerprint)) {
-                                    is Result.Success -> relationResult.data.name.lowercase()
-                                    is Result.Error -> null
-                                }
+                                service.classifyRelation(rootId, queriedFingerprint)
                             }
 
                         call.response.header(HttpHeaders.ETag, etag)

--- a/current/src/main/resources/db/migration/V11__Add_Project_Config_Fingerprint_History.sql
+++ b/current/src/main/resources/db/migration/V11__Add_Project_Config_Fingerprint_History.sql
@@ -1,0 +1,15 @@
+-- V11: Fingerprint history for the fast-forward push guard
+--
+-- Adds a single NULLABLE column to project_config: fingerprint_history, a JSON array of prior
+-- fingerprints for the root (newest first, pruned to 20 entries by the repository). Used to
+-- classify an incoming push's fingerprint as CURRENT / SUPERSEDED / UNKNOWN so a stale local
+-- config.yaml checkout can be detected and rejected (or force-overridden) instead of silently
+-- reverting a later push made from elsewhere.
+--
+-- Pure ADD COLUMN — SQLite supports this natively, no table recreation required (see
+-- V10__Project_Config.sql for the base table). Existing rows get NULL, which the repository
+-- treats as "no known ancestors": classifyFingerprint returns UNKNOWN for any non-current
+-- fingerprint on a NULL-history row, identical to pre-migration behavior until history
+-- accumulates on subsequent upserts. No backfill needed.
+
+ALTER TABLE project_config ADD COLUMN fingerprint_history TEXT;

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushServiceTest.kt
@@ -1,0 +1,122 @@
+package io.github.jpicklyk.mcptask.current.application.service
+
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteProjectConfigRepository
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteWorkItemRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Exercises [ProjectConfigPushService.push] directly against a real H2-backed
+ * [SQLiteProjectConfigRepository] and [SQLiteWorkItemRepository] — mirrors
+ * [io.github.jpicklyk.mcptask.current.application.tools.config.ManageProjectConfigToolTest]'s DB-backed
+ * style. Focused on the embedded `project.rootId` guard added on top of the existing
+ * validate-then-persist pipeline (size cap / existence / depth-0 / parse are already covered at the
+ * tool and route layers — this file's `basic push still works` case is a smoke check, not a full
+ * re-test of that pipeline).
+ */
+class ProjectConfigPushServiceTest {
+    private lateinit var service: ProjectConfigPushService
+    private lateinit var workItemRepository: SQLiteWorkItemRepository
+    private lateinit var projectConfigRepository: SQLiteProjectConfigRepository
+    private lateinit var rootId: UUID
+    private lateinit var otherRootId: UUID
+
+    private val plainYaml =
+        """
+        work_item_schemas:
+          feature-task:
+            notes:
+              - key: spec
+                role: queue
+                required: true
+        """.trimIndent()
+
+    @BeforeEach
+    fun setUp() =
+        runBlocking {
+            val dbName = "test_${System.nanoTime()}"
+            val database = Database.connect("jdbc:h2:mem:$dbName;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+            val databaseManager = DatabaseManager(database)
+            DirectDatabaseSchemaManager().updateSchema()
+
+            workItemRepository = SQLiteWorkItemRepository(databaseManager)
+            projectConfigRepository = SQLiteProjectConfigRepository(databaseManager)
+
+            val repositoryProvider = mockk<RepositoryProvider>(relaxed = true)
+            every { repositoryProvider.workItemRepository() } returns workItemRepository
+            every { repositoryProvider.projectConfigRepository() } returns projectConfigRepository
+
+            service = ProjectConfigPushService(repositoryProvider)
+
+            rootId = (workItemRepository.create(WorkItem(title = "Root", type = "project")) as Result.Success).data.id
+            otherRootId = (workItemRepository.create(WorkItem(title = "Other Root", type = "project")) as Result.Success).data.id
+        }
+
+    // Deliberately plain concatenation (not a nested trimIndent template) — interpolating an
+    // already-trimIndent'd multi-line constant into another trimIndent block would get its
+    // indentation re-mangled by the outer trim's common-margin computation.
+    private fun yamlWithEmbeddedRootId(embedded: String) = "project:\n  rootId: $embedded\n$plainYaml"
+
+    @Test
+    fun `push with no project block succeeds unchanged`() =
+        runBlocking {
+            val result = service.push(rootId, plainYaml)
+
+            assertTrue(result is ProjectConfigPushResult.Success)
+        }
+
+    @Test
+    fun `push with embedded rootId matching the target succeeds`() =
+        runBlocking {
+            val result = service.push(rootId, yamlWithEmbeddedRootId(rootId.toString()))
+
+            assertTrue(result is ProjectConfigPushResult.Success)
+        }
+
+    @Test
+    fun `push with embedded rootId differing from the target is rejected and stores nothing`() =
+        runBlocking {
+            val result = service.push(rootId, yamlWithEmbeddedRootId(otherRootId.toString()))
+
+            assertTrue(result is ProjectConfigPushResult.RootIdMismatch)
+            val mismatch = result as ProjectConfigPushResult.RootIdMismatch
+            assertEquals(rootId, mismatch.targetRootId)
+            assertEquals(otherRootId, mismatch.embeddedRootId)
+
+            val stored = projectConfigRepository.get(rootId)
+            assertTrue(stored is Result.Success)
+            assertNull((stored as Result.Success).data, "mismatched push must not write a row")
+        }
+
+    @Test
+    fun `push with a malformed non-UUID embedded rootId proceeds unchanged`() =
+        runBlocking {
+            val result = service.push(rootId, yamlWithEmbeddedRootId("not-a-uuid"))
+
+            assertTrue(result is ProjectConfigPushResult.Success)
+        }
+
+    @Test
+    fun `push with force true bypasses a mismatched embedded rootId`() =
+        runBlocking {
+            val result = service.push(rootId, yamlWithEmbeddedRootId(otherRootId.toString()), force = true)
+
+            assertTrue(result is ProjectConfigPushResult.Success)
+            val stored = projectConfigRepository.get(rootId)
+            assertTrue(stored is Result.Success)
+            assertEquals(rootId, (stored as Result.Success).data?.rootItemId)
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushServiceTest.kt
@@ -119,4 +119,81 @@ class ProjectConfigPushServiceTest {
             assertTrue(stored is Result.Success)
             assertEquals(rootId, (stored as Result.Success).data?.rootItemId)
         }
+
+    // ──────────────────────────────────────────────
+    // fast-forward (known-old) fingerprint guard
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `push with an UNKNOWN fingerprint (brand-new content) proceeds normally`() =
+        runBlocking {
+            val yamlA = "work_item_schemas:\n  a: {}\n"
+            val yamlB = "work_item_schemas:\n  b: {}\n"
+            service.push(rootId, yamlA)
+
+            // yamlB has never been pushed to this root before — UNKNOWN, not SUPERSEDED.
+            val result = service.push(rootId, yamlB)
+
+            assertTrue(result is ProjectConfigPushResult.Success)
+            val stored = (projectConfigRepository.get(rootId) as Result.Success).data
+            assertEquals(yamlB, stored?.configYaml)
+        }
+
+    @Test
+    fun `push with the CURRENT fingerprint (idempotent re-push) proceeds normally`() =
+        runBlocking {
+            val yaml = "work_item_schemas:\n  a: {}\n"
+            val first = service.push(rootId, yaml)
+            assertTrue(first is ProjectConfigPushResult.Success)
+
+            val second = service.push(rootId, yaml)
+
+            assertTrue(second is ProjectConfigPushResult.Success)
+            assertEquals(
+                (first as ProjectConfigPushResult.Success).fingerprint,
+                (second as ProjectConfigPushResult.Success).fingerprint
+            )
+        }
+
+    @Test
+    fun `push with a SUPERSEDED (known-old) fingerprint is rejected naming the server's updatedAt`() =
+        runBlocking {
+            val yamlA = "work_item_schemas:\n  a: {}\n"
+            val yamlB = "work_item_schemas:\n  b: {}\n"
+            service.push(rootId, yamlA)
+            service.push(rootId, yamlB)
+
+            // yamlA is now superseded — pushing it again (e.g. from a stale checkout) must be
+            // rejected, not silently accepted as a normal re-push.
+            val result = service.push(rootId, yamlA)
+
+            assertTrue(result is ProjectConfigPushResult.Superseded)
+            val superseded = result as ProjectConfigPushResult.Superseded
+            assertEquals(rootId, superseded.rootItemId)
+
+            val currentStored = (projectConfigRepository.get(rootId) as Result.Success).data
+            assertEquals(
+                currentStored?.updatedAt,
+                superseded.currentUpdatedAt,
+                "Superseded.currentUpdatedAt should name the server's current row's updatedAt"
+            )
+
+            // The rejected push must not have overwritten the server's current (yamlB) state.
+            assertEquals(yamlB, currentStored?.configYaml)
+        }
+
+    @Test
+    fun `push with force true bypasses a SUPERSEDED fingerprint and overwrites`() =
+        runBlocking {
+            val yamlA = "work_item_schemas:\n  a: {}\n"
+            val yamlB = "work_item_schemas:\n  b: {}\n"
+            service.push(rootId, yamlA)
+            service.push(rootId, yamlB)
+
+            val result = service.push(rootId, yamlA, force = true)
+
+            assertTrue(result is ProjectConfigPushResult.Success)
+            val stored = (projectConfigRepository.get(rootId) as Result.Success).data
+            assertEquals(yamlA, stored?.configYaml, "force=true should allow reverting to the known-old content")
+        }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushServiceTest.kt
@@ -196,4 +196,62 @@ class ProjectConfigPushServiceTest {
             val stored = (projectConfigRepository.get(rootId) as Result.Success).data
             assertEquals(yamlA, stored?.configYaml, "force=true should allow reverting to the known-old content")
         }
+
+    // ──────────────────────────────────────────────
+    // t3: ignoredSections
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `push reports ignoredSections when the doc has a top-level key not honored per-root`() =
+        runBlocking {
+            val yaml =
+                """
+                work_item_schemas:
+                  feature-task:
+                    notes: []
+                actor_authentication:
+                  mode: jwks
+                """.trimIndent()
+
+            val result = service.push(rootId, yaml)
+
+            assertTrue(result is ProjectConfigPushResult.Success)
+            assertEquals(listOf("actor_authentication"), (result as ProjectConfigPushResult.Success).ignoredSections)
+        }
+
+    @Test
+    fun `push omits ignoredSections when the doc only uses honored top-level keys`() =
+        runBlocking {
+            val yaml =
+                """
+                work_item_schemas:
+                  feature-task:
+                    notes: []
+                note_schemas: {}
+                traits: {}
+                project:
+                  name: "Some Project"
+                note_limits:
+                  mode: reject
+                status_labels:
+                  start: "custom-started"
+                """.trimIndent()
+
+            val result = service.push(rootId, yaml)
+
+            assertTrue(result is ProjectConfigPushResult.Success)
+            assertTrue(
+                (result as ProjectConfigPushResult.Success).ignoredSections.isEmpty(),
+                "A document that only uses honored keys must report no ignored sections"
+            )
+        }
+
+    @Test
+    fun `push reports an empty ignoredSections list for an empty document`() =
+        runBlocking {
+            val result = service.push(rootId, "")
+
+            assertTrue(result is ProjectConfigPushResult.Success)
+            assertTrue((result as ProjectConfigPushResult.Success).ignoredSections.isEmpty())
+        }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContextResolveSchemaTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContextResolveSchemaTest.kt
@@ -488,7 +488,14 @@ class ToolExecutionContextResolveSchemaTest {
             val rootId = UUID.randomUUID()
             val perRoot = mockk<PerRootConfigService>()
             val perRootSchema = schemaWithReview("feature-task")
-            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns perRootSchema
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = mapOf("feature-task" to perRootSchema),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = null,
+                    fingerprint = "fp"
+                )
 
             val repoProvider = mockk<RepositoryProvider>(relaxed = true)
             val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
@@ -506,9 +513,15 @@ class ToolExecutionContextResolveSchemaTest {
         runBlocking {
             val rootId = UUID.randomUUID()
             val perRoot = mockk<PerRootConfigService>()
-            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns null
-            // No per-root row at all — the "default" probe (whole-algorithm-first) also misses.
-            coEvery { perRoot.getSchemaForType(rootId, "default") } returns null
+            // Per-root row exists but defines neither the exact type nor "default".
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = emptyMap(),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = null,
+                    fingerprint = "fp"
+                )
 
             val globalSchema = schemaWithReview("feature-task")
             every { noteSchemaService.getSchemaForType("feature-task") } returns globalSchema
@@ -520,8 +533,9 @@ class ToolExecutionContextResolveSchemaTest {
             val result = ctx.resolveSchema(item)
 
             assertEquals(globalSchema, result)
-            coVerify(exactly = 1) { perRoot.getSchemaForType(rootId, "feature-task") }
-            coVerify(exactly = 1) { perRoot.getSchemaForType(rootId, "default") }
+            // Exactly ONE snapshot fetch for the whole resolveSchema call (schema/trait resolution
+            // reuse the same already-fetched snapshot instead of re-querying per facet).
+            coVerify(exactly = 1) { perRoot.getSnapshot(rootId) }
         }
 
     @Test
@@ -529,9 +543,15 @@ class ToolExecutionContextResolveSchemaTest {
         runBlocking {
             val rootId = UUID.randomUUID()
             val perRoot = mockk<PerRootConfigService>()
-            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns null
             val perRootDefault = WorkItemSchema(type = "default", notes = listOf(workEntry()))
-            coEvery { perRoot.getSchemaForType(rootId, "default") } returns perRootDefault
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = mapOf("default" to perRootDefault),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = null,
+                    fingerprint = "fp"
+                )
 
             // Global has an EXACT type match — under whole-algorithm-first, the per-root default
             // must still win; the global layer must never be consulted.
@@ -553,9 +573,15 @@ class ToolExecutionContextResolveSchemaTest {
         runBlocking {
             val rootId = UUID.randomUUID()
             val perRoot = mockk<PerRootConfigService>()
-            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns null
             val emptyPerRootDefault = WorkItemSchema(type = "default", notes = emptyList())
-            coEvery { perRoot.getSchemaForType(rootId, "default") } returns emptyPerRootDefault
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = mapOf("default" to emptyPerRootDefault),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = null,
+                    fingerprint = "fp"
+                )
 
             val repoProvider = mockk<RepositoryProvider>(relaxed = true)
             val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
@@ -575,8 +601,8 @@ class ToolExecutionContextResolveSchemaTest {
         runBlocking {
             val rootId = UUID.randomUUID()
             val perRoot = mockk<PerRootConfigService>()
-            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns null
-            coEvery { perRoot.getSchemaForType(rootId, "default") } returns null
+            // No per-root config row at all for this root.
+            coEvery { perRoot.getSnapshot(rootId) } returns null
 
             // No global exact match either — but getSchemaForType("feature-task") mimics the real
             // YamlNoteSchemaService's own internal exact -> "default" fallback by directly returning
@@ -607,10 +633,9 @@ class ToolExecutionContextResolveSchemaTest {
             val result = ctx.resolveSchema(item)
 
             assertEquals(globalSchema, result)
-            // Zero interactions with the per-root layer at all — not just the type-lookup method.
-            coVerify(exactly = 0) { perRoot.getSchemaForType(any(), any()) }
-            coVerify(exactly = 0) { perRoot.getSchemas(any()) }
-            coVerify(exactly = 0) { perRoot.getTraitNotes(any(), any()) }
+            // Zero interactions with the per-root layer at all — a null rootId must never even
+            // attempt a snapshot fetch.
+            coVerify(exactly = 0) { perRoot.getSnapshot(any()) }
         }
 
     @Test
@@ -625,15 +650,19 @@ class ToolExecutionContextResolveSchemaTest {
                     notes = listOf(workEntry()),
                     defaultTraits = listOf("needs-perf-review")
                 )
+            val perRootTraitNote = traitEntry("performance-baseline-per-root")
             // Type lookup misses per-root (exact and "default") and falls to the global base
             // schema — trait layering is independent of where the base schema itself came from.
-            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns null
-            coEvery { perRoot.getSchemaForType(rootId, "default") } returns null
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = emptyMap(),
+                    traits = mapOf("needs-perf-review" to listOf(perRootTraitNote)),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = null,
+                    fingerprint = "fp"
+                )
             every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
             every { noteSchemaService.getDefaultTraits("feature-task") } returns listOf("needs-perf-review")
-
-            val perRootTraitNote = traitEntry("performance-baseline-per-root")
-            coEvery { perRoot.getTraitNotes(rootId, "needs-perf-review") } returns listOf(perRootTraitNote)
 
             val repoProvider = mockk<RepositoryProvider>(relaxed = true)
             val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
@@ -653,7 +682,14 @@ class ToolExecutionContextResolveSchemaTest {
             val rootId = UUID.randomUUID()
             val perRoot = mockk<PerRootConfigService>()
             val perRootDefault = WorkItemSchema(type = "default", notes = listOf(workEntry()))
-            coEvery { perRoot.getSchemas(rootId) } returns mapOf("default" to perRootDefault)
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = mapOf("default" to perRootDefault),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = null,
+                    fingerprint = "fp"
+                )
 
             val repoProvider = mockk<RepositoryProvider>(relaxed = true)
             val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
@@ -707,7 +743,7 @@ class ToolExecutionContextResolveSchemaTest {
                 )
 
             assertEquals("warn", ctx.resolveNoteLimitsMode(null))
-            coVerify(exactly = 0) { perRoot.getNoteLimitsMode(any()) }
+            coVerify(exactly = 0) { perRoot.getSnapshot(any()) }
         }
 
     @Test
@@ -715,7 +751,14 @@ class ToolExecutionContextResolveSchemaTest {
         runBlocking {
             val rootId = UUID.randomUUID()
             val perRoot = mockk<PerRootConfigService>()
-            coEvery { perRoot.getNoteLimitsMode(rootId) } returns null
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = emptyMap(),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = null,
+                    fingerprint = "fp"
+                )
             every { noteSchemaService.getNoteLimitsMode() } returns "warn"
             val repoProvider = mockk<RepositoryProvider>(relaxed = true)
             val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
@@ -728,7 +771,14 @@ class ToolExecutionContextResolveSchemaTest {
         runBlocking {
             val rootId = UUID.randomUUID()
             val perRoot = mockk<PerRootConfigService>()
-            coEvery { perRoot.getNoteLimitsMode(rootId) } returns "reject"
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = emptyMap(),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = "reject",
+                    statusLabels = null,
+                    fingerprint = "fp"
+                )
             every { noteSchemaService.getNoteLimitsMode() } returns "warn"
             val repoProvider = mockk<RepositoryProvider>(relaxed = true)
             val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
@@ -752,7 +802,7 @@ class ToolExecutionContextResolveSchemaTest {
                 )
 
             assertEquals("in-progress", ctx.resolveStatusLabel("start", null))
-            coVerify(exactly = 0) { perRoot.getStatusLabels(any()) }
+            coVerify(exactly = 0) { perRoot.getSnapshot(any()) }
         }
 
     @Test
@@ -760,7 +810,14 @@ class ToolExecutionContextResolveSchemaTest {
         runBlocking {
             val rootId = UUID.randomUUID()
             val perRoot = mockk<PerRootConfigService>()
-            coEvery { perRoot.getStatusLabels(rootId) } returns mapOf("start" to "root-started")
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = emptyMap(),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = mapOf("start" to "root-started"),
+                    fingerprint = "fp"
+                )
             val globalLabels = mockk<StatusLabelService>()
             every { globalLabels.resolveLabel("complete") } returns "done"
             val repoProvider = mockk<RepositoryProvider>(relaxed = true)
@@ -785,7 +842,14 @@ class ToolExecutionContextResolveSchemaTest {
         runBlocking {
             val rootId = UUID.randomUUID()
             val perRoot = mockk<PerRootConfigService>()
-            coEvery { perRoot.getStatusLabels(rootId) } returns mapOf("complete" to null)
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = emptyMap(),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = mapOf("complete" to null),
+                    fingerprint = "fp"
+                )
             val globalLabels = mockk<StatusLabelService>()
             every { globalLabels.resolveLabel("complete") } returns "done"
             val repoProvider = mockk<RepositoryProvider>(relaxed = true)
@@ -802,5 +866,36 @@ class ToolExecutionContextResolveSchemaTest {
                 "An explicit null value for a present trigger key must win over the global label, not fall through"
             )
             verify(exactly = 0) { globalLabels.resolveLabel("complete") }
+        }
+
+    @Test
+    fun `resolveStatusLabels resolves the whole trigger set from a single snapshot fetch`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>()
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = emptyMap(),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = mapOf("start" to "root-started"),
+                    fingerprint = "fp"
+                )
+            val globalLabels = mockk<StatusLabelService>()
+            every { globalLabels.resolveLabel("cascade") } returns "done"
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx =
+                ToolExecutionContext(
+                    repoProvider,
+                    noteSchemaService,
+                    statusLabelService = globalLabels,
+                    perRootConfigService = perRoot
+                )
+
+            val resolved = ctx.resolveStatusLabels(setOf("start", "cascade"), rootId)
+
+            assertEquals("root-started", resolved["start"])
+            assertEquals("done", resolved["cascade"])
+            coVerify(exactly = 1) { perRoot.getSnapshot(rootId) }
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContextResolveSchemaTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContextResolveSchemaTest.kt
@@ -506,6 +506,8 @@ class ToolExecutionContextResolveSchemaTest {
             val rootId = UUID.randomUUID()
             val perRoot = mockk<PerRootConfigService>()
             coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns null
+            // No per-root row at all — the "default" probe (whole-algorithm-first) also misses.
+            coEvery { perRoot.getSchemaForType(rootId, "default") } returns null
 
             val globalSchema = schemaWithReview("feature-task")
             every { noteSchemaService.getSchemaForType("feature-task") } returns globalSchema
@@ -518,6 +520,76 @@ class ToolExecutionContextResolveSchemaTest {
 
             assertEquals(globalSchema, result)
             coVerify(exactly = 1) { perRoot.getSchemaForType(rootId, "feature-task") }
+            coVerify(exactly = 1) { perRoot.getSchemaForType(rootId, "default") }
+        }
+
+    @Test
+    fun `resolveSchema per-root default wins over global exact type match (whole-algorithm-first)`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>()
+            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns null
+            val perRootDefault = WorkItemSchema(type = "default", notes = listOf(workEntry()))
+            coEvery { perRoot.getSchemaForType(rootId, "default") } returns perRootDefault
+
+            // Global has an EXACT type match — under whole-algorithm-first, the per-root default
+            // must still win; the global layer must never be consulted.
+            val globalSchema = schemaWithReview("feature-task")
+            every { noteSchemaService.getSchemaForType("feature-task") } returns globalSchema
+
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
+
+            val item = makeItem(type = "feature-task", rootId = rootId)
+            val result = ctx.resolveSchema(item)
+
+            assertEquals(perRootDefault, result)
+            verify(exactly = 0) { noteSchemaService.getSchemaForType("feature-task") }
+        }
+
+    @Test
+    fun `resolveSchema empty per-root default schema fences off global entirely`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>()
+            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns null
+            val emptyPerRootDefault = WorkItemSchema(type = "default", notes = emptyList())
+            coEvery { perRoot.getSchemaForType(rootId, "default") } returns emptyPerRootDefault
+
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
+
+            val item = makeItem(type = "feature-task", rootId = rootId)
+            val result = ctx.resolveSchema(item)
+
+            assertNotNull(result)
+            assertTrue(result.notes.isEmpty(), "Empty per-root default must resolve to a zero-note schema")
+            // Global must NEVER be consulted once a per-root default (even an empty one) resolves.
+            verify(exactly = 0) { noteSchemaService.getSchemaForType(any()) }
+            verify(exactly = 0) { noteSchemaService.getSchemaForTags(any()) }
+        }
+
+    @Test
+    fun `resolveSchema no per-root row and no global exact match falls through to global default`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>()
+            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns null
+            coEvery { perRoot.getSchemaForType(rootId, "default") } returns null
+
+            // No global exact match either — but getSchemaForType("feature-task") mimics the real
+            // YamlNoteSchemaService's own internal exact -> "default" fallback by directly returning
+            // the global default schema here (the mock stands in for that internal behavior).
+            val globalDefault = WorkItemSchema(type = "default", notes = listOf(workEntry()))
+            every { noteSchemaService.getSchemaForType("feature-task") } returns globalDefault
+
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
+
+            val item = makeItem(type = "feature-task", rootId = rootId)
+            val result = ctx.resolveSchema(item)
+
+            assertEquals(globalDefault, result)
         }
 
     @Test
@@ -552,9 +624,10 @@ class ToolExecutionContextResolveSchemaTest {
                     notes = listOf(workEntry()),
                     defaultTraits = listOf("needs-perf-review")
                 )
-            // Type lookup misses per-root and falls to the global base schema — trait layering is
-            // independent of where the base schema itself came from.
+            // Type lookup misses per-root (exact and "default") and falls to the global base
+            // schema — trait layering is independent of where the base schema itself came from.
             coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns null
+            coEvery { perRoot.getSchemaForType(rootId, "default") } returns null
             every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
             every { noteSchemaService.getDefaultTraits("feature-task") } returns listOf("needs-perf-review")
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContextResolveSchemaTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContextResolveSchemaTest.kt
@@ -1,6 +1,7 @@
 package io.github.jpicklyk.mcptask.current.application.tools
 
 import io.github.jpicklyk.mcptask.current.application.service.NoteSchemaService
+import io.github.jpicklyk.mcptask.current.application.service.StatusLabelService
 import io.github.jpicklyk.mcptask.current.domain.model.*
 import io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
@@ -684,5 +685,122 @@ class ToolExecutionContextResolveSchemaTest {
             val result = ctxWithoutService.resolveSchema(item)
 
             assertEquals(globalSchema, result)
+        }
+
+    // ──────────────────────────────────────────────
+    // T3: resolveNoteLimitsMode / resolveStatusLabel (per-root layering)
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `resolveNoteLimitsMode falls through to global when rootId is null`() =
+        runBlocking {
+            val perRoot = mockk<PerRootConfigService>()
+            val globalStatusLabels = mockk<StatusLabelService>(relaxed = true)
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            every { noteSchemaService.getNoteLimitsMode() } returns "warn"
+            val ctx =
+                ToolExecutionContext(
+                    repoProvider,
+                    noteSchemaService,
+                    statusLabelService = globalStatusLabels,
+                    perRootConfigService = perRoot
+                )
+
+            assertEquals("warn", ctx.resolveNoteLimitsMode(null))
+            coVerify(exactly = 0) { perRoot.getNoteLimitsMode(any()) }
+        }
+
+    @Test
+    fun `resolveNoteLimitsMode falls through to global when the per-root doc has no explicit mode`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>()
+            coEvery { perRoot.getNoteLimitsMode(rootId) } returns null
+            every { noteSchemaService.getNoteLimitsMode() } returns "warn"
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
+
+            assertEquals("warn", ctx.resolveNoteLimitsMode(rootId))
+        }
+
+    @Test
+    fun `resolveNoteLimitsMode uses the per-root explicit mode over the global mode`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>()
+            coEvery { perRoot.getNoteLimitsMode(rootId) } returns "reject"
+            every { noteSchemaService.getNoteLimitsMode() } returns "warn"
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
+
+            assertEquals("reject", ctx.resolveNoteLimitsMode(rootId))
+        }
+
+    @Test
+    fun `resolveStatusLabel falls through to global when rootId is null`() =
+        runBlocking {
+            val perRoot = mockk<PerRootConfigService>()
+            val globalLabels = mockk<StatusLabelService>()
+            every { globalLabels.resolveLabel("start") } returns "in-progress"
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx =
+                ToolExecutionContext(
+                    repoProvider,
+                    noteSchemaService,
+                    statusLabelService = globalLabels,
+                    perRootConfigService = perRoot
+                )
+
+            assertEquals("in-progress", ctx.resolveStatusLabel("start", null))
+            coVerify(exactly = 0) { perRoot.getStatusLabels(any()) }
+        }
+
+    @Test
+    fun `resolveStatusLabel falls through to global per-trigger when the per-root map is partial`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>()
+            coEvery { perRoot.getStatusLabels(rootId) } returns mapOf("start" to "root-started")
+            val globalLabels = mockk<StatusLabelService>()
+            every { globalLabels.resolveLabel("complete") } returns "done"
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx =
+                ToolExecutionContext(
+                    repoProvider,
+                    noteSchemaService,
+                    statusLabelService = globalLabels,
+                    perRootConfigService = perRoot
+                )
+
+            assertEquals("root-started", ctx.resolveStatusLabel("start", rootId))
+            assertEquals(
+                "done",
+                ctx.resolveStatusLabel("complete", rootId),
+                "A trigger absent from the partial per-root map must fall through to global"
+            )
+        }
+
+    @Test
+    fun `resolveStatusLabel honors an explicit null per-root label without falling through`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>()
+            coEvery { perRoot.getStatusLabels(rootId) } returns mapOf("complete" to null)
+            val globalLabels = mockk<StatusLabelService>()
+            every { globalLabels.resolveLabel("complete") } returns "done"
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx =
+                ToolExecutionContext(
+                    repoProvider,
+                    noteSchemaService,
+                    statusLabelService = globalLabels,
+                    perRootConfigService = perRoot
+                )
+
+            assertNull(
+                ctx.resolveStatusLabel("complete", rootId),
+                "An explicit null value for a present trigger key must win over the global label, not fall through"
+            )
+            verify(exactly = 0) { globalLabels.resolveLabel("complete") }
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
@@ -107,11 +107,11 @@ class ToolTokenBudgetTest {
             "advance_item" to 1450, // was 1407; see note above
             "get_blocked_items" to 1250, // was 830; T2.3 added the `ancestorId` scope parameter
             "get_next_status" to 470,
-            "manage_project_config" to 1900, // T3.3: new tool, measured 1609 chars
+            "manage_project_config" to 2300, // measured 1999 after push `force` param (rootId mismatch guard)
         )
 
     /** Sum of the (unrounded) measured-per-tool-values * 1.15; see BUDGET PHILOSOPHY point 2. */
-    private val totalCeiling = 39_550
+    private val totalCeiling = 39_950
 
     // explicitNulls = false mirrors the compact-wire-shape convention already used elsewhere
     // in this codebase (see EventRoutes.kt / ItemWriteRoutes.kt / NoteWriteRoutes.kt) — a

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
@@ -107,11 +107,11 @@ class ToolTokenBudgetTest {
             "advance_item" to 1450, // was 1407; see note above
             "get_blocked_items" to 1250, // was 830; T2.3 added the `ancestorId` scope parameter
             "get_next_status" to 470,
-            "manage_project_config" to 2300, // measured 1999 after push `force` param (rootId mismatch guard)
+            "manage_project_config" to 3150, // measured 2698 after get `fingerprint` param + relation (fast-forward guard, t5)
         )
 
     /** Sum of the (unrounded) measured-per-tool-values * 1.15; see BUDGET PHILOSOPHY point 2. */
-    private val totalCeiling = 39_950
+    private val totalCeiling = 40_800
 
     // explicitNulls = false mirrors the compact-wire-shape convention already used elsewhere
     // in this codebase (see EventRoutes.kt / ItemWriteRoutes.kt / NoteWriteRoutes.kt) — a

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigToolTest.kt
@@ -327,6 +327,121 @@ class ManageProjectConfigToolTest {
         assertEquals(ErrorCodes.RESOURCE_NOT_FOUND, errorOf(result)["code"]!!.jsonPrimitive.content)
     }
 
+    private fun getWithFingerprint(
+        rootItemId: String,
+        fingerprint: String
+    ): JsonElement =
+        runBlocking {
+            tool.execute(
+                params(
+                    "operation" to JsonPrimitive("get"),
+                    "rootItemId" to JsonPrimitive(rootItemId),
+                    "fingerprint" to JsonPrimitive(fingerprint)
+                ),
+                context
+            )
+        }
+
+    @Test
+    fun `get without a fingerprint param omits relation from the response`() {
+        push(rootId.toString(), validYaml)
+
+        val result = get(rootId.toString())
+
+        assertTrue(isSuccess(result))
+        assertNull(dataOf(result)["relation"])
+    }
+
+    @Test
+    fun `get with a fingerprint matching current returns relation current`() {
+        val pushResult = push(rootId.toString(), validYaml)
+        val currentFingerprint = dataOf(pushResult)["fingerprint"]!!.jsonPrimitive.content
+
+        val result = getWithFingerprint(rootId.toString(), currentFingerprint)
+
+        assertTrue(isSuccess(result))
+        assertEquals("current", dataOf(result)["relation"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `get with a superseded fingerprint returns relation superseded`() {
+        val validYaml2 =
+            """
+            work_item_schemas:
+              feature-task:
+                notes:
+                  - key: other
+                    role: queue
+                    required: true
+            """.trimIndent()
+        val firstPush = push(rootId.toString(), validYaml)
+        val firstFingerprint = dataOf(firstPush)["fingerprint"]!!.jsonPrimitive.content
+        push(rootId.toString(), validYaml2)
+
+        val result = getWithFingerprint(rootId.toString(), firstFingerprint)
+
+        assertTrue(isSuccess(result))
+        assertEquals("superseded", dataOf(result)["relation"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `get with an unrelated fingerprint returns relation unknown`() {
+        push(rootId.toString(), validYaml)
+
+        val result = getWithFingerprint(rootId.toString(), "0".repeat(64))
+
+        assertTrue(isSuccess(result))
+        assertEquals("unknown", dataOf(result)["relation"]!!.jsonPrimitive.content)
+    }
+
+    // ──────────────────────────────────────────────
+    // fast-forward (known-old) push guard
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `push with a superseded fingerprint is rejected as CONFLICT_ERROR and does not overwrite`() {
+        val validYaml2 =
+            """
+            work_item_schemas:
+              feature-task:
+                notes:
+                  - key: other
+                    role: queue
+                    required: true
+            """.trimIndent()
+        push(rootId.toString(), validYaml)
+        push(rootId.toString(), validYaml2)
+
+        val result = push(rootId.toString(), validYaml)
+
+        assertFalse(isSuccess(result))
+        assertEquals(ErrorCodes.CONFLICT_ERROR, errorOf(result)["code"]!!.jsonPrimitive.content)
+
+        val getResult = get(rootId.toString())
+        assertEquals(validYaml2, dataOf(getResult)["configYaml"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `push with force true bypasses a superseded fingerprint`() {
+        val validYaml2 =
+            """
+            work_item_schemas:
+              feature-task:
+                notes:
+                  - key: other
+                    role: queue
+                    required: true
+            """.trimIndent()
+        push(rootId.toString(), validYaml)
+        push(rootId.toString(), validYaml2)
+
+        val result = push(rootId.toString(), validYaml, force = true)
+
+        assertTrue(isSuccess(result))
+        val getResult = get(rootId.toString())
+        assertEquals(validYaml, dataOf(getResult)["configYaml"]!!.jsonPrimitive.content)
+    }
+
     // ──────────────────────────────────────────────
     // validateParams
     // ──────────────────────────────────────────────

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigToolTest.kt
@@ -130,6 +130,28 @@ class ManageProjectConfigToolTest {
     }
 
     @Test
+    fun `push surfaces ignoredSections when the doc has an unhonored top-level key`() {
+        // Plain concatenation (not a nested trimIndent template) — interpolating an already-
+        // trimIndent'd multi-line constant into another trimIndent block would get its indentation
+        // re-mangled by the outer trim's common-margin computation (see ProjectConfigPushServiceTest).
+        val yamlWithActorAuth = "$validYaml\nactor_authentication:\n  mode: jwks\n"
+
+        val result = push(rootId.toString(), yamlWithActorAuth)
+
+        assertTrue(isSuccess(result))
+        val ignoredSections = dataOf(result)["ignoredSections"]!!.jsonArray.map { it.jsonPrimitive.content }
+        assertEquals(listOf("actor_authentication"), ignoredSections)
+    }
+
+    @Test
+    fun `push omits ignoredSections when the doc only uses honored keys`() {
+        val result = push(rootId.toString(), validYaml)
+
+        assertTrue(isSuccess(result))
+        assertNull(dataOf(result)["ignoredSections"], "ignoredSections must be omitted entirely when empty, not an empty array")
+    }
+
+    @Test
     fun `push with hex-prefix rootItemId resolves the item`() {
         val prefix = rootId.toString().replace("-", "").take(8)
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/config/ManageProjectConfigToolTest.kt
@@ -85,14 +85,18 @@ class ManageProjectConfigToolTest {
 
     private fun push(
         rootItemId: String,
-        configYaml: String
+        configYaml: String,
+        force: Boolean? = null
     ): JsonElement =
         runBlocking {
             tool.execute(
                 params(
-                    "operation" to JsonPrimitive("push"),
-                    "rootItemId" to JsonPrimitive(rootItemId),
-                    "configYaml" to JsonPrimitive(configYaml)
+                    *buildList {
+                        add("operation" to JsonPrimitive("push"))
+                        add("rootItemId" to JsonPrimitive(rootItemId))
+                        add("configYaml" to JsonPrimitive(configYaml))
+                        if (force != null) add("force" to JsonPrimitive(force))
+                    }.toTypedArray()
                 ),
                 context
             )
@@ -241,6 +245,60 @@ class ManageProjectConfigToolTest {
             dataOf(first)["fingerprint"]!!.jsonPrimitive.content,
             dataOf(second)["fingerprint"]!!.jsonPrimitive.content
         )
+    }
+
+    // ──────────────────────────────────────────────
+    // rootId mismatch guard
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `push with embedded project rootId matching the target succeeds`() {
+        val yaml = "project:\n  rootId: $rootId\n$validYaml"
+
+        val result = push(rootId.toString(), yaml)
+
+        assertTrue(isSuccess(result))
+    }
+
+    @Test
+    fun `push with embedded project rootId differing from the target is rejected naming both ids`() {
+        val otherRootId = UUID.randomUUID()
+        val yaml = "project:\n  rootId: $otherRootId\n$validYaml"
+
+        val result = push(rootId.toString(), yaml)
+
+        assertFalse(isSuccess(result))
+        val error = errorOf(result)
+        assertEquals(ErrorCodes.VALIDATION_ERROR, error["code"]!!.jsonPrimitive.content)
+        val message = error["message"]!!.jsonPrimitive.content
+        assertTrue(message.contains(rootId.toString()), "message should name the target rootId: $message")
+        assertTrue(message.contains(otherRootId.toString()), "message should name the embedded rootId: $message")
+
+        // Rejected mismatch must not have stored anything.
+        val getResult = get(rootId.toString())
+        assertFalse(isSuccess(getResult))
+        assertEquals(ErrorCodes.RESOURCE_NOT_FOUND, errorOf(getResult)["code"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `push with a malformed non-UUID embedded project rootId proceeds unchanged`() {
+        val yaml = "project:\n  rootId: not-a-uuid\n$validYaml"
+
+        val result = push(rootId.toString(), yaml)
+
+        assertTrue(isSuccess(result))
+    }
+
+    @Test
+    fun `push with force true bypasses a mismatched embedded project rootId`() {
+        val otherRootId = UUID.randomUUID()
+        val yaml = "project:\n  rootId: $otherRootId\n$validYaml"
+
+        val result = push(rootId.toString(), yaml, force = true)
+
+        assertTrue(isSuccess(result))
+        val getResult = get(rootId.toString())
+        assertTrue(isSuccess(getResult))
     }
 
     // ──────────────────────────────────────────────

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolTest.kt
@@ -6,11 +6,16 @@ import io.github.jpicklyk.mcptask.current.application.tools.ToolValidationExcept
 import io.github.jpicklyk.mcptask.current.application.tools.workflow.AdvanceItemTool
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
 import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.WorkItemsTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
+import io.mockk.coEvery
+import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.*
 import org.jetbrains.exposed.v1.core.eq
@@ -2067,6 +2072,200 @@ class QueryItemsToolTest {
             )
         }
     }
+
+    // ──────────────────────────────────────────────
+    // Schema operation: per-root awareness (T2)
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `schema operation with type and rootId returns per-root schema, fingerprint, and configSource`(): Unit =
+        runBlocking {
+            val rootId = UUID.fromString(createItem("Project Root"))
+            val perRoot = mockk<PerRootConfigService>()
+            val perRootSchema =
+                WorkItemSchema(
+                    type = "feature-task",
+                    notes =
+                        listOf(
+                            NoteSchemaEntry(key = "per-root-note", role = Role.QUEUE, required = true, description = "Per-root note")
+                        )
+                )
+            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns perRootSchema
+            coEvery { perRoot.getFingerprint(rootId) } returns "per-root-fp-1"
+
+            val schemaContext = ToolExecutionContext(repositoryProvider, schemaServiceForSchemaOp(), perRootConfigService = perRoot)
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("schema"),
+                        "type" to JsonPrimitive("feature-task"),
+                        "rootId" to JsonPrimitive(rootId.toString())
+                    ),
+                    schemaContext
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals("feature-task", data["type"]!!.jsonPrimitive.content)
+            assertEquals("per-root-fp-1", data["configFingerprint"]!!.jsonPrimitive.content)
+            assertEquals("per-root", data["configSource"]!!.jsonPrimitive.content)
+            val notes = data["notes"]!!.jsonArray
+            assertEquals(1, notes.size)
+            assertEquals("per-root-note", notes[0].jsonObject["key"]!!.jsonPrimitive.content)
+        }
+
+    @Test
+    fun `schema operation with type and rootId falls back to per-root default when exact type misses`(): Unit =
+        runBlocking {
+            val rootId = UUID.fromString(createItem("Project Root"))
+            val perRoot = mockk<PerRootConfigService>()
+            val perRootDefault =
+                WorkItemSchema(
+                    type = "default",
+                    notes = listOf(NoteSchemaEntry(key = "default-note", role = Role.WORK, required = false, description = "Default note"))
+                )
+            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns null
+            coEvery { perRoot.getSchemaForType(rootId, "default") } returns perRootDefault
+            coEvery { perRoot.getFingerprint(rootId) } returns "per-root-fp-2"
+
+            val schemaContext = ToolExecutionContext(repositoryProvider, schemaServiceForSchemaOp(), perRootConfigService = perRoot)
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("schema"),
+                        "type" to JsonPrimitive("feature-task"),
+                        "rootId" to JsonPrimitive(rootId.toString())
+                    ),
+                    schemaContext
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals("default", data["type"]!!.jsonPrimitive.content)
+            assertEquals("per-root-fp-2", data["configFingerprint"]!!.jsonPrimitive.content)
+            assertEquals("per-root", data["configSource"]!!.jsonPrimitive.content)
+        }
+
+    @Test
+    fun `schema operation with type and rootId falls back to global when root has no per-root config`(): Unit =
+        runBlocking {
+            val rootId = UUID.fromString(createItem("Project Root"))
+            val perRoot = mockk<PerRootConfigService>()
+            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns null
+            coEvery { perRoot.getSchemaForType(rootId, "default") } returns null
+
+            val schemaContext = ToolExecutionContext(repositoryProvider, schemaServiceForSchemaOp(), perRootConfigService = perRoot)
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("schema"),
+                        "type" to JsonPrimitive("feature-task"),
+                        "rootId" to JsonPrimitive(rootId.toString())
+                    ),
+                    schemaContext
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals("feature-task", data["type"]!!.jsonPrimitive.content)
+            assertEquals("fp-123", data["configFingerprint"]!!.jsonPrimitive.content)
+            assertEquals("global", data["configSource"]!!.jsonPrimitive.content)
+        }
+
+    @Test
+    fun `schema operation with type and no rootId is unchanged global behavior`(): Unit =
+        runBlocking {
+            val schemaContext = ToolExecutionContext(repositoryProvider, schemaServiceForSchemaOp())
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("schema"),
+                        "type" to JsonPrimitive("feature-task")
+                    ),
+                    schemaContext
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals("feature-task", data["type"]!!.jsonPrimitive.content)
+            assertEquals("fp-123", data["configFingerprint"]!!.jsonPrimitive.content)
+            assertEquals("global", data["configSource"]!!.jsonPrimitive.content)
+        }
+
+    @Test
+    fun `schema operation by itemId reports per-root fingerprint and source when item's root resolved it`(): Unit =
+        runBlocking {
+            val rootId = UUID.fromString(createItem("Project Root"))
+            val itemId = createItem("Tagged item", parentId = rootId.toString(), type = "feature-task")
+
+            val perRoot = mockk<PerRootConfigService>()
+            val perRootSchema =
+                WorkItemSchema(
+                    type = "feature-task",
+                    notes =
+                        listOf(
+                            NoteSchemaEntry(key = "per-root-note", role = Role.QUEUE, required = true, description = "Per-root note")
+                        )
+                )
+            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns perRootSchema
+            coEvery { perRoot.getFingerprint(rootId) } returns "per-root-fp-3"
+
+            val schemaContext = ToolExecutionContext(repositoryProvider, schemaServiceForSchemaOp(), perRootConfigService = perRoot)
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("schema"),
+                        "itemId" to JsonPrimitive(itemId)
+                    ),
+                    schemaContext
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals("feature-task", data["type"]!!.jsonPrimitive.content)
+            assertEquals("per-root-fp-3", data["configFingerprint"]!!.jsonPrimitive.content)
+            assertEquals("per-root", data["configSource"]!!.jsonPrimitive.content)
+        }
+
+    @Test
+    fun `schema operation by itemId reports global fingerprint and source for a null-rootId item`(): Unit =
+        runBlocking {
+            // Simulates a legacy pre-backfill row: created directly via the repository (bypassing
+            // CreateItemHandler's rootId auto-assignment) with rootId explicitly null.
+            val legacyItem =
+                WorkItem(
+                    id = UUID.randomUUID(),
+                    title = "Legacy item",
+                    type = "feature-task",
+                    depth = 0,
+                    rootId = null
+                )
+            val created = context.workItemRepository().create(legacyItem)
+            assertTrue(created is Result.Success)
+
+            val perRoot = mockk<PerRootConfigService>()
+            val schemaContext = ToolExecutionContext(repositoryProvider, schemaServiceForSchemaOp(), perRootConfigService = perRoot)
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("schema"),
+                        "itemId" to JsonPrimitive(legacyItem.id.toString())
+                    ),
+                    schemaContext
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals("feature-task", data["type"]!!.jsonPrimitive.content)
+            assertEquals("fp-123", data["configFingerprint"]!!.jsonPrimitive.content)
+            assertEquals("global", data["configSource"]!!.jsonPrimitive.content)
+        }
 
     // ──────────────────────────────────────────────
     // Validation

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolTest.kt
@@ -2090,8 +2090,14 @@ class QueryItemsToolTest {
                             NoteSchemaEntry(key = "per-root-note", role = Role.QUEUE, required = true, description = "Per-root note")
                         )
                 )
-            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns perRootSchema
-            coEvery { perRoot.getFingerprint(rootId) } returns "per-root-fp-1"
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = mapOf("feature-task" to perRootSchema),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = null,
+                    fingerprint = "per-root-fp-1"
+                )
 
             val schemaContext = ToolExecutionContext(repositoryProvider, schemaServiceForSchemaOp(), perRootConfigService = perRoot)
 
@@ -2125,9 +2131,14 @@ class QueryItemsToolTest {
                     type = "default",
                     notes = listOf(NoteSchemaEntry(key = "default-note", role = Role.WORK, required = false, description = "Default note"))
                 )
-            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns null
-            coEvery { perRoot.getSchemaForType(rootId, "default") } returns perRootDefault
-            coEvery { perRoot.getFingerprint(rootId) } returns "per-root-fp-2"
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = mapOf("default" to perRootDefault),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = null,
+                    fingerprint = "per-root-fp-2"
+                )
 
             val schemaContext = ToolExecutionContext(repositoryProvider, schemaServiceForSchemaOp(), perRootConfigService = perRoot)
 
@@ -2153,8 +2164,7 @@ class QueryItemsToolTest {
         runBlocking {
             val rootId = UUID.fromString(createItem("Project Root"))
             val perRoot = mockk<PerRootConfigService>()
-            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns null
-            coEvery { perRoot.getSchemaForType(rootId, "default") } returns null
+            coEvery { perRoot.getSnapshot(rootId) } returns null
 
             val schemaContext = ToolExecutionContext(repositoryProvider, schemaServiceForSchemaOp(), perRootConfigService = perRoot)
 
@@ -2211,8 +2221,14 @@ class QueryItemsToolTest {
                             NoteSchemaEntry(key = "per-root-note", role = Role.QUEUE, required = true, description = "Per-root note")
                         )
                 )
-            coEvery { perRoot.getSchemaForType(rootId, "feature-task") } returns perRootSchema
-            coEvery { perRoot.getFingerprint(rootId) } returns "per-root-fp-3"
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = mapOf("feature-task" to perRootSchema),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = null,
+                    fingerprint = "per-root-fp-3"
+                )
 
             val schemaContext = ToolExecutionContext(repositoryProvider, schemaServiceForSchemaOp(), perRootConfigService = perRoot)
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesToolTest.kt
@@ -1810,12 +1810,26 @@ class ManageNotesToolTest {
         runBlocking {
             val strictRootId = UUID.randomUUID()
             val laxRootId = UUID.randomUUID()
-            // relaxed=true: resolveSchema's tag-fallback path also probes getSchemas/getSchemaForType
-            // on this same mock (to look up the note's maxLength) — only note_limits behavior is
-            // under test here, so those unrelated calls just get harmless defaults (null).
-            val perRoot = mockk<PerRootConfigService>(relaxed = true)
-            coEvery { perRoot.getNoteLimitsMode(strictRootId) } returns "reject"
-            coEvery { perRoot.getNoteLimitsMode(laxRootId) } returns null
+            // resolveSchema's tag-fallback path also consults this same mock's snapshot (to look up
+            // the note's maxLength) — only note_limits behavior is under test here, so each
+            // snapshot's workItemSchemas/traits are empty, giving that path a harmless miss.
+            val perRoot = mockk<PerRootConfigService>()
+            coEvery { perRoot.getSnapshot(strictRootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = emptyMap(),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = "reject",
+                    statusLabels = null,
+                    fingerprint = "fp-strict"
+                )
+            coEvery { perRoot.getSnapshot(laxRootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = emptyMap(),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = null,
+                    fingerprint = "fp-lax"
+                )
 
             val schemaEntries = listOf(NoteSchemaEntry(key = "limited", role = Role.WORK, maxLength = 10))
             val schemaContext = contextWithSchemaLimitsAndPerRoot(schemaEntries, "limited-schema", "warn", perRoot)

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/ManageNotesToolTest.kt
@@ -7,9 +7,12 @@ import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
 import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.management.DirectDatabaseSchemaManager
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
+import io.mockk.coEvery
+import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.*
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -1646,6 +1649,32 @@ class ManageNotesToolTest {
         return ToolExecutionContext(repositoryProvider, noteSchemaService)
     }
 
+    /** Same as [contextWithSchemaAndLimitsMode], but with a [perRoot] layer wired in for t3 tests. */
+    private fun contextWithSchemaLimitsAndPerRoot(
+        entries: List<NoteSchemaEntry>,
+        matchTag: String,
+        globalNoteLimitsMode: String,
+        perRoot: PerRootConfigService
+    ): ToolExecutionContext {
+        val noteSchemaService =
+            object : NoteSchemaService {
+                override fun getSchemaForTags(tags: List<String>): List<NoteSchemaEntry>? = if (tags.contains(matchTag)) entries else null
+
+                override fun getNoteLimitsMode(): String = globalNoteLimitsMode
+            }
+        return ToolExecutionContext(repositoryProvider, noteSchemaService, perRootConfigService = perRoot)
+    }
+
+    private suspend fun createTestItemWithTagsAndRoot(
+        rootId: UUID,
+        tags: String,
+        title: String = "Test Item"
+    ): String {
+        val item = WorkItem(title = title, tags = tags, role = Role.QUEUE, rootId = rootId)
+        val result = context.workItemRepository().create(item)
+        return ((result as Result.Success).data.id).toString()
+    }
+
     @Test
     fun `upsert warns when body exceeds maxLength in default warn mode`(): Unit =
         runBlocking {
@@ -1770,6 +1799,113 @@ class ManageNotesToolTest {
             assertEquals(1, data["upserted"]!!.jsonPrimitive.int, "warn mode still accepts the note")
             val note = data["notes"]!!.jsonArray[0] as JsonObject
             assertTrue(note.containsKey("warning"), "maxLength must be enforced on bodyFromFile content as well as inline body")
+        }
+
+    // ──────────────────────────────────────────────
+    // t3: per-root note_limits layering
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `upsert per-root note_limits reject mode rejects an over-limit note for that root while another root stays on global warn`(): Unit =
+        runBlocking {
+            val strictRootId = UUID.randomUUID()
+            val laxRootId = UUID.randomUUID()
+            // relaxed=true: resolveSchema's tag-fallback path also probes getSchemas/getSchemaForType
+            // on this same mock (to look up the note's maxLength) — only note_limits behavior is
+            // under test here, so those unrelated calls just get harmless defaults (null).
+            val perRoot = mockk<PerRootConfigService>(relaxed = true)
+            coEvery { perRoot.getNoteLimitsMode(strictRootId) } returns "reject"
+            coEvery { perRoot.getNoteLimitsMode(laxRootId) } returns null
+
+            val schemaEntries = listOf(NoteSchemaEntry(key = "limited", role = Role.WORK, maxLength = 10))
+            val schemaContext = contextWithSchemaLimitsAndPerRoot(schemaEntries, "limited-schema", "warn", perRoot)
+
+            val strictItemId = createTestItemWithTagsAndRoot(strictRootId, "limited-schema")
+            val laxItemId = createTestItemWithTagsAndRoot(laxRootId, "limited-schema")
+
+            val strictResult =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("upsert"),
+                        "notes" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("itemId", JsonPrimitive(strictItemId))
+                                        put("key", JsonPrimitive("limited"))
+                                        put("role", JsonPrimitive("work"))
+                                        put("body", JsonPrimitive("this body is way over the limit"))
+                                    }
+                                )
+                            )
+                    ),
+                    schemaContext
+                ) as JsonObject
+            val strictData = strictResult["data"] as JsonObject
+            assertEquals(0, strictData["upserted"]!!.jsonPrimitive.int, "the strict root's per-root reject mode must reject")
+            assertEquals(1, strictData["failed"]!!.jsonPrimitive.int)
+            val failure = strictData["failures"]!!.jsonArray[0] as JsonObject
+            assertEquals("NOTE_BODY_TOO_LONG", failure["code"]!!.jsonPrimitive.content)
+
+            val laxResult =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("upsert"),
+                        "notes" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("itemId", JsonPrimitive(laxItemId))
+                                        put("key", JsonPrimitive("limited"))
+                                        put("role", JsonPrimitive("work"))
+                                        put("body", JsonPrimitive("this body is way over the limit"))
+                                    }
+                                )
+                            )
+                    ),
+                    schemaContext
+                ) as JsonObject
+            val laxData = laxResult["data"] as JsonObject
+            assertEquals(
+                1,
+                laxData["upserted"]!!.jsonPrimitive.int,
+                "no per-root value for this root must fall back to the global warn mode"
+            )
+            assertEquals(0, laxData["failed"]!!.jsonPrimitive.int)
+            val laxNote = laxData["notes"]!!.jsonArray[0] as JsonObject
+            assertTrue(laxNote.containsKey("warning"), "global warn mode should still accept the note with a warning")
+        }
+
+    @Test
+    fun `upsert falls back to the global note_limits mode when the item has a null rootId`(): Unit =
+        runBlocking {
+            val perRoot = mockk<PerRootConfigService>()
+            val schemaEntries = listOf(NoteSchemaEntry(key = "limited", role = Role.WORK, maxLength = 10))
+            val schemaContext = contextWithSchemaLimitsAndPerRoot(schemaEntries, "limited-schema", "reject", perRoot)
+            val itemId = createTestItemWithTags(tags = "limited-schema") // rootId defaults to null
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("upsert"),
+                        "notes" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("itemId", JsonPrimitive(itemId))
+                                        put("key", JsonPrimitive("limited"))
+                                        put("role", JsonPrimitive("work"))
+                                        put("body", JsonPrimitive("this body is way over the limit"))
+                                    }
+                                )
+                            )
+                    ),
+                    schemaContext
+                ) as JsonObject
+
+            val data = result["data"] as JsonObject
+            assertEquals(0, data["upserted"]!!.jsonPrimitive.int, "a null rootId must still use the global mode (reject here)")
+            assertEquals(1, data["failed"]!!.jsonPrimitive.int)
         }
 
     @Test

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
@@ -12,6 +12,7 @@ import io.github.jpicklyk.mcptask.current.domain.repository.RepositoryError
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.domain.repository.RoleTransitionRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
+import io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
 import io.github.jpicklyk.mcptask.current.test.TestStatusLabelService
 import io.mockk.coEvery
@@ -64,6 +65,15 @@ class AdvanceItemToolTest {
     private fun contextWithLabels(labelService: StatusLabelService): ToolExecutionContext =
         ToolExecutionContext(repoProvider, statusLabelService = labelService)
 
+    /**
+     * Build a custom context with a global [labelService] AND a [perRoot] layer, reusing existing
+     * mocked repos — for t3's per-root status_labels tests.
+     */
+    private fun contextWithPerRootLabels(
+        labelService: StatusLabelService,
+        perRoot: PerRootConfigService
+    ): ToolExecutionContext = ToolExecutionContext(repoProvider, statusLabelService = labelService, perRootConfigService = perRoot)
+
     /** Build a custom context with a specific ActorVerifier, reusing existing mocked repos. */
     private fun contextWithVerifier(verifier: ActorVerifier): ToolExecutionContext =
         ToolExecutionContext(repoProvider, actorVerifier = verifier)
@@ -74,7 +84,8 @@ class AdvanceItemToolTest {
         previousRole: Role? = null,
         title: String = "Test Item",
         parentId: UUID? = null,
-        depth: Int = if (parentId != null) 1 else 0
+        depth: Int = if (parentId != null) 1 else 0,
+        rootId: UUID? = null
     ): WorkItem =
         WorkItem(
             id = id,
@@ -82,7 +93,8 @@ class AdvanceItemToolTest {
             role = role,
             previousRole = previousRole,
             parentId = parentId,
-            depth = depth
+            depth = depth,
+            rootId = rootId
         )
 
     private fun buildParams(vararg transitions: JsonObject): JsonObject =
@@ -1935,6 +1947,95 @@ class AdvanceItemToolTest {
             assertEquals("work", r["newRole"]!!.jsonPrimitive.content)
             // Custom config label "working" should be used (resolution.statusLabel is null for start)
             assertEquals("working", r["statusLabel"]!!.jsonPrimitive.content)
+        }
+
+    // ──────────────────────────────────────────────
+    // t3: per-root status_labels layering
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `per-root status_labels override the global label on that root's start transition`(): Unit =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            // relaxed=true: AdvanceService's schemaResolver also calls resolveSchema, which probes
+            // getSchemas/getSchemaForType/getTraitNotes on this same per-root mock — only
+            // status_labels behavior is under test here, so those calls just get harmless defaults.
+            val perRoot = mockk<PerRootConfigService>(relaxed = true)
+            coEvery { perRoot.getStatusLabels(rootId) } returns mapOf("start" to "root-started")
+            val globalLabels = TestStatusLabelService(mapOf("start" to "in-progress"))
+            val customContext = contextWithPerRootLabels(globalLabels, perRoot)
+
+            val itemId = UUID.randomUUID()
+            val item = makeItem(id = itemId, role = Role.QUEUE, rootId = rootId)
+
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+            coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+            coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+            every { depRepo.findByToItemId(itemId) } returns emptyList()
+            every { depRepo.findByFromItemId(itemId) } returns emptyList()
+
+            val params = buildParams(transitionObj(itemId, "start"))
+            val result = tool.execute(params, customContext)
+
+            val r = extractResults(result)[0].jsonObject
+            assertTrue(r["applied"]!!.jsonPrimitive.boolean)
+            assertEquals("root-started", r["statusLabel"]!!.jsonPrimitive.content)
+        }
+
+    @Test
+    fun `partial per-root status_labels falls through to global per trigger`(): Unit =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>(relaxed = true)
+            // Only "start" is overridden for this root — "complete" must fall through to global.
+            coEvery { perRoot.getStatusLabels(rootId) } returns mapOf("start" to "root-started")
+            val globalLabels = TestStatusLabelService(mapOf("start" to "in-progress", "complete" to "finished"))
+            val customContext = contextWithPerRootLabels(globalLabels, perRoot)
+
+            val itemId = UUID.randomUUID()
+            val item = makeItem(id = itemId, role = Role.QUEUE, rootId = rootId)
+
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+            coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+            coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+            every { depRepo.findByToItemId(itemId) } returns emptyList()
+            every { depRepo.findByFromItemId(itemId) } returns emptyList()
+
+            val params = buildParams(transitionObj(itemId, "complete"))
+            val result = tool.execute(params, customContext)
+
+            val r = extractResults(result)[0].jsonObject
+            assertTrue(r["applied"]!!.jsonPrimitive.boolean)
+            assertEquals(
+                "finished",
+                r["statusLabel"]!!.jsonPrimitive.content,
+                "trigger not present in the per-root map must fall through to the global label"
+            )
+        }
+
+    @Test
+    fun `a null rootId uses the global StatusLabelService even when a per-root layer is wired`(): Unit =
+        runBlocking {
+            val perRoot = mockk<PerRootConfigService>()
+            val globalLabels = TestStatusLabelService(mapOf("start" to "in-progress"))
+            val customContext = contextWithPerRootLabels(globalLabels, perRoot)
+
+            val itemId = UUID.randomUUID()
+            val item = makeItem(id = itemId, role = Role.QUEUE, rootId = null)
+
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+            coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+            coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+            every { depRepo.findByToItemId(itemId) } returns emptyList()
+            every { depRepo.findByFromItemId(itemId) } returns emptyList()
+
+            val params = buildParams(transitionObj(itemId, "start"))
+            val result = tool.execute(params, customContext)
+
+            val r = extractResults(result)[0].jsonObject
+            assertTrue(r["applied"]!!.jsonPrimitive.boolean)
+            assertEquals("in-progress", r["statusLabel"]!!.jsonPrimitive.content)
+            coVerify(exactly = 0) { perRoot.getStatusLabels(any()) }
         }
 
     @Test

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
@@ -1957,11 +1957,18 @@ class AdvanceItemToolTest {
     fun `per-root status_labels override the global label on that root's start transition`(): Unit =
         runBlocking {
             val rootId = UUID.randomUUID()
-            // relaxed=true: AdvanceService's schemaResolver also calls resolveSchema, which probes
-            // getSchemas/getSchemaForType/getTraitNotes on this same per-root mock — only
-            // status_labels behavior is under test here, so those calls just get harmless defaults.
-            val perRoot = mockk<PerRootConfigService>(relaxed = true)
-            coEvery { perRoot.getStatusLabels(rootId) } returns mapOf("start" to "root-started")
+            // AdvanceService's schemaResolver also calls resolveSchema, which consults this same
+            // per-root mock's snapshot — only status_labels behavior is under test here, so
+            // workItemSchemas/traits are empty, giving that path a harmless miss.
+            val perRoot = mockk<PerRootConfigService>()
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = emptyMap(),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = mapOf("start" to "root-started"),
+                    fingerprint = "fp"
+                )
             val globalLabels = TestStatusLabelService(mapOf("start" to "in-progress"))
             val customContext = contextWithPerRootLabels(globalLabels, perRoot)
 
@@ -1980,15 +1987,28 @@ class AdvanceItemToolTest {
             val r = extractResults(result)[0].jsonObject
             assertTrue(r["applied"]!!.jsonPrimitive.boolean)
             assertEquals("root-started", r["statusLabel"]!!.jsonPrimitive.content)
+            // A single advance resolves the per-root layer from exactly two snapshot fetches — one
+            // for schema resolution (AdvanceService's schemaResolver) and one for status-label
+            // resolution (resolveRootAwareStatusLabelService) — NOT one fetch per trigger and NOT
+            // the old 8-wide (every UserTrigger + "cascade") fan-out. The status-label fetch alone
+            // resolves both consulted triggers ("start" + "cascade") from a SINGLE snapshot.
+            coVerify(exactly = 2) { perRoot.getSnapshot(rootId) }
         }
 
     @Test
     fun `partial per-root status_labels falls through to global per trigger`(): Unit =
         runBlocking {
             val rootId = UUID.randomUUID()
-            val perRoot = mockk<PerRootConfigService>(relaxed = true)
+            val perRoot = mockk<PerRootConfigService>()
             // Only "start" is overridden for this root — "complete" must fall through to global.
-            coEvery { perRoot.getStatusLabels(rootId) } returns mapOf("start" to "root-started")
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = emptyMap(),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = mapOf("start" to "root-started"),
+                    fingerprint = "fp"
+                )
             val globalLabels = TestStatusLabelService(mapOf("start" to "in-progress", "complete" to "finished"))
             val customContext = contextWithPerRootLabels(globalLabels, perRoot)
 
@@ -2035,7 +2055,7 @@ class AdvanceItemToolTest {
             val r = extractResults(result)[0].jsonObject
             assertTrue(r["applied"]!!.jsonPrimitive.boolean)
             assertEquals("in-progress", r["statusLabel"]!!.jsonPrimitive.content)
-            coVerify(exactly = 0) { perRoot.getStatusLabels(any()) }
+            coVerify(exactly = 0) { perRoot.getSnapshot(any()) }
         }
 
     @Test

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigServiceTest.kt
@@ -312,6 +312,56 @@ note_limits:
             )
         }
 
+    // --- getSnapshot: single-pass combined view ---
+
+    @Test
+    fun `getSnapshot returns null when no config row exists`() =
+        runBlocking {
+            assertNull(service.getSnapshot(rootItemId))
+        }
+
+    @Test
+    fun `getSnapshot combines schemas, traits, note_limits, status_labels, and fingerprint from one parse`() =
+        runBlocking {
+            repository.upsert(
+                rootItemId,
+                """
+work_item_schemas:
+  bug-fix:
+    notes:
+      - key: repro-steps
+        role: queue
+        required: true
+        description: "Repro steps"
+traits:
+  needs-migration-review:
+    notes:
+      - key: migration-assessment
+        role: queue
+        required: true
+        description: "Migration assessment"
+note_limits:
+  mode: reject
+status_labels:
+  start: "root-started"
+                """.trimIndent()
+            )
+
+            val snapshot = service.getSnapshot(rootItemId)
+            assertNotNull(snapshot)
+            assertEquals(
+                "repro-steps",
+                snapshot.workItemSchemas["bug-fix"]
+                    ?.notes
+                    ?.get(0)
+                    ?.key
+            )
+            assertEquals("migration-assessment", snapshot.traits["needs-migration-review"]?.get(0)?.key)
+            assertEquals("reject", snapshot.noteLimitsModeExplicit)
+            assertEquals("root-started", snapshot.statusLabels?.get("start"))
+            assertEquals(service.getFingerprint(rootItemId), snapshot.fingerprint)
+        }
+
     // --- getStatusLabels: absent-vs-explicit, partial map ---
 
     @Test

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigServiceTest.kt
@@ -259,4 +259,99 @@ work_item_schemas:
 
             assertNull(service.getSchemas(rootItemId))
         }
+
+    // --- getNoteLimitsMode: absent-vs-explicit ---
+
+    @Test
+    fun `getNoteLimitsMode returns null when no config row exists`() =
+        runBlocking {
+            assertNull(service.getNoteLimitsMode(rootItemId))
+        }
+
+    @Test
+    fun `getNoteLimitsMode returns null when the per-root doc has no note_limits section`() =
+        runBlocking {
+            repository.upsert(
+                rootItemId,
+                """
+work_item_schemas:
+  default:
+    notes: []
+                """.trimIndent()
+            )
+
+            assertNull(
+                service.getNoteLimitsMode(rootItemId),
+                "Absence of the note_limits key must fall through to global, not resolve to a default"
+            )
+        }
+
+    @Test
+    fun `getNoteLimitsMode returns the explicit mode when the per-root doc configures note_limits`() =
+        runBlocking {
+            repository.upsert(
+                rootItemId,
+                """
+note_limits:
+  mode: reject
+                """.trimIndent()
+            )
+
+            assertEquals("reject", service.getNoteLimitsMode(rootItemId))
+        }
+
+    @Test
+    fun `getNoteLimitsMode resolves to the warn default when note_limits is present without a mode key`() =
+        runBlocking {
+            repository.upsert(rootItemId, "note_limits: {}\n")
+
+            assertEquals(
+                "warn",
+                service.getNoteLimitsMode(rootItemId),
+                "Presence of the note_limits key is what counts as explicit, even with no mode sub-key"
+            )
+        }
+
+    // --- getStatusLabels: absent-vs-explicit, partial map ---
+
+    @Test
+    fun `getStatusLabels returns null when no config row exists`() =
+        runBlocking {
+            assertNull(service.getStatusLabels(rootItemId))
+        }
+
+    @Test
+    fun `getStatusLabels returns null when the per-root doc has no status_labels section`() =
+        runBlocking {
+            repository.upsert(
+                rootItemId,
+                """
+work_item_schemas:
+  default:
+    notes: []
+                """.trimIndent()
+            )
+
+            assertNull(service.getStatusLabels(rootItemId))
+        }
+
+    @Test
+    fun `getStatusLabels returns a partial map when the per-root doc only overrides some triggers`() =
+        runBlocking {
+            repository.upsert(
+                rootItemId,
+                """
+status_labels:
+  start: "root-started"
+  complete: null
+                """.trimIndent()
+            )
+
+            val labels = service.getStatusLabels(rootItemId)
+            assertNotNull(labels)
+            assertEquals("root-started", labels["start"])
+            assertTrue(labels.containsKey("complete"), "An explicit null value must still be a present key")
+            assertNull(labels["complete"], "Explicit null means 'no label', distinct from the key being absent")
+            assertTrue(!labels.containsKey("cancel"), "A trigger not mentioned in the doc must be absent from the map")
+        }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteProjectConfigRepositoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteProjectConfigRepositoryTest.kt
@@ -1,5 +1,6 @@
 package io.github.jpicklyk.mcptask.current.infrastructure.database.repository
 
+import io.github.jpicklyk.mcptask.current.domain.model.FingerprintRelation
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
@@ -143,5 +144,149 @@ class SQLiteProjectConfigRepositoryTest {
             val fetched = projectConfigRepository.get(rootItemId)
             assertIs<Result.Success<*>>(fetched)
             assertNull((fetched as Result.Success).data, "Expected CASCADE delete to remove the project_config row")
+        }
+
+    // --- computeFingerprint ---
+
+    @Test
+    fun `computeFingerprint is stable for identical content and matches the fingerprint stored by upsert`() =
+        runBlocking {
+            val yaml = "work_item_schemas:\n  default: {}\n"
+            val computed = projectConfigRepository.computeFingerprint(yaml)
+            assertEquals(computed, projectConfigRepository.computeFingerprint(yaml))
+
+            val stored = (projectConfigRepository.upsert(rootItemId, yaml) as Result.Success).data
+            assertEquals(computed, stored.fingerprint)
+        }
+
+    // --- fingerprint history: append on change, no-op on identical re-push, prune at 20 ---
+
+    @Test
+    fun `upsert appends the outgoing fingerprint to history, newest first, when the fingerprint changes`() =
+        runBlocking {
+            val yamlA = "work_item_schemas:\n  a: {}\n"
+            val yamlB = "work_item_schemas:\n  b: {}\n"
+            val yamlC = "work_item_schemas:\n  c: {}\n"
+
+            val fingerprintA = projectConfigRepository.computeFingerprint(yamlA)
+            val fingerprintB = projectConfigRepository.computeFingerprint(yamlB)
+
+            projectConfigRepository.upsert(rootItemId, yamlA)
+            projectConfigRepository.upsert(rootItemId, yamlB)
+            projectConfigRepository.upsert(rootItemId, yamlC)
+
+            // A is superseded (in history, not current); B is superseded too (was current, then
+            // replaced by C); newest-first means B (the most recent outgoing) precedes A.
+            assertEquals(
+                FingerprintRelation.SUPERSEDED,
+                (projectConfigRepository.classifyFingerprint(rootItemId, fingerprintB) as Result.Success).data
+            )
+            assertEquals(
+                FingerprintRelation.SUPERSEDED,
+                (projectConfigRepository.classifyFingerprint(rootItemId, fingerprintA) as Result.Success).data
+            )
+        }
+
+    @Test
+    fun `re-pushing identical content does not consume fingerprint history budget`() =
+        runBlocking {
+            val v1 = "work_item_schemas:\n  v1: {}\n"
+            val fingerprintV1 = projectConfigRepository.computeFingerprint(v1)
+
+            projectConfigRepository.upsert(rootItemId, v1)
+            // Nine redundant re-pushes of identical content — if these incorrectly appended to
+            // history, they would consume prune budget and evict v1 from history early below.
+            repeat(9) { projectConfigRepository.upsert(rootItemId, v1) }
+
+            // 19 further distinct pushes create exactly 19 real fingerprint transitions
+            // (v1->v2, v2->v3, ..., v19->v20) — within the 20-entry cap, so v1 must still be
+            // present in history. If the redundant re-pushes above had wrongly added entries,
+            // this history would already be full and v1 would have been pruned before this point.
+            for (i in 2..20) {
+                projectConfigRepository.upsert(rootItemId, "work_item_schemas:\n  v$i: {}\n")
+            }
+
+            val result = projectConfigRepository.classifyFingerprint(rootItemId, fingerprintV1)
+            assertEquals(
+                FingerprintRelation.SUPERSEDED,
+                (result as Result.Success).data,
+                "v1 should still be in history — redundant re-pushes must not consume prune budget"
+            )
+        }
+
+    @Test
+    fun `fingerprint history is pruned to 20 entries`() =
+        runBlocking {
+            val fingerprints = mutableListOf<String>()
+            // 22 pushes v1..v22 (current = v22): each push v_k (k>=2) prepends the OUTGOING
+            // fingerprint fp(v_{k-1}) to history. After all 22 pushes, history holds the 20 most
+            // recent outgoing fingerprints — fp(v21) down to fp(v2) — and fp(v1) (the oldest
+            // outgoing entry, from the v1->v2 transition) has been pruned out.
+            for (i in 1..22) {
+                val yaml = "work_item_schemas:\n  v$i: {}\n"
+                fingerprints.add(projectConfigRepository.computeFingerprint(yaml))
+                projectConfigRepository.upsert(rootItemId, yaml)
+            }
+
+            assertEquals(
+                FingerprintRelation.UNKNOWN,
+                (projectConfigRepository.classifyFingerprint(rootItemId, fingerprints[0]) as Result.Success).data,
+                "v1's fingerprint should have been pruned from history (the 21st-oldest entry)"
+            )
+            // The most recent 20 outgoing fingerprints (v2..v21, indices 1..20) must remain — check
+            // the retained boundary (v2, index 1) and the most-recently-superseded (v21, index 20).
+            assertEquals(
+                FingerprintRelation.SUPERSEDED,
+                (projectConfigRepository.classifyFingerprint(rootItemId, fingerprints[1]) as Result.Success).data,
+                "v2's fingerprint should still be in history (the oldest retained entry)"
+            )
+            assertEquals(
+                FingerprintRelation.SUPERSEDED,
+                (projectConfigRepository.classifyFingerprint(rootItemId, fingerprints[20]) as Result.Success).data,
+                "v21's fingerprint (the most recently superseded) should still be in history"
+            )
+        }
+
+    // --- classifyFingerprint ---
+
+    @Test
+    fun `classifyFingerprint returns CURRENT for the stored current fingerprint`() =
+        runBlocking {
+            val yaml = "work_item_schemas:\n  default: {}\n"
+            val stored = (projectConfigRepository.upsert(rootItemId, yaml) as Result.Success).data
+
+            val result = projectConfigRepository.classifyFingerprint(rootItemId, stored.fingerprint)
+            assertEquals(FingerprintRelation.CURRENT, (result as Result.Success).data)
+        }
+
+    @Test
+    fun `classifyFingerprint returns UNKNOWN for a fingerprint with no stored row at all`() =
+        runBlocking {
+            val result = projectConfigRepository.classifyFingerprint(rootItemId, "0".repeat(64))
+            assertEquals(FingerprintRelation.UNKNOWN, (result as Result.Success).data)
+        }
+
+    @Test
+    fun `classifyFingerprint returns UNKNOWN for a NULL-history row and any non-current fingerprint`() =
+        runBlocking {
+            // A single upsert leaves fingerprint_history NULL (no prior row to derive history from)
+            // — this is also what a pre-V11 row looks like. Any non-current fingerprint must
+            // classify as UNKNOWN, not SUPERSEDED, since there is no known ancestor to compare against.
+            projectConfigRepository.upsert(rootItemId, "work_item_schemas:\n  default: {}\n")
+
+            val result = projectConfigRepository.classifyFingerprint(rootItemId, "1".repeat(64))
+            assertEquals(FingerprintRelation.UNKNOWN, (result as Result.Success).data)
+        }
+
+    @Test
+    fun `classifyFingerprint returns UNKNOWN for a divergent fingerprint never seen by this root`() =
+        runBlocking {
+            val yamlA = "work_item_schemas:\n  a: {}\n"
+            val yamlB = "work_item_schemas:\n  b: {}\n"
+            projectConfigRepository.upsert(rootItemId, yamlA)
+            projectConfigRepository.upsert(rootItemId, yamlB)
+
+            val result = projectConfigRepository.classifyFingerprint(rootItemId, "2".repeat(64))
+            assertEquals(FingerprintRelation.UNKNOWN, (result as Result.Success).data)
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutesTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutesTest.kt
@@ -335,6 +335,73 @@ class ProjectConfigPutRouteTest {
             val persisted = runBlocking { repo.projectConfigRepository().get(root.id) }
             assertTrue((persisted as Result.Success).data != null, "force=true should allow the push to persist")
         }
+
+    @Test
+    fun `PUT roots rootId config with a known-old (superseded) fingerprint returns 409 superseded`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+            val yamlB = VALID_YAML + "\n"
+
+            client.put("/api/v1/roots/${root.id}/config") {
+                header("Authorization", "Bearer $WRITE_TOKEN")
+                contentType(ContentType.Text.Plain)
+                setBody(VALID_YAML)
+            }
+            client.put("/api/v1/roots/${root.id}/config") {
+                header("Authorization", "Bearer $WRITE_TOKEN")
+                contentType(ContentType.Text.Plain)
+                setBody(yamlB)
+            }
+
+            // VALID_YAML is now superseded by yamlB — pushing it again must be rejected as 409,
+            // distinct from the 412 If-Match/concurrent-write case.
+            val response =
+                client.put("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Text.Plain)
+                    setBody(VALID_YAML)
+                }
+
+            assertEquals(HttpStatusCode.Conflict, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("superseded"), "Should report the superseded error code: $body")
+
+            val persisted = runBlocking { repo.projectConfigRepository().get(root.id) }
+            assertEquals(yamlB, (persisted as Result.Success).data?.configYaml, "Rejected push must not overwrite the current row")
+        }
+
+    @Test
+    fun `PUT roots rootId config with force=true bypasses a superseded fingerprint`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+            val yamlB = VALID_YAML + "\n"
+
+            client.put("/api/v1/roots/${root.id}/config") {
+                header("Authorization", "Bearer $WRITE_TOKEN")
+                contentType(ContentType.Text.Plain)
+                setBody(VALID_YAML)
+            }
+            client.put("/api/v1/roots/${root.id}/config") {
+                header("Authorization", "Bearer $WRITE_TOKEN")
+                contentType(ContentType.Text.Plain)
+                setBody(yamlB)
+            }
+
+            val response =
+                client.put("/api/v1/roots/${root.id}/config?force=true") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Text.Plain)
+                    setBody(VALID_YAML)
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val persisted = runBlocking { repo.projectConfigRepository().get(root.id) }
+            assertEquals(VALID_YAML, (persisted as Result.Success).data?.configYaml)
+        }
 }
 
 class ProjectConfigGetRouteTest {
@@ -419,6 +486,102 @@ class ProjectConfigGetRouteTest {
                 }
 
             assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `GET roots rootId config with no fingerprint query param omits relation`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+
+            client.put("/api/v1/roots/${root.id}/config") {
+                header("Authorization", "Bearer $WRITE_TOKEN")
+                contentType(ContentType.Text.Plain)
+                setBody(VALID_YAML)
+            }
+
+            val response =
+                client.get("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $PROJECT_CONFIG_READ_ONLY_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(!response.bodyAsText().contains("relation"), "relation must be omitted when ?fingerprint= is absent")
+        }
+
+    @Test
+    fun `GET roots rootId config with fingerprint matching current returns relation current`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+
+            client.put("/api/v1/roots/${root.id}/config") {
+                header("Authorization", "Bearer $WRITE_TOKEN")
+                contentType(ContentType.Text.Plain)
+                setBody(VALID_YAML)
+            }
+            val currentFingerprint = runBlocking { repo.projectConfigRepository().computeFingerprint(VALID_YAML) }
+
+            val response =
+                client.get("/api/v1/roots/${root.id}/config?fingerprint=$currentFingerprint") {
+                    header("Authorization", "Bearer $PROJECT_CONFIG_READ_ONLY_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("\"relation\":\"current\""))
+        }
+
+    @Test
+    fun `GET roots rootId config with a superseded fingerprint returns relation superseded`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+            val yamlB = VALID_YAML + "\n"
+
+            client.put("/api/v1/roots/${root.id}/config") {
+                header("Authorization", "Bearer $WRITE_TOKEN")
+                contentType(ContentType.Text.Plain)
+                setBody(VALID_YAML)
+            }
+            client.put("/api/v1/roots/${root.id}/config") {
+                header("Authorization", "Bearer $WRITE_TOKEN")
+                contentType(ContentType.Text.Plain)
+                setBody(yamlB)
+            }
+            val supersededFingerprint = runBlocking { repo.projectConfigRepository().computeFingerprint(VALID_YAML) }
+
+            val response =
+                client.get("/api/v1/roots/${root.id}/config?fingerprint=$supersededFingerprint") {
+                    header("Authorization", "Bearer $PROJECT_CONFIG_READ_ONLY_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("\"relation\":\"superseded\""))
+        }
+
+    @Test
+    fun `GET roots rootId config with an unrelated fingerprint returns relation unknown`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+
+            client.put("/api/v1/roots/${root.id}/config") {
+                header("Authorization", "Bearer $WRITE_TOKEN")
+                contentType(ContentType.Text.Plain)
+                setBody(VALID_YAML)
+            }
+
+            val response =
+                client.get("/api/v1/roots/${root.id}/config?fingerprint=${"0".repeat(64)}") {
+                    header("Authorization", "Bearer $PROJECT_CONFIG_READ_ONLY_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("\"relation\":\"unknown\""))
         }
 }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutesTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutesTest.kt
@@ -290,6 +290,51 @@ class ProjectConfigPutRouteTest {
             val body = response.bodyAsText()
             assertTrue(body.contains("depth-0"), "Should name the depth-0 constraint: $body")
         }
+
+    @Test
+    fun `PUT roots rootId config with a mismatched embedded project rootId returns 422 naming both ids`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            val otherRootId = UUID.randomUUID()
+            application { configureProjectConfigTestApp(repo) }
+
+            val response =
+                client.put("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Text.Plain)
+                    setBody("project:\n  rootId: $otherRootId\n$VALID_YAML")
+                }
+
+            assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("rootid_mismatch"), "Should report rootid_mismatch: $body")
+            assertTrue(body.contains(root.id.toString()), "Should name the target rootId: $body")
+            assertTrue(body.contains(otherRootId.toString()), "Should name the embedded rootId: $body")
+
+            val persisted = runBlocking { repo.projectConfigRepository().get(root.id) }
+            assertTrue((persisted as Result.Success).data == null, "Mismatched embedded rootId must never be stored")
+        }
+
+    @Test
+    fun `PUT roots rootId config with force=true bypasses a mismatched embedded project rootId`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            val otherRootId = UUID.randomUUID()
+            application { configureProjectConfigTestApp(repo) }
+
+            val response =
+                client.put("/api/v1/roots/${root.id}/config?force=true") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Text.Plain)
+                    setBody("project:\n  rootId: $otherRootId\n$VALID_YAML")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val persisted = runBlocking { repo.projectConfigRepository().get(root.id) }
+            assertTrue((persisted as Result.Success).data != null, "force=true should allow the push to persist")
+        }
 }
 
 class ProjectConfigGetRouteTest {

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutesTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ProjectConfigRoutesTest.kt
@@ -33,6 +33,7 @@ import kotlinx.serialization.json.buildJsonObject
 import org.junit.jupiter.api.Test
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -117,6 +118,45 @@ class ProjectConfigPutRouteTest {
             val config = (persisted as Result.Success).data
             assertNotNull(config, "Config should be persisted")
             assertEquals(VALID_YAML, config!!.configYaml)
+        }
+
+    @Test
+    fun `PUT roots rootId config surfaces ignoredSections when the doc has an unhonored top-level key`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+
+            val response =
+                client.put("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.parse("application/yaml"))
+                    setBody("$VALID_YAML\nactor_authentication:\n  mode: jwks\n")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("ignoredSections"), "Response should surface ignoredSections: $body")
+            assertTrue(body.contains("actor_authentication"), "ignoredSections should name actor_authentication: $body")
+        }
+
+    @Test
+    fun `PUT roots rootId config omits ignoredSections when the doc only uses honored keys`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val root = createRoot(repo)
+            application { configureProjectConfigTestApp(repo) }
+
+            val response =
+                client.put("/api/v1/roots/${root.id}/config") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.parse("application/yaml"))
+                    setBody(VALID_YAML)
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertFalse(body.contains("ignoredSections"), "ignoredSections must be omitted entirely when empty: $body")
         }
 
     @Test


### PR DESCRIPTION
## Summary
Closes five cross-project/multi-session gaps in per-root config sync, found in a code review of the feature (2026-07-16):

- **rootId mismatch guard** — a pushed config embedding a different `project.rootId` than the target root is rejected (422 `rootid_mismatch` / MCP validation error naming both ids); `force` overrides. Kills the copy-paste-config-between-projects clobber footgun.
- **Fast-forward (superseded) push guard** — the server keeps the last 20 fingerprints per root (V11, additive nullable column); a push whose content the server has already moved past is rejected (409 `superseded` / `CONFLICT_ERROR`), and the `config-sync` hook skips it client-side with a stale-checkout warning. Stale branches/worktrees/machines can no longer silently revert live config. True divergence stays last-writer-wins by design.
- **Whole-algorithm-first resolution** — per-root exact type → per-root `default` → global exact → global default (type path now consistent with the tag path). **Intentional semantic change:** a per-root `default` beats a global exact-type match (fence semantics). The documented empty-default pattern (`default: {notes: []}`) gives schema-free/business-workflow projects a complete opt-out from the global floor.
- **Per-root-aware schema introspection** — `query_items(operation="schema")` accepts `rootId`, reports the fingerprint of the layer that actually answered plus a `configSource` field. Fingerprint-based caches now see per-root config changes.
- **Per-root `note_limits` + `status_labels` honored** — with absent-vs-explicit fallback discipline (absent section → global; partial labels fall through per trigger). Push responses list `ignoredSections` (e.g. `actor_authentication`) so pushes are never silently partial.

Feature-level `/simplify` pass applied 7 findings (shared `Sha256Hex` util, single per-root snapshot read per request, status-label resolution narrowed to the ≤2 consulted triggers, hook `relation`-as-authority, shared relation mapper); 3 skipped findings tracked as backlog items.

## ⚠ Plugin note for deployment
`hooks/config-sync.mjs` changed — plugin users must **remove and re-add the marketplace** to pick up fast-forward sync (hook content is cached). Server must run V11 (auto via Flyway on restart).

## Children completed
- Guard config push against embedded project.rootId mismatch (`f2d85f32-af04-4445-b3f3-5ec7bc6e80ad`)
- Whole-algorithm-first per-root resolution + per-root availableTraits (`b3a753fb-4921-475b-8778-0540e1872ca8`)
- Make query_items schema operation per-root aware + correct configFingerprint (`d483b8f2-87b7-417b-8afa-a82d0afc83fb`)
- Honor per-root note_limits and status_labels; ignoredSections warning (`a9350349-57fa-47ab-855a-66e840c6cfc9`)
- Fingerprint history + known-old (fast-forward) push guard (`556bee0d-9768-414f-b39e-63d7efdf1ddb`)

## Test Results
2625 completed / 0 failed / 2 skipped + ktlintCheck clean — verified after every wave and re-confirmed with a clean `--rerun-tasks` execution after the simplify refactor. ~75 new tests across repository/service/route/tool layers (precedence matrix, fence proofs, history prune boundaries, NULL-history legacy rows, 409-vs-412 discrimination, hook relation branches).

## Review
Each child independently reviewed by a non-implementing agent (review-checklist + trait-gated api-compatibility/plugin-impact/migration-assessment notes on the MCP items). Feature verdict: pass with observations — tracked follow-ups: REST/MCP status-label parity (`80e48e55`, medium), sha256 consolidation in auth/SSE (`43b30d66`), push double-read (`05020d91`), ParsedConfig absence-encoding convention (`4d0cfd1a`).

## MCP
Parent: `7769603e-ccdd-4d3c-9bcc-864fe1a6dfe9`
Children: `f2d85f32`, `b3a753fb`, `d483b8f2`, `a9350349`, `556bee0d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Z9sREcwrac6AwN5wSeosr