### PR TITLE
feat: config dogfood split, opt-in task review, schema/skill drift fixes

### DIFF
--- a/.claude/commands/deploy_to_docker.md
+++ b/.claude/commands/deploy_to_docker.md
@@ -56,11 +56,11 @@ docker inspect mcp-task-orchestrator-http --format '{{range .Config.Env}}{{print
   | grep -E 'API_ENABLED|API_AUTH_MODE|API_ALLOW_UNAUTHENTICATED|API_TOKENS_PATH|LOG_LEVEL' || echo '(no existing container)'
 # config mount present?
 docker inspect mcp-task-orchestrator-http --format '{{range .Mounts}}{{.Source}} -> {{.Destination}}{{println}}{{end}}' 2>/dev/null \
-  | grep -q '/project/.taskorchestrator' && echo 'config-mount: project' || echo 'config-mount: none'
+  | grep -q '/project/.taskorchestrator' && echo 'config-mount: floor' || echo 'config-mount: none'
 ```
 Derive the **REST mode** from the env: `API_ENABLED=false` → **off**; `API_ENABLED=true` + `API_AUTH_MODE=none` → **unauthenticated**; `+ API_AUTH_MODE=bearer` → **bearer**.
 
-If no container exists, fall back (in order) to: the persisted file `${HOME}/.taskorchestrator/deploy.env` (see 4d); else the **defaults** — HTTP transport, REST **off**, **project** config mount, loopback `127.0.0.1:3001`, debug off.
+If no container exists, fall back (in order) to: the persisted file `${HOME}/.taskorchestrator/deploy.env` (see 4d); else the **defaults** — HTTP transport, REST **off**, **floor** config mount, loopback `127.0.0.1:3001`, debug off.
 
 Build a one-line `DETECTED` summary, e.g. `HTTP · REST=unauthenticated (local) · config-mount=none · debug=off · 127.0.0.1:3001 · image=task-orchestrator:current`.
 
@@ -93,7 +93,7 @@ AskUserQuestion(questions: [{
   ]
 }])
 ```
-For **STDIO**, use the legacy interactive run (`docker run --rm -i -v mcp-task-data:/app/data [-v <pwd>/.taskorchestrator:/project/.taskorchestrator:ro -e AGENT_CONFIG_DIR=/project] [-e LOG_LEVEL=DEBUG -e DATABASE_SHOW_SQL=true] <image-tag>`) and skip the HTTP questions below.
+For **STDIO**, use the legacy interactive run (`docker run --rm -i -v mcp-task-data:/app/data [-v <pwd>/deploy/global-config/.taskorchestrator:/project/.taskorchestrator:ro -e AGENT_CONFIG_DIR=/project] [-e LOG_LEVEL=DEBUG -e DATABASE_SHOW_SQL=true] <image-tag>`) and skip the HTTP questions below.
 
 For **HTTP**, ask:
 
