### PR TITLE
fix(plugin): use documented PreToolUse deny shape in enforce-actor-attribution

### DIFF
--- a/claude-plugins/task-orchestrator/hooks/enforce-actor-attribution.mjs
+++ b/claude-plugins/task-orchestrator/hooks/enforce-actor-attribution.mjs
@@ -116,8 +116,11 @@ if (!missing) {
 }
 
 process.stdout.write(JSON.stringify({
-  decision: 'block',
-  reason: 'Actor authentication is enabled \u2014 actor attribution required. Include an "actor" object ' +
-    'with "id" (string) and "kind" (orchestrator|subagent|user|external) on every ' +
-    'transition/note element. For subagents, include "parent" with the dispatching agent\'s id.'
+  hookSpecificOutput: {
+    hookEventName: 'PreToolUse',
+    permissionDecision: 'deny',
+    permissionDecisionReason: 'Actor authentication is enabled \u2014 actor attribution required. Include an "actor" object ' +
+      'with "id" (string) and "kind" (orchestrator|subagent|user|external) on every ' +
+      'transition/note element. For subagents, include "parent" with the dispatching agent\'s id.'
+  }
 }));


### PR DESCRIPTION
## Summary
- `enforce-actor-attribution.mjs`: replaced legacy top-level `{decision:'block', reason}` with the documented PreToolUse denial contract — `hookSpecificOutput.permissionDecision:'deny'` + `permissionDecisionReason`, exit 0; guidance text unchanged
- `subagent-start.mjs` needs **no change**: a live probe this session (docs-sweep subagent) confirmed its `hookSpecificOutput.additionalContext` is injected as clean prose, not literal JSON — keeping the working JSON form

## Test Results
Five fixture cases piped into the hook (`AGENT_CONFIG_DIR` → temp configs), all passing:
- enabled + actor-less `advance_item` → deny JSON emitted, exit 0
- enabled + actor present → silent, exit 0
- enabled + actor-less `manage_notes(upsert)` → deny JSON emitted, exit 0
- disabled config → silent, exit 0
- non-target tool → silent, exit 0

No Kotlin changes — gradle suite not affected.

## Review
Pass — Direct-tier inline review; single-file 7/4-line diff, LF endings verified, no version bump (owned by /prepare-release). Note: plugin hook content is cached — marketplace remove/re-add needed to pick this up locally after merge.

## MCP
5227a30f-7b8d-415b-804b-e6371c72a4e9

🤖 Generated with [Claude Code](https://claude.com/claude-code)