### PR TITLE
fix(dependency): align failed count with failures detail list

### DIFF
--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -904,12 +904,15 @@ spans the entire batch).
 {
   "dependencies": [],
   "created": 0,
-  "failed": 1,
-  "failures": [{ "index": 0, "error": "A dependency cannot reference the same item on both sides" }]
+  "failed": 2,
+  "failures": [
+    { "index": 0, "error": "Dependency at index 0: invalid type 'FOO'. Valid: BLOCKS, IS_BLOCKED_BY, RELATES_TO" },
+    { "index": 2, "error": "Dependency at index 2: 'fromItemId' could not be resolved: not-a-uuid" }
+  ]
 }
 ```
 
-Note: atomicity is preserved — either all dependencies are created or none. On any validation failure, `created` is always 0 and `failures` contains a single entry describing the rejection reason. The `failures[].index` field is 0-based (the first item is index 0).
+Note: atomicity is preserved — either all dependencies are created or none. On any validation failure, `created` is always 0 and `failed` **always equals `failures.length`**. Every element of the `dependencies` array is validated independently, so `failures` reports **one entry per invalid element**, each carrying that element's 0-based `index` — a batch with three specs where the first and third are malformed returns two failures at indices 0 and 2 (the valid middle element is still not created). A batch-level rejection that is a property of the whole batch rather than one element — a cycle formed across multiple specs, or a duplicate of an existing dependency — is reported as a single failure entry.
 
 **Constraint: `RELATES_TO` and `unblockAt`.** Specifying `unblockAt` on a `RELATES_TO` dependency is a validation error. `RELATES_TO` dependencies have no blocking semantics and do not support an unblock threshold; providing one will return a validation failure response.
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/dependency/ManageDependenciesTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/dependency/ManageDependenciesTool.kt
@@ -407,18 +407,28 @@ with `deleteAll=true` for every dependency on that item.
         val sharedUnblockAt = optionalString(params, "unblockAt")
 
         val dependencies: List<Dependency> =
-            try {
-                if (depsArray != null) {
-                    parseDependenciesArray(depsArray, sharedType, sharedUnblockAt, context)
-                } else {
-                    generateFromPattern(params, pattern!!, sharedType, sharedUnblockAt, context)
+            if (depsArray != null) {
+                // Validate every element, collecting all per-index failures (batch-create convention).
+                val (parsed, failures) = parseDependenciesArray(depsArray, sharedType, sharedUnblockAt, context)
+                if (failures.isNotEmpty()) {
+                    return successResponse(buildValidationFailureResponse(failures))
                 }
-            } catch (e: ToolValidationException) {
-                val failedCount = depsArray?.size ?: 1
-                return successResponse(buildValidationFailureResponse(e.message ?: "Validation failed", failedCount))
-            } catch (e: ValidationException) {
-                val failedCount = depsArray?.size ?: 1
-                return successResponse(buildValidationFailureResponse(e.message ?: "Domain validation failed", failedCount))
+                parsed
+            } else {
+                // A pattern is a single logical spec — first-error reporting is correct here.
+                try {
+                    generateFromPattern(params, pattern!!, sharedType, sharedUnblockAt, context)
+                } catch (e: ToolValidationException) {
+                    return successResponse(
+                        buildValidationFailureResponse(listOf(DependencyFailure(0, e.message ?: "Validation failed")))
+                    )
+                } catch (e: ValidationException) {
+                    return successResponse(
+                        buildValidationFailureResponse(
+                            listOf(DependencyFailure(0, e.message ?: "Domain validation failed"))
+                        )
+                    )
+                }
             }
 
         val repo = context.dependencyRepository()
@@ -447,64 +457,90 @@ with `deleteAll=true` for every dependency on that item.
                 }
             successResponse(data)
         } catch (e: ValidationException) {
-            successResponse(buildValidationFailureResponse(e.message ?: "Dependency creation failed", dependencies.size))
+            // Batch-level rejection (cycle/duplicate detected across the whole batch) — a single failure.
+            successResponse(
+                buildValidationFailureResponse(listOf(DependencyFailure(0, e.message ?: "Dependency creation failed")))
+            )
         } catch (e: Exception) {
             errorResponse(e.message ?: "Unexpected error creating dependencies", ErrorCodes.INTERNAL_ERROR)
         }
     }
 
+    /**
+     * Validates every element of the `dependencies` array independently, returning the successfully
+     * parsed dependencies alongside a per-index list of validation failures. Unlike a fail-fast parse,
+     * this reports ALL invalid elements in one pass so batch callers see every error at once
+     * (batch-create convention). Creation stays atomic: the caller must not create anything when the
+     * returned failure list is non-empty.
+     */
     private suspend fun parseDependenciesArray(
         depsArray: JsonArray,
         sharedType: DependencyType,
         sharedUnblockAt: String?,
         context: ToolExecutionContext
-    ): List<Dependency> {
+    ): Pair<List<Dependency>, List<DependencyFailure>> {
         val result = mutableListOf<Dependency>()
+        val failures = mutableListOf<DependencyFailure>()
         for ((index, element) in depsArray.withIndex()) {
-            val depObj =
-                element as? JsonObject
-                    ?: throw ToolValidationException("Dependency at index $index must be a JSON object")
-
-            val fromItemIdStr =
-                extractItemString(depObj, "fromItemId")
-                    ?: throw ToolValidationException("Dependency at index $index: 'fromItemId' is required")
-            val toItemIdStr =
-                extractItemString(depObj, "toItemId")
-                    ?: throw ToolValidationException("Dependency at index $index: 'toItemId' is required")
-
-            val (fromItemId, fromErr) = resolveIdString(fromItemIdStr, context)
-            if (fromErr != null || fromItemId == null) {
-                throw ToolValidationException(
-                    "Dependency at index $index: 'fromItemId' could not be resolved: $fromItemIdStr"
-                )
-            }
-            val (toItemId, toErr) = resolveIdString(toItemIdStr, context)
-            if (toErr != null || toItemId == null) {
-                throw ToolValidationException(
-                    "Dependency at index $index: 'toItemId' could not be resolved: $toItemIdStr"
-                )
-            }
-
-            val typeStr = extractItemString(depObj, "type")
-            val type =
-                if (typeStr != null) {
-                    DependencyType.fromString(typeStr)
-                        ?: throw ToolValidationException(
-                            "Dependency at index $index: invalid type '$typeStr'. Valid: BLOCKS, IS_BLOCKED_BY, RELATES_TO"
-                        )
-                } else {
-                    sharedType
-                }
-
-            val unblockAt = extractItemString(depObj, "unblockAt") ?: sharedUnblockAt
-
             try {
-                result.add(Dependency(fromItemId = fromItemId, toItemId = toItemId, type = type, unblockAt = unblockAt))
-            } catch (e: ValidationException) {
-                throw ToolValidationException("Dependency at index $index: ${e.message}")
+                result.add(parseOneDependency(index, element, sharedType, sharedUnblockAt, context))
+            } catch (e: ToolValidationException) {
+                failures.add(DependencyFailure(index, e.message ?: "Validation failed"))
             }
         }
-        return result
+        return result to failures
+    }
+
+    /** Parses and validates a single dependency element, throwing [ToolValidationException] on any failure. */
+    private suspend fun parseOneDependency(
+        index: Int,
+        element: JsonElement,
+        sharedType: DependencyType,
+        sharedUnblockAt: String?,
+        context: ToolExecutionContext
+    ): Dependency {
+        val depObj =
+            element as? JsonObject
+                ?: throw ToolValidationException("Dependency at index $index must be a JSON object")
+
+        val fromItemIdStr =
+            extractItemString(depObj, "fromItemId")
+                ?: throw ToolValidationException("Dependency at index $index: 'fromItemId' is required")
+        val toItemIdStr =
+            extractItemString(depObj, "toItemId")
+                ?: throw ToolValidationException("Dependency at index $index: 'toItemId' is required")
+
+        val (fromItemId, fromErr) = resolveIdString(fromItemIdStr, context)
+        if (fromErr != null || fromItemId == null) {
+            throw ToolValidationException(
+                "Dependency at index $index: 'fromItemId' could not be resolved: $fromItemIdStr"
+            )
+        }
+        val (toItemId, toErr) = resolveIdString(toItemIdStr, context)
+        if (toErr != null || toItemId == null) {
+            throw ToolValidationException(
+                "Dependency at index $index: 'toItemId' could not be resolved: $toItemIdStr"
+            )
+        }
+
+        val typeStr = extractItemString(depObj, "type")
+        val type =
+            if (typeStr != null) {
+                DependencyType.fromString(typeStr)
+                    ?: throw ToolValidationException(
+                        "Dependency at index $index: invalid type '$typeStr'. Valid: BLOCKS, IS_BLOCKED_BY, RELATES_TO"
+                    )
+            } else {
+                sharedType
+            }
+
+        val unblockAt = extractItemString(depObj, "unblockAt") ?: sharedUnblockAt
+
+        return try {
+            Dependency(fromItemId = fromItemId, toItemId = toItemId, type = type, unblockAt = unblockAt)
+        } catch (e: ValidationException) {
+            throw ToolValidationException("Dependency at index $index: ${e.message}")
+        }
     }
 
     private suspend fun generateFromPattern(
@@ -684,23 +720,30 @@ with `deleteAll=true` for every dependency on that item.
         return if (content.isBlank()) null else content
     }
 
-    private fun buildValidationFailureResponse(
-        error: String,
-        failedCount: Int
-    ): JsonObject =
+    /** A single validation failure tied to its 0-based position in the request's `dependencies` array. */
+    private data class DependencyFailure(
+        val index: Int,
+        val error: String
+    )
+
+    /**
+     * Builds the atomic-failure response. `failed` is always the length of [failures] so the count can
+     * never overstate the number of documented failures (the phantom-count bug this replaced).
+     */
+    private fun buildValidationFailureResponse(failures: List<DependencyFailure>): JsonObject =
         buildJsonObject {
             put("dependencies", JsonArray(emptyList()))
             put("created", JsonPrimitive(0))
-            put("failed", JsonPrimitive(failedCount))
+            put("failed", JsonPrimitive(failures.size))
             put(
                 "failures",
                 JsonArray(
-                    listOf(
+                    failures.map { failure ->
                         buildJsonObject {
-                            put("index", JsonPrimitive(0))
-                            put("error", JsonPrimitive(error))
+                            put("index", JsonPrimitive(failure.index))
+                            put("error", JsonPrimitive(failure.error))
                         }
-                    )
+                    }
                 )
             )
         }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/dependency/ManageDependenciesToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/dependency/ManageDependenciesToolTest.kt
@@ -667,6 +667,8 @@ class ManageDependenciesToolTest {
             assertTrue(data["failed"]!!.jsonPrimitive.int > 0)
             val failures = data["failures"]!!.jsonArray
             assertEquals(1, failures.size)
+            // Invariant: `failed` count must equal the number of documented failures (no phantom count).
+            assertEquals(failures.size, data["failed"]!!.jsonPrimitive.int)
             assertTrue(
                 failures[0]
                     .jsonObject["error"]!!
@@ -677,6 +679,94 @@ class ManageDependenciesToolTest {
             // Verify nothing was created (atomic)
             val deps = context.dependencyRepository().findByItemId(itemA)
             assertTrue(deps.isEmpty())
+        }
+
+    @Test
+    fun `create batch reports failed count matching failures length (phantom count regression)`(): Unit =
+        runBlocking {
+            // Exact repro from the bug report: two specs where only the FIRST is invalid (bad type).
+            // Before the fix this returned failed=2 (whole batch size) with a single failure detail.
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("create"),
+                        "dependencies" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("fromItemId", JsonPrimitive(itemA.toString()))
+                                        put("toItemId", JsonPrimitive(itemB.toString()))
+                                        put("type", JsonPrimitive("INVALID_TYPE"))
+                                    },
+                                    buildJsonObject {
+                                        put("fromItemId", JsonPrimitive(itemC.toString()))
+                                        put("toItemId", JsonPrimitive(itemD.toString()))
+                                    }
+                                )
+                            )
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(0, data["created"]!!.jsonPrimitive.int)
+            val failures = data["failures"]!!.jsonArray
+            assertEquals(1, failures.size, "only the first spec is invalid; the second is well-formed")
+            assertEquals(1, data["failed"]!!.jsonPrimitive.int, "failed must equal failures.length, not batch size")
+            assertEquals(0, failures[0].jsonObject["index"]!!.jsonPrimitive.int)
+            assertTrue(
+                failures[0]
+                    .jsonObject["error"]!!
+                    .jsonPrimitive.content
+                    .contains("invalid type", ignoreCase = true)
+            )
+
+            // Atomic: nothing created even though the second spec was valid.
+            assertTrue(context.dependencyRepository().findByItemId(itemC).isEmpty())
+        }
+
+    @Test
+    fun `create batch collects all per-element validation errors with correct indices`(): Unit =
+        runBlocking {
+            // Non-contiguous invalid indices: index 0 (bad type), index 1 valid, index 2 (bad UUID).
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("create"),
+                        "dependencies" to
+                            JsonArray(
+                                listOf(
+                                    buildJsonObject {
+                                        put("fromItemId", JsonPrimitive(itemA.toString()))
+                                        put("toItemId", JsonPrimitive(itemB.toString()))
+                                        put("type", JsonPrimitive("INVALID_TYPE"))
+                                    },
+                                    buildJsonObject {
+                                        put("fromItemId", JsonPrimitive(itemC.toString()))
+                                        put("toItemId", JsonPrimitive(itemD.toString()))
+                                    },
+                                    buildJsonObject {
+                                        put("fromItemId", JsonPrimitive("not-a-uuid"))
+                                        put("toItemId", JsonPrimitive(itemE.toString()))
+                                    }
+                                )
+                            )
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            assertEquals(0, data["created"]!!.jsonPrimitive.int)
+            val failures = data["failures"]!!.jsonArray
+            assertEquals(2, failures.size, "both invalid elements should be reported")
+            assertEquals(2, data["failed"]!!.jsonPrimitive.int)
+            val reportedIndices = failures.map { it.jsonObject["index"]!!.jsonPrimitive.int }.toSet()
+            assertEquals(setOf(0, 2), reportedIndices, "indices must reflect the actual offending positions")
+
+            // Atomic: the valid middle element is not created.
+            assertTrue(context.dependencyRepository().findByItemId(itemC).isEmpty())
         }
 
     @Test


### PR DESCRIPTION
## Summary
- `manage_dependencies(create)` set `failed` to the whole batch size while `failures` held a single hardcoded index-0 entry — a multi-element array reported a phantom failure with no detail (e.g. two specs, first invalid → `{failed: 2, failures: [1 entry]}`).
- Now validates every element of the `dependencies` array independently and collects **all** per-index failures (batch-create convention); `failed` is derived from `failures.size` so the two can never desync.
- `failures` reports one entry per invalid element with its true 0-based `index`; batch-level rejections (cross-spec cycle / duplicate) remain a single entry. Atomic all-or-nothing creation is unchanged.
- Extracted per-element parsing into `parseOneDependency`; updated the `api-reference.md` dependency-create contract + example.

## Test Results
`./gradlew :current:test :current:ktlintCheck` — BUILD SUCCESSFUL, full suite green, lint clean.
New tests: phantom-count regression (exact repro), collect-all with non-contiguous invalid indices {0,2}. Strengthened the existing atomic-cycle-within-batch test with a `failed == failures.size` invariant assertion.

## Review
Inline review (Direct tier) — PASS on plan alignment, correctness (atomic guard, preserved error messages), test quality, and simplification. No blocking issues.

## MCP
e09b2b6f-3f65-4f13-86f0-8301104dd2ce

🤖 Generated with [Claude Code](https://claude.com/claude-code)