### PR TITLE
fix: FTS search under REST API + status-label stamping (3 bugs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,7 +243,7 @@ Add to `gradle/libs.versions.toml` (`[versions]` + `[libraries]`), then referenc
 | Workflow config | `.taskorchestrator/config.yaml` |
 | Note schema service | `current/.../infrastructure/config/YamlWorkItemSchemaService.kt` (backward-compat typealias `YamlNoteSchemaService`) |
 | FTS5 search utilities | `current/.../application/service/search/` (FtsQuerySanitizer, RrfFusion) |
-| Search types (SearchResult, SearchHit, SearchScope, SearchMatchMode) | `current/.../infrastructure/repository/SQLiteWorkItemRepository.kt` |
+| Search types (SearchResult, SearchHit, SearchScope, SearchMatchMode) | `current/.../domain/repository/SearchTypes.kt` |
 | BacklinkRow (domain model) | `current/.../domain/model/BacklinkRow.kt` |
 | Plugin | `claude-plugins/task-orchestrator/` |
 | Tests | `current/src/test/kotlin/` |

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceService.kt
@@ -218,13 +218,22 @@ class AdvanceService(
         // 2. Resolve — schema-driven review-phase detection.
         val hasReviewPhase = itemSchema?.hasReviewPhase() ?: false
         val resolution = handler.resolveTransition(item, trigger, hasReviewPhase)
-        val configLabel = statusLabelService.resolveLabel(trigger)
         if (!resolution.success || resolution.targetRole == null) {
             return AdvanceOutcome.Failure(
                 AdvanceFailure.ResolutionFailed(resolution.error ?: "Failed to resolve transition")
             )
         }
         val targetRole = resolution.targetRole
+        // "start" ordinarily maps to the in-progress label, but resolveStart() returns
+        // targetRole=TERMINAL when the schema has no review phase (WORK->TERMINAL) or the item was
+        // already in REVIEW (REVIEW->TERMINAL) — the item is actually completing, not merely
+        // starting work. Look the label up under "complete" in that case so start-to-terminal and
+        // complete-to-terminal converge on the same terminal label instead of stamping the
+        // work-phase label ("in-progress") on a terminal item (bug 100da214). "cancel" already
+        // carries its own hardcoded resolution.statusLabel ("cancelled"), which takes precedence
+        // below regardless of this lookup, so it is deliberately excluded from the remap.
+        val labelLookupTrigger = if (trigger == "start" && targetRole == Role.TERMINAL) "complete" else trigger
+        val configLabel = statusLabelService.resolveLabel(labelLookupTrigger)
 
         // 3. Validate dependency constraints.
         val validation = handler.validateTransition(item, targetRole, dependencyRepository, workItemRepository)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
@@ -220,6 +220,39 @@ class ToolExecutionContext(
     }
 
     /**
+     * Builds a [StatusLabelService] bound to a single item's [rootId] and pre-resolved for
+     * [trigger], for handing to [io.github.jpicklyk.mcptask.current.application.service.AdvanceService]
+     * (whose constructor takes a plain, non-suspending [StatusLabelService] and has no rootId
+     * awareness of its own). Since [StatusLabelService.resolveLabel] is synchronous, the per-root
+     * layering ([resolveStatusLabels]) must run to completion BEFORE this method returns; the
+     * resulting map is then served from a trivial synchronous lookup.
+     *
+     * Resolves every trigger key a single `advance()` call can ever consult: the primary [trigger]
+     * itself, `"complete"` (consulted instead of `"start"` when a start resolves to TERMINAL — see
+     * bug 100da214 / [io.github.jpicklyk.mcptask.current.application.service.AdvanceService.advance]),
+     * and the system-internal `"cascade"` trigger (consulted only when a cascade is detected and
+     * applied). [resolveStatusLabels] collapses this 3-key resolution into a SINGLE per-root
+     * snapshot fetch rather than one per trigger, so widening the set costs nothing extra.
+     *
+     * Shared by [io.github.jpicklyk.mcptask.current.application.tools.workflow.AdvanceItemTool]
+     * (MCP) and the REST `POST /items/{id}/advance` route so both paths resolve config-driven,
+     * per-root status labels identically (bug 80e48e55 — REST previously constructed its
+     * [io.github.jpicklyk.mcptask.current.application.service.AdvanceService] with
+     * [io.github.jpicklyk.mcptask.current.application.service.NoOpStatusLabelService] and never
+     * applied labels at all).
+     */
+    suspend fun rootAwareStatusLabelService(
+        rootId: UUID?,
+        trigger: String
+    ): StatusLabelService {
+        val consultedTriggers = setOf(trigger, "complete", "cascade")
+        val resolved = resolveStatusLabels(consultedTriggers, rootId)
+        return object : StatusLabelService {
+            override fun resolveLabel(trigger: String): String? = resolved[trigger]
+        }
+    }
+
+    /**
      * Returns the union of trait names available for the given [rootIds], per-root traits first
      * (in [rootIds] iteration order), followed by the global trait list — deduplicated, preserving
      * first-seen order. Used by response hints (e.g. `availableTraits` on item creation) so callers

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
@@ -7,9 +7,8 @@ import io.github.jpicklyk.mcptask.current.domain.model.Priority
 import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
-import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteWorkItemRepository
-import io.github.jpicklyk.mcptask.current.infrastructure.repository.SearchMatchMode
-import io.github.jpicklyk.mcptask.current.infrastructure.repository.SearchScope
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchMatchMode
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchScope
 import io.modelcontextprotocol.kotlin.sdk.types.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.*
@@ -704,7 +703,7 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
     /**
      * Full-text search over work-item titles and summaries via FTS5.
      *
-     * Sanitizes the user query, delegates to [SQLiteWorkItemRepository.ftsSearch], and
+     * Sanitizes the user query, delegates to [WorkItemRepository.ftsSearch], and
      * serializes the [SearchResult] into the response shape defined in plan §7:
      * `{ hits: [...], totalHits, nextOffset, truncated }`.
      *
@@ -801,30 +800,24 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
                 return errorResponse(e.message ?: "Invalid search query", ErrorCodes.VALIDATION_ERROR)
             }
 
-        // Delegate to repository
+        // Delegate to repository — dispatched via the WorkItemRepository interface so this
+        // works whether the tool context holds the concrete SQLite repo or a decorator
+        // (e.g. EventPublishingWorkItemRepository, when the REST API is enabled). Non-FTS
+        // dialects (H2 tests) are handled inside ftsSearch, which returns an empty result.
         val repo = context.workItemRepository()
         val searchResult =
-            if (repo is SQLiteWorkItemRepository) {
-                try {
-                    repo.ftsSearch(
-                        sanitizedFtsQuery = sanitizedQuery,
-                        matchMode = matchMode,
-                        scope = scope,
-                        limit = limit,
-                        offset = offset,
-                    )
-                } catch (e: Exception) {
-                    return errorResponse(
-                        "FTS5 search failed: ${e.message}",
-                        ErrorCodes.INTERNAL_ERROR
-                    )
-                }
-            } else {
-                // Non-SQLite environment (H2 tests): return empty result
-                io.github.jpicklyk.mcptask.current.infrastructure.repository.SearchResult(
-                    hits = emptyList(),
-                    totalHits = 0,
-                    nextOffset = null,
+            try {
+                repo.ftsSearch(
+                    sanitizedFtsQuery = sanitizedQuery,
+                    matchMode = matchMode,
+                    scope = scope,
+                    limit = limit,
+                    offset = offset,
+                )
+            } catch (e: Exception) {
+                return errorResponse(
+                    "FTS5 search failed: ${e.message}",
+                    ErrorCodes.INTERNAL_ERROR
                 )
             }
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/QueryNotesTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/QueryNotesTool.kt
@@ -3,10 +3,9 @@ package io.github.jpicklyk.mcptask.current.application.tools.notes
 import io.github.jpicklyk.mcptask.current.application.service.search.FtsQuerySanitizer
 import io.github.jpicklyk.mcptask.current.application.tools.*
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
-import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteNoteRepository
-import io.github.jpicklyk.mcptask.current.infrastructure.repository.SearchMatchMode
-import io.github.jpicklyk.mcptask.current.infrastructure.repository.SearchResult
-import io.github.jpicklyk.mcptask.current.infrastructure.repository.SearchScope
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchMatchMode
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchResult
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchScope
 import io.modelcontextprotocol.kotlin.sdk.types.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.*
@@ -385,7 +384,7 @@ by note role (queue/work/review), use `list` instead — `search`'s `scope` has 
     /**
      * Full-text search over note bodies via FTS5.
      *
-     * Sanitizes the user query, delegates to [SQLiteNoteRepository.ftsSearch], and
+     * Sanitizes the user query, delegates to [NoteRepository.ftsSearch], and
      * serializes the [SearchResult] into the response shape defined in plan §7:
      * `{ hits: [...], totalHits, nextOffset, truncated }`.
      *
@@ -490,27 +489,25 @@ by note role (queue/work/review), use `list` instead — `search`'s `scope` has 
                 return errorResponse(e.message ?: "Invalid search query", ErrorCodes.VALIDATION_ERROR)
             }
 
-        // Delegate to repository — mirrors T4's SQLiteWorkItemRepository cast pattern.
+        // Delegate to repository — dispatched via the NoteRepository interface so this works
+        // whether the tool context holds the concrete SQLite repo or a decorator (e.g.
+        // EventPublishingNoteRepository, when the REST API is enabled). Non-FTS dialects
+        // (H2 tests) are handled inside ftsSearch, which returns an empty result.
         val repo = context.noteRepository()
         val searchResult: SearchResult =
-            if (repo is SQLiteNoteRepository) {
-                try {
-                    repo.ftsSearch(
-                        sanitizedFtsQuery = sanitizedQuery,
-                        matchMode = matchMode,
-                        scope = scope,
-                        limit = limit,
-                        offset = offset,
-                    )
-                } catch (e: Exception) {
-                    return errorResponse(
-                        "FTS5 note search failed: ${e.message}",
-                        ErrorCodes.INTERNAL_ERROR
-                    )
-                }
-            } else {
-                // Non-SQLite environment (H2 tests): FTS5 is SQLite-only — return empty result.
-                SearchResult(hits = emptyList(), totalHits = 0, nextOffset = null)
+            try {
+                repo.ftsSearch(
+                    sanitizedFtsQuery = sanitizedQuery,
+                    matchMode = matchMode,
+                    scope = scope,
+                    limit = limit,
+                    offset = offset,
+                )
+            } catch (e: Exception) {
+                return errorResponse(
+                    "FTS5 note search failed: ${e.message}",
+                    ErrorCodes.INTERNAL_ERROR
+                )
             }
 
         // Serialize hits

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -3,7 +3,6 @@ package io.github.jpicklyk.mcptask.current.application.tools.workflow
 import io.github.jpicklyk.mcptask.current.application.service.AdvanceFailure
 import io.github.jpicklyk.mcptask.current.application.service.AdvanceOutcome
 import io.github.jpicklyk.mcptask.current.application.service.AdvanceService
-import io.github.jpicklyk.mcptask.current.application.service.StatusLabelService
 import io.github.jpicklyk.mcptask.current.application.service.buildExpectedNotesJson
 import io.github.jpicklyk.mcptask.current.application.service.computePhaseNoteContext
 import io.github.jpicklyk.mcptask.current.application.tools.*
@@ -332,7 +331,8 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
             // Shared advance pipeline (ownership → resolve → validate → gate → apply → cascade →
             // unblock). Built per-item (not once for the whole batch) because statusLabelService
             // must be bound to THIS item's rootId — a batch can mix items from different roots, each
-            // with its own per-root status_labels override (see resolveRootAwareStatusLabelService).
+            // with its own per-root status_labels override (see
+            // ToolExecutionContext.rootAwareStatusLabelService).
             // MCP enforces claim ownership (enforceOwnership = true); the REST route passes false.
             val advanceService =
                 AdvanceService(
@@ -340,7 +340,7 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                     roleTransitionRepository = context.roleTransitionRepository(),
                     dependencyRepository = context.dependencyRepository(),
                     noteRepository = context.noteRepository(),
-                    statusLabelService = resolveRootAwareStatusLabelService(context, item.rootId, trigger),
+                    statusLabelService = context.rootAwareStatusLabelService(item.rootId, trigger),
                     schemaResolver = { context.resolveSchema(it) }
                 )
 
@@ -549,42 +549,6 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                     missingNotes = NoteSchemaJsonHelpers.buildMissingNotesArray(failure.missingNotes)
                 )
         }
-
-    // Divergence note (pre-existing, tracked as backlog): REST transitions
-    // (ItemWriteRoutes' advance route) construct their AdvanceService with a NoOpStatusLabelService
-    // and do NOT apply status labels at all — including this per-root layer. Only the MCP path
-    // below resolves and applies status labels. Not addressed here; out of scope for this pass.
-
-    /**
-     * Builds a [StatusLabelService] bound to a single item's [rootId], for handing to [AdvanceService]
-     * (whose constructor takes a plain, non-suspending [StatusLabelService] and has no rootId
-     * awareness of its own — see `docs: AdvanceService.kt` is out of this task's scope). Since
-     * [StatusLabelService.resolveLabel] is synchronous, the per-root layering
-     * ([ToolExecutionContext.resolveStatusLabels]) must run to completion BEFORE this method
-     * returns; the resulting map is then served from a trivial synchronous lookup.
-     *
-     * Resolves only the trigger set [AdvanceService.advance] can actually consult for a single
-     * advance call: the primary [trigger] itself (passed unconditionally to
-     * `statusLabelService.resolveLabel(trigger)` for the primary transition) plus the
-     * system-internal `"cascade"` trigger (consulted only when a cascade is detected and applied —
-     * see `AdvanceService.detectAndApplyTerminalCascades`/`applyCascadeEvents`). No other
-     * [UserTrigger] value is ever looked up during a single call, so precomputing the full 8-trigger
-     * set (every [UserTrigger] plus `"cascade"`) — as this used to do — resolved 6 triggers that
-     * could never be consulted. [ToolExecutionContext.resolveStatusLabels] additionally collapses
-     * this 2-element (or 1-element, when [trigger] happens to be `"cascade"`) resolution into a
-     * SINGLE per-root snapshot fetch rather than one per trigger.
-     */
-    private suspend fun resolveRootAwareStatusLabelService(
-        context: ToolExecutionContext,
-        rootId: UUID?,
-        trigger: String
-    ): StatusLabelService {
-        val consultedTriggers = setOf(trigger, "cascade")
-        val resolved = context.resolveStatusLabels(consultedTriggers, rootId)
-        return object : StatusLabelService {
-            override fun resolveLabel(trigger: String): String? = resolved[trigger]
-        }
-    }
 
     private fun buildErrorResult(
         itemId: UUID,

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/NoteRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/NoteRepository.kt
@@ -23,4 +23,25 @@ interface NoteRepository {
     ): Result<Note?>
 
     suspend fun findByItemIds(itemIds: Set<UUID>): Result<Map<UUID, List<Note>>>
+
+    /**
+     * Full-text search on note bodies using the V7 FTS5 virtual tables.
+     *
+     * **H2 (test environment):** FTS5 is SQLite-only. Implementations return an empty
+     * [SearchResult] immediately when the current dialect is H2.
+     *
+     * @param sanitizedFtsQuery FTS5 query string, already sanitized by the caller (QueryNotesTool).
+     * @param matchMode Which FTS table(s) to query.
+     * @param scope     Optional structural scope filters. [SearchScope.itemId] narrows to notes on
+     *   that specific item; [SearchScope.ancestorId] narrows to notes whose item_id is in the subtree.
+     * @param limit     Maximum hits to return (enforced at 100; default 20).
+     * @param offset    Zero-based page offset.
+     */
+    suspend fun ftsSearch(
+        sanitizedFtsQuery: String,
+        matchMode: SearchMatchMode = SearchMatchMode.AUTO,
+        scope: SearchScope? = null,
+        limit: Int = 20,
+        offset: Int = 0,
+    ): SearchResult
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/SearchTypes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/SearchTypes.kt
@@ -1,0 +1,89 @@
+package io.github.jpicklyk.mcptask.current.domain.repository
+
+import io.github.jpicklyk.mcptask.current.domain.model.Role
+import java.util.UUID
+
+// ---------------------------------------------------------------------------
+// FTS5 search types — shared by WorkItemRepository.ftsSearch and
+// NoteRepository.ftsSearch. Defined in the domain layer (not infrastructure)
+// so the repository interfaces can reference them without depending on the
+// concrete SQLite implementation. RRF fusion is delegated to RrfFusion
+// (application.service.search layer). BacklinkRow is in domain.model to
+// keep the domain boundary clean.
+// ---------------------------------------------------------------------------
+
+/** Controls which FTS5 virtual table(s) are queried during a search call. */
+enum class SearchMatchMode {
+    /** Query both trigram and text tables; fuse via RRF (k=60). Default. */
+    AUTO,
+
+    /** Query only the trigram table (substring / case-insensitive matching). */
+    SUBSTRING,
+
+    /** Query only the porter+unicode61 text table (stemming / natural language). */
+    TEXT,
+}
+
+/**
+ * Structural scope filters applied on top of the FTS5 full-text match.
+ *
+ * @property itemId     Narrow to a single work item (only content produced by that item).
+ * @property ancestorId Narrow to a subtree rooted at this item (recursive CTE). Singular form;
+ *   takes precedence when both [ancestorId] and [ancestorIds] are set.
+ * @property ancestorIds Narrow to descendants of ANY of these roots (multi-root, additive OR).
+ *   Only used when [ancestorId] is null. Null means no subtree filter (unrestricted). An empty
+ *   set means "no roots match" and results in an always-false WHERE clause (no hits).
+ * @property tags      OR-match any of the supplied tags on the work item.
+ * @property role      Exact role filter on the work item.
+ */
+data class SearchScope(
+    val itemId: UUID? = null,
+    val ancestorId: UUID? = null,
+    val ancestorIds: Set<UUID>? = null,
+    val tags: List<String>? = null,
+    val role: Role? = null,
+)
+
+/**
+ * A single ranked match returned by a search call.
+ *
+ * @property kind        "item" for work-item hits, "note" for note body hits.
+ * @property itemId      UUID of the owning work item.
+ * @property noteKey     Note key (only present when [kind] == "note").
+ * @property field       Which field matched ("title", "summary", or "body").
+ * @property snippet     ~32-token excerpt with `<mark>…</mark>` delimiters.
+ * @property score       Descending RRF fused score (higher = more relevant).
+ * @property matchedIn   Which FTS table(s) contributed to this hit.
+ * @property trigramRank Raw BM25 rank from the trigram table (lower is better; null if not matched).
+ * @property textRank    Raw BM25 rank from the text table (lower is better; null if not matched).
+ */
+data class SearchHit(
+    val kind: String,
+    val itemId: UUID,
+    val noteKey: String? = null,
+    val field: String,
+    val snippet: String,
+    val score: Double,
+    val matchedIn: List<String>,
+    val trigramRank: Double? = null,
+    val textRank: Double? = null,
+)
+
+/**
+ * Paginated result container returned by search calls.
+ *
+ * @property hits       Ranked list of matching hits.
+ * @property totalHits  Total hits in the in-memory RRF-fused list for this call.
+ *   The repository fetches up to `effectiveLimit + offset + 1` rows per FTS table,
+ *   so for large result sets the true database total may exceed [totalHits]. This is
+ *   the page-bounded count, not the global match count. When [truncated] is true,
+ *   refine the query or use scope filters to narrow results.
+ * @property nextOffset Offset to pass for the next page, or null when exhausted.
+ * @property truncated  True when totalHits exceeds the hard cap of 100.
+ */
+data class SearchResult(
+    val hits: List<SearchHit>,
+    val totalHits: Int,
+    val nextOffset: Int?,
+    val truncated: Boolean = false,
+)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/WorkItemRepository.kt
@@ -509,6 +509,29 @@ interface WorkItemRepository {
      * When [rootIds] is empty, returns an empty map immediately.
      */
     suspend fun countInScopeByRole(rootIds: Set<UUID>): Result<Map<Role, Int>>
+
+    /**
+     * Full-text search on work items using the V7 FTS5 virtual tables.
+     *
+     * **H2 (test environment):** FTS5 is SQLite-only. Implementations return an empty
+     * [SearchResult] immediately when the current dialect is H2 — unit tests that exercise
+     * the search path must use a real SQLite DB (see `Fts5MigrationTest`).
+     *
+     * @param sanitizedFtsQuery FTS5 query string. Callers (QueryItemsTool / FtsQuerySanitizer)
+     *   are responsible for sanitizing user input before calling this method. Passing raw user
+     *   input may cause FTS5 syntax errors.
+     * @param matchMode Which FTS table(s) to query.
+     * @param scope     Optional structural scope filters (subtree, tags, role).
+     * @param limit     Maximum hits to return (enforced at 100; default 20).
+     * @param offset    Zero-based page offset.
+     */
+    suspend fun ftsSearch(
+        sanitizedFtsQuery: String,
+        matchMode: SearchMatchMode = SearchMatchMode.AUTO,
+        scope: SearchScope? = null,
+        limit: Int = 20,
+        offset: Int = 0,
+    ): SearchResult
 }
 
 /**

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepository.kt
@@ -9,6 +9,10 @@ import io.github.jpicklyk.mcptask.current.domain.model.VerificationStatus
 import io.github.jpicklyk.mcptask.current.domain.repository.NoteRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.RepositoryError
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchHit
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchMatchMode
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchResult
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchScope
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.NotesTable
 import org.jetbrains.exposed.v1.core.ResultRow
@@ -255,12 +259,12 @@ class SQLiteNoteRepository(
      * @param limit     Maximum hits to return (enforced at 100; default 20).
      * @param offset    Zero-based page offset.
      */
-    suspend fun ftsSearch(
+    override suspend fun ftsSearch(
         sanitizedFtsQuery: String,
-        matchMode: SearchMatchMode = SearchMatchMode.AUTO,
-        scope: SearchScope? = null,
-        limit: Int = 20,
-        offset: Int = 0,
+        matchMode: SearchMatchMode,
+        scope: SearchScope?,
+        limit: Int,
+        offset: Int,
     ): SearchResult {
         val effectiveLimit = limit.coerceIn(1, 100)
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepository.kt
@@ -11,6 +11,10 @@ import io.github.jpicklyk.mcptask.current.domain.repository.ItemFetchResult
 import io.github.jpicklyk.mcptask.current.domain.repository.ReleaseResult
 import io.github.jpicklyk.mcptask.current.domain.repository.RepositoryError
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchHit
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchMatchMode
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchResult
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchScope
 import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.WorkItemsTable
@@ -52,88 +56,6 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.UUID
-
-// ---------------------------------------------------------------------------
-// FTS5 search types — defined here and imported by SQLiteNoteRepository and
-// SQLiteDependencyRepository. RRF fusion is delegated to RrfFusion (application
-// service layer). BacklinkRow is in domain.model to keep the domain boundary clean.
-// ---------------------------------------------------------------------------
-
-/** Controls which FTS5 virtual table(s) are queried during a search call. */
-enum class SearchMatchMode {
-    /** Query both trigram and text tables; fuse via RRF (k=60). Default. */
-    AUTO,
-
-    /** Query only the trigram table (substring / case-insensitive matching). */
-    SUBSTRING,
-
-    /** Query only the porter+unicode61 text table (stemming / natural language). */
-    TEXT,
-}
-
-/**
- * Structural scope filters applied on top of the FTS5 full-text match.
- *
- * @property itemId     Narrow to a single work item (only content produced by that item).
- * @property ancestorId Narrow to a subtree rooted at this item (recursive CTE). Singular form;
- *   takes precedence when both [ancestorId] and [ancestorIds] are set.
- * @property ancestorIds Narrow to descendants of ANY of these roots (multi-root, additive OR).
- *   Only used when [ancestorId] is null. Null means no subtree filter (unrestricted). An empty
- *   set means "no roots match" and results in an always-false WHERE clause (no hits).
- * @property tags      OR-match any of the supplied tags on the work item.
- * @property role      Exact role filter on the work item.
- */
-data class SearchScope(
-    val itemId: UUID? = null,
-    val ancestorId: UUID? = null,
-    val ancestorIds: Set<UUID>? = null,
-    val tags: List<String>? = null,
-    val role: Role? = null,
-)
-
-/**
- * A single ranked match returned by a search call.
- *
- * @property kind        "item" for work-item hits, "note" for note body hits.
- * @property itemId      UUID of the owning work item.
- * @property noteKey     Note key (only present when [kind] == "note").
- * @property field       Which field matched ("title", "summary", or "body").
- * @property snippet     ~32-token excerpt with `<mark>…</mark>` delimiters.
- * @property score       Descending RRF fused score (higher = more relevant).
- * @property matchedIn   Which FTS table(s) contributed to this hit.
- * @property trigramRank Raw BM25 rank from the trigram table (lower is better; null if not matched).
- * @property textRank    Raw BM25 rank from the text table (lower is better; null if not matched).
- */
-data class SearchHit(
-    val kind: String,
-    val itemId: UUID,
-    val noteKey: String? = null,
-    val field: String,
-    val snippet: String,
-    val score: Double,
-    val matchedIn: List<String>,
-    val trigramRank: Double? = null,
-    val textRank: Double? = null,
-)
-
-/**
- * Paginated result container returned by search calls.
- *
- * @property hits       Ranked list of matching hits.
- * @property totalHits  Total hits in the in-memory RRF-fused list for this call.
- *   The repository fetches up to `effectiveLimit + offset + 1` rows per FTS table,
- *   so for large result sets the true database total may exceed [totalHits]. This is
- *   the page-bounded count, not the global match count. When [truncated] is true,
- *   refine the query or use scope filters to narrow results.
- * @property nextOffset Offset to pass for the next page, or null when exhausted.
- * @property truncated  True when totalHits exceeds the hard cap of 100.
- */
-data class SearchResult(
-    val hits: List<SearchHit>,
-    val totalHits: Int,
-    val nextOffset: Int?,
-    val truncated: Boolean = false,
-)
 
 /**
  * SQLite implementation of WorkItemRepository.
@@ -682,12 +604,12 @@ class SQLiteWorkItemRepository(
      * @param limit     Maximum hits to return (enforced at 100; default 20).
      * @param offset    Zero-based page offset.
      */
-    suspend fun ftsSearch(
+    override suspend fun ftsSearch(
         sanitizedFtsQuery: String,
-        matchMode: SearchMatchMode = SearchMatchMode.AUTO,
-        scope: SearchScope? = null,
-        limit: Int = 20,
-        offset: Int = 0,
+        matchMode: SearchMatchMode,
+        scope: SearchScope?,
+        limit: Int,
+        offset: Int,
     ): SearchResult {
         val effectiveLimit = limit.coerceIn(1, 100)
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemWriteRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemWriteRoutes.kt
@@ -5,7 +5,7 @@ import io.github.jpicklyk.mcptask.current.application.service.AdvanceOutcome
 import io.github.jpicklyk.mcptask.current.application.service.AdvanceService
 import io.github.jpicklyk.mcptask.current.application.service.IdempotencyCache
 import io.github.jpicklyk.mcptask.current.application.service.ItemHierarchyValidator
-import io.github.jpicklyk.mcptask.current.application.service.NoOpStatusLabelService
+import io.github.jpicklyk.mcptask.current.application.service.StatusLabelService
 import io.github.jpicklyk.mcptask.current.application.service.WorkItemSchemaService
 import io.github.jpicklyk.mcptask.current.application.service.rest.MergePatchApplier
 import io.github.jpicklyk.mcptask.current.application.service.rest.WorkItemPatchProjection
@@ -17,6 +17,7 @@ import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.infrastructure.config.AppConfig
 import io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService
+import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlStatusLabelService
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.audit.ApiAuditBridge
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiCapability
@@ -193,6 +194,11 @@ private suspend fun respondAdvanceFailure(
  *
  * @param schemaService used to resolve the item's actual `hasReviewPhase` on advance, mirroring
  *   [io.github.jpicklyk.mcptask.current.application.tools.workflow.AdvanceItemTool] (trait-merged).
+ * @param statusLabelService config-driven, root-layerable status label resolution — the SAME
+ *   [StatusLabelService] instance the MCP `advance_item` tool uses, so REST-driven advances stamp
+ *   identical labels (bug 80e48e55 — REST previously hardcoded [NoOpStatusLabelService] and never
+ *   applied labels at all). Defaults to a fresh [YamlStatusLabelService] for callers (tests) that
+ *   don't need to share the production instance.
  */
 fun Route.itemWriteRoutes(
     repositoryProvider: RepositoryProvider,
@@ -200,6 +206,7 @@ fun Route.itemWriteRoutes(
     idempotencyCache: IdempotencyCache,
     schemaService: WorkItemSchemaService,
     warnOnClaimedAdvance: Boolean = defaultWarnOnClaimedAdvance,
+    statusLabelService: StatusLabelService = YamlStatusLabelService(),
 ) {
     val workItemRepo = repositoryProvider.workItemRepository()
     val roleTransitionRepo = repositoryProvider.roleTransitionRepository()
@@ -209,13 +216,15 @@ fun Route.itemWriteRoutes(
     // Schema-resolution context — reuses the EXACT trait-merging + review-phase logic from
     // AdvanceItemTool (via ToolExecutionContext.resolveHasReviewPhase). Repository access is shared;
     // no MCP behavior is affected since this context is read-only for schema resolution here.
-    // perRootConfigService is passed by name (all other trailing ToolExecutionContext params keep
-    // their defaults) so REST advances get the SAME per-root schema layering as MCP tool calls —
-    // otherwise this independently-constructed context would silently resolve global-only.
+    // statusLabelService and perRootConfigService are passed by name (all other trailing
+    // ToolExecutionContext params keep their defaults) so REST advances get the SAME per-root
+    // schema layering AND the SAME config-driven status labels as MCP tool calls — otherwise this
+    // independently-constructed context would silently resolve global-only / labels at all.
     val schemaResolutionContext =
         ToolExecutionContext(
             repositoryProvider,
             schemaService,
+            statusLabelService = statusLabelService,
             perRootConfigService = PerRootConfigService(repositoryProvider.projectConfigRepository()),
         )
 
@@ -750,13 +759,20 @@ fun Route.itemWriteRoutes(
             // not fleet agents). The advance SUCCEEDS even when the item is claimed by a different
             // MCP agent, while the synthesized API actor is still recorded on the role_transitions
             // row for audit. Unlike the prior userTransition() path, the gate is now ENFORCED.
+            // statusLabelService is bound to THIS item's rootId via the SAME root-aware factory
+            // AdvanceItemTool uses, so REST advances stamp identical (config-driven, per-root)
+            // status labels instead of applying none at all (bug 80e48e55).
             val advanceService =
                 AdvanceService(
                     workItemRepository = workItemRepo,
                     roleTransitionRepository = roleTransitionRepo,
                     dependencyRepository = depRepo,
                     noteRepository = repositoryProvider.noteRepository(),
-                    statusLabelService = NoOpStatusLabelService,
+                    statusLabelService =
+                        schemaResolutionContext.rootAwareStatusLabelService(
+                            item.rootId,
+                            userTrigger.triggerString,
+                        ),
                     schemaResolver = { schemaResolutionContext.resolveSchema(it) },
                 )
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/NoteRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/NoteRoutes.kt
@@ -2,10 +2,9 @@ package io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes
 
 import io.github.jpicklyk.mcptask.current.application.service.search.FtsQuerySanitizer
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchMatchMode
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchScope
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
-import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteNoteRepository
-import io.github.jpicklyk.mcptask.current.infrastructure.repository.SearchMatchMode
-import io.github.jpicklyk.mcptask.current.infrastructure.repository.SearchScope
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiCapability
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiPrincipalKey
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.enforceScopeForItem
@@ -38,7 +37,7 @@ private val noteLogger = LoggerFactory.getLogger("NoteRoutes")
  * [AttributionRedactor] (env-driven, defaults to redact).
  *
  * **FTS5 search caveat:** the `/notes/search` endpoint delegates to
- * [SQLiteNoteRepository.ftsSearch] which returns empty results when running against H2
+ * [NoteRepository.ftsSearch] which returns empty results when running against H2
  * (test environment). Use real SQLite fixtures for integration tests of this endpoint.
  */
 fun Route.noteRoutes(repositoryProvider: RepositoryProvider) {
@@ -178,15 +177,12 @@ fun Route.noteRoutes(repositoryProvider: RepositoryProvider) {
                     else -> SearchScope()
                 }
 
-            val repo = noteRepo
-            if (repo !is SQLiteNoteRepository) {
-                // H2 test environment — FTS5 not available
-                call.respond(HttpStatusCode.OK, emptyList<SearchHitDto>())
-                return@get
-            }
-
+            // Dispatched via the NoteRepository interface so this works whether noteRepo is the
+            // concrete SQLite repo or a decorator (e.g. EventPublishingNoteRepository — always the
+            // case when the REST API is enabled). Non-FTS dialects (H2 tests) are handled inside
+            // ftsSearch, which returns an empty result.
             val result =
-                repo.ftsSearch(
+                noteRepo.ftsSearch(
                     sanitizedFtsQuery = sanitizedQuery,
                     matchMode = SearchMatchMode.AUTO,
                     scope = scope,

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/SearchRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/SearchRoutes.kt
@@ -2,10 +2,9 @@ package io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes
 
 import io.github.jpicklyk.mcptask.current.application.service.search.FtsQuerySanitizer
 import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchMatchMode
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchScope
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
-import io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteWorkItemRepository
-import io.github.jpicklyk.mcptask.current.infrastructure.repository.SearchMatchMode
-import io.github.jpicklyk.mcptask.current.infrastructure.repository.SearchScope
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiCapability
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiPrincipalKey
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.enforceScopeForItem
@@ -95,15 +94,12 @@ fun Route.searchRoutes(repositoryProvider: RepositoryProvider) {
                     else -> SearchScope(role = role, tags = tags)
                 }
 
-            val repo = workItemRepo
-            if (repo !is SQLiteWorkItemRepository) {
-                // H2 test environment — FTS5 not available
-                call.respond(HttpStatusCode.OK, emptyList<SearchHitDto>())
-                return@get
-            }
-
+            // Dispatched via the WorkItemRepository interface so this works whether workItemRepo
+            // is the concrete SQLite repo or a decorator (e.g. EventPublishingWorkItemRepository —
+            // always the case when the REST API is enabled). Non-FTS dialects (H2 tests) are
+            // handled inside ftsSearch, which returns an empty result.
             val result =
-                repo.ftsSearch(
+                workItemRepo.ftsSearch(
                     sanitizedFtsQuery = sanitizedQuery,
                     matchMode = SearchMatchMode.AUTO,
                     scope = scope,

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
@@ -1,6 +1,7 @@
 package io.github.jpicklyk.mcptask.current.interfaces.mcp
 
 import io.github.jpicklyk.mcptask.current.application.service.IdempotencyCache
+import io.github.jpicklyk.mcptask.current.application.service.StatusLabelService
 import io.github.jpicklyk.mcptask.current.application.service.WorkItemSchemaService
 import io.github.jpicklyk.mcptask.current.application.tools.ToolDefinition
 import io.github.jpicklyk.mcptask.current.application.tools.compound.CompleteTreeTool
@@ -21,6 +22,7 @@ import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetNextItem
 import io.github.jpicklyk.mcptask.current.application.tools.workflow.GetNextStatusTool
 import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
 import io.github.jpicklyk.mcptask.current.infrastructure.config.AppConfig
+import io.github.jpicklyk.mcptask.current.infrastructure.config.YamlStatusLabelService
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
 import io.github.jpicklyk.mcptask.current.infrastructure.shutdown.ShutdownCoordinator
@@ -123,6 +125,7 @@ class CurrentMcpServer(
             val toolContext = composition.toolContext
             val apiWiring = composition.apiWiring
             val noteSchemaService = composition.noteSchemaService
+            val statusLabelService = composition.statusLabelService
             val degradedModePolicy = composition.degradedModePolicy
             val idempotencyCache = composition.idempotencyCache
             val mcpLoggingService = composition.mcpLoggingService
@@ -174,6 +177,7 @@ class CurrentMcpServer(
                         toolCount,
                         apiWiring,
                         noteSchemaService,
+                        statusLabelService,
                         degradedModePolicy,
                         idempotencyCache,
                         composition.actorAuthEnabled
@@ -237,6 +241,7 @@ class CurrentMcpServer(
         toolCount: Int,
         apiWiring: ApiWiring,
         noteSchemaService: WorkItemSchemaService,
+        statusLabelService: StatusLabelService,
         degradedModePolicy: DegradedModePolicy,
         idempotencyCache: IdempotencyCache,
         actorAuthEnabled: Boolean,
@@ -314,6 +319,7 @@ class CurrentMcpServer(
                     serverVersion = version,
                     actorAuthEnabled = actorAuthEnabled,
                     noteSchemaService = noteSchemaService,
+                    statusLabelService = statusLabelService,
                     degradedModePolicy = degradedModePolicy,
                     idempotencyCache = idempotencyCache,
                     jwksVerifier = jwksVerifier,
@@ -461,6 +467,7 @@ internal fun Application.installRestApiRoutes(
     serverVersion: String,
     actorAuthEnabled: Boolean,
     noteSchemaService: WorkItemSchemaService,
+    statusLabelService: StatusLabelService = YamlStatusLabelService(),
     degradedModePolicy: DegradedModePolicy,
     idempotencyCache: IdempotencyCache,
     jwksVerifier: JwksApiVerifier? = null,
@@ -511,6 +518,7 @@ internal fun Application.installRestApiRoutes(
                 idempotencyCache,
                 noteSchemaService,
                 warnOnClaimedAdvance = appConfig.apiWarnOnClaimedAdvance,
+                statusLabelService = statusLabelService,
             )
             noteWriteRoutes(effectiveProvider, degradedModePolicy, idempotencyCache)
             dependencyWriteRoutes(effectiveProvider, degradedModePolicy)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/ServerComposition.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/ServerComposition.kt
@@ -4,6 +4,7 @@ import io.github.jpicklyk.mcptask.current.application.service.ActorVerifier
 import io.github.jpicklyk.mcptask.current.application.service.IdempotencyCache
 import io.github.jpicklyk.mcptask.current.application.service.NextItemRecommender
 import io.github.jpicklyk.mcptask.current.application.service.NoOpActorVerifier
+import io.github.jpicklyk.mcptask.current.application.service.StatusLabelService
 import io.github.jpicklyk.mcptask.current.application.service.WorkItemSchemaService
 import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
 import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
@@ -65,6 +66,7 @@ class CompositionResult(
     val toolContext: ToolExecutionContext,
     val apiWiring: ApiWiring,
     val noteSchemaService: WorkItemSchemaService,
+    val statusLabelService: StatusLabelService,
     val degradedModePolicy: DegradedModePolicy,
     val idempotencyCache: IdempotencyCache,
     val mcpLoggingService: DefaultMcpLoggingService,
@@ -154,6 +156,7 @@ class ServerComposition(
             toolContext = toolContext,
             apiWiring = apiWiring,
             noteSchemaService = noteSchemaService,
+            statusLabelService = statusLabelService,
             degradedModePolicy = degradedModePolicy,
             idempotencyCache = idempotencyCache,
             mcpLoggingService = mcpLoggingService,

--- a/current/src/main/resources/db/migration/V13__Repair_Terminal_Status_Labels.sql
+++ b/current/src/main/resources/db/migration/V13__Repair_Terminal_Status_Labels.sql
@@ -1,0 +1,15 @@
+-- Data-only repair for bug 100da214: a "start" trigger that resolved to TERMINAL (WORK->TERMINAL
+-- on a no-review schema, or REVIEW->TERMINAL) stamped the work-phase label ("in-progress") instead
+-- of the terminal label ("done"), because the pre-fix label lookup was keyed on the raw trigger
+-- string rather than the resolved target role. This backfills existing terminal rows that were
+-- mislabeled by that bug.
+--
+-- Idempotent: re-running finds no matching rows the second time (status_label is already 'done').
+-- NULL-tolerant: rows with a NULL status_label are left untouched (not part of this bug's symptom).
+-- Does not touch 'cancelled' rows (cancel already stamps its own correct label) or rows already
+-- 'done'. No schema/table change -- DirectDatabaseSchemaManager is unaffected.
+UPDATE work_items
+SET status_label = 'done'
+WHERE role = 'terminal'
+  AND status_label IS NOT NULL
+  AND status_label NOT IN ('done', 'cancelled');

--- a/current/src/main/resources/db/migration/V13__Repair_Terminal_Status_Labels.sql
+++ b/current/src/main/resources/db/migration/V13__Repair_Terminal_Status_Labels.sql
@@ -4,12 +4,18 @@
 -- string rather than the resolved target role. This backfills existing terminal rows that were
 -- mislabeled by that bug.
 --
--- Idempotent: re-running finds no matching rows the second time (status_label is already 'done').
--- NULL-tolerant: rows with a NULL status_label are left untouched (not part of this bug's symptom).
--- Does not touch 'cancelled' rows (cancel already stamps its own correct label) or rows already
--- 'done'. No schema/table change -- DirectDatabaseSchemaManager is unaffected.
+-- Scope is deliberately NARROW: it repairs ONLY the default work-phase label 'in-progress' left on a
+-- terminal row. It does NOT blanket-rewrite every non-'done'/'cancelled' terminal label, because
+-- status_labels is a supported per-root override (a project may legitimately configure a custom
+-- terminal label such as 'finished' or 'shipped'), and those correctly-labeled rows must not be
+-- clobbered. A deployment that also customized its start/work-phase label away from 'in-progress'
+-- will not be auto-repaired here (it can repair manually) -- that is the safe trade-off versus
+-- corrupting customized terminal labels.
+--
+-- Idempotent: re-running finds no matching rows the second time (the row is already 'done').
+-- 'cancelled'-safe and NULL-tolerant by construction (neither equals 'in-progress').
+-- No schema/table change -- DirectDatabaseSchemaManager is unaffected.
 UPDATE work_items
 SET status_label = 'done'
 WHERE role = 'terminal'
-  AND status_label IS NOT NULL
-  AND status_label NOT IN ('done', 'cancelled');
+  AND status_label = 'in-progress';

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceServiceTest.kt
@@ -363,6 +363,144 @@ class AdvanceServiceTest {
             assertIs<AdvanceFailure.OwnershipRejected>(failure.failure)
         }
 
+    // ──────────────────────────────────────────────
+    // Bug 100da214: start-to-terminal label convergence
+    //
+    // A "start" trigger that RESOLVES to TERMINAL (WORK->TERMINAL on a no-review schema, or
+    // REVIEW->TERMINAL) must stamp the SAME terminal label "complete" would stamp, not the
+    // work-phase "in-progress" label the raw trigger string would otherwise map to.
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `start on WORK with no review phase resolves to TERMINAL and stamps the terminal label`(): Unit =
+        runBlocking {
+            // No schema at all -> hasReviewPhase() is false -> resolveStart(WORK) targets TERMINAL.
+            val item = makeItem(role = Role.WORK)
+            val outcome =
+                serviceWith(schema = null).advance(
+                    item,
+                    "start",
+                    null,
+                    null,
+                    null,
+                    DegradedModePolicy.ACCEPT_CACHED,
+                    enforceOwnership = true,
+                )
+            val success = assertIs<AdvanceOutcome.Success>(outcome)
+            assertEquals(Role.TERMINAL, success.result.newRole)
+            assertEquals("done", success.result.statusLabel, "start->TERMINAL must stamp the 'complete' label, not 'in-progress'")
+        }
+
+    @Test
+    fun `start on REVIEW resolves to TERMINAL and stamps the terminal label`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.REVIEW)
+            val sc = schema(NoteSchemaEntry("review-checklist", Role.REVIEW, required = false, description = "x"))
+            val outcome =
+                serviceWith(sc).advance(item, "start", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true)
+            val success = assertIs<AdvanceOutcome.Success>(outcome)
+            assertEquals(Role.TERMINAL, success.result.newRole)
+            assertEquals("done", success.result.statusLabel)
+        }
+
+    @Test
+    fun `full start-only lifecycle queue-work-terminal (no review phase) ends with the terminal label`(): Unit =
+        runBlocking {
+            val id = UUID.randomUUID()
+            val service = serviceWith(schema = null)
+            var item = makeItem(id = id, role = Role.QUEUE)
+
+            val step1 =
+                assertIs<AdvanceOutcome.Success>(
+                    service.advance(item, "start", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true),
+                )
+            assertEquals(Role.WORK, step1.result.newRole)
+            assertEquals("in-progress", step1.result.statusLabel)
+
+            item = step1.result.appliedItem
+            val step2 =
+                assertIs<AdvanceOutcome.Success>(
+                    service.advance(item, "start", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true),
+                )
+            assertEquals(Role.TERMINAL, step2.result.newRole)
+            assertEquals("done", step2.result.statusLabel, "final start-driven transition must not leave a stale 'in-progress' label")
+        }
+
+    @Test
+    fun `full start-only lifecycle queue-work-review-terminal ends with the terminal label`(): Unit =
+        runBlocking {
+            val id = UUID.randomUUID()
+            val sc = schema(NoteSchemaEntry("review-checklist", Role.REVIEW, required = false, description = "x"))
+            val service = serviceWith(sc)
+            var item = makeItem(id = id, role = Role.QUEUE)
+
+            val step1 =
+                assertIs<AdvanceOutcome.Success>(
+                    service.advance(item, "start", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true),
+                )
+            assertEquals(Role.WORK, step1.result.newRole)
+            assertEquals("in-progress", step1.result.statusLabel)
+
+            item = step1.result.appliedItem
+            val step2 =
+                assertIs<AdvanceOutcome.Success>(
+                    service.advance(item, "start", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true),
+                )
+            assertEquals(Role.REVIEW, step2.result.newRole)
+            assertEquals("in-progress", step2.result.statusLabel, "WORK->REVIEW is still in-flight work, not completion")
+
+            item = step2.result.appliedItem
+            val step3 =
+                assertIs<AdvanceOutcome.Success>(
+                    service.advance(item, "start", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true),
+                )
+            assertEquals(Role.TERMINAL, step3.result.newRole)
+            assertEquals("done", step3.result.statusLabel)
+        }
+
+    // ──────────────────────────────────────────────
+    // Regression pins: BLOCKED / reopen label handling must be unaffected by the above fix
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `block preserves the item's existing statusLabel when the configured block label is explicitly null`(): Unit =
+        runBlocking {
+            // Exercises the "targetRole == BLOCKED -> preserve current.statusLabel" branch in
+            // RoleTransitionHandler.applyTransition, which only fires when the resolved config
+            // label for "block" is null (NoOpStatusLabelService's default "blocked" would NOT
+            // preserve — this pins the null-config-label preserve path specifically).
+            val nullBlockLabelService =
+                object : StatusLabelService {
+                    override fun resolveLabel(trigger: String): String? =
+                        if (trigger == "block") null else NoOpStatusLabelService.resolveLabel(trigger)
+                }
+            val service =
+                AdvanceService(
+                    workItemRepository = workItemRepo,
+                    roleTransitionRepository = roleTransitionRepo,
+                    dependencyRepository = depRepo,
+                    noteRepository = noteRepo,
+                    statusLabelService = nullBlockLabelService,
+                    schemaResolver = { null },
+                )
+            val item = makeItem(role = Role.WORK).copy(statusLabel = "in-progress")
+            val outcome = service.advance(item, "block", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true)
+            val success = assertIs<AdvanceOutcome.Success>(outcome)
+            assertEquals(Role.BLOCKED, success.result.newRole)
+            assertEquals("in-progress", success.result.statusLabel)
+        }
+
+    @Test
+    fun `reopen clears the terminal item's statusLabel`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.TERMINAL).copy(statusLabel = "done")
+            val outcome =
+                serviceWith().advance(item, "reopen", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true)
+            val success = assertIs<AdvanceOutcome.Success>(outcome)
+            assertEquals(Role.QUEUE, success.result.newRole)
+            assertEquals(null, success.result.statusLabel)
+        }
+
     @Test
     fun `enforceOwnership false allows advance on item claimed by another agent`(): Unit =
         runBlocking {

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolFtsDecoratorDispatchTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolFtsDecoratorDispatchTest.kt
@@ -1,0 +1,94 @@
+package io.github.jpicklyk.mcptask.current.application.tools.items
+
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchHit
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchResult
+import io.github.jpicklyk.mcptask.current.test.MockRepositoryProvider
+import io.mockk.coEvery
+import io.mockk.coVerify
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for bug 56aa72f0 — `query_items` operation=search silently returned an empty
+ * result whenever [ToolExecutionContext.workItemRepository] was NOT the concrete
+ * `SQLiteWorkItemRepository` type (e.g. the `EventPublishingWorkItemRepository` decorator used
+ * when the REST API is enabled). The tool used to gate FTS dispatch behind an
+ * `is SQLiteWorkItemRepository` check; [MockRepositoryProvider]'s mocked `WorkItemRepository`
+ * is exactly such a non-concrete instance, so it reproduces the old failure mode without needing
+ * a real decorator or database.
+ *
+ * After the fix, [QueryItemsTool] dispatches `ftsSearch` directly on the `WorkItemRepository`
+ * interface, so this now succeeds regardless of the concrete repository type.
+ */
+class QueryItemsToolFtsDecoratorDispatchTest {
+    private fun params(vararg pairs: Pair<String, kotlinx.serialization.json.JsonElement>) = JsonObject(mapOf(*pairs))
+
+    @Test
+    fun `search dispatches ftsSearch on the WorkItemRepository interface regardless of concrete type`() =
+        runBlocking {
+            val mocks = MockRepositoryProvider()
+            val sentinelItemId = UUID.randomUUID()
+            val sentinelHit =
+                SearchHit(
+                    kind = "item",
+                    itemId = sentinelItemId,
+                    field = "title",
+                    snippet = "sentinel <mark>needle</mark> snippet",
+                    score = 1.0,
+                    matchedIn = listOf("text"),
+                )
+            val sentinel = SearchResult(hits = listOf(sentinelHit), totalHits = 1, nextOffset = null)
+
+            coEvery {
+                mocks.workItemRepo.ftsSearch(
+                    sanitizedFtsQuery = any(),
+                    matchMode = any(),
+                    scope = any(),
+                    limit = any(),
+                    offset = any(),
+                )
+            } returns sentinel
+
+            val tool = QueryItemsTool()
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("search"),
+                        "query" to JsonPrimitive("needle"),
+                    ),
+                    mocks.context(),
+                ) as JsonObject
+
+            // Prove the tool actually called through to the (mocked) repository — the old
+            // `is SQLiteWorkItemRepository` gate would have skipped this call entirely and
+            // returned a hardcoded empty result without ever touching the mock. The query
+            // argument is matched with `any()` (not `eq("needle")`) because FtsQuerySanitizer
+            // wraps each token in literal quotes as an FTS5 phrase term (e.g. `"needle"`).
+            coVerify(exactly = 1) {
+                mocks.workItemRepo.ftsSearch(
+                    sanitizedFtsQuery = any(),
+                    matchMode = any(),
+                    scope = any(),
+                    limit = any(),
+                    offset = any(),
+                )
+            }
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(1, data["totalHits"]!!.jsonPrimitive.int)
+            val hits = data["hits"]!!.jsonArray
+            assertEquals(1, hits.size)
+            assertEquals(sentinelItemId.toString(), hits[0].jsonObject["itemId"]!!.jsonPrimitive.content)
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/QueryNotesToolFtsDecoratorDispatchTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/notes/QueryNotesToolFtsDecoratorDispatchTest.kt
@@ -1,0 +1,94 @@
+package io.github.jpicklyk.mcptask.current.application.tools.notes
+
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchHit
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchResult
+import io.github.jpicklyk.mcptask.current.test.MockRepositoryProvider
+import io.mockk.coEvery
+import io.mockk.coVerify
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for bug 56aa72f0 — `query_notes` operation=search silently returned an empty
+ * result whenever [ToolExecutionContext.noteRepository] was NOT the concrete
+ * `SQLiteNoteRepository` type (e.g. the `EventPublishingNoteRepository` decorator used when the
+ * REST API is enabled). The tool used to gate FTS dispatch behind an `is SQLiteNoteRepository`
+ * check; [MockRepositoryProvider]'s mocked `NoteRepository` is exactly such a non-concrete
+ * instance, so it reproduces the old failure mode without needing a real decorator or database.
+ *
+ * After the fix, [QueryNotesTool] dispatches `ftsSearch` directly on the `NoteRepository`
+ * interface, so this now succeeds regardless of the concrete repository type.
+ */
+class QueryNotesToolFtsDecoratorDispatchTest {
+    private fun params(vararg pairs: Pair<String, kotlinx.serialization.json.JsonElement>) = JsonObject(mapOf(*pairs))
+
+    @Test
+    fun `search dispatches ftsSearch on the NoteRepository interface regardless of concrete type`() =
+        runBlocking {
+            val mocks = MockRepositoryProvider()
+            val sentinelItemId = UUID.randomUUID()
+            val sentinelHit =
+                SearchHit(
+                    kind = "note",
+                    itemId = sentinelItemId,
+                    noteKey = "requirements",
+                    field = "body",
+                    snippet = "sentinel <mark>needle</mark> snippet",
+                    score = 1.0,
+                    matchedIn = listOf("text"),
+                )
+            val sentinel = SearchResult(hits = listOf(sentinelHit), totalHits = 1, nextOffset = null)
+
+            coEvery {
+                mocks.noteRepo.ftsSearch(
+                    sanitizedFtsQuery = any(),
+                    matchMode = any(),
+                    scope = any(),
+                    limit = any(),
+                    offset = any(),
+                )
+            } returns sentinel
+
+            val tool = QueryNotesTool()
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("search"),
+                        "query" to JsonPrimitive("needle"),
+                    ),
+                    mocks.context(),
+                ) as JsonObject
+
+            // Prove the tool actually called through to the (mocked) repository — the old
+            // `is SQLiteNoteRepository` gate would have skipped this call entirely and returned a
+            // hardcoded empty result without ever touching the mock. The query argument is
+            // matched with `any()` (not `eq("needle")`) because FtsQuerySanitizer wraps each
+            // token in literal quotes as an FTS5 phrase term (e.g. `"needle"`).
+            coVerify(exactly = 1) {
+                mocks.noteRepo.ftsSearch(
+                    sanitizedFtsQuery = any(),
+                    matchMode = any(),
+                    scope = any(),
+                    limit = any(),
+                    offset = any(),
+                )
+            }
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(1, data["totalHits"]!!.jsonPrimitive.int)
+            val hits = data["hits"]!!.jsonArray
+            assertEquals(1, hits.size)
+            assertEquals(sentinelItemId.toString(), hits[0].jsonObject["itemId"]!!.jsonPrimitive.content)
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/V13StatusLabelRepairMigrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/V13StatusLabelRepairMigrationTest.kt
@@ -1,0 +1,186 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database
+
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.sql.Connection
+import java.sql.DriverManager
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Integration test for the V13 migration (`V13__Repair_Terminal_Status_Labels.sql`) — the
+ * data-only repair for bug 100da214 (a "start" trigger resolving to TERMINAL stamped the
+ * work-phase "in-progress" label instead of the terminal "done" label).
+ *
+ * Follows the [V12PlanDocumentsMigrationTest] pattern: hand-build a minimal pre-V13 `work_items`
+ * table with raw SQL (just the columns the migration touches), apply the real V13 SQL file read
+ * straight off the classpath, then assert the UPDATE's effect via raw JDBC.
+ */
+class V13StatusLabelRepairMigrationTest {
+    private lateinit var database: Database
+    private lateinit var keepAliveConnection: Connection
+
+    @BeforeEach
+    fun setUp() {
+        val dbName = "v13_status_label_repair_${System.nanoTime()}"
+        val jdbcUrl = "jdbc:sqlite:file:$dbName?mode=memory&cache=shared"
+        keepAliveConnection = DriverManager.getConnection(jdbcUrl)
+        database = Database.connect(url = jdbcUrl, driver = "org.sqlite.JDBC")
+        TransactionManager.manager.defaultIsolationLevel = Connection.TRANSACTION_SERIALIZABLE
+        createMinimalWorkItemsTable()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        try {
+            TransactionManager.closeAndUnregister(database)
+        } catch (_: Exception) {
+        }
+        try {
+            keepAliveConnection.close()
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun createMinimalWorkItemsTable() {
+        transaction(db = database) {
+            exec(
+                """
+                CREATE TABLE work_items (
+                    id           BLOB PRIMARY KEY DEFAULT (randomblob(16)),
+                    title        TEXT NOT NULL,
+                    role         TEXT NOT NULL DEFAULT 'queue',
+                    status_label TEXT
+                )
+                """.trimIndent()
+            )
+        }
+    }
+
+    /**
+     * Reads the real `V13__Repair_Terminal_Status_Labels.sql` off the classpath and executes each
+     * statement. Strips full-line `--` comments, then splits on `;` (mirrors
+     * [V12PlanDocumentsMigrationTest.applyV12Migration]) — safe here since the migration's single
+     * UPDATE statement contains no embedded semicolon.
+     */
+    private fun applyV13Migration() {
+        val resourceStream =
+            requireNotNull(
+                Thread.currentThread().contextClassLoader.getResourceAsStream(
+                    "db/migration/V13__Repair_Terminal_Status_Labels.sql"
+                )
+            ) { "V13__Repair_Terminal_Status_Labels.sql not found on the test classpath" }
+        val sqlText = resourceStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+        val withoutComments =
+            sqlText
+                .lineSequence()
+                .filterNot { it.trimStart().startsWith("--") }
+                .joinToString("\n")
+        val statements =
+            withoutComments
+                .split(";")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+
+        transaction(db = database) {
+            statements.forEach { statement -> exec(statement) }
+        }
+    }
+
+    private fun insertWorkItem(
+        id: UUID,
+        title: String,
+        role: String,
+        statusLabel: String?
+    ) {
+        keepAliveConnection
+            .prepareStatement("INSERT INTO work_items (id, title, role, status_label) VALUES (?, ?, ?, ?)")
+            .use { stmt ->
+                stmt.setBytes(1, uuidToBytes(id))
+                stmt.setString(2, title)
+                stmt.setString(3, role)
+                if (statusLabel != null) stmt.setString(4, statusLabel) else stmt.setNull(4, java.sql.Types.VARCHAR)
+                stmt.executeUpdate()
+            }
+    }
+
+    private fun readStatusLabel(id: UUID): String? {
+        var result: String? = null
+        keepAliveConnection.prepareStatement("SELECT status_label FROM work_items WHERE id = ?").use { stmt ->
+            stmt.setBytes(1, uuidToBytes(id))
+            stmt.executeQuery().use { rs ->
+                if (rs.next()) result = rs.getString(1)
+            }
+        }
+        return result
+    }
+
+    private fun uuidToBytes(id: UUID): ByteArray {
+        val buf = ByteBuffer.allocate(16)
+        buf.putLong(id.mostSignificantBits)
+        buf.putLong(id.leastSignificantBits)
+        return buf.array()
+    }
+
+    @Test
+    fun `V13 repairs a terminal row mislabeled in-progress to done`(): Unit =
+        runBlocking {
+            val id = UUID.randomUUID()
+            insertWorkItem(id, "Mislabeled Terminal", role = "terminal", statusLabel = "in-progress")
+
+            applyV13Migration()
+
+            assertEquals("done", readStatusLabel(id), "Terminal row stuck on the work-phase label must be repaired to 'done'")
+        }
+
+    @Test
+    fun `V13 does not touch a cancelled terminal row`(): Unit =
+        runBlocking {
+            val id = UUID.randomUUID()
+            insertWorkItem(id, "Cancelled", role = "terminal", statusLabel = "cancelled")
+
+            applyV13Migration()
+
+            assertEquals("cancelled", readStatusLabel(id), "Cancelled rows must be left untouched")
+        }
+
+    @Test
+    fun `V13 is idempotent for a terminal row already labeled done`(): Unit =
+        runBlocking {
+            val id = UUID.randomUUID()
+            insertWorkItem(id, "Already Done", role = "terminal", statusLabel = "done")
+
+            applyV13Migration()
+
+            assertEquals("done", readStatusLabel(id))
+        }
+
+    @Test
+    fun `V13 does not touch a non-terminal row`(): Unit =
+        runBlocking {
+            val id = UUID.randomUUID()
+            insertWorkItem(id, "Still In Progress", role = "work", statusLabel = "in-progress")
+
+            applyV13Migration()
+
+            assertEquals("in-progress", readStatusLabel(id), "Non-terminal rows must be left untouched")
+        }
+
+    @Test
+    fun `V13 leaves a terminal row with a NULL status_label untouched`(): Unit =
+        runBlocking {
+            val id = UUID.randomUUID()
+            insertWorkItem(id, "Null Label Terminal", role = "terminal", statusLabel = null)
+
+            applyV13Migration()
+
+            assertNull(readStatusLabel(id), "NULL status_label on a terminal row is not this bug's symptom and must be left alone")
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/V13StatusLabelRepairMigrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/V13StatusLabelRepairMigrationTest.kt
@@ -183,4 +183,21 @@ class V13StatusLabelRepairMigrationTest {
 
             assertNull(readStatusLabel(id), "NULL status_label on a terminal row is not this bug's symptom and must be left alone")
         }
+
+    @Test
+    fun `V13 does not clobber a terminal row with a custom (non-default) terminal label`(): Unit =
+        runBlocking {
+            val id = UUID.randomUUID()
+            // A project may configure a custom terminal label via per-root status_labels (e.g. 'finished').
+            // Such a row is correctly labeled and is NOT this bug's symptom — it must survive the repair.
+            insertWorkItem(id, "Custom Terminal Label", role = "terminal", statusLabel = "finished")
+
+            applyV13Migration()
+
+            assertEquals(
+                "finished",
+                readStatusLabel(id),
+                "A legitimate custom per-root terminal label must not be rewritten to 'done'"
+            )
+        }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepositoryFtsTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteNoteRepositoryFtsTest.kt
@@ -3,6 +3,8 @@ package io.github.jpicklyk.mcptask.current.infrastructure.repository
 import io.github.jpicklyk.mcptask.current.domain.model.Note
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchMatchMode
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchScope
 import io.github.jpicklyk.mcptask.current.test.BaseFts5RepositoryTest
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepositoryFtsTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteWorkItemRepositoryFtsTest.kt
@@ -3,6 +3,8 @@ package io.github.jpicklyk.mcptask.current.infrastructure.repository
 import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchMatchMode
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchScope
 import io.github.jpicklyk.mcptask.current.test.BaseFts5RepositoryTest
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/events/EventPublishingRepositoryProviderFtsForwardingTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/events/EventPublishingRepositoryProviderFtsForwardingTest.kt
@@ -1,0 +1,92 @@
+package io.github.jpicklyk.mcptask.current.interfaces.api.v1.events
+
+import io.github.jpicklyk.mcptask.current.domain.repository.NoteRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.SearchResult
+import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for bug 56aa72f0 — FTS search (`query_items`/`query_notes` operation=search,
+ * and the `/search` / `/notes/search` REST routes) silently returned empty whenever the REST API
+ * was enabled.
+ *
+ * Root cause: `ftsSearch()` lived only on the concrete `SQLiteWorkItemRepository` /
+ * `SQLiteNoteRepository` classes, not on the `WorkItemRepository` / `NoteRepository` interfaces.
+ * Callers gated dispatch behind an `is SQLite*Repository` check. When the REST API is enabled,
+ * `ServerComposition` wraps repositories in `EventPublishing*Repository` decorators (`... by
+ * inner`), which are NOT instances of the concrete SQLite types — so the `is` check always failed
+ * and FTS never ran, even though the underlying database and FTS5 index were healthy.
+ *
+ * The fix promotes `ftsSearch` onto the `WorkItemRepository`/`NoteRepository` interfaces; the
+ * `by inner` decorators then auto-forward the call to the wrapped repository with no code change
+ * needed in [EventPublishingRepositoryProvider] itself. These tests pin that forwarding contract
+ * using fake inner repositories that return a distinctive sentinel [SearchResult] — proving the
+ * decorator returns the EXACT object the inner repository produced, not a silent fallback empty
+ * result (which is what the old `is`-check gate used to produce).
+ */
+class EventPublishingRepositoryProviderFtsForwardingTest {
+    @Test
+    fun `EventPublishingWorkItemRepository forwards ftsSearch to the inner repository`(): Unit =
+        runBlocking {
+            val sentinel = SearchResult(hits = emptyList(), totalHits = 42, nextOffset = null)
+            val innerWorkItemRepo = mockk<WorkItemRepository>()
+            coEvery {
+                innerWorkItemRepo.ftsSearch(
+                    sanitizedFtsQuery = "needle",
+                    matchMode = any(),
+                    scope = any(),
+                    limit = any(),
+                    offset = any(),
+                )
+            } returns sentinel
+
+            val delegate = mockk<RepositoryProvider>()
+            every { delegate.workItemRepository() } returns innerWorkItemRepo
+
+            val provider = EventPublishingRepositoryProvider(delegate, ApiEventBus())
+            // provider.workItemRepository() returns the EventPublishingWorkItemRepository decorator,
+            // NOT the mocked inner repo directly — this is the exact shape production code sees
+            // when the REST API is enabled.
+            val result = provider.workItemRepository().ftsSearch(sanitizedFtsQuery = "needle")
+
+            assertSame(
+                sentinel,
+                result,
+                "Decorator must forward ftsSearch to the inner WorkItemRepository unchanged",
+            )
+        }
+
+    @Test
+    fun `EventPublishingNoteRepository forwards ftsSearch to the inner repository`(): Unit =
+        runBlocking {
+            val sentinel = SearchResult(hits = emptyList(), totalHits = 7, nextOffset = null)
+            val innerNoteRepo = mockk<NoteRepository>()
+            coEvery {
+                innerNoteRepo.ftsSearch(
+                    sanitizedFtsQuery = "needle",
+                    matchMode = any(),
+                    scope = any(),
+                    limit = any(),
+                    offset = any(),
+                )
+            } returns sentinel
+
+            val delegate = mockk<RepositoryProvider>()
+            every { delegate.noteRepository() } returns innerNoteRepo
+
+            val provider = EventPublishingRepositoryProvider(delegate, ApiEventBus())
+            val result = provider.noteRepository().ftsSearch(sanitizedFtsQuery = "needle")
+
+            assertSame(
+                sentinel,
+                result,
+                "Decorator must forward ftsSearch to the inner NoteRepository unchanged",
+            )
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/WriteRoutesTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/WriteRoutesTest.kt
@@ -2,6 +2,8 @@ package io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes
 
 import io.github.jpicklyk.mcptask.current.application.service.IdempotencyCache
 import io.github.jpicklyk.mcptask.current.application.service.NoOpNoteSchemaService
+import io.github.jpicklyk.mcptask.current.application.service.NoOpStatusLabelService
+import io.github.jpicklyk.mcptask.current.application.service.StatusLabelService
 import io.github.jpicklyk.mcptask.current.application.service.WorkItemSchemaService
 import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
 import io.github.jpicklyk.mcptask.current.domain.model.Dependency
@@ -65,6 +67,9 @@ private const val READ_ONLY_TOKEN = TEST_TOKEN
  *
  * @param schemaService schema service used by the advance route to resolve hasReviewPhase.
  *   Defaults to [NoOpNoteSchemaService] (schema-free → no review phase).
+ * @param statusLabelService config-driven status label resolution used by the advance route.
+ *   Defaults to [NoOpStatusLabelService] (deterministic hardcoded defaults, no file I/O) — tests
+ *   asserting REST/MCP status-label parity (bug 80e48e55) rely on this default.
  */
 fun Application.configureWriteTestApp(
     repo: DefaultRepositoryProvider,
@@ -72,6 +77,7 @@ fun Application.configureWriteTestApp(
     degradedModePolicy: DegradedModePolicy = DegradedModePolicy.ACCEPT_CACHED,
     authConfig: ApiAuthConfig.Bearer = makeWriteAuthConfig(),
     schemaService: WorkItemSchemaService = NoOpNoteSchemaService,
+    statusLabelService: StatusLabelService = NoOpStatusLabelService,
 ) {
     install(ContentNegotiation) { json(McpJson) }
     install(SSE)
@@ -89,7 +95,7 @@ fun Application.configureWriteTestApp(
             noteRoutes(repo)
             dependencyRoutes(repo)
             // WRITE routes under test
-            itemWriteRoutes(repo, degradedModePolicy, idempotencyCache, schemaService)
+            itemWriteRoutes(repo, degradedModePolicy, idempotencyCache, schemaService, statusLabelService = statusLabelService)
             noteWriteRoutes(repo, degradedModePolicy, idempotencyCache)
             dependencyWriteRoutes(repo, degradedModePolicy)
         }
@@ -771,6 +777,80 @@ class AdvanceRouteTest {
                     .data.role.name
                     .lowercase() != "queue",
                 "Item role should have advanced from queue"
+            )
+        }
+
+    @Test
+    fun `POST items id advance stamps a config-driven statusLabel (bug 80e48e55 REST-MCP parity)`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            val item =
+                runBlocking {
+                    repo.workItemRepository().create(WorkItem(title = "Label Parity", depth = 0)).getOrNull()!!
+                }
+            application { configureWriteTestApp(repo, statusLabelService = NoOpStatusLabelService) }
+
+            val response =
+                client.post("/api/v1/items/${item.id}/advance") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"trigger":"start"}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(
+                body.contains("\"statusLabel\":\"in-progress\""),
+                "REST advance must stamp a config-driven statusLabel; previously used NoOpStatusLabelService " +
+                    "unconditionally and applied no label at all: $body",
+            )
+
+            // Hard assertion: the persisted item carries the stamped label, not just the response body.
+            val persisted = runBlocking { repo.workItemRepository().getById(item.id) }
+            assertEquals(
+                "in-progress",
+                (persisted as Result.Success).data.statusLabel,
+                "Persisted item must carry the REST-stamped statusLabel",
+            )
+        }
+
+    @Test
+    fun `POST items id advance start on WORK with no review phase stamps the terminal label (bug 100da214 + 80e48e55)`(): Unit =
+        testApplication {
+            val repo = buildH2RepositoryProvider()
+            // 'flat-type' has no REVIEW-phase note -> hasReviewPhase() false -> start from WORK
+            // resolves straight to TERMINAL. Before the fix this stamped "in-progress" (bug
+            // 100da214) via a NoOpStatusLabelService that REST never even consulted (bug 80e48e55).
+            val item =
+                runBlocking {
+                    repo
+                        .workItemRepository()
+                        .create(WorkItem(title = "No Review Label", type = "flat-type", role = Role.WORK, depth = 0))
+                        .getOrNull()!!
+                }
+            application {
+                configureWriteTestApp(
+                    repo,
+                    schemaService = ReviewPhaseSchemaService(),
+                    statusLabelService = NoOpStatusLabelService,
+                )
+            }
+
+            val response =
+                client.post("/api/v1/items/${item.id}/advance") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"trigger":"start"}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val persisted = runBlocking { repo.workItemRepository().getById(item.id) }
+            val data = (persisted as Result.Success).data
+            assertEquals("terminal", data.role.name.lowercase())
+            assertEquals(
+                "done",
+                data.statusLabel,
+                "REST start->TERMINAL must stamp the terminal label, not 'in-progress' or null",
             )
         }
 


### PR DESCRIPTION
Batch of three related workflow/search bug fixes, all surfaced during the plan-document-ingestion session's diagnostics.

## Bugs fixed

### 1. FTS search silently returns empty when the REST API is enabled (`56aa72f0`, high)
`ftsSearch()` was a concrete-only method on `SQLiteWorkItemRepository`/`SQLiteNoteRepository`, and the callers gated it behind `if (repo is SQLiteWorkItemRepository)`. When `API_ENABLED=true`, the tool context is fed the `EventPublishingRepositoryProvider` decorator (a `... by inner` delegate), so the `is` check is false and every search fell through to the "non-SQLite → empty" branch. This silently broke `query_items`/`query_notes` search **and** the REST `/search` + `/notes/search` endpoints on the now-recommended HTTP+REST default — with no error surfaced. The database/FTS index were always healthy; FTS just never ran.
- **Fix:** promote `ftsSearch` onto the `WorkItemRepository`/`NoteRepository` interfaces (decorators auto-forward via `by inner`); drop the `is SQLite*Repository` gate at all four call sites. Search value types moved to `domain/repository/SearchTypes.kt` to keep the domain layer free of an infrastructure dependency.

### 2. Start-to-terminal left a stale work-phase status label (`100da214`, medium)
`advance_item(trigger="start")` taking an item WORK→TERMINAL (no-review schema) or REVIEW→TERMINAL stamped `"in-progress"` instead of the terminal label, because the label lookup keyed on the raw trigger, not the resolved target role.
- **Fix:** in `AdvanceService`, remap the label-lookup trigger to `complete` when a `start` resolves to TERMINAL, so both converge on the configured terminal label (respects per-root `status_labels`). V13 migration repairs existing rows stuck at `'in-progress'` (narrowly scoped — custom terminal labels are left untouched).

### 3. REST transitions never applied status labels (`80e48e55`, medium)
`ItemWriteRoutes` wired `AdvanceService` with `NoOpStatusLabelService`, so REST advances never stamped labels (MCP/REST parity gap, widened by the per-root label work).
- **Fix:** extracted a shared root-aware `StatusLabelService` factory and threaded the real `YamlStatusLabelService` through to the REST advance path.

## Test results
Full `:current:test` + `:current:ktlintCheck` green (orchestrator-owned, exit codes captured). New regression tests genuinely fail against pre-fix code: decorator-forwarding + non-concrete-repo tool dispatch for FTS; start-only full-lifecycle label assertions + REST advance label parity; V13 migration (repairs `in-progress`, leaves `cancelled`/custom/NULL/non-terminal untouched, idempotent).

## Review
Two independent reviews — both Pass. The statusLabel review flagged the V13 predicate as too broad (would clobber custom per-root terminal labels); narrowed to `status_label='in-progress'` before merge with a test proving custom labels survive.

## Post-merge
Requires a redeploy for the FTS fix to take effect on the running server (`API_ENABLED=true`). V13 will repair the existing mislabeled terminal rows on startup.

## MCP
Observations: 56aa72f0, 100da214, 80e48e55

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM5g2mYecQdGf7oVKcSq2d