@@ -115,10 +115,10 @@ AskUserQuestion(questions: [{
 **Config mount:**
 ```
 AskUserQuestion(questions: [{
-  question: "Mount this project's config as the server's global/fallback config?", header: "Config mount", multiSelect: false,
+  question: "Mount the process-schema floor config as the server's global/fallback config?", header: "Config mount", multiSelect: false,
   options: [
-    { label: "This project (fallback)", description: "Mount ./.taskorchestrator read-only as AGENT_CONFIG_DIR — the global fallback config." },
-    { label: "None (multi-project)", description: "No project mount. Per-project config flows in via the config-sync hook into the DB per root." }
+    { label: "Floor config (recommended)", description: "Mount ./deploy/global-config/.taskorchestrator read-only as AGENT_CONFIG_DIR — the process-schema floor (agent-observation, session-retrospective, improvement-proposal, container). Project-specific schemas still flow in per-root via config-sync." },
+    { label: "None (multi-project)", description: "No global mount. All schemas — including the process ones — flow in via the config-sync hook into the DB per root." }
   ]
 }])
 ```
@@ -135,7 +135,7 @@ IMAGE_TAG=<image-tag>
 TRANSPORT=http
 REST_MODE=<off|unauth|bearer>
 TOKENS_HOST_PATH=<host path, bearer only>
-CONFIG_MOUNT=<project|none>
+CONFIG_MOUNT=<floor|none>
 DEBUG=<true|false>
 EOF
 ```
@@ -189,4 +189,4 @@ If **unauthenticated** REST was selected, repeat the loopback-only SECURITY cave
 - **Build fails:** verify the Dockerfile exists at project root; check disk space.
 - **Container won't start:** reconfigure with Debug logging; `docker logs mcp-task-orchestrator-http`. If you set REST unauthenticated on a **pre-#237 image**, the old loader rejects `API_AUTH_MODE=none` at startup — rebuild first.
 - **DB permission errors:** `docker run --rm -v mcp-task-data:/app/data --user root amazoncorretto:25-al2023-headless chown -R 1001:1001 /app/data`.
-- **Config not found:** use a config mount (not None) if you rely on the global fallback config; verify `.taskorchestrator/` exists.
+- **Config not found:** use a config mount (not None) if you rely on the global fallback config; verify `deploy/global-config/.taskorchestrator/` exists.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,8 @@
 {
-  "enabledPlugins": {}
+  "enabledPlugins": {
+    "task-orchestrator@task-orchestrator-marketplace": true
+  },
+  "env": {
+    "TASK_ORCHESTRATOR_API_URL": "http://localhost:3001"
+  }
 }

--- a/.claude/skills/api-compat-review/SKILL.md
+++ b/.claude/skills/api-compat-review/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: api-compat-review
+description: Compatibility assessment for items with the needs-api-compat-review trait. Evaluates the MCP tool surface and the REST surface separately, since their compatibility models differ. Invoked via skillPointer when filling api-compatibility notes.
+user-invocable: false
+---
+
+# API Compatibility Review Framework
+
+Assess API changes by surface — the MCP tool surface (dynamically re-discovered by clients) and the REST surface (hardcoded clients) have different compatibility models. Do not apply REST-style breaking-change caution to MCP tools, and do not apply MCP's rename-friendliness to REST.
+
+## Step 1: Classify the Change
+
+Determine which surface(s) the change touches:
+- **MCP tools** — `application/tools/` tool definitions, `parameterSchema`, tool `description` strings
+- **REST API** — `interfaces/api/v1/routes/`, `interfaces/api/v1/dto/Dtos.kt`, `openapi.yaml`
+
+A single change (e.g., a domain model field rename) can touch both surfaces independently — assess each.
+
+## Step 2: MCP Surface Assessment
+
+LLM clients re-read the `tools/list` schema every session — there is no persistent client binding to break. A pure parameter rename does NOT require keeping the old name working. Verify instead:
+- [ ] Every changed param's `parameterSchema` key and its arg-parsing read site stay in sync — no schema-says-X/code-reads-Y drift
+- [ ] ALL first-party callers update in lockstep: plugin skills, hooks, output styles, auto-memory references, and `api-reference.md`. This doc coordination is the real cost of an MCP change, not client breakage.
+- [ ] The tool `description` string accurately reflects the new behavior
+
+## Step 3: REST Surface Assessment
+
+HTTP clients hardcode field and param names, so compatibility DOES matter here:
+- [ ] Response-shape changes are additive (new fields only) where possible
+- [ ] Renames or removals of existing fields/params have an explicit migration path or version bump — not a silent break
+- [ ] Note when a surface has effectively zero consumers (e.g., a days-old endpoint) so the reviewer can right-size caution instead of over-indexing on hypothetical clients
+- [ ] `openapi.yaml` is updated for any REST-facing change
+- [ ] `api-rest.md` is updated for any REST-facing change
+
+## Output
+
+Compose the `api-compatibility` note with findings from Step 2 and/or Step 3, scoped to whichever surface(s) the change actually touches. If a surface wasn't touched, say so explicitly rather than omitting it silently.

--- a/.claude/skills/feature-implementation/SKILL.md
+++ b/.claude/skills/feature-implementation/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: feature-implementation
-description: "Guides the full lifecycle of a feature-implementation tagged MCP item (the feature container) — from queue through review. Creates or resumes the feature container, fills gate-enforced notes at each phase (requirements, design, implementation-notes, test-results), dispatches implementation subagents, and advances through queue, work, and review to terminal. Use when the user says: implement a feature, start a new feature, feature workflow, resume feature work, guide feature lifecycle, or references a feature-implementation item UUID."
+description: "Guides the full lifecycle of a feature-implementation tagged MCP item (the feature container) — from queue through review. Creates or resumes the feature container, fills gate-enforced notes at each phase (feature-summary, implementation-notes, session-tracking, review-checklist), dispatches implementation subagents, and advances through queue, work, and review to terminal. Use when the user says: implement a feature, start a new feature, feature workflow, resume feature work, guide feature lifecycle, or references a feature-implementation item UUID."
 ---
 
 # Feature Implementation Workflow
 
 End-to-end workflow for a `feature-implementation` tagged item — the **feature container**
-that holds the specification, plan, and holistic review. Child work items under this
-container use the `feature-task` tag with lighter gates (task-scope instead of full
-specification, task-level review without `/simplify`).
+that holds the plan and holistic review. Child work items under this container use the
+`feature-task` tag with lighter gates (`task-scope` instead of the feature-level
+`feature-summary`, and no review phase by default — task-level review is opt-in via the
+`needs-task-review` trait, which adds a `review-checklist` note to that child).
 
 Covers all three phases (queue → work → review) with gate-enforced notes at each transition.
 
@@ -40,61 +41,49 @@ then continue to Phase 1.
 
 ---
 
-## Phase 1 — Queue: Define Requirements and Design
+## Phase 1 — Queue: Define the Feature Summary
 
-**Goal:** Fill the two required queue-phase notes before advancing to work.
+**Goal:** Fill the single required queue-phase note before advancing to work.
 
-### 1a. Fill `requirements`
+### 1a. Fill `feature-summary`
 
-Use `manage_notes` to upsert the `requirements` note:
+Use `manage_notes` to upsert the `feature-summary` note:
 ```
 manage_notes(
   operation="upsert",
   notes=[{
     itemId: "<uuid>",
-    key: "requirements",
+    key: "feature-summary",
     role: "queue",
     body: "<content>"
   }]
 )
 ```
 
-**What to write:** The problem this solves. Who benefits. 2–5 concrete acceptance criteria
-that define done. Reference any existing observations or bug items that motivated this feature.
+**What to write:** Keep this note lean (target under 2k chars) — it stays at the feature
+level, not the child-task level where the full spec-quality disciplines apply. Cover:
+- **Goal** — the problem this solves and who benefits.
+- **Findings → tasks table** — a table mapping each finding or requirement to the child
+  task that will address it.
+- **Dependency edges** — ordering constraints between child tasks, if any.
+- **Non-goals pointer** — a reference to where non-goals are documented per child (each
+  child's `task-scope` note carries its own alternatives/non-goals/blast-radius/risk/test
+  strategy per the spec-quality framework); this note does not repeat that analysis.
 
-### 1b. Fill `design`
+### 1b. Enter plan mode
 
-```
-manage_notes(
-  operation="upsert",
-  notes=[{
-    itemId: "<uuid>",
-    key: "design",
-    role: "queue",
-    body: "<content>"
-  }]
-)
-```
-
-**What to write:** Chosen approach. Alternatives considered and why they were ruled out.
-Key risks or constraints (schema migrations, tight coupling areas, ORM quirks, test isolation issues).
-Reference specific files and classes that will be touched.
-
-### 1c. Enter plan mode
-
-After filling both notes, use `EnterPlanMode` to explore the codebase and produce a concrete
+After filling the note, use `EnterPlanMode` to explore the codebase and produce a concrete
 implementation plan. The `pre-plan` hook will inject additional guidance.
 
 When the plan is approved, `post-plan` hook fires — proceed directly to Phase 2 without pausing.
 
-### 1d. Advance to work
+### 1c. Advance to work
 
 ```
 advance_item(transitions=[{ itemId: "<uuid>", trigger: "start" }])
 ```
 
-Gate check: both `requirements` and `design` must be filled. If gate rejects, fill the missing
-notes and retry.
+Gate check: `feature-summary` must be filled. If gate rejects, fill the missing note and retry.
 
 Confirm `newRole: "work"` in the response before dispatching implementation subagents.
 
@@ -107,7 +96,10 @@ Confirm `newRole: "work"` in the response before dispatching implementation suba
 ### 2a. Materialize any child items
 
 If the feature has sub-tasks, create them now using `create_work_tree` with the feature UUID
-as `parentId`. Dispatch implementation subagents with each child item UUID.
+as `parentId` and the `feature-task` tag. Each child fills a `task-scope` queue note (the
+full spec-quality disciplines — alternatives, non-goals, blast radius, risk flags, test
+strategy — apply there, not in the feature-level `feature-summary`). Dispatch
+implementation subagents with each child item UUID.
 
 Each subagent must:
 - Call `advance_item(trigger="start")` on their item to enter work phase
@@ -115,6 +107,11 @@ Each subagent must:
   provides guidance via `guidancePointer` and `skillPointer`)
 - Return to the orchestrator — do NOT call `advance_item` again. The orchestrator
   handles all further transitions.
+
+By default, `feature-task` items have no review phase — `advance_item(trigger="start")`
+from work goes straight to terminal. A child only gets a review phase if it (or its
+schema's `default_traits`) carries the `needs-task-review` trait, which adds the
+`review-checklist` note back in.
 
 ### 2b. Fill `implementation-notes`
 
@@ -131,26 +128,27 @@ manage_notes(
 )
 ```
 
-**What to write:** Key decisions made during implementation. Deviations from the design note.
+**What to write:** Key decisions made during implementation. Deviations from the plan.
 Any surprises (wrong class names, API differences, test isolation issues). Files changed with
 line counts. If an observation was fixed, reference its item ID.
 
-### 2c. Fill `test-results`
+### 2c. Fill `session-tracking`
 
 ```
 manage_notes(
   operation="upsert",
   notes=[{
     itemId: "<uuid>",
-    key: "test-results",
+    key: "session-tracking",
     role: "work",
     body: "<content>"
   }]
 )
 ```
 
-**What to write:** Run `./gradlew :current:test`. Report total count and any failures.
-List new test classes or cases added. If root-module tests were affected, report those too.
+**What to write:** Run `./gradlew :current:test`. Report total count and any failures,
+new test classes or cases added, and a summary of what changed this session. This note
+comes from the `session-tracked` default trait and feeds `/session-retrospective`.
 
 ### 2d. Advance to review
 
@@ -158,26 +156,50 @@ List new test classes or cases added. If root-module tests were affected, report
 advance_item(transitions=[{ itemId: "<uuid>", trigger: "start" }])
 ```
 
-Gate check: both `implementation-notes` and `test-results` must be filled.
+Gate check: both `implementation-notes` and `session-tracking` must be filled.
 Confirm `newRole: "review"` in the response.
 
 ---
 
-## Phase 3 — Review: Deploy and Verify
+## Phase 3 — Review: Verify, Deploy, and Close
 
-**Goal:** Deploy, verify in the running MCP server, then close the item.
+**Goal:** Fill the required `review-checklist` note (per the review-quality skill), deploy
+and verify in the running MCP server, then close the item.
 
-### 3a. Deploy to Docker (if needed)
+### 3a. Fill `review-checklist`
+
+Follow the `review-quality` skill's framework — plan alignment against `feature-summary`
+and each child's `task-scope`, test quality, and (if `/simplify` ran) test coverage of its
+changes.
+
+```
+manage_notes(
+  operation="upsert",
+  notes=[{
+    itemId: "<uuid>",
+    key: "review-checklist",
+    role: "review",
+    body: "<content>"
+  }]
+)
+```
+
+**What to write:** A feature-level verdict aggregating across children — reference each
+child's own review-checklist if the `needs-task-review` trait produced one. See the
+review-quality skill for the full findings format and verdict types (Pass / Fail —
+blocking issues / Pass with observations).
+
+### 3b. Deploy to Docker (if needed)
 
 Run `/deploy_to_docker --current` to rebuild the image with the new code.
 Reconnect MCP after deploy: `/mcp`.
 
-### 3b. Smoke test the change
+### 3c. Smoke test the change
 
 Exercise the new capability via MCP tool calls. Confirm it behaves as described in the
-`requirements` note acceptance criteria.
+`feature-summary` note's goal.
 
-### 3c. Fill `deploy-notes` (optional)
+### 3d. Fill `deploy-notes` (optional)
 
 ```
 manage_notes(
@@ -194,7 +216,7 @@ manage_notes(
 **What to write:** Whether a Docker rebuild was done and what image tag was used.
 Plugin version bump (if any). MCP reconnect required. Any smoke test results.
 
-### 3d. Close the item
+### 3e. Close the item
 
 ```
 advance_item(transitions=[{ itemId: "<uuid>", trigger: "start", summary: "<one-line summary>" }])
@@ -208,9 +230,9 @@ Confirm `newRole: "terminal"`. Run `get_context()` health check to verify no sta
 
 | Phase | Required notes | Advance trigger |
 |-------|---------------|-----------------|
-| queue | `requirements`, `design` | `start` → work |
-| work | `implementation-notes`, `test-results` | `start` → review |
-| review | _(none required)_ | `start` → terminal |
+| queue | `feature-summary` | `start` → work |
+| work | `implementation-notes`, `session-tracking` | `start` → review |
+| review | `review-checklist` | `start` → terminal |
 
 **Gate error pattern:** `"required notes not filled for <phase> phase: <keys>"`
 → Fill the listed notes, then retry `advance_item`.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -388,7 +388,9 @@ Before dispatching or performing review, check the item's current role. Inspect
 
 - **If `newRole` is `terminal`:** The item's schema has no review phase (lightweight
   lifecycle). Review dispatch is not needed — the item completed through its natural
-  lifecycle. Proceed to Step 6.
+  lifecycle. Proceed to Step 6. Note: `feature-task` items skip review by default
+  (work→terminal directly) — the `needs-task-review` trait re-enables a review phase
+  for a specific child when needed.
 - **If `newRole` is `review`:** Continue with review per tier below.
 
 This step is **tier-conditional**:
@@ -521,11 +523,13 @@ Report the PR URL and a summary.
 
 For Parallel-tier features with a shared feature worktree:
 
-**For each child task** (after its review passes):
+**For each child task** (after its review passes, if it has one):
 
-1. Confirm the child's `review-checklist` note is filled.
+1. For children whose schema/trait declares a review phase (e.g. `needs-task-review`),
+   confirm `review-checklist` is filled. Children without one advance work→terminal
+   directly — there is nothing to confirm.
 2. `advance_item(itemId=<child-uuid>, trigger="start")` to move work→review→terminal
-   as the child's schema dictates.
+   (or work→terminal directly) as the child's schema dictates.
 3. **Do NOT push. Do NOT create a PR.** The work is committed to `feat/<feature-slug>`
    inside the shared worktree; that's the integration point.
 
@@ -611,9 +615,11 @@ When processing a Parallel-tier feature with multiple child tasks autonomously:
    (or between sequential children), the orchestrator runs `:current:test` and
    `:current:ktlintCheck` from the feature worktree. Fix failures before advancing
    any child to review.
-4. **Step 5 — Review per child, scoped to that child's commit range.** Review agent
-   reads from the shared worktree but scopes its diff to `<pre-sha>..<post-sha>` for
-   the child being reviewed.
+4. **Step 5 — Review per child, scoped to that child's commit range, when the child has
+   a review phase.** `feature-task` children skip review by default (work→terminal
+   directly) unless the `needs-task-review` trait is set. When a review phase applies,
+   the review agent reads from the shared worktree but scopes its diff to
+   `<pre-sha>..<post-sha>` for the child being reviewed.
 5. **Step 6 — One PR at parent finalization.** Children advance to terminal without
    pushing or PR'ing. Only when the parent feature itself reaches terminal does the
    orchestrator push `feat/<slug>` and open the single feature-level PR.

--- a/.claude/skills/migration-review/SKILL.md
+++ b/.claude/skills/migration-review/SKILL.md
@@ -51,4 +51,4 @@ For migrations that modify existing data:
 
 ## Output
 
-Compose the `migration-assessment` note with findings from each step. Flag any SQLite-specific risks. Reference `project-concerns.md` for additional codebase constraints.
+Compose the `migration-assessment` note with findings from each step. Flag any SQLite-specific risks. Reference `.claude/skills/spec-quality/references/project-concerns.md` for additional codebase constraints.

--- a/.claude/skills/review-quality/SKILL.md
+++ b/.claude/skills/review-quality/SKILL.md
@@ -28,14 +28,16 @@ The reviewer is given an MCP item ID. Use MCP tools and codebase access to gathe
 you need — do not expect context to be pre-loaded for you.
 
 1. **Load the item's notes** — `query_notes(itemId=..., includeBody=true)` to retrieve
-   the `specification` and `implementation-notes`.
+   the planning note and `implementation-notes`. The planning note's key depends on the
+   item's schema: `feature-summary` (feature-implementation), `task-scope` (feature-task),
+   or `diagnosis` (bug-fix).
 2. **Read the changed files** — use the implementation notes to identify which files were
    modified, then read them directly. Review the actual code, not just summaries.
 3. **Run the test suite** — execute the project's test command and capture the results.
    Do not assume tests pass because the implementation agent said they did.
 
-If the specification or implementation notes are missing, the review cannot proceed.
-Report this as a blocking issue.
+If the planning note (feature-summary / task-scope / diagnosis) or implementation notes
+are missing, the review cannot proceed. Report this as a blocking issue.
 
 ---
 
@@ -61,11 +63,12 @@ issue — the item cannot advance with a failing test suite.
 
 ### 2. Plan Alignment
 
-Compare what was built against the specification. The goal is to catch drift in both
-directions — work that was planned but not done, and work that was done but not planned.
+Compare what was built against the planning note (feature-summary / task-scope /
+diagnosis). The goal is to catch drift in both directions — work that was planned but
+not done, and work that was done but not planned.
 
 **Check each acceptance criterion.** Walk through the acceptance criteria from the
-specification one by one. For each criterion, identify the specific code change that
+planning note one by one. For each criterion, identify the specific code change that
 satisfies it. If a criterion has no corresponding implementation, flag it — either the
 work is incomplete or the criterion was intentionally descoped (which should appear in
 the implementation notes).
@@ -75,12 +78,12 @@ trace back to any acceptance criterion. Unplanned changes aren't automatically w
 sometimes implementation reveals necessary adjacent work. But they should be
 acknowledged and justified in the implementation notes, not silent.
 
-**Check non-goals weren't violated.** Review the specification's non-goals list. If the
+**Check non-goals weren't violated.** Review the planning note's non-goals list. If the
 implementation touched areas that were explicitly scoped out, flag it.
 
 ### 3. Test Quality
 
-The specification's test strategy defined what should be tested — happy paths, failure
+The planning note's test strategy defined what should be tested — happy paths, failure
 paths, and edge cases. The reviewer verifies that the tests actually deliver on that
 strategy, not just that they exist and pass.
 
@@ -88,7 +91,7 @@ This is where the separation of concerns matters most. The agent that wrote the 
 has an inherent bias toward believing they're correct. An independent reviewer can
 evaluate whether the tests verify real behavior or just confirm that code runs.
 
-**Map tests to the test strategy.** For each scenario in the specification's test
+**Map tests to the test strategy.** For each scenario in the planning note's test
 strategy, identify the corresponding test. Missing coverage is a gap to report.
 
 **Evaluate test substance.** Watch for these patterns that produce green results
@@ -112,16 +115,20 @@ development, check whether tests were added for those too.
 
 ### 4. Simplification
 
-Run the `/simplify` skill on the changed files and document its findings. The reviewer
-records what simplify identifies — it does not apply fixes.
+The reviewer does not run `/simplify` — that pass belongs at the feature level, not
+per-task review. Check the implementation notes for whether `/simplify` was run during
+implementation.
 
-Document each finding from simplify with:
-- The file and area affected
-- What simplify identified (duplication, unnecessary complexity, over-engineering)
-- Whether it's minor (style/preference) or substantive (affects maintainability)
+**If `/simplify` made changes**, verify those changes have test coverage. This is the
+one thing the reviewer checks here — not the simplification itself, just whether the
+resulting code is tested. Report coverage gaps; do not re-run simplify or evaluate its
+judgment calls.
 
-Simplification findings are not blocking unless they indicate a structural problem
-that would make the code difficult to maintain or extend.
+**If `/simplify` was not run or made no changes**, there is nothing to check in this
+area — move on.
+
+Coverage gaps found here are not blocking unless they leave a structural change
+entirely unverified.
 
 ---
 
@@ -146,7 +153,7 @@ Every review must end with a clear verdict:
 ### Findings Format
 
 For each finding, state:
-- **What was expected** (from the specification or test strategy)
+- **What was expected** (from the planning note or test strategy)
 - **What was found** (in the code or test output)
 - **Severity** (blocking or observation)
 

--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,10 @@ current/logs/
 CLAUDE.local.md
 
 ### Task Orchestrator folder ###
-/.taskorchestrator/
+# config.yaml is git-tracked dogfood config + a living schema/trait example.
+# api-tokens.yaml (and everything else under this folder) stays ignored — secrets file.
+/.taskorchestrator/*
+!/.taskorchestrator/config.yaml
 
 ### Temporary plans folder ###
 /plans/

--- a/.taskorchestrator/config.yaml
+++ b/.taskorchestrator/config.yaml
@@ -1,0 +1,170 @@
+project:
+  rootId: "ce064d2c-7c03-4eac-ae7d-89a14c2ba273"
+  name: "TaskOrchestrator"
+
+retrospective:
+  mode: dispatch
+
+work_item_schemas:
+
+  feature-implementation:
+    lifecycle: auto
+    default_traits: [delegated, session-tracked]
+    notes:
+      - key: feature-summary
+        role: queue
+        required: true
+        description: "Lean feature-level summary — goal, findings-to-tasks mapping, dependency edges, non-goals pointer."
+        skill: "spec-quality"
+        guidance: "Keep this lean — target under 2k chars. Cover: (1) the goal in 2-3 sentences, (2) a findings→tasks table mapping brainstorm/research findings to the child task-scope items created for them, (3) dependency edges between those child tasks, (4) a pointer to where non-goals and alternatives are recorded — the full spec-quality bar (alternatives, blast radius, risk flags, test strategy) belongs in each child's task-scope note, not here."
+      - key: implementation-notes
+        role: work
+        required: true
+        description: "Context handoff for downstream agents — deviations, surprises, and decisions that affect dependent work."
+        guidance: "Document decisions made during implementation that weren't in the feature-summary. Focus on what downstream agents need to know: deviations from the plan, API or interface surprises, assumptions that turned out wrong, and any patterns discovered that affect dependent tasks."
+      - key: review-checklist
+        role: review
+        required: true
+        description: "Quality gate — plan alignment, test quality, and simplification review."
+        skill: "review-quality"
+        guidance: "Verify: (1) what was built aligns with the feature-summary and each child's task-scope — flag planned items that were missed or unplanned changes that were added, (2) tests add specific value and cover the test strategy from the feature's planning notes — not strawman tests that pass without verifying real behavior, (3) if /simplify was run and made changes, verify those changes have test coverage — the reviewer does not run simplify or make fixes, only reports gaps. Also flag changes outside the feature's declared scope."
+
+  feature-task:
+    lifecycle: auto
+    default_traits: [delegated, session-tracked]
+    notes:
+      - key: task-scope
+        role: queue
+        required: true
+        description: "What to build — target files, acceptance criteria, constraints."
+        skill: "spec-quality"
+        guidance: "Define the narrow scope of this task. Include: what to build (specific behavior or component), target files and modules, acceptance criteria (how to verify it works), and constraints or dependencies on other tasks. The parent feature specification covers the 'why' and alternatives — this note covers the 'what' for this specific task."
+      - key: implementation-notes
+        role: work
+        required: true
+        description: "Context handoff — deviations, surprises, and decisions that affect dependent work."
+        guidance: "Document decisions made during implementation that weren't in the task scope. Focus on what downstream agents need to know: deviations from the plan, API or interface surprises, assumptions that turned out wrong, and any patterns discovered that affect dependent tasks."
+
+  bug-fix:
+    lifecycle: auto
+    default_traits: [delegated, session-tracked]
+    notes:
+      - key: diagnosis
+        role: queue
+        required: true
+        description: "Reproduction, root cause, and fix approach."
+        skill: "spec-quality"
+        guidance: "This note must cover: reproduction steps (exact inputs and expected vs actual output), root cause (specific file, function, and condition), fix approach with alternatives considered (min 2 options + 'do nothing'), blast radius of the fix, and test strategy (regression test for the bug, edge cases around the fix). Read references/project-concerns.md for codebase-specific constraints."
+      - key: implementation-notes
+        role: work
+        required: true
+        description: "Context handoff for downstream agents — what changed, deviations from the diagnosis, and patterns to apply elsewhere."
+        guidance: "Document what was changed and why. Focus on what downstream agents need to know: deviations from the planned fix, whether the root cause was different than diagnosed, patterns that should be applied elsewhere (e.g., same bug exists in similar code paths), and any assumptions that turned out wrong."
+      - key: review-checklist
+        role: review
+        required: true
+        description: "Quality gate — fix alignment, test quality, and simplification review."
+        skill: "review-quality"
+        guidance: "Verify: (1) the fix addresses the diagnosed root cause and doesn't just mask symptoms, (2) a regression test exists that would have caught the original bug, (3) tests cover edge cases from the diagnosis test strategy, (4) if /simplify was run and made changes, verify those changes have test coverage — the reviewer does not run simplify or make fixes, only reports gaps."
+
+  plugin-change:
+    lifecycle: auto
+    default_traits: [session-tracked]
+    notes:
+      - key: specification
+        role: queue
+        required: true
+        description: "What is changing, why, and expected behavior after the change."
+        guidance: "Describe the plugin/config change: what files are affected, what behavior changes, and how to verify. For skill changes, include the trigger phrase and expected output. For hook changes, include the event and matcher. **Plugin blast radius:** consider whether hook caching requires /mcp reconnect, whether CRLF line endings will break script execution, and whether new skill trigger phrases conflict with existing skills. No implementation-notes gate — config changes are self-documenting."
+
+  quick-fix:
+    lifecycle: auto
+    notes:
+      - key: session-tracking
+        role: work
+        required: true
+        description: "Brief record of what was changed and test results."
+        guidance: "This feeds /session-retrospective — one-paragraph summary: what file(s) changed, what the fix was, test pass/fail count. No structured sections needed — keep it under 100 words."
+
+  container:
+    lifecycle: manual
+    notes:
+      - key: container-summary
+        role: queue
+        required: false
+        description: "Optional high-level description of what this container organizes."
+        guidance: "Brief description of the container's purpose and scope. Not required — containers exist to group work items, not to carry implementation detail."
+
+  default:
+    lifecycle: auto
+    default_traits: [session-tracked]
+    notes: []
+
+traits:
+  needs-migration-review:
+    notes:
+      - key: migration-assessment
+        role: queue
+        required: true
+        description: "SQLite migration strategy — table recreation patterns, data migration, rollback plan."
+        skill: "migration-review"
+        guidance: "Document: (1) what schema changes are needed (new columns, table recreation, index changes), (2) SQLite constraints (no ALTER COLUMN — requires table recreation if modifying existing columns), (3) data migration strategy for existing rows, (4) Flyway migration file name and version number, (5) DirectDatabaseSchemaManager table ordering impact. Reference .claude/skills/spec-quality/references/project-concerns.md for SQLite-specific gotchas."
+
+  needs-api-compat-review:
+    notes:
+      - key: api-compatibility
+        role: review
+        required: true
+        description: "Compatibility assessment for API changes — the MCP tool surface (dynamically re-discovered) and the REST surface (hardcoded clients) have different compatibility models."
+        skill: "api-compat-review"
+        guidance: "Assess the MCP surface and the REST surface separately — their compatibility models differ, see the api-compat-review skill for the full framework. For any REST-facing change, update openapi.yaml and api-rest.md."
+
+  needs-plugin-update:
+    notes:
+      - key: plugin-impact
+        role: review
+        required: true
+        description: "Assessment of plugin skill and hook changes needed."
+        skill: "plugin-impact-review"
+        guidance: "Check: (1) which skills reference the changed behavior (grep skill files for affected tool names, config keys, or concepts), (2) which hooks inject context that references the changed behavior, (3) whether config-format.md needs updating, (4) whether output style references need updating. List specific files and sections that need changes. Plugin content is cached — note if /mcp reconnect is needed."
+
+  needs-security-review:
+    notes:
+      - key: security-assessment
+        role: review
+        required: true
+        description: "Security review of auth, data handling, and access control."
+        guidance: "Evaluate: (1) input validation — are all user/external inputs validated before use? (2) injection risk — SQL injection via Exposed ORM (parameterized queries), command injection, XSS in response payloads, (3) access control — does the change respect existing authorization patterns? (4) data handling — sensitive data not logged, not stored in plain text unnecessarily. Flag any OWASP Top 10 concerns."
+
+  needs-perf-review:
+    notes:
+      - key: performance-baseline
+        role: queue
+        required: false
+        description: "Performance impact assessment and measurement plan."
+        skill: "perf-review"
+        guidance: "Document: (1) which hot paths are affected (per-request, per-item loops, startup), (2) expected performance impact (new DB queries, JSON parsing, file I/O), (3) whether the change is O(n) where n could be large, (4) measurement plan — how to verify performance is acceptable. This note is optional — use it when the change touches known hot paths or adds significant new work."
+
+  delegated:
+    notes:
+      - key: delegation-metadata
+        role: work
+        required: false
+        description: "Model, isolation, rationale, and outcome for a delegated dispatch (orchestrator-filled)."
+        guidance: "Filled by the orchestrator AFTER a subagent returns (the subagent doesn't know which model it ran on). Record model (haiku/sonnet/opus), isolation (inline or worktree:<path>), a one-line rationale, and a one-line outcome. Optional — feeds /session-retrospective delegation-alignment scoring; absent is tolerated."
+
+  needs-task-review:
+    notes:
+      - key: review-checklist
+        role: review
+        required: true
+        description: "Task-level quality gate — scope alignment and test coverage."
+        guidance: "Verify: (1) what was built matches the task-scope note — flag scope creep or missed acceptance criteria, (2) tests cover the stated acceptance criteria and aren't strawman tests, (3) no unintended side effects on files outside the task scope. Task-level review does not run /simplify — that happens at the feature-container level."
+
+  session-tracked:
+    notes:
+      - key: session-tracking
+        role: work
+        required: true
+        description: "Session context — what was done, how it went, and anything the retrospective should know."
+        guidance: "Record what happened during implementation. Structure: - **Outcome**: success | partial | failure - **Files changed**: list with brief rationale - **Deviations**: anything that differed from the specification or plan - **Friction**: tool errors, roundtrips, workarounds, API confusion (type + description) - **Gate interactions**: note fill attempts, gate failures encountered - **Observations**: anything worth tracking for process improvement - **Test results**: pass/fail counts, new tests added. Keep it factual and concise — this feeds the session retrospective."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ java -jar current/build/libs/mcp-task-orchestrator-*.jar
 docker build -t task-orchestrator:dev .
 docker run --rm -i \
   -v mcp-task-data:/app/data \
-  -v "$(pwd)"/.taskorchestrator:/project/.taskorchestrator:ro \
+  -v "$(pwd)"/deploy/global-config/.taskorchestrator:/project/.taskorchestrator:ro \
   -e AGENT_CONFIG_DIR=/project \
   task-orchestrator:dev
 ```
@@ -139,6 +139,7 @@ private fun getConfigPath(): Path {
 - In local dev: not needed (uses working directory)
 - Currently used by: `YamlWorkItemSchemaService`
 - **This is the GLOBAL/fallback config.** `AGENT_CONFIG_DIR` locates the single, server-wide `.taskorchestrator/config.yaml`, read once at startup (restart to reload). Per-**project** config is stored per-root in the DB — pushed via `manage_project_config` or `PUT /api/v1/roots/{rootId}/config`, synced from the workspace file by the `config-sync` SessionStart hook — and hot-reloads without a restart, layering over this global file per item `rootId`. See `claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md` → "Global vs Per-Project Config".
+- This repo's own `.taskorchestrator/config.yaml` is git-tracked dogfood config and doubles as a living schema/trait example — it is delivered to the server per-root via the `config-sync` hook, not mounted as the global config. The actual global mount is the process-schema floor at `deploy/global-config/.taskorchestrator/` — agent-observation, session-retrospective, improvement-proposal, and container schemas only, shared across every project the server serves.
 
 ## Adding New Components
 

--- a/claude-plugins/task-orchestrator/hooks/session-start.mjs
+++ b/claude-plugins/task-orchestrator/hooks/session-start.mjs
@@ -118,7 +118,7 @@ Active project: ${label}
 
 - Pass \`ancestorId: "${project.rootId}"\` on \`query_items\` (list mode), \`get_next_item\`, \`get_context\`, and \`get_blocked_items\` to scope results to this project.
 - Anchor new root-level items under this project by setting \`parentId: "${project.rootId}"\`.
-- Process-global containers (Session Retrospectives, Improvement Proposals, agent-observations) stay OUTSIDE the project root at depth 0 — do not anchor them under \`${project.rootId}\`.`;
+- Process-global items stay OUTSIDE the project root at depth 0: the Session Retrospectives and Improvement Proposals containers, and standalone agent-observation items — do not anchor any of them under \`${project.rootId}\`.`;
 }
 
 let additionalContext;

--- a/claude-plugins/task-orchestrator/output-styles/schema-orchestrator.md
+++ b/claude-plugins/task-orchestrator/output-styles/schema-orchestrator.md
@@ -36,7 +36,7 @@ Whether you implement inline or dispatch a subagent is your call per the work â€
 
 ## Project Scope
 
-When session context carries a project rootId (injected by the SessionStart hook from `.taskorchestrator/config.yaml`'s `project:` block), operate project-scoped by default: pass `ancestorId: "<rootId>"` on `query_items` list mode, `get_next_item`, `get_context`, and `get_blocked_items`; anchor new root-level items under the project root via `parentId`. Process-global containers (Session Retrospectives, Improvement Proposals, `agent-observation` items) stay at depth 0 outside any project root. Without a configured rootId, whole-workspace behavior is unchanged.
+When session context carries a project rootId (injected by the SessionStart hook from `.taskorchestrator/config.yaml`'s `project:` block), operate project-scoped by default: pass `ancestorId: "<rootId>"` on `query_items` list mode, `get_next_item`, `get_context`, and `get_blocked_items`; anchor new root-level items under the project root via `parentId`. Process-global items stay at depth 0 outside any project root: the Session Retrospectives and Improvement Proposals containers, and standalone `agent-observation` items (each its own root, not a child of any container). Without a configured rootId, whole-workspace behavior is unchanged.
 
 ## Delegation
 

--- a/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
+++ b/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
@@ -58,7 +58,7 @@ Review applies only when the item's schema declares review-phase notes; otherwis
 
 ## Project Scope
 
-When session context carries a project rootId (injected by the SessionStart hook from `.taskorchestrator/config.yaml`'s `project:` block), operate project-scoped by default: pass `ancestorId: "<rootId>"` on `query_items` list mode, `get_next_item`, `get_context`, and `get_blocked_items`; anchor new root-level items under the project root via `parentId`. Process-global containers (Session Retrospectives, Improvement Proposals, `agent-observation` items) stay at depth 0 outside any project root — never anchor or scope those. Without a configured rootId, whole-workspace behavior is unchanged; suggest `/adopt-project-scope` only when the user mentions multiple projects sharing a database.
+When session context carries a project rootId (injected by the SessionStart hook from `.taskorchestrator/config.yaml`'s `project:` block), operate project-scoped by default: pass `ancestorId: "<rootId>"` on `query_items` list mode, `get_next_item`, `get_context`, and `get_blocked_items`; anchor new root-level items under the project root via `parentId`. Process-global items stay at depth 0 outside any project root — never anchor or scope those: the Session Retrospectives and Improvement Proposals containers, and standalone `agent-observation` items (each its own root, not a child of any container). Without a configured rootId, whole-workspace behavior is unchanged; suggest `/adopt-project-scope` only when the user mentions multiple projects sharing a database.
 
 ## Delegation
 

--- a/claude-plugins/task-orchestrator/skills/adopt-project-scope/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/adopt-project-scope/SKILL.md
@@ -127,7 +127,7 @@ Classify **every depth-0 root** into exactly one bucket:
 
 | Bucket | Rule | Action |
 |--------|------|--------|
-| **KEEP-GLOBAL** | Title matches a global container — `Session Retrospectives`, `Improvement Proposals`; OR the root is a `container` (tag or `type`) whose children are `agent-observation` items; OR the root itself is tagged `agent-observation`. | Stays at depth 0. |
+| **KEEP-GLOBAL** | Title matches a global container — `Session Retrospectives`, `Improvement Proposals`; OR the root itself is tagged/typed `agent-observation` (these are standalone depth-0 items, each its own root — never children of a container). | Stays at depth 0. |
 | **MOVE** | Any work container or work tree (a root with work/queue/review children), and any standalone work item. Everything that is real project work. | Re-parented under the new anchor. |
 | **CLEANUP-CANDIDATE** | Evident test artifacts: titles containing `probe`, `smoke`, `depth-test`, `zzprobe`; or tags matching `mtest-*`. | **Flagged only** — never moved, never deleted. Recommend `/batch-complete`. |
 

--- a/claude-plugins/task-orchestrator/skills/create-item/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/create-item/SKILL.md
@@ -78,7 +78,7 @@ Empty (no project root exists):
   → No: create category container at depth 0 → create item under it
 ```
 
-**Exception (all branches):** `agent-observation` items never anchor under a project root or category container — they are process-global containers that live at depth 0 alongside (not under) any project root, per Step 2.
+**Exception (all branches):** `agent-observation` items never anchor under a project root or category container — they are standalone process-global items (each its own root, not a child of any container) that live at depth 0 alongside (not under) any project root, per Step 2.
 
 ---
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
@@ -132,6 +132,46 @@ Schema resolution uses **type-first lookup with tag fallback**:
 
 ---
 
+## Trait Merge Semantics
+
+How trait notes merge into an item's resolved schema (`ToolExecutionContext.resolveSchema()` /
+`mergeTraits()`):
+
+1. **Base-schema note keys always win.** If a trait declares a note with the same `key` as one
+   already in the schema's own `notes` list, the trait's note is dropped — the base schema's
+   version (role, required, guidance, skill) is kept unchanged.
+2. **`default_traits` merge before per-item `traits`.** The schema-level trait list is applied
+   first; traits carried on the item's own `properties.traits` are layered on after.
+3. **First-trait-in-order wins on duplicate trait keys.** When two traits being applied (across
+   `default_traits` and per-item `traits`, in application order) both declare a note with the same
+   key, the earlier one keeps its note — the later duplicate is dropped, same as rule 1.
+4. **Trait notes append after base notes.** The final note list order is: base schema notes, then
+   surviving trait notes in application order.
+5. **Per-root trait definitions replace the global trait wholesale, per trait name.** There is no
+   note-level merge between a per-root and a global trait sharing a name — resolution picks
+   `perRoot ?: global` for the *entire* trait definition (all its notes), not a union of the two.
+6. **Traits can only add note keys — never override or relax a base-schema gate.** A trait cannot
+   turn a base-schema `required: true` note optional, and it cannot change a base note's role; the
+   only way a trait can affect an existing base key is to be silently ignored (rule 1).
+
+**Example — base key wins:**
+
+```yaml
+work_item_schemas:
+  feature-task:
+    default_traits: [needs-task-review]
+    notes:
+      - {key: implementation-notes, role: work, required: true}
+
+traits:
+  needs-task-review:
+    notes:
+      - {key: implementation-notes, role: review, required: false}  # dropped — key collides with base
+      - {key: review-checklist, role: review, required: true}       # added
+```
+
+---
+
 ## Phase Flow
 
 ```
@@ -427,6 +467,18 @@ per-root config has been pushed.
 
 **Layer roles:** global = server-wide floor; per-root = the project's complete self-description,
 which can lower the floor to zero via the empty default (see below).
+
+**This project's own split.** In this repository, the **global** config
+(`deploy/global-config/.taskorchestrator/config.yaml`, mounted via `AGENT_CONFIG_DIR`) carries
+*only* the process/self-improvement schemas that every project sharing the server should get for
+free — `agent-observation`, `session-retrospective`, `improvement-proposal`, and the generic
+`container` schema. Project-specific schemas (`feature-implementation`, `feature-task`, `bug-fix`,
+and the `traits:` section) live entirely in this project's own git-tracked
+`.taskorchestrator/config.yaml` and reach the server per-root via the `config-sync` SessionStart
+hook — they are never part of the global floor. Because per-root resolution is whole-algorithm-first
+(see above), this project's per-root `default` schema (if any) or exact-type match for its own
+schemas beats a global exact-type match, even though in practice the global floor only defines
+process schemas this project's config doesn't redeclare.
 
 **Precedence — the workspace file is canonical; the per-root DB row is a synced replica.** The `config-sync.mjs` SessionStart hook (and the `manage-schemas` / `quick-start` push steps) copy the local `.taskorchestrator/config.yaml` into the per-root store whenever it changes. Durable edits belong in the **file**: a runtime `manage_project_config` push that isn't reflected in the file is overwritten at the next session's sync. A byte-identical file is a no-op (fingerprints match).
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/example-schemas.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/example-schemas.md
@@ -4,12 +4,13 @@ Real schemas from the MCP Task Orchestrator project — use as reference when de
 
 ## `feature-implementation` (queue + work + review)
 
-Full lifecycle with design gates, implementation evidence, and review verification.
+Full lifecycle with design gates, implementation evidence, and review verification. `session-tracking` and `delegation-metadata` are not listed as base notes below — they arrive via `default_traits: [delegated, session-tracked]` (see Traits Example below); trait notes append after the base notes shown here.
 
 ```yaml
 work_item_schemas:
   feature-implementation:
     lifecycle: auto
+    default_traits: [delegated, session-tracked]
     notes:
       - key: feature-summary
         role: queue
@@ -22,11 +23,6 @@ work_item_schemas:
         required: true
         description: "Context handoff for downstream agents — deviations, surprises, decisions."
         guidance: "Document decisions not in the feature-summary. Focus on what downstream agents need: deviations, API surprises, wrong assumptions, patterns affecting dependent work."
-      - key: session-tracking
-        role: work
-        required: true
-        description: "Session context for retrospective."
-        guidance: "Record outcome, files changed, deviations, friction, test results."
       - key: review-checklist
         role: review
         required: true
@@ -35,14 +31,14 @@ work_item_schemas:
         guidance: "Verify: (1) what was built aligns with the feature-summary and each child's task-scope, (2) tests cover the test strategy, (3) no unnecessary complexity."
 ```
 
-## `feature-task` (queue + work + review, lighter than feature-implementation)
+## `feature-task` (queue + work, lighter than feature-implementation)
 
-Schema for child work items under a feature container. Lighter queue gate (task scope instead of full specification) and task-scoped review.
+Schema for child work items under a feature container. Lighter queue gate (task scope instead of full specification). Review is opt-in here, not a base note — apply the `needs-task-review` trait per-item when a task needs task-scoped review (see Traits Example below). `session-tracking` and `delegation-metadata` come from `default_traits: [delegated, session-tracked]`, not an inline base note.
 
 ```yaml
   feature-task:
     lifecycle: auto
-    default_traits: [delegated]
+    default_traits: [delegated, session-tracked]
     notes:
       - key: task-scope
         role: queue
@@ -54,16 +50,6 @@ Schema for child work items under a feature container. Lighter queue gate (task 
         required: true
         description: "Context handoff — deviations, surprises, decisions affecting dependent work."
         guidance: "Document decisions not in the task scope. Focus on what downstream agents need."
-      - key: review-checklist
-        role: review
-        required: true
-        description: "Task-level quality gate — scope alignment and test coverage."
-        guidance: "Verify scope alignment, test coverage, no unintended side effects."
-      - key: session-tracking
-        role: work
-        required: true
-        description: "Session context for retrospective."
-        guidance: "Record outcome, files changed, deviations, friction, test results."
 ```
 
 ## `bug-fix` (queue + work + review)
@@ -73,7 +59,7 @@ Root cause analysis before code, verification after.
 ```yaml
   bug-fix:
     lifecycle: auto
-    default_traits: [delegated]
+    default_traits: [delegated, session-tracked]
     notes:
       - key: diagnosis
         role: queue
@@ -86,11 +72,6 @@ Root cause analysis before code, verification after.
         required: true
         description: "Context handoff — what changed, deviations from diagnosis."
         guidance: "Document what changed and why. Note if root cause differed from diagnosis."
-      - key: session-tracking
-        role: work
-        required: true
-        description: "Session context for retrospective."
-        guidance: "Record outcome, files changed, deviations, friction, test results."
       - key: review-checklist
         role: review
         required: true
@@ -98,6 +79,8 @@ Root cause analysis before code, verification after.
         skill: "review-quality"
         guidance: "Verify: (1) fix addresses root cause, (2) regression test exists, (3) edge cases covered."
 ```
+
+`session-tracking` comes from the `session-tracked` default trait, not an inline base note (same pattern as `feature-implementation` and `feature-task` above).
 
 ## `container` (manual lifecycle, gate-free)
 
@@ -116,9 +99,9 @@ Schema for root-level category containers (Features, Bugs, Tech Debt). No requir
 
 Set `type: container` on root containers so they match this schema instead of `default`.
 
-## `agent-observation` (queue only, minimal)
+## `agent-observation` — process-global schema (global floor, not per-project)
 
-Single-note schema for lightweight tracking — no work phase gates.
+Unlike the schemas above, this one is **not** defined in a project's own `.taskorchestrator/config.yaml`. It's delivered by the shared server's **global** config (`deploy/global-config/.taskorchestrator/config.yaml`), which carries only process/self-improvement schemas — `agent-observation`, `session-retrospective`, `improvement-proposal`, and `container` — so every project sharing the server gets them for free without redeclaring them. See "Global vs Per-Project Config" in `config-format.md`. `agent-observation` items are always standalone depth-0 roots, never children of a container.
 
 ```yaml
   agent-observation:
@@ -128,7 +111,12 @@ Single-note schema for lightweight tracking — no work phase gates.
         role: queue
         required: true
         description: "Expected vs actual behavior and suggested improvement."
-        guidance: "Describe what was observed. State expected behavior. Suggest a concrete improvement."
+        guidance: "Describe what you observed. State what you expected instead. Suggest a concrete improvement. Tag the observation type: optimization, friction, bug, or missing-capability."
+      - key: resolution
+        role: work
+        required: false
+        description: "Outcome when the observation is addressed — what was done, or why it was rejected."
+        guidance: "Record the disposition: fixed, rejected, or superseded. Optional — lets retrospectives calibrate which observation types convert to real fixes."
 ```
 
 ## Traits Example
@@ -152,6 +140,7 @@ traits:
         role: review
         required: true
         description: "Compatibility assessment for API changes — the MCP tool surface (dynamically re-discovered) and the REST surface (hardcoded clients) have different compatibility models."
+        skill: "api-compat-review"
         guidance: "Assess by surface. **MCP tools:** clients re-read the tools/list schema each session, so parameter renames/additions are NOT breaking — verify instead that each changed param's schema key and its read site stay in sync, and that all first-party callers (skills, hooks, output styles, memory, api-reference.md) update in lockstep; a pure rename needn't keep the old name working. **REST API:** clients hardcode field/param names, so compatibility matters — keep response shapes additive, and renames/removals need a migration path or version bump. Update openapi.yaml + api-rest.md for REST changes."
 
   needs-plugin-update:
@@ -187,6 +176,22 @@ traits:
         required: false
         description: "Model, isolation, rationale, and outcome for a delegated dispatch (orchestrator-filled)."
         guidance: "Filled by the orchestrator AFTER a subagent returns (the subagent doesn't know which model it ran on). Record model (haiku/sonnet/opus), isolation (inline or worktree:<path>), a one-line rationale, and a one-line outcome. Optional — feeds /session-retrospective delegation-alignment scoring; absent is tolerated."
+
+  session-tracked:
+    notes:
+      - key: session-tracking
+        role: work
+        required: true
+        description: "Session context — what was done, how it went, and anything the retrospective should know."
+        guidance: "Record what happened during implementation. Structure: **Outcome** (success/partial/failure), **Files changed** (list with rationale), **Deviations** (from spec/plan), **Friction** (tool errors, roundtrips, workarounds), **Gate interactions**, **Observations**, **Test results** (pass/fail counts). Keep it factual and concise — this feeds the session retrospective."
+
+  needs-task-review:
+    notes:
+      - key: review-checklist
+        role: review
+        required: true
+        description: "Task-level quality gate — scope alignment and test coverage."
+        guidance: "Verify: (1) what was built matches the task-scope note — flag scope creep or missed acceptance criteria, (2) tests cover the stated acceptance criteria and aren't strawman tests, (3) no unintended side effects on files outside the task scope."
 ```
 
-Apply traits at item creation: `manage_items(operation="create", items=[{..., traits: "needs-migration-review"}])` or via schema-level `default_traits`.
+Apply traits at item creation: `manage_items(operation="create", items=[{..., traits: "needs-migration-review"}])` or via schema-level `default_traits`. Most schemas in this project apply `session-tracked` (and often `delegated`) via `default_traits` rather than per-item, since nearly every item needs session tracking for `/session-retrospective`; `needs-task-review` is the opt-in trait that layers a review phase onto `feature-task`.

--- a/claude-plugins/task-orchestrator/skills/quick-start/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/quick-start/SKILL.md
@@ -158,7 +158,7 @@ Show the structure:
 
 This is **the project board side** — these items track progress. The plan file (if this were a real feature) would contain the *design decisions* behind each of these tasks.
 
-**Fill required notes (gate prerequisite):** `feature-task` items require a `task-scope` note (queue, required) before `advance_item(trigger="start")` will succeed, and a `complete` trigger checks ALL required notes across every phase (queue + work + review) — not just the current one. `create_work_tree` above created the children with no notes — its `createNotes` option only auto-fills blank bodies, which don't count as "filled" for gate purposes — so fill all four required notes on the design item now, before Step 5a, so both the `start` and `complete` calls succeed:
+**Fill required notes (gate prerequisite):** `feature-task` items require a `task-scope` note (queue, required) before `advance_item(trigger="start")` will succeed, and a `complete` trigger checks ALL required notes across every phase the *resolved* schema declares — not just the current phase, and not just the base schema's own notes. Traits merge in too: a `session-tracked` default trait adds a required `session-tracking` work note, for example, while review-phase notes like `review-checklist` are typically opt-in per item via a trait (e.g. `needs-task-review`), not a base requirement. Call `get_context(itemId="<design-UUID>")` to see the exact resolved note list before filling — schemas vary per project. `create_work_tree` above created the children with no notes — its `createNotes` option only auto-fills blank bodies, which don't count as "filled" for gate purposes — so fill every required note the resolved schema lists on the design item now, before Step 5a, so both the `start` and `complete` calls succeed. For a `feature-task` schema with the common `task-scope` + `implementation-notes` base plus a `session-tracked` default trait:
 
 ```
 manage_notes(
@@ -166,13 +166,12 @@ manage_notes(
   notes=[
     { itemId: "<design-UUID>", key: "task-scope", role: "queue", body: "Define requirements and approach for <topic>." },
     { itemId: "<design-UUID>", key: "implementation-notes", role: "work", body: "Design work completed for <topic>." },
-    { itemId: "<design-UUID>", key: "session-tracking", role: "work", body: "Design phase completed this session." },
-    { itemId: "<design-UUID>", key: "review-checklist", role: "review", body: "Design reviewed and approved." }
+    { itemId: "<design-UUID>", key: "session-tracking", role: "work", body: "Design phase completed this session." }
   ]
 )
 ```
 
-**Explain to the user:** in a real workflow, subagents fill these notes as work actually happens, phase by phase. Here we're pre-filling all of them up front purely so the tutorial's Step 5b `complete` call isn't gate-blocked — note bodies don't need to match the item's current role to be saved, only to satisfy the gate check at advance time.
+**Explain to the user:** in a real workflow, subagents fill these notes as work actually happens, phase by phase. Here we're pre-filling all of them up front purely so the tutorial's Step 5b `complete` call isn't gate-blocked — note bodies don't need to match the item's current role to be saved, only to satisfy the gate check at advance time. If `get_context` shows additional required notes (e.g. a `review-checklist` from an opted-in review trait), fill those too before advancing.
 
 ---
 

--- a/deploy/global-config/.taskorchestrator/config.yaml
+++ b/deploy/global-config/.taskorchestrator/config.yaml
@@ -1,0 +1,86 @@
+# Global process-schema floor config.
+#
+# This is the shared MCP Task Orchestrator server's GLOBAL/fallback config
+# (mounted via AGENT_CONFIG_DIR, read once at server startup). It carries
+# ONLY the process/self-improvement schemas that every project sharing this
+# server should get for free: agent-observation, session-retrospective, and
+# improvement-proposal items, plus the generic container schema.
+#
+# Project-specific schemas (feature-implementation, feature-task, bug-fix,
+# traits, etc.) do NOT belong here — those are delivered per-root via the
+# config-sync hook from each project's own tracked .taskorchestrator/config.yaml
+# and layered over this floor per item rootId. See
+# claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+# -> "Global vs Per-Project Config".
+#
+# Mount this directory as AGENT_CONFIG_DIR, e.g.:
+#   -v "$(pwd)"/deploy/global-config/.taskorchestrator:/project/.taskorchestrator:ro
+#   -e AGENT_CONFIG_DIR=/project
+
+work_item_schemas:
+
+  agent-observation:
+    lifecycle: auto
+    notes:
+      - key: observation-detail
+        role: queue
+        required: true
+        description: "Expected vs actual behavior and suggested improvement."
+        guidance: "Describe what you observed (tool call, parameters, result). State what you expected instead. Suggest a concrete improvement — API change, error message improvement, or new capability. Tag the observation type: **optimization** (works but could be better), **friction** (workflow impediment), **bug** (incorrect behavior), or **missing-capability** (needed feature that doesn't exist)."
+      - key: resolution
+        role: work
+        required: false
+        description: "Outcome when the observation is addressed — what was done, or why it was rejected."
+        guidance: "Record the disposition: fixed (link the implementing item or commit), rejected (why — e.g., by design, not reproducible), or superseded (link the successor observation). Optional — but filling it lets retrospectives calibrate which observation types convert to real fixes versus noise."
+
+  improvement-proposal:
+    lifecycle: auto
+    notes:
+      - key: proposal
+        role: queue
+        required: true
+        description: "Problem, evidence, proposed change, expected measurable effect, and scope."
+        guidance: "State: (1) the problem pattern with evidence — cite session-tracking notes, agent-observation items, or retrospective IDs (2+ occurrences preferred), (2) the concrete change (exact YAML for schema changes, file+section for skill/doc changes, event+matcher for hooks), (3) expected effect and HOW it will be measured in later sessions, (4) blast radius — which schemas, skills, or agents the change touches, (5) scope — **global** (server floor config, plugin skills/hooks, process containers) or **project-specific** (one project's per-root config or workflow); name the target rootId(s) when project-specific. Anchor project-specific proposals under that project's root; global proposals belong in the process-global Improvement Proposals container."
+      - key: adoption-decision
+        role: work
+        required: true
+        description: "Accepted / rejected / deferred, with rationale."
+        guidance: "Record the decision and why. If accepted: link the implementing item or commit, and confirm the change landed in the layer matching its scope (global config/plugin vs the project's own config.yaml synced per-root). If rejected: state the reason so future retrospectives don't re-propose it. If deferred: state the trigger condition for revisiting."
+      - key: outcome-verification
+        role: review
+        required: true
+        description: "Did the change produce the expected effect?"
+        guidance: "Compare post-change sessions against the expected effect stated in the proposal note. Cite specific retrospective or session-tracking evidence — scoped to the target project for project-specific changes. Verdict: **effective** | **ineffective** | **inconclusive**. Ineffective outcomes are as valuable as effective ones; say what to try instead."
+
+  session-retrospective:
+    lifecycle: auto
+    notes:
+      - key: session-metrics
+        role: queue
+        required: true
+        description: "Quantitative session data — items, agents, schemas, token efficiency."
+        guidance: "Record from distributed session-tracking notes: items touched (count + IDs), schemas used (tag + count), agent delegations (from delegation-metadata notes if present: model x count x rationale), self-implementation violations, MCP call count, estimated token waste from over-fetches or verbose returns. Record the active project rootId(s) the session's items belonged to — scope attribution for downstream proposals. Use structured lists, not prose."
+      - key: workflow-evaluation
+        role: queue
+        required: true
+        description: "Qualitative workflow assessment across all evaluation dimensions."
+        guidance: "Evaluate: (1) schema usefulness — per schema note, was content quality good? Was guidance followed? (2) delegation alignment — model assignments vs output style table (use delegation-metadata notes if present), (3) note effectiveness — did downstream agents benefit from upstream notes? (4) plan-to-execution alignment — ad-hoc items, skipped items, scope changes, (5) friction synthesis — themes from session-tracking friction entries and agent-observation items. Score each dimension."
+      - key: improvement-signals
+        role: queue
+        required: true
+        description: "Trends, proposals, and extension promotions."
+        guidance: "List patterns seen in 2+ sessions. Reference prior retrospective item IDs. For each trend at threshold: propose a concrete change (schema modification with exact YAML, new hook with event/matcher, skill update with section reference, output style adjustment with zone). Classify each proposal's scope: **global** (server floor config, plugin skills/hooks, process containers) vs **project-specific** (one project's workflow or per-root config) — name the target rootId for project-specific proposals."
+      - key: actions-taken
+        role: work
+        required: true
+        description: "Closure record — which improvement-proposal items were created or updated from this retrospective's signals."
+        guidance: "List each materialized action: improvement-proposal item UUID + one-line summary + scope (global | project:<rootId>). If a signal was intentionally not acted on, say why. 'No actions — <rationale>' is a valid body. This makes the retrospective-to-proposal edge queryable so future retrospectives can trace whether prior signals went anywhere."
+
+  container:
+    lifecycle: manual
+    notes:
+      - key: container-summary
+        role: queue
+        required: false
+        description: "Optional high-level description of what this container organizes."
+        guidance: "Brief description of the container's purpose and scope. Not required — containers exist to group work items, not to carry implementation detail."


### PR DESCRIPTION
## Summary

- **Track `.taskorchestrator/config.yaml` in git** as dogfood + a living schema/trait example (`api-tokens.yaml` stays ignored via contents-glob + negation)
- **Split server config layering**: new global floor at `deploy/global-config/.taskorchestrator/config.yaml` carrying only the process/self-improvement schemas (agent-observation, session-retrospective, improvement-proposal, container); project schemas are delivered per-root via the config-sync hook (env now wired in `.claude/settings.json`)
- **Review cadence**: `feature-task` no longer has a default review phase — per-task review is opt-in via the new `needs-task-review` trait (evidence: 1-2 blocking verdicts across 40+ historical task reviews); the feature-level review remains and now checks for out-of-scope changes
- **New traits**: `session-tracked` (DRYs five duplicated session-tracking guidance blobs via `default_traits`), `needs-task-review`; `needs-api-compat-review` guidance extracted to a new `api-compat-review` skill
- **Schema cleanups**: deprecated `specification` entry deleted; `plugin-change`'s zero-gate optional review note deleted; `task-scope` now routes to spec-quality
- **Skill drift fixes**: review-quality (stale `specification` gate + /simplify contradiction), feature-implementation (full rekey to current note keys), migration-review (project-concerns path), implement (review steps now conditional on schema review phase)
- **Plugin fixes**: session-start hook + output styles no longer claim an "agent-observations" container; config-format.md documents trait merge semantics (six rules, verified against `ToolExecutionContext.mergeTraits`) and the floor-vs-project layering

## Post-merge ops (required, in order)

1. Reconcile main checkout's untracked `.taskorchestrator/config.yaml` (collides with incoming tracked file)
2. Redeploy server with the new floor mount (global config loads at startup)
3. Re-push project config per-root to `ce064d2c` (config-sync handles it next session start)
4. Marketplace remove/re-add (hook/output-style content is cached)

## Test plan

- [x] YAML safe-load on both configs; JSON parse on settings.json; `node --check` on session-start.mjs
- [x] `git check-ignore`: api-tokens.yaml ignored, config.yaml tracked
- [x] Independent review per child task (5/5 Pass or Pass-with-observations); merge-rule docs verified against Kotlin source
- [x] No Kotlin/test surface touched — docs/config/JS-string-only diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)