### PR TITLE
fix(tools): type-aware error for JSON-array param validation

### DIFF
--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/BaseToolDefinition.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/BaseToolDefinition.kt
@@ -297,7 +297,7 @@ abstract class BaseToolDefinition : ToolDefinition {
             return element
         }
 
-        throw ToolValidationException("Parameter $name must be a JSON array")
+        throw jsonArrayTypeError(name, element)
     }
 
     /**
@@ -324,7 +324,26 @@ abstract class BaseToolDefinition : ToolDefinition {
             return element
         }
 
-        throw ToolValidationException("Parameter $name must be a JSON array")
+        throw jsonArrayTypeError(name, element)
+    }
+
+    /**
+     * Builds a [ToolValidationException] whose message distinguishes the received type when a
+     * JSON array was expected. The contract stays strict — string-encoded arrays are still
+     * rejected — but the message tells the caller *why* so the call can be fixed at a glance.
+     */
+    private fun jsonArrayTypeError(
+        name: String,
+        element: JsonElement
+    ): ToolValidationException {
+        val hint =
+            when {
+                element is JsonPrimitive && element.isString ->
+                    "received as a string; pass a native JSON array, not string-encoded"
+                element is JsonObject -> "received an object; expected a JSON array"
+                else -> "expected a JSON array"
+            }
+        return ToolValidationException("Parameter $name $hint")
     }
 
     // ──────────────────────────────────────────────

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/BaseToolDefinitionTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/BaseToolDefinitionTest.kt
@@ -379,6 +379,36 @@ class BaseToolDefinitionTest {
     }
 
     @Test
+    fun `requireJsonArray error distinguishes string from object from other primitive`() {
+        val stringErr =
+            assertFailsWith<ToolValidationException> {
+                tool.testRequireJsonArray(params("items" to JsonPrimitive("[1,2]")), "items")
+            }
+        assertTrue(
+            stringErr.message!!.contains("received as a string"),
+            "string value should be flagged as such, was: ${stringErr.message}"
+        )
+
+        val objectErr =
+            assertFailsWith<ToolValidationException> {
+                tool.testRequireJsonArray(params("items" to buildJsonObject { put("a", 1) }), "items")
+            }
+        assertTrue(
+            objectErr.message!!.contains("received an object"),
+            "object value should be flagged as such, was: ${objectErr.message}"
+        )
+
+        val numberErr =
+            assertFailsWith<ToolValidationException> {
+                tool.testRequireJsonArray(params("items" to JsonPrimitive(42)), "items")
+            }
+        assertTrue(
+            numberErr.message!!.contains("expected a JSON array"),
+            "non-string primitive should fall through to the generic hint, was: ${numberErr.message}"
+        )
+    }
+
+    @Test
     fun `optionalJsonArray returns array when present`() {
         val array = JsonArray(listOf(JsonPrimitive(1), JsonPrimitive(2)))
         val p = params("items" to array)
@@ -399,6 +429,27 @@ class BaseToolDefinitionTest {
         assertFailsWith<ToolValidationException> {
             tool.testOptionalJsonArray(p, "items")
         }
+    }
+
+    @Test
+    fun `optionalJsonArray error distinguishes string from object from other primitive`() {
+        val stringErr =
+            assertFailsWith<ToolValidationException> {
+                tool.testOptionalJsonArray(params("items" to JsonPrimitive("[1,2]")), "items")
+            }
+        assertTrue(stringErr.message!!.contains("received as a string"))
+
+        val objectErr =
+            assertFailsWith<ToolValidationException> {
+                tool.testOptionalJsonArray(params("items" to buildJsonObject { put("a", 1) }), "items")
+            }
+        assertTrue(objectErr.message!!.contains("received an object"))
+
+        val numberErr =
+            assertFailsWith<ToolValidationException> {
+                tool.testOptionalJsonArray(params("items" to JsonPrimitive(42)), "items")
+            }
+        assertTrue(numberErr.message!!.contains("expected a JSON array"))
     }
 
     // ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Resolves friction observation `acac3914` — `manage_items` (and, it turns out, three other tools) returned an undiagnosable `Parameter items must be a JSON array` whether the value arrived as a JSON-encoded string, an object, or a non-array primitive.

The generic message lives in the two shared helpers `optionalJsonArray` / `requireJsonArray` in `BaseToolDefinition.kt`, which back the array params of **`manage_items`, `manage_notes`, `manage_dependencies`, and `advance_item`** — so the ambiguity was felt across the whole tool surface, not just `manage_items`.

## Change

- Add a private `jsonArrayTypeError(name, element)` helper and route both throw sites through it.
- Message now distinguishes the received type:
  - string → `"received as a string; pass a native JSON array, not string-encoded"`
  - object → `"received an object; expected a JSON array"`
  - other → `"expected a JSON array"`

**Contract is unchanged** — strict, still rejects string-encoded arrays, still throws `ToolValidationException`. Only the diagnostic text differs. No parse-fallback, no schema/doc-surface change, no migration.

## Tests

- Existing `throws on non-array type` tests stay green (they assert the exception type, not the message).
- Added message-level coverage for the string / object / other-primitive branches on both helpers.
- `./gradlew test` — full suite green.

Refs `acac3914`

🤖 Generated with [Claude Code](https://claude.com/claude-code)