### PR TITLE
fix(tools): singular advance_item sugar + retain terminal containers with open work

### DIFF
--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -236,7 +236,7 @@ snippets, filtered list search, or hierarchical overview.
 | `includeChildren` | boolean | No | Include direct children on each root item (global mode only, default: false) |
 | `limit` | integer | No | Max root items (default: 50; global and anchored modes only) |
 | `offset` | integer | No | Skip N root items for pagination (default: 0; global and anchored modes only — scoped overview always returns all direct children, unpaginated) |
-| `excludeTerminal` | boolean | No | Default false. Global and anchored modes: drop terminal-role roots from `items` before their children/counts are even fetched, and `total`/`truncated` reflect the filtered set. Scoped mode: drop terminal-role items from `children` only — the parent is always returned regardless of its own role, and `childCounts` stays unfiltered. |
+| `excludeTerminal` | boolean | No | Default false. Global mode: drop terminal-role roots from `items` at the SQL level before their children/counts are even fetched, and `total`/`truncated` reflect the filtered set. Anchored and scoped modes: drop terminal-role items from the `items`/`children` array, **except** a terminal-role item that still has non-terminal descendants, which is retained (it represents active work parked under a done container). The scoped parent is always returned regardless of its own role, and `childCounts` stays unfiltered. |
 
 #### Key Parameters — schema
 
@@ -1039,8 +1039,14 @@ detection → unblock detection. The MCP path enforces claim ownership; the REST
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `transitions` | array | Yes | Array of transition objects: `[{ itemId, trigger, summary?, actor? }]` |
+| `transitions` | array | Conditional | Array of transition objects: `[{ itemId, trigger, summary?, actor? }]`. Required unless the singular-form sugar (`itemId` + `trigger`) is used instead. |
+| `itemId` | string (UUID or 4+ char prefix) | Conditional | Singular-form sugar: advance a single item without a `transitions` array. Provide with `trigger` (and optional top-level `summary`/`actor`); the server wraps it into a one-element `transitions` array. Ignored when `transitions` is present. |
+| `trigger` | string | Conditional | Singular-form sugar: the trigger for the single item named by top-level `itemId`. |
+| `summary` | string | No | Singular-form sugar (optional): transition summary for the single top-level `itemId`. |
+| `actor` | object | No | Singular-form sugar (optional): actor claim for the single top-level `itemId`, same shape as a transition's `actor`. |
 | `requestId` | string (UUID) | No | Client-generated UUID for idempotency. Repeated calls with the same `(actor.id, requestId)` within ~10 minutes return the cached response without re-executing. Uses the first transition's `actor.id` as the idempotency key actor. |
+
+Provide **either** a `transitions` array **or** the singular `itemId` + `trigger`. If `transitions` is present, the top-level singular fields are ignored.
 
 **Transition object fields:**
 
