### PR TITLE
chore(docs): sweep stale schema keys, mount paths, and skill frontmatter

### DIFF
--- a/.claude/skills/spec-quality/SKILL.md
+++ b/.claude/skills/spec-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-quality
-description: Specification quality framework for planning. Defines the minimum bar for what a plan must address — alternatives, non-goals, blast radius, risk flags, and test strategy. Referenced by schema guidance fields during queue-phase note filling. Use when filling requirements or design notes for any MCP work item.
+description: Specification quality framework for planning. Defines the minimum bar for what a plan must address — alternatives, non-goals, blast radius, risk flags, and test strategy. Referenced by schema guidance fields during queue-phase note filling. Use when filling feature-summary, task-scope, diagnosis, or other queue-phase specification notes for any MCP work item.
 user-invocable: false
 ---
 

--- a/claude-plugins/task-orchestrator/skills/configure-server/references/runtime-config.md
+++ b/claude-plugins/task-orchestrator/skills/configure-server/references/runtime-config.md
@@ -45,7 +45,7 @@ TASK_ORCHESTRATOR_API_URL=http://localhost:3001
 | REST off | `-e API_ENABLED=false` |
 | REST unauthenticated (recommended) | `-e API_ENABLED=true -e API_AUTH_MODE=none -e API_ALLOW_UNAUTHENTICATED=true` |
 | REST bearer | `-e API_ENABLED=true -e API_AUTH_MODE=bearer -e API_TOKENS_PATH=/run/secrets/api-tokens.yaml -v <TOKENS_HOST_PATH>:/run/secrets/api-tokens.yaml:ro` |
-| Config mount = project (fallback) | `-v "<pwd>/.taskorchestrator:/project/.taskorchestrator:ro" -e AGENT_CONFIG_DIR=/project` |
+| Config mount = global floor (recommended) | `-v "<pwd>/deploy/global-config/.taskorchestrator:/project/.taskorchestrator:ro" -e AGENT_CONFIG_DIR=/project` |
 | Config mount = none (multi-project via config-sync) | *(omit)* |
 | Debug on | `-e LOG_LEVEL=DEBUG -e DATABASE_SHOW_SQL=true` |
 | Port publish (loopback only) | `-p 127.0.0.1:3001:3001` |

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -155,7 +155,7 @@ Setting `parentId` to JSON null moves the item to root.
       "tags": "task-implementation",
       "schemaMatch": true,
       "expectedNotes": [
-        { "key": "requirements", "role": "queue", "required": true, "exists": false }
+        { "key": "feature-summary", "role": "queue", "required": true, "exists": false }
       ]
     }
   ],
@@ -255,7 +255,7 @@ snippets, filtered list search, or hierarchical overview.
   "configFingerprint": "a1b2c3d4",
   "configSource": "global",
   "notes": [
-    { "key": "specification", "role": "queue", "required": true, "description": "...", "guidance": "...", "skill": "spec-quality", "maxLength": 4000 },
+    { "key": "feature-summary", "role": "queue", "required": true, "description": "...", "guidance": "...", "skill": "spec-quality", "maxLength": 4000 },
     { "key": "implementation-notes", "role": "work", "required": true, "description": "..." }
   ]
 }
@@ -477,7 +477,7 @@ Nesting depth is unbounded. The root item can be at any depth; each child's dept
 {
   "root": {
     "title": "Feature X",
-    "noteAnchors": [{ "noteKey": "requirements", "role": "queue", "anchor": "overview" }]
+    "noteAnchors": [{ "noteKey": "feature-summary", "role": "queue", "anchor": "overview" }]
   },
   "parentId": "<project-root-uuid>",
   "docRef": { "slug": "my-plan" },
@@ -548,7 +548,7 @@ When `createNotes=false` (default) or no items match a schema, `notes` is `[]`.
   "root": {"title": "Feature X"},
   "children": [{"ref": "t1", "title": "Task 1"}],
   "notes": [
-    {"itemRef": "root", "key": "specification", "role": "queue", "body": "Full plan..."},
+    {"itemRef": "root", "key": "feature-summary", "role": "queue", "body": "Full plan..."},
     {"itemRef": "t1", "key": "task-scope", "role": "queue", "body": "Build the thing"}
   ]
 }
@@ -668,7 +668,7 @@ The `(itemId, key)` pair is unique — upserting with an existing pair updates t
   "notes": [
     {
       "itemId": "550e8400-e29b-41d4-a716-446655440001",
-      "key": "requirements",
+      "key": "feature-summary",
       "role": "queue",
       "body": "The handler must validate JWT signatures and return 401 on failure."
     }
@@ -679,7 +679,7 @@ The `(itemId, key)` pair is unique — upserting with an existing pair updates t
 {
   "operation": "upsert",
   "notes": [
-    { "itemId": "550e8400-e29b-41d4-a716-446655440001", "key": "test-results", "role": "work", "bodyFromFile": "logs/test-run.txt" }
+    { "itemId": "550e8400-e29b-41d4-a716-446655440001", "key": "implementation-notes", "role": "work", "bodyFromFile": "logs/test-run.txt" }
   ]
 }
 
@@ -692,7 +692,7 @@ The `(itemId, key)` pair is unique — upserting with an existing pair updates t
 ```json
 {
   "notes": [
-    { "id": "uuid", "itemId": "uuid", "key": "requirements", "role": "queue" }
+    { "id": "uuid", "itemId": "uuid", "key": "feature-summary", "role": "queue" }
   ],
   "upserted": 1,
   "failed": 0,
@@ -772,7 +772,7 @@ WorkItem, or FTS5 full-text search across note bodies.
 { "operation": "list", "itemId": "550e8400-e29b-41d4-a716-446655440001", "role": "queue" }
 
 // List specific notes by key, with full bodies
-{ "operation": "list", "itemId": "550e8400-e29b-41d4-a716-446655440001", "keys": ["requirements"], "includeBody": true }
+{ "operation": "list", "itemId": "550e8400-e29b-41d4-a716-446655440001", "keys": ["feature-summary"], "includeBody": true }
 
 // FTS5 search across all note bodies for "authentication"
 { "operation": "search", "query": "authentication token", "limit": 10 }
@@ -788,7 +788,7 @@ WorkItem, or FTS5 full-text search across note bodies.
   "notes": [
     {
       "id": "uuid",
-      "key": "requirements",
+      "key": "feature-summary",
       "role": "queue",
       "bodyLength": 42,
       "createdAt": "2025-01-01T00:00:00Z",
@@ -1172,9 +1172,9 @@ All cascade types are recorded in `cascadeEvents`.
       "itemId": "uuid",
       "trigger": "start",
       "applied": false,
-      "error": "Gate check failed: required notes not filled for queue phase: requirements",
+      "error": "Gate check failed: required notes not filled for queue phase: feature-summary",
       "missingNotes": [
-        { "key": "requirements", "description": "...", "guidance": "...", "skill": "spec-quality" }
+        { "key": "feature-summary", "description": "...", "guidance": "...", "skill": "spec-quality" }
       ]
     }
   ],
@@ -1286,7 +1286,7 @@ When `mode` is omitted, the mode is inferred from which parameters are present (
   "mode": "item",
   "item": { "id": "uuid", "title": "JWT Handler", "role": "queue", "tags": "task-implementation", "depth": 1 },
   "schema": [
-    { "key": "requirements", "role": "queue", "required": true, "exists": true, "filled": true },
+    { "key": "task-scope", "role": "queue", "required": true, "exists": true, "filled": true },
     { "key": "done-criteria", "role": "work", "required": true, "exists": false, "filled": false }
   ],
   "gateStatus": { "canAdvance": true, "phase": "queue", "missing": [] },
@@ -2300,7 +2300,7 @@ When using `jwks_path`, the `.agentlair/` directory must be mounted into the con
 ```bash
 docker run --rm -i \
   -v mcp-task-data:/app/data \
-  -v "$(pwd)"/.taskorchestrator:/project/.taskorchestrator:ro \
+  -v "$(pwd)"/deploy/global-config/.taskorchestrator:/project/.taskorchestrator:ro \
   -v "$(pwd)"/.agentlair:/project/.agentlair:ro \
   -e AGENT_CONFIG_DIR=/project \
   task-orchestrator:dev

--- a/current/docs/fleet-deployment.md
+++ b/current/docs/fleet-deployment.md
@@ -276,7 +276,7 @@ The `DEGRADED_MODE_POLICY` environment variable overrides the YAML `degraded_mod
 # Docker — set reject policy for fleet deployments
 docker run --rm -i \
   -v mcp-task-data:/app/data \
-  -v "$(pwd)"/.taskorchestrator:/project/.taskorchestrator:ro \
+  -v "$(pwd)"/deploy/global-config/.taskorchestrator:/project/.taskorchestrator:ro \
   -e AGENT_CONFIG_DIR=/project \
   -e DEGRADED_MODE_POLICY=reject \
   task-orchestrator:dev
@@ -537,7 +537,7 @@ Values below 100ms are clamped to 100ms. Values that cannot be parsed as integer
 ```bash
 docker run --rm -i \
   -v mcp-task-data:/app/data \
-  -v "$(pwd)"/.taskorchestrator:/project/.taskorchestrator:ro \
+  -v "$(pwd)"/deploy/global-config/.taskorchestrator:/project/.taskorchestrator:ro \
   -e AGENT_CONFIG_DIR=/project \
   -e DATABASE_BUSY_TIMEOUT_MS=15000 \
   task-orchestrator:dev

--- a/current/docs/integration-guides/claude-md-driven.md
+++ b/current/docs/integration-guides/claude-md-driven.md
@@ -102,9 +102,9 @@ CLAUDE.md can instruct agents to fill specific note keys even without schema gat
 ## Note Conventions
 
 When creating a feature item, always fill these notes:
-- `requirements` (role: queue) — what the feature must do
-- `implementation-plan` (role: work) — how you'll build it
-- `test-results` (role: review) — test output and coverage
+- `feature-summary` (role: queue) — what the feature must do
+- `implementation-notes` (role: work) — how you built it
+- `review-checklist` (role: review) — test output and coverage
 ```
 
 This is convention-based — the agent follows the instructions but nothing enforces them. For enforcement, add [Note Schemas](note-schemas.md) (Tier 3).

--- a/current/docs/integration-guides/note-schemas.md
+++ b/current/docs/integration-guides/note-schemas.md
@@ -33,17 +33,17 @@ Create `.taskorchestrator/config.yaml` in your project root:
 ```yaml
 note_schemas:
   my-feature:
-    - key: requirements
+    - key: task-scope
       role: queue
       required: true
       description: "What the feature must do."
-    - key: implementation-plan
+    - key: implementation-notes
       role: work
       required: true
       description: "How you will build it."
 ```
 
-This schema says: any item tagged `my-feature` must have a `requirements` note filled before it can advance past queue, and an `implementation-plan` note before it can advance past work.
+This schema says: any item tagged `my-feature` must have a `task-scope` note filled before it can advance past queue, and an `implementation-notes` note before it can advance past work.
 
 ### Docker Mount
 
@@ -124,7 +124,7 @@ A full lifecycle schema with gates at every transition:
 ```yaml
 note_schemas:
   feature:
-    - key: specification
+    - key: feature-summary
       role: queue
       required: true
       description: "Problem statement, approach, and acceptance criteria."
@@ -133,16 +133,16 @@ note_schemas:
       role: work
       required: true
       description: "What was built, deviations from the plan, decisions made."
-      guidance: "Document decisions not captured in the spec. Focus on what downstream agents or reviewers need to know."
+      guidance: "Document decisions not captured in the feature-summary. Focus on what downstream agents or reviewers need to know."
     - key: review-checklist
       role: review
       required: true
       description: "Quality gate — plan alignment and test coverage."
-      guidance: "Verify: what was built matches the specification, tests cover the acceptance criteria."
+      guidance: "Verify: what was built matches the feature-summary, tests cover the acceptance criteria."
 ```
 
 With this schema:
-- `advance_item(trigger="start")` from queue checks `specification` exists, then advances to work
+- `advance_item(trigger="start")` from queue checks `feature-summary` exists, then advances to work
 - `advance_item(trigger="start")` from work checks `implementation-notes` exists, then advances to review
 - `advance_item(trigger="start")` from review checks `review-checklist` exists, then advances to terminal
 - `advance_item(trigger="complete")` checks all required notes across all phases before advancing to terminal
@@ -175,7 +175,7 @@ This means every item gets at least `session-tracking` enforced, even items with
 The `guidance` field is a communication channel from the schema author to the agent. `get_context` and `advance_item` return only a `guidanceKey` — the key of the first unfilled required note with guidance — not the guidance text itself.
 
 ```yaml
-- key: specification
+- key: feature-summary
   role: queue
   required: true
   description: "Problem statement and approach."

--- a/current/docs/workflow-guide.md
+++ b/current/docs/workflow-guide.md
@@ -158,13 +158,13 @@ Set `lifecycle` at the schema level in `work_item_schemas:`:
 
 ```yaml
 work_item_schemas:
-  feature:
-    lifecycle: MANUAL
+  quick-fix:
+    lifecycle: AUTO
     notes:
-      - key: requirements
-        role: queue
+      - key: session-tracking
+        role: work
         required: true
-        description: "Problem statement and acceptance criteria."
+        description: "Brief record of what was changed and test results."
 ```
 
 ### Complete Example Schema
@@ -174,31 +174,21 @@ work_item_schemas:
   feature-implementation:
     lifecycle: AUTO
     notes:
-      - key: requirements
+      - key: feature-summary
         role: queue
         required: true
-        description: "Problem statement and acceptance criteria."
-        guidance: "Describe what problem this solves. List 2-5 acceptance criteria."
-      - key: design
-        role: queue
-        required: true
-        description: "Chosen approach, alternatives considered."
-        guidance: "Describe the chosen implementation approach. List alternatives considered and why they were rejected."
+        description: "Lean feature-level summary — goal, findings-to-tasks mapping, dependency edges, non-goals pointer."
+        guidance: "Cover the goal in 2-3 sentences, a findings→tasks mapping, dependency edges between child tasks, and a pointer to where non-goals and alternatives are recorded."
       - key: implementation-notes
         role: work
         required: true
-        description: "Key decisions made during implementation."
-        guidance: "Document key decisions made during coding. Include any deviations from the design and why."
-      - key: test-results
-        role: work
-        required: true
-        description: "Test pass/fail count and new tests added."
-        guidance: "State total tests passing and failing. List new test cases added and what edge cases they cover."
-      - key: deploy-notes
+        description: "Context handoff for downstream agents — deviations, surprises, and decisions that affect dependent work."
+        guidance: "Document decisions made during implementation that weren't in the feature-summary. Focus on deviations from the plan, interface surprises, and assumptions that turned out wrong."
+      - key: review-checklist
         role: review
-        required: false
-        description: "Deploy needed? Version bump? Reconnect required?"
-        guidance: "Note any deployment steps, config changes, version bumps, or client reconnection requirements."
+        required: true
+        description: "Quality gate — plan alignment, test quality, and simplification review."
+        guidance: "Verify what was built aligns with the feature-summary, tests cover the test strategy, and any /simplify changes have test coverage."
 ```
 
 > The legacy `note_schemas:` flat-list format is still accepted. New configs should prefer `work_item_schemas:` for access to the `lifecycle:` and `traits:` fields.
@@ -207,17 +197,17 @@ work_item_schemas:
 
 ```
 queue
-  requires: requirements (filled), design (filled)
+  requires: feature-summary (filled)
       |
    [start]
       |
     work
-  requires: implementation-notes (filled), test-results (filled)
+  requires: implementation-notes (filled)
       |
    [start]
       |
    review
-  requires: (no required notes in this example)
+  requires: review-checklist (filled)
       |
    [start]
       |
@@ -236,9 +226,9 @@ Notes are created or updated using `manage_notes(operation="upsert")`.
 manage_notes(operation="upsert", notes=[
   {
     "itemId": "abc-123",
-    "key": "requirements",
+    "key": "feature-summary",
     "role": "queue",
-    "body": "## Problem\nUsers cannot reset passwords via email.\n\n## Acceptance Criteria\n- User receives reset email within 60s\n- Link expires after 24h\n- Old password no longer works after reset"
+    "body": "## Goal\nAllow users to reset passwords via email.\n\n## Findings -> Tasks\n- Token storage design -> PasswordResetTokenRepository task\n\n## Dependencies\nNone.\n\n## Non-goals\nSee linked spec doc for alternatives considered."
   }
 ])
 ```
@@ -261,29 +251,20 @@ Response includes:
   "gateStatus": {
     "canAdvance": false,
     "phase": "queue",
-    "missing": ["design"]
+    "missing": ["feature-summary"]
   },
   "schema": [
     {
-      "key": "requirements",
+      "key": "feature-summary",
       "role": "queue",
       "required": true,
-      "description": "Problem statement and acceptance criteria.",
-      "guidance": "Describe what problem this solves. List 2-5 acceptance criteria.",
-      "exists": true,
-      "filled": true
-    },
-    {
-      "key": "design",
-      "role": "queue",
-      "required": true,
-      "description": "Chosen approach, alternatives considered.",
-      "guidance": "Describe the chosen implementation approach. List alternatives considered and why they were rejected.",
+      "description": "Lean feature-level summary — goal, findings-to-tasks mapping, dependency edges, non-goals pointer.",
+      "guidance": "Cover the goal in 2-3 sentences, a findings->tasks mapping, dependency edges between child tasks, and a pointer to where non-goals and alternatives are recorded.",
       "exists": false,
       "filled": false
     }
   ],
-  "guidancePointer": "Describe the chosen implementation approach. List alternatives considered and why they were rejected."
+  "guidancePointer": "Cover the goal in 2-3 sentences, a findings->tasks mapping, dependency edges between child tasks, and a pointer to where non-goals and alternatives are recorded."
 }
 ```
 
@@ -323,11 +304,9 @@ The response includes `expectedNotes` when the type (or tags) match a schema:
   "role": "queue",
   "tags": "feature-implementation",
   "expectedNotes": [
-    { "key": "requirements", "role": "queue", "required": true, "description": "Problem statement and acceptance criteria.", "guidance": "Describe what problem this solves. List 2-5 acceptance criteria.", "exists": false },
-    { "key": "design",        "role": "queue", "required": true, "description": "Chosen approach, alternatives considered.", "guidance": "Describe the chosen implementation approach. List alternatives considered and why they were rejected.", "exists": false },
-    { "key": "implementation-notes", "role": "work", "required": true, "description": "Key decisions made during implementation.", "guidance": "Document key decisions made during coding. Include any deviations from the design and why.", "exists": false },
-    { "key": "test-results",  "role": "work", "required": true, "description": "Test pass/fail count and new tests added.", "guidance": "State total tests passing and failing. List new test cases added and what edge cases they cover.", "exists": false },
-    { "key": "deploy-notes",  "role": "review", "required": false, "description": "Deploy needed? Version bump? Reconnect required?", "exists": false }
+    { "key": "feature-summary", "role": "queue", "required": true, "description": "Lean feature-level summary — goal, findings-to-tasks mapping, dependency edges, non-goals pointer.", "guidance": "Cover the goal in 2-3 sentences, a findings->tasks mapping, dependency edges between child tasks, and a pointer to where non-goals and alternatives are recorded.", "exists": false },
+    { "key": "implementation-notes", "role": "work", "required": true, "description": "Context handoff for downstream agents — deviations, surprises, and decisions that affect dependent work.", "guidance": "Document decisions made during implementation that weren't in the feature-summary. Focus on deviations from the plan, interface surprises, and assumptions that turned out wrong.", "exists": false },
+    { "key": "review-checklist", "role": "review", "required": true, "description": "Quality gate — plan alignment, test quality, and simplification review.", "guidance": "Verify what was built aligns with the feature-summary, tests cover the test strategy, and any /simplify changes have test coverage.", "exists": false }
   ]
 }
 ```
@@ -338,24 +317,18 @@ Before writing notes, consult `guidancePointer` for authoring instructions:
 
 ```json
 get_context(itemId="abc-123")
-// guidancePointer: "Describe what problem this solves. List 2-5 acceptance criteria."
+// guidancePointer: "Cover the goal in 2-3 sentences, a findings->tasks mapping, dependency edges between child tasks, and a pointer to where non-goals and alternatives are recorded."
 ```
 
-Use the guidance to author each note:
+Use the guidance to author the note:
 
 ```json
 manage_notes(operation="upsert", notes=[
   {
     "itemId": "abc-123",
-    "key": "requirements",
+    "key": "feature-summary",
     "role": "queue",
-    "body": "Users need to reset passwords by email.\n\nAcceptance Criteria:\n- Reset email delivered < 60s\n- Link expires after 24h"
-  },
-  {
-    "itemId": "abc-123",
-    "key": "design",
-    "role": "queue",
-    "body": "Use HMAC token stored in DB. Chose over JWT to allow server-side invalidation."
+    "body": "Goal: let users reset passwords by email.\n\nFindings -> Tasks:\n- Token storage design -> PasswordResetTokenRepository task\n\nDependencies: none.\n\nNon-goals: see linked spec doc."
   }
 ])
 ```
@@ -376,10 +349,10 @@ Consult `guidancePointer` again — it now points to the first unfilled work-pha
 
 ```json
 get_context(itemId="abc-123")
-// guidancePointer: "Document key decisions made during coding. Include any deviations from the design and why."
+// guidancePointer: "Document decisions made during implementation that weren't in the feature-summary. Focus on deviations from the plan, interface surprises, and assumptions that turned out wrong."
 ```
 
-Use the guidance to author each work-phase note:
+Use the guidance to author the work-phase note:
 
 ```json
 manage_notes(operation="upsert", notes=[
@@ -387,13 +360,7 @@ manage_notes(operation="upsert", notes=[
     "itemId": "abc-123",
     "key": "implementation-notes",
     "role": "work",
-    "body": "Added PasswordResetTokenRepository. Token TTL configurable via env var."
-  },
-  {
-    "itemId": "abc-123",
-    "key": "test-results",
-    "role": "work",
-    "body": "42 tests passing, 0 failing. Added 8 new tests for token expiry edge cases."
+    "body": "Added PasswordResetTokenRepository. Token TTL configurable via env var. 42 tests passing, 0 failing; added 8 new tests for token expiry edge cases."
   }
 ])
 ```
@@ -495,9 +462,9 @@ Orchestration hooks (e.g., `SubagentStart`) can inject `guidancePointer` into a 
 ```
 System context injected by hook:
   Item: abc-123 — Password Reset Feature (role: queue)
-  Required note: design
-  Guidance: Describe the chosen implementation approach. List alternatives considered
-            and why they were rejected.
+  Required note: feature-summary
+  Guidance: Cover the goal in 2-3 sentences, a findings->tasks mapping, dependency edges
+            between child tasks, and a pointer to where non-goals and alternatives are recorded.
 ```
 
 The agent receives this context at session start and can proceed directly to `manage_notes(upsert)`.
@@ -507,12 +474,12 @@ The agent receives this context at session start and can proceed directly to `ma
 When dispatching a subagent to fill notes for a specific item, embed the guidance directly in the prompt:
 
 ```
-Fill the "design" note for item abc-123.
+Fill the "feature-summary" note for item abc-123.
 
-Guidance from schema: "Describe the chosen implementation approach. List alternatives
-considered and why they were rejected."
+Guidance from schema: "Cover the goal in 2-3 sentences, a findings->tasks mapping, dependency
+edges between child tasks, and a pointer to where non-goals and alternatives are recorded."
 
-Use manage_notes(operation="upsert") with itemId="abc-123", key="design", role="queue".
+Use manage_notes(operation="upsert") with itemId="abc-123", key="feature-summary", role="queue".
 ```
 
 ---
@@ -933,7 +900,7 @@ work_item_schemas:
 - Docker override: set `AGENT_CONFIG_DIR` environment variable to the directory containing `.taskorchestrator/`.
 
 ```bash
-docker run -e AGENT_CONFIG_DIR=/project -v "$(pwd)"/.taskorchestrator:/project/.taskorchestrator:ro task-orchestrator:dev
+docker run -e AGENT_CONFIG_DIR=/project -v "$(pwd)"/deploy/global-config/.taskorchestrator:/project/.taskorchestrator:ro task-orchestrator:dev
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Cluster (a): replaced retired example note keys (`requirements`, `design`, `test-results`, generic-context `specification`) with live dogfood keys (`feature-summary`, `task-scope`, `implementation-notes`, `review-checklist`, `session-tracking`) across workflow-guide.md, api-reference.md, note-schemas.md, and claude-md-driven.md (found via broad sweep)
- Cluster (b): updated stale `"$(pwd)"/.taskorchestrator` global-mount examples to `deploy/global-config/.taskorchestrator` in api-reference.md, fleet-deployment.md (x2), workflow-guide.md
- Cluster (c): spec-quality SKILL.md frontmatter now references current queue-phase note keys
- Cluster (d): configure-server runtime-config.md env-fragment table row now documents the global floor mount

Full-repo token sweep with per-hit classification; live usages (`plugin-change`'s `specification` key, quick-start.md's generic per-project mounts, gradle `test-results` paths) intentionally left.

## Test Results
Docs/markdown only — no code changes, no test impact.

## Review
Pass — inline orchestrator review of full diff: rewritten examples internally coherent, live keys preserved, mount paths match CLAUDE.md canonical form.

## MCP
b3afc05c-e100-4f53-910c-e19d916a0611

🤖 Generated with [Claude Code](https://claude.com/claude-code)