### PR TITLE
docs(schemas): document missing traits in example-schemas.md

### DIFF
--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/example-schemas.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/example-schemas.md
@@ -146,6 +146,23 @@ traits:
         skill: "migration-review"
         guidance: "Document schema changes, SQLite constraints, data migration strategy, Flyway migration details."
 
+  needs-api-compat-review:
+    notes:
+      - key: api-compatibility
+        role: review
+        required: true
+        description: "Compatibility assessment for API changes — the MCP tool surface (dynamically re-discovered) and the REST surface (hardcoded clients) have different compatibility models."
+        guidance: "Assess by surface. **MCP tools:** clients re-read the tools/list schema each session, so parameter renames/additions are NOT breaking — verify instead that each changed param's schema key and its read site stay in sync, and that all first-party callers (skills, hooks, output styles, memory, api-reference.md) update in lockstep; a pure rename needn't keep the old name working. **REST API:** clients hardcode field/param names, so compatibility matters — keep response shapes additive, and renames/removals need a migration path or version bump. Update openapi.yaml + api-rest.md for REST changes."
+
+  needs-plugin-update:
+    notes:
+      - key: plugin-impact
+        role: review
+        required: true
+        description: "Assessment of plugin skill and hook changes needed after a behavior change."
+        skill: "plugin-impact-review"
+        guidance: "Identify which skills reference the changed behavior, which hooks inject affected context, and whether config-format docs or output styles need updating. List specific files/sections. Plugin content is cached — note if an /mcp reconnect is needed."
+
   needs-security-review:
     notes:
       - key: security-assessment
@@ -153,6 +170,15 @@ traits:
         required: true
         description: "Security review of auth, data handling, and access control."
         guidance: "Evaluate input validation, injection risks, access control, data handling. Flag OWASP Top 10 concerns."
+
+  needs-perf-review:
+    notes:
+      - key: performance-baseline
+        role: queue
+        required: false
+        description: "Performance impact assessment and measurement plan."
+        skill: "perf-review"
+        guidance: "Document affected hot paths, expected impact (new queries, parsing, file I/O), any O(n) risk where n could be large, and a measurement plan. Optional — use when the change touches known hot paths."
 
   delegated:
     notes:


### PR DESCRIPTION
## Summary

Documents the three traits that were **missing** from the `example-schemas.md` traits reference — it previously showed only 3 of the 6 traits this project defines.

- **`needs-api-compat-review`** — carries the refined **MCP-vs-REST** compatibility guidance: MCP tool schemas are re-read from `tools/list` each session, so parameter renames aren't breaking (verify schema-key/read-site sync + first-party caller lockstep instead); REST clients hardcode field names, so there compatibility genuinely matters (additive shapes, or a migration path / version bump for renames).
- **`needs-plugin-update`** — assessing which skills/hooks/config-docs/output-styles need updating after a behavior change (skill: `plugin-impact-review`).
- **`needs-perf-review`** — optional hot-path/measurement-plan assessment (skill: `perf-review`).

Added in the order that mirrors the trait definitions (migration → api-compat → plugin-update → security → perf → delegated).

## Context

Follow-up to the API parameter normalization (`de711807`, PR #246). During the post-merge audit of that change, the reference doc was found to document only half the traits — and the `needs-api-compat-review` guidance embodies the MCP-vs-REST distinction that motivated the rename being non-breaking.

## Impact

Docs-only — a fenced YAML example block in a reference file. No code, no schema loading, no build impact. The added guidance is copy-paste-ready for anyone adopting these traits in their own `config.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