@@ -1102,6 +1108,9 @@ All cascade types are recorded in `cascadeEvents`.
 ```json
 // Single transition
 { "transitions": [{ "itemId": "550e8400-e29b-41d4-a716-446655440001", "trigger": "start" }] }
+
+// Single transition — singular-form sugar (equivalent to the above)
+{ "itemId": "550e8400-e29b-41d4-a716-446655440001", "trigger": "start" }
 
 // Batch
 {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsTool.kt
@@ -391,10 +391,12 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
                                     "Overview operation only, default false. Global overview (no itemId): excludes " +
                                         "terminal-role roots from `items` — they are filtered at the SQL level before " +
                                         "child counts/claim summaries are fetched, and `total`/`truncated` reflect the " +
-                                        "filtered (non-terminal) root count. Scoped overview (itemId set): excludes " +
-                                        "terminal-role items from the `children` array only — the parent item is always " +
-                                        "returned regardless of its own role, and `childCounts` still reflects the full, " +
-                                        "unfiltered role breakdown."
+                                        "filtered (non-terminal) root count. Scoped (itemId) and anchored (anchorId) " +
+                                        "overviews: exclude terminal-role items from the `children`/`items` array, EXCEPT " +
+                                        "a terminal-role item that still has non-terminal descendants, which is retained " +
+                                        "(it represents active work parked under a done container). The scoped parent " +
+                                        "item is always returned regardless of its own role, and `childCounts` still " +
+                                        "reflects the full, unfiltered role breakdown."
                                 )
                             )
                         }
@@ -1177,7 +1179,18 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
             }
         // excludeTerminal filters the emitted list only — childCounts above stays unfiltered so
         // callers can still see how many terminal children exist even when they're hidden here.
-        val visibleChildren = if (excludeTerminal) children.filterNot { it.role == Role.TERMINAL } else children
+        // A terminal-role child that still holds open descendants is RETAINED (bug 18fd99a7): it
+        // represents active work parked under a done container and must not silently disappear.
+        val visibleChildren =
+            if (excludeTerminal) {
+                buildList {
+                    for (child in children) {
+                        if (child.role != Role.TERMINAL || hasOpenDescendants(child.id, context)) add(child)
+                    }
+                }
+            } else {
+                children
+            }
 
         val data =
             buildJsonObject {
@@ -1234,9 +1247,19 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
         // findChildren has no SQL-level excludeTerminal or ordering — filter and sort in memory.
         // excludeTerminal narrows the roots set itself (same layer as the global path), so
         // total/truncated below reflect the filtered count, not the raw direct-children count.
-        val visibleChildren =
-            (if (excludeTerminal) allChildren.filterNot { it.role == Role.TERMINAL } else allChildren)
-                .sortedByDescending { it.createdAt }
+        // A terminal-role child that still holds open descendants is RETAINED (bug 18fd99a7):
+        // it is a live workstream parked under a done container and must stay in the roots set.
+        val retainedChildren =
+            if (excludeTerminal) {
+                buildList {
+                    for (child in allChildren) {
+                        if (child.role != Role.TERMINAL || hasOpenDescendants(child.id, context)) add(child)
+                    }
+                }
+            } else {
+                allChildren
+            }
+        val visibleChildren = retainedChildren.sortedByDescending { it.createdAt }
         val totalChildren = visibleChildren.size
         val pagedChildren = visibleChildren.drop(offset).take(limit)
 
@@ -1387,6 +1410,29 @@ guidance + skill + maxLength per entry) — the reference target for keys-only `
             }
 
         return successResponse(data)
+    }
+
+    /**
+     * True when [itemId] has at least one non-terminal descendant (QUEUE/WORK/REVIEW/BLOCKED)
+     * anywhere in its subtree. Used by `excludeTerminal` overview filtering so a terminal-role
+     * container that still holds open work is NOT dropped from a scoped view (bug 18fd99a7):
+     * filtering on a child's own role alone hid active workstreams parked under a done container.
+     *
+     * `countInScopeByRole` is roots-inclusive, but this is only called for terminal-role items,
+     * so the item's own role lands in the TERMINAL bucket — any non-terminal bucket therefore
+     * reflects descendants only. On a count error we fail closed (treat as no open descendants)
+     * to preserve the prior filtering behavior rather than surfacing a partial view.
+     */
+    private suspend fun hasOpenDescendants(
+        itemId: java.util.UUID,
+        context: ToolExecutionContext
+    ): Boolean {
+        val counts =
+            when (val result = context.workItemRepository().countInScopeByRole(rootIds = setOf(itemId))) {
+                is Result.Success -> result.data
+                is Result.Error -> return false
+            }
+        return counts.any { (role, count) -> role != Role.TERMINAL && count > 0 }
     }
 
     /**

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -40,6 +40,10 @@ class AdvanceItemTool :
         """
 Trigger-based role transitions for WorkItems with validation, cascade detection, and unblock reporting.
 
+**Call shapes:** `transitions=[{itemId, trigger, summary?, actor?}, ...]` (batch), OR top-level
+singular sugar `itemId`+`trigger` (+ optional `summary`, `actor`) for one item — the server wraps it
+into a one-element array. If `transitions` is present the singular fields are ignored.
+
 **Trigger effects:**
 - start: QUEUE->WORK, WORK->REVIEW (or TERMINAL if no review phase in schema), REVIEW->TERMINAL
 - complete: any non-TERMINAL/BLOCKED -> TERMINAL
@@ -85,6 +89,26 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                         }
                     )
                     put(
+                        "itemId",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put(
+                                "description",
+                                JsonPrimitive(
+                                    "Singular-form sugar (UUID or hex prefix): advance one item with `trigger` instead of " +
+                                        "a `transitions` array; optional `summary`/`actor` are accepted too. See the description."
+                                )
+                            )
+                        }
+                    )
+                    put(
+                        "trigger",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("Singular-form sugar: the trigger for the single `itemId`."))
+                        }
+                    )
+                    put(
                         "requestId",
                         buildJsonObject {
                             put("type", JsonPrimitive("string"))
@@ -98,11 +122,46 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
                         }
                     )
                 },
-            required = listOf("transitions")
+            required = emptyList()
         )
 
+    /**
+     * Normalizes the singular call shape into the canonical `transitions` array (eb4b3fd5).
+     *
+     * If `transitions` is already present, params pass through unchanged. Otherwise, a top-level
+     * `itemId` is wrapped into a one-element `transitions=[{itemId, trigger?, summary?, actor?}]`,
+     * carrying the singular sugar fields; any other top-level params (e.g. `requestId`) are
+     * preserved. With neither `transitions` nor `itemId`, params pass through so downstream
+     * validation raises the (now shape-naming) missing-parameter error.
+     */
+    private fun normalizeParams(params: JsonElement): JsonElement {
+        val obj = params as? JsonObject ?: return params
+        if (obj.containsKey("transitions")) return params
+        val itemId = obj["itemId"] ?: return params
+        val sugarKeys = setOf("itemId", "trigger", "summary", "actor")
+        val singular =
+            buildJsonObject {
+                put("itemId", itemId)
+                obj["trigger"]?.let { put("trigger", it) }
+                obj["summary"]?.let { put("summary", it) }
+                obj["actor"]?.let { put("actor", it) }
+            }
+        return buildJsonObject {
+            obj.forEach { (k, v) -> if (k !in sugarKeys) put(k, v) }
+            put("transitions", JsonArray(listOf(singular)))
+        }
+    }
+
     override fun validateParams(params: JsonElement) {
-        val transitions = requireJsonArray(params, "transitions")
+        val normalized = normalizeParams(params)
+        val normalizedObj = normalized as? JsonObject
+        if (normalizedObj == null || !normalizedObj.containsKey("transitions")) {
+            throw ToolValidationException(
+                "advance_item requires either a `transitions` array or the singular `itemId` + `trigger`. " +
+                    "Example: transitions=[{\"itemId\": \"...\", \"trigger\": \"complete\"}]"
+            )
+        }
+        val transitions = requireJsonArray(normalized, "transitions")
         if (transitions.isEmpty()) {
             throw ToolValidationException("transitions array must not be empty")
         }
@@ -183,8 +242,9 @@ Trigger-based role transitions for WorkItems with validation, cascade detection,
         params: JsonElement,
         context: ToolExecutionContext
     ): JsonElement {
-        val transitions = requireJsonArray(params, "transitions")
-        val requestIdStr = optionalString(params, "requestId")
+        val normalized = normalizeParams(params)
+        val transitions = requireJsonArray(normalized, "transitions")
+        val requestIdStr = optionalString(normalized, "requestId")
         val requestId =
             requestIdStr?.let {
                 try {

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
@@ -106,7 +106,7 @@ class ToolTokenBudgetTest {
             "manage_notes" to 2057,
             "complete_tree" to 1760, // was 1712; see note above
             "query_dependencies" to 1708,
-            "advance_item" to 1450, // was 1407; see note above
+            "advance_item" to 2100, // was 1450; measured 2006 after singular itemId+trigger call-shape sugar (eb4b3fd5)
             "get_blocked_items" to 1250, // was 830; T2.3 added the `ancestorId` scope parameter
             "get_next_status" to 470,
             "manage_project_config" to 3150, // measured 2698 after get `fingerprint` param + relation (fast-forward guard, t5)

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/items/QueryItemsToolTest.kt
@@ -1083,6 +1083,40 @@ class QueryItemsToolTest {
         }
 
     @Test
+    fun `scoped overview excludeTerminal retains a terminal child that has open descendants`(): Unit =
+        runBlocking {
+            // Regression for 18fd99a7: a done-labeled container that still holds open work is a
+            // live workstream and must not vanish from a scoped excludeTerminal view.
+            val parentId = createItem("Dashboard Root")
+            val doneContainerId = createItem("Done Container", parentId = parentId, role = "terminal")
+            createItem("Open Grandchild", parentId = doneContainerId, role = "queue")
+            // A terminal child with NO open descendants stays hidden — the filter still works.
+            createItem("Fully Done", parentId = parentId, role = "terminal")
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("overview"),
+                        "itemId" to JsonPrimitive(parentId),
+                        "excludeTerminal" to JsonPrimitive(true)
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            val childTitles = data["children"]!!.jsonArray.map { it.jsonObject["title"]!!.jsonPrimitive.content }
+            assertTrue(
+                childTitles.contains("Done Container"),
+                "terminal container with open descendants must be retained (18fd99a7); got $childTitles"
+            )
+            assertFalse(
+                childTitles.contains("Fully Done"),
+                "terminal child with no open descendants must stay hidden; got $childTitles"
+            )
+        }
+
+    @Test
     fun `overview excludeTerminal omitted defaults to false and preserves current behavior`(): Unit =
         runBlocking {
             val parentId = createItem("Parent")
@@ -1805,6 +1839,43 @@ class QueryItemsToolTest {
             // excludeTerminal (unlike scoped overview, where childCounts stays unfiltered but
             // here the roots set itself is what's filtered).
             assertEquals(1, data["total"]!!.jsonPrimitive.int)
+        }
+
+    @Test
+    fun `anchored overview excludeTerminal retains a terminal child that has open descendants`(): Unit =
+        runBlocking {
+            // Regression for 18fd99a7: work-summary anchors the overview to the project root, so
+            // a terminal-role container with open descendants must survive the anchored filter too.
+            val anchorId = createItem("Project Anchor")
+            val doneContainerId = createItem("Done Container", parentId = anchorId, role = "terminal")
+            createItem("Open Grandchild", parentId = doneContainerId, role = "queue")
+            createItem("Fully Done Container", parentId = anchorId, role = "terminal")
+            createItem("Active Child", parentId = anchorId, role = "queue")
+
+            val result =
+                tool.execute(
+                    params(
+                        "operation" to JsonPrimitive("overview"),
+                        "anchorId" to JsonPrimitive(anchorId),
+                        "excludeTerminal" to JsonPrimitive(true)
+                    ),
+                    context
+                ) as JsonObject
+
+            assertTrue(result["success"]!!.jsonPrimitive.boolean)
+            val data = result["data"] as JsonObject
+            val titles = data["items"]!!.jsonArray.map { it.jsonObject["title"]!!.jsonPrimitive.content }
+            assertTrue(titles.contains("Active Child"), "non-terminal child must appear; got $titles")
+            assertTrue(
+                titles.contains("Done Container"),
+                "terminal container with open descendants must be retained (18fd99a7); got $titles"
+            )
+            assertFalse(
+                titles.contains("Fully Done Container"),
+                "terminal child with no open descendants must stay hidden; got $titles"
+            )
+            // total reflects the retained set: Active Child + Done Container.
+            assertEquals(2, data["total"]!!.jsonPrimitive.int)
         }
 
     @Test

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
@@ -901,6 +901,117 @@ class AdvanceItemToolTest {
     }
 
     // ──────────────────────────────────────────────
+    // Singular call-shape sugar (eb4b3fd5)
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `singular itemId plus trigger advances a single item`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            val item = makeItem(id = itemId, role = Role.QUEUE)
+
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+            coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+            coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+            every { depRepo.findByToItemId(itemId) } returns emptyList()
+            every { depRepo.findByFromItemId(itemId) } returns emptyList()
+
+            // Singular sugar: no transitions array, top-level itemId + trigger.
+            val params =
+                buildJsonObject {
+                    put("itemId", JsonPrimitive(itemId.toString()))
+                    put("trigger", JsonPrimitive("start"))
+                }
+            val result = tool.execute(params, context)
+
+            val results = extractResults(result)
+            assertEquals(1, results.size)
+            val r = results[0].jsonObject
+            assertTrue(r["applied"]!!.jsonPrimitive.boolean)
+            assertEquals("work", r["newRole"]!!.jsonPrimitive.content)
+            assertEquals(itemId.toString(), r["itemId"]!!.jsonPrimitive.content)
+
+            val summary = extractSummary(result)
+            assertEquals(1, summary["succeeded"]!!.jsonPrimitive.int)
+        }
+
+    @Test
+    fun `singular form carries summary through to the result`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            val item = makeItem(id = itemId, role = Role.QUEUE)
+
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+            coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+            coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+            every { depRepo.findByToItemId(itemId) } returns emptyList()
+            every { depRepo.findByFromItemId(itemId) } returns emptyList()
+
+            val params =
+                buildJsonObject {
+                    put("itemId", JsonPrimitive(itemId.toString()))
+                    put("trigger", JsonPrimitive("start"))
+                    put("summary", JsonPrimitive("Kicking off"))
+                }
+            val result = tool.execute(params, context)
+
+            val r = extractResults(result)[0].jsonObject
+            assertTrue(r["applied"]!!.jsonPrimitive.boolean)
+            assertEquals("Kicking off", r["summary"]!!.jsonPrimitive.content)
+        }
+
+    @Test
+    fun `singular itemId plus trigger passes validation`() {
+        // No exception thrown = valid.
+        tool.validateParams(
+            buildJsonObject {
+                put("itemId", JsonPrimitive(UUID.randomUUID().toString()))
+                put("trigger", JsonPrimitive("complete"))
+            }
+        )
+    }
+
+    @Test
+    fun `missing both transitions and singular itemId fails with shape-naming message`() {
+        val ex =
+            assertFailsWith<ToolValidationException> {
+                tool.validateParams(buildJsonObject { })
+            }
+        assertTrue(ex.message!!.contains("transitions"), "message should name the transitions array form")
+        assertTrue(ex.message!!.contains("itemId"), "message should name the singular itemId form")
+    }
+
+    @Test
+    fun `transitions array takes precedence over singular itemId`(): Unit =
+        runBlocking {
+            val batchId = UUID.randomUUID()
+            val ignoredId = UUID.randomUUID()
+            val item = makeItem(id = batchId, role = Role.QUEUE)
+
+            coEvery { workItemRepo.getById(batchId) } returns Result.Success(item)
+            coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+            coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+            every { depRepo.findByToItemId(any()) } returns emptyList()
+            every { depRepo.findByFromItemId(any()) } returns emptyList()
+
+            // Both shapes present: the transitions array wins; the singular itemId is ignored.
+            // getById(ignoredId) is intentionally NOT stubbed — if the singular form leaked
+            // through, the transition would fail to resolve and this assertion would break.
+            val params =
+                buildJsonObject {
+                    put("transitions", buildJsonArray { add(transitionObj(batchId, "start")) })
+                    put("itemId", JsonPrimitive(ignoredId.toString()))
+                    put("trigger", JsonPrimitive("complete"))
+                }
+            val result = tool.execute(params, context)
+
+            val results = extractResults(result)
+            assertEquals(1, results.size)
+            assertEquals(batchId.toString(), results[0].jsonObject["itemId"]!!.jsonPrimitive.content)
+            assertTrue(results[0].jsonObject["applied"]!!.jsonPrimitive.boolean)
+        }
+
+    // ──────────────────────────────────────────────
     // userSummary tests
     // ──────────────────────────────────────────────
 


### PR DESCRIPTION
Two release-hardening fixes to the MCP tool surface, bundled per the pre-release triage. The third triaged item (`63528f7f`, MCP HTTP auth) is **deferred** — its mitigation already ships (startup warnings + `MCP_HTTP_HOST`), and bearer-auth-on-`/mcp` is a separate feature.

## `eb4b3fd5` — advance_item singular-form sugar

`advance_item` required a `transitions[]` array, so every plugin skill/doc that showed the singular `itemId`+`trigger` form hit a guaranteed `Missing required parameter: transitions` failure and burned a round-trip on first use.

- Accept top-level `itemId` + `trigger` (+ optional `summary`/`actor`) as sugar for a one-element `transitions` array.
- A shared `normalizeParams()` wraps the singular form in **both** `validateParams` and `execute`.
- The batch `transitions` array is unchanged and **wins** when both shapes are supplied.
- The missing-parameter error now **names both accepted shapes**.
- Makes the existing plugin docs correct-as-written — no doc sweep needed.

## `18fd99a7` — overview `excludeTerminal` drops active work

Scoped (`itemId`) and anchored (`anchorId`) overview with `excludeTerminal=true` dropped a terminal-role container that still held **non-terminal descendants** — filtering on a child's own role alone. This hid live workstreams: a `Tech Debt` container (terminal role, 10 open children) silently vanished from `/work-summary`.

- Shared `hasOpenDescendants()` helper retains a terminal-role item when its subtree has any QUEUE/WORK/REVIEW/BLOCKED descendant.
- Applied to the scoped and anchored paths — the two `/work-summary` uses when a project rootId is known.
- **Scope note:** the global (unscoped, SQL-level) overview path has the same latent behavior and is **left for a separate follow-up** — it needs a repository/SQL change, and work-summary never hits it when a rootId is set.

## Docs + tests

- `api-reference.md` updated for both surfaces (singular sugar rows + example; `excludeTerminal` retention caveat).
- `advance_item` per-tool token-budget ceiling bumped **1450 → 2100** (measured 2006) — an intentional, documented bump for the new call-shape sugar; the aggregate payload ceiling still passes with headroom.
- Added regression tests: singular-form execute/validate/precedence (`AdvanceItemToolTest`) and terminal-container retention for scoped + anchored overview (`QueryItemsToolTest`).
- `./gradlew test` — full suite green.

Refs `eb4b3fd5`, `18fd99a7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)