### PR TITLE
fix(hooks): substance-gate retrospective dispatch; fix section-exit parser

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,22 @@ jobs:
     - name: Run tests
       run: ./gradlew :current:test --no-daemon
 
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+
+    - name: Run plugin hook tests
+      run: |
+        set -o pipefail
+        node --test "claude-plugins/task-orchestrator/hooks/tests/*.test.mjs" | tee /tmp/hook-test-output.txt
+        test_count=$(grep '^# tests ' /tmp/hook-test-output.txt | awk '{print $3}')
+        if [ -z "$test_count" ] || [ "$test_count" -lt 1 ]; then
+          echo "::error::No plugin hook tests ran (test_count=${test_count:-0}) — the test glob matched nothing. Failing so an empty glob can't go silently green."
+          exit 1
+        fi
+        echo "Ran $test_count plugin hook tests."
+
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v4
       if: always()

--- a/.taskorchestrator/config.yaml
+++ b/.taskorchestrator/config.yaml
@@ -4,6 +4,7 @@ project:
 
 retrospective:
   mode: dispatch
+  dispatchThreshold: 3
 
 work_item_schemas:
 

--- a/claude-plugins/task-orchestrator/hooks/config-sync.mjs
+++ b/claude-plugins/task-orchestrator/hooks/config-sync.mjs
@@ -17,7 +17,9 @@
 
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { createHash } from 'crypto';
+import { readSection, scalar } from './yaml-lite.mjs';
 
 const REQUEST_TIMEOUT_MS = 2000;
 
@@ -44,21 +46,10 @@ function findConfigBytes() {
 }
 
 /** Extract project.rootId from the config text (mirrors session-start.mjs's parser). */
-function parseRootId(text) {
-  let inProject = false;
-  for (const line of text.split('\n')) {
-    const trimmed = line.trim();
-    if (/^project\s*:\s*$/.test(trimmed)) {
-      inProject = true;
-      continue;
-    }
-    if (inProject && /^\S/.test(line)) inProject = false;
-    if (inProject) {
-      const m = trimmed.match(/^rootId\s*:\s*["']?([^"'#]+?)["']?\s*(#.*)?$/);
-      if (m) return m[1].trim();
-    }
-  }
-  return null;
+export function parseRootId(text) {
+  const section = readSection(text, 'project', { blockOnly: true });
+  if (!section) return null;
+  return scalar(section.lines, 'rootId');
 }
 
 function emit(line) {
@@ -186,5 +177,10 @@ async function main() {
   }
 }
 
+// Only auto-run when invoked directly as a hook (`node config-sync.mjs`), not when imported
+// (e.g. by a test importing `parseRootId` for direct unit coverage) — importing must never
+// trigger a live sync attempt as a side effect.
 // Fail-open: swallow every error so the hook always exits 0 and never blocks session start.
-main().catch(() => {});
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch(() => {});
+}

--- a/claude-plugins/task-orchestrator/hooks/enforce-actor-attribution.mjs
+++ b/claude-plugins/task-orchestrator/hooks/enforce-actor-attribution.mjs
@@ -11,6 +11,7 @@
 
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import { readSection, scalar, inlineScalar } from './yaml-lite.mjs';
 
 let input = '';
 try {
@@ -62,38 +63,14 @@ function readConfigContent() {
 function isActorAuthenticationEnabled(configContent) {
   if (!configContent) return false;
 
-  let inActorAuthSection = false;
+  const section = readSection(configContent, 'actor_authentication');
+  if (!section) return false;
 
-  for (const line of configContent.split('\n')) {
-    const trimmed = line.trim();
+  const raw = section.inline !== null
+    ? inlineScalar(section.inline, 'enabled')
+    : scalar(section.lines, 'enabled');
 
-    // Detect top-level "actor_authentication:" — check for inline form first
-    if (/^actor_authentication\s*:/.test(trimmed)) {
-      // Handle inline: `actor_authentication: { enabled: true }`
-      const inlineMatch = trimmed.match(/^actor_authentication\s*:\s*\{(.+)\}/);
-      if (inlineMatch) {
-        const inner = inlineMatch[1];
-        const enabledMatch = inner.match(/enabled\s*:\s*(\S+)/);
-        return enabledMatch ? enabledMatch[1].replace(/#.*$/, '').trim().toLowerCase() === 'true' : false;
-      }
-      inActorAuthSection = true;
-      continue;
-    }
-
-    // Any other top-level key (non-indented, non-empty) ends the actor_authentication section
-    if (inActorAuthSection && /^\S/.test(line)) {
-      inActorAuthSection = false;
-    }
-
-    if (inActorAuthSection) {
-      const match = trimmed.match(/^enabled\s*:\s*(.+)/);
-      if (match) {
-        return match[1].replace(/#.*$/, '').trim().toLowerCase() === 'true';
-      }
-    }
-  }
-
-  return false;
+  return raw !== null && raw.toLowerCase() === 'true';
 }
 
 const configContent = readConfigContent();

--- a/claude-plugins/task-orchestrator/hooks/plan-capture.mjs
+++ b/claude-plugins/task-orchestrator/hooks/plan-capture.mjs
@@ -16,6 +16,8 @@
 
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { readSection, scalar } from './yaml-lite.mjs';
 
 const REQUEST_TIMEOUT_MS = 2000;
 const MAX_SLUG_LENGTH = 64;
@@ -43,21 +45,10 @@ function findConfigText() {
 }
 
 /** Extract project.rootId from the config text (mirrors config-sync.mjs's parser). */
-function parseRootId(text) {
-  let inProject = false;
-  for (const line of text.split('\n')) {
-    const trimmed = line.trim();
-    if (/^project\s*:\s*$/.test(trimmed)) {
-      inProject = true;
-      continue;
-    }
-    if (inProject && /^\S/.test(line)) inProject = false;
-    if (inProject) {
-      const m = trimmed.match(/^rootId\s*:\s*["']?([^"'#]+?)["']?\s*(#.*)?$/);
-      if (m) return m[1].trim();
-    }
-  }
-  return null;
+export function parseRootId(text) {
+  const section = readSection(text, 'project', { blockOnly: true });
+  if (!section) return null;
+  return scalar(section.lines, 'rootId');
 }
 
 /** Derives a URL-safe slug from the plan's first H1 heading; falls back to a timestamp slug. */
@@ -149,5 +140,10 @@ async function main() {
   }
 }
 
+// Only auto-run when invoked directly as a hook (`node plan-capture.mjs`), not when imported
+// (e.g. by a test importing `parseRootId` for direct unit coverage) — importing must never
+// trigger a synchronous stdin read as a side effect.
 // Fail-open: swallow every error so the hook always exits 0 and never blocks ExitPlanMode.
-main().catch(() => {});
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch(() => {});
+}

--- a/claude-plugins/task-orchestrator/hooks/retro-ack.mjs
+++ b/claude-plugins/task-orchestrator/hooks/retro-ack.mjs
@@ -28,6 +28,7 @@ function ackMarker(path) {
     handledAt: Date.now(),
     sawTerminal: false,
     pendingRoots: [],
+    terminalCount: 0,
   });
 }
 

--- a/claude-plugins/task-orchestrator/hooks/retro-backstop.mjs
+++ b/claude-plugins/task-orchestrator/hooks/retro-backstop.mjs
@@ -4,6 +4,19 @@
 // arrived to turn it into a nudge/dispatch, this hook escalates it once the turn ends, so a run
 // that finishes on a lone terminal item (no cascade, no complete_tree) still gets surfaced.
 //
+// Always nudges, never dispatches, in ANY configured mode — it fires on the deferred
+// `sawTerminal` flag, which by construction is not a confirmed run boundary (see
+// retro-trigger.mjs's LONE_TERMINAL comment: "a single leaf finishing isn't necessarily a run
+// boundary"). Escalating that into a hard background dispatch would be the worst-case firing —
+// a single housekeeping item finishing could spawn a full retrospective agent.
+//
+// When there is no identifiable root (pendingRoots empty), this emits a nudge with NO UUID
+// argument rather than falling back to the project anchor — a supplied root UUID is treated as
+// authoritative scope by /session-retrospective (see SKILL.md), so falling back to the whole
+// project root would force the most expensive possible scope for what may be a single
+// unrelated item. An unscoped nudge instead lets the skill's own fallback scan apply, which is
+// narrower (rootId-scoped, discards items older than 24h).
+//
 // Fail-open by design: any read/parse error, missing config, or unrecognized marker state
 // results in a silent `{}` on stdout and exit 0 — this hook must never block termination.
 //
@@ -15,14 +28,12 @@
 import { readFileSync } from 'fs';
 import {
   findConfigContent,
-  parseRetrospectiveMode,
+  parseRetrospectiveConfig,
   parseProjectRootId,
   markerPath,
   readMarker,
   writeMarker,
-  COOLDOWN_MS,
   buildNudge,
-  buildDispatch,
 } from './retro-lib.mjs';
 
 function emitEmpty() {
@@ -55,8 +66,10 @@ try {
   const sessionId = hookInput.session_id;
 
   const configContent = findConfigContent();
-  const mode = parseRetrospectiveMode(configContent);
-  if (mode === 'off') emitEmpty();
+  const config = parseRetrospectiveConfig(configContent);
+  if (config.mode === 'off') emitEmpty();
+
+  const cooldownMs = config.cooldownMinutes * 60 * 1000;
 
   const rootId = parseProjectRootId(configContent);
   const key = rootId || sessionId || 'unknown';
@@ -66,21 +79,22 @@ try {
 
   if (!marker.sawTerminal) emitEmpty();
 
-  if (marker.handledAt && (now - marker.handledAt <= COOLDOWN_MS)) emitEmpty();
+  if (marker.handledAt && (now - marker.handledAt <= cooldownMs)) emitEmpty();
 
-  const roots = (marker.pendingRoots && marker.pendingRoots.length)
-    ? marker.pendingRoots
-    : (rootId ? [rootId] : []);
+  // No project-anchor fallback here — see the header comment. An empty pendingRoots list
+  // renders as a bare `/session-retrospective` with no UUID argument (buildNudge in
+  // retro-lib.mjs handles the empty-list case cleanly).
+  const roots = (marker.pendingRoots && marker.pendingRoots.length) ? marker.pendingRoots : [];
 
   writeMarker(path, {
     ...marker,
     handledAt: now,
     sawTerminal: false,
     pendingRoots: [],
+    terminalCount: 0,
   });
 
-  const text = mode === 'dispatch' ? buildDispatch(roots, rootId) : buildNudge(roots);
-  emitBlock(text);
+  emitBlock(buildNudge(roots));
 } catch {
   emitEmpty();
 }

--- a/claude-plugins/task-orchestrator/hooks/retro-lib.mjs
+++ b/claude-plugins/task-orchestrator/hooks/retro-lib.mjs
@@ -4,6 +4,7 @@
 import { readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { resolve, join, dirname } from 'path';
 import os from 'os';
+import { readSection, scalar, inlineScalar } from './yaml-lite.mjs';
 
 // Locate and read .taskorchestrator/config.yaml — check AGENT_CONFIG_DIR, then walk up from
 // cwd. Handles worktrees where cwd is nested under .claude/worktrees/<name>/.
@@ -30,79 +31,64 @@ export function findConfigContent() {
 }
 
 const VALID_MODES = ['nudge', 'dispatch', 'off'];
+const DEFAULT_MODE = 'nudge';
+const DEFAULT_DISPATCH_THRESHOLD = 3;
+const DEFAULT_COOLDOWN_MINUTES = 30;
 
 // Parses the top-level `retrospective:` block:
 //   retrospective:
 //     mode: dispatch
-// Also supports the inline form `retrospective: { mode: dispatch }`. Strips quotes and
-// trailing `#` comments. Returns 'nudge' | 'dispatch' | 'off' — defaults to 'nudge' when the
-// file, block, or key is absent, or the value is unrecognized.
-export function parseRetrospectiveMode(configContent) {
-  if (!configContent) return 'nudge';
+//     dispatchThreshold: 3
+//     cooldownMinutes: 30
+// Also supports the inline form `retrospective: { mode: dispatch }`. Absent keys, an absent
+// block, or an unrecognized/invalid value all fall back to the documented default for that key
+// — this never throws. Returns `{ mode, dispatchThreshold, cooldownMinutes }`.
+export function parseRetrospectiveConfig(configContent) {
+  const result = {
+    mode: DEFAULT_MODE,
+    dispatchThreshold: DEFAULT_DISPATCH_THRESHOLD,
+    cooldownMinutes: DEFAULT_COOLDOWN_MINUTES,
+  };
+  if (!configContent) return result;
 
-  let inSection = false;
+  const section = readSection(configContent, 'retrospective');
+  if (!section) return result;
 
-  for (const line of configContent.split('\n')) {
-    const trimmed = line.trim();
+  const read = (key) => (section.inline !== null ? inlineScalar(section.inline, key) : scalar(section.lines, key));
 
-    if (/^retrospective\s*:/.test(trimmed)) {
-      const inlineMatch = trimmed.match(/^retrospective\s*:\s*\{(.+)\}/);
-      if (inlineMatch) {
-        const modeMatch = inlineMatch[1].match(/mode\s*:\s*([^,}]+)/);
-        if (modeMatch) {
-          const val = modeMatch[1].replace(/#.*$/, '').trim().replace(/^["']|["']$/g, '').toLowerCase();
-          return VALID_MODES.includes(val) ? val : 'nudge';
-        }
-        return 'nudge';
-      }
-      inSection = true;
-      continue;
-    }
-
-    if (inSection && /^\S/.test(line)) {
-      inSection = false;
-    }
-
-    if (inSection) {
-      const match = trimmed.match(/^mode\s*:\s*(.+)/);
-      if (match) {
-        const val = match[1].replace(/#.*$/, '').trim().replace(/^["']|["']$/g, '').toLowerCase();
-        return VALID_MODES.includes(val) ? val : 'nudge';
-      }
-    }
+  const rawMode = read('mode');
+  if (rawMode !== null) {
+    const val = rawMode.toLowerCase();
+    if (VALID_MODES.includes(val)) result.mode = val;
   }
 
-  return 'nudge';
+  const rawThreshold = read('dispatchThreshold');
+  if (rawThreshold !== null) {
+    const n = Number(rawThreshold);
+    if (Number.isInteger(n) && n >= 0) result.dispatchThreshold = n;
+  }
+
+  const rawCooldown = read('cooldownMinutes');
+  if (rawCooldown !== null) {
+    const n = Number(rawCooldown);
+    if (Number.isFinite(n) && n > 0) result.cooldownMinutes = n;
+  }
+
+  return result;
+}
+
+// Thin wrapper for any caller that only wants the mode.
+export function parseRetrospectiveMode(configContent) {
+  return parseRetrospectiveConfig(configContent).mode;
 }
 
 // Parses the top-level `project:` block for its `rootId` value. Mirrors parseProjectBlock in
 // session-start.mjs, but returns only the rootId string (or null).
 export function parseProjectRootId(configContent) {
   if (!configContent) return null;
-
-  let inProjectSection = false;
-
-  for (const line of configContent.split('\n')) {
-    const trimmed = line.trim();
-
-    if (/^project\s*:\s*$/.test(trimmed)) {
-      inProjectSection = true;
-      continue;
-    }
-
-    if (inProjectSection && /^\S/.test(line)) {
-      inProjectSection = false;
-    }
-
-    if (inProjectSection) {
-      const rootIdMatch = trimmed.match(/^rootId\s*:\s*["']?([^"'#]+?)["']?\s*(#.*)?$/);
-      if (rootIdMatch) {
-        return rootIdMatch[1].trim();
-      }
-    }
-  }
-
-  return null;
+  const section = readSection(configContent, 'project', { blockOnly: true });
+  if (!section) return null;
+  return scalar(section.lines, 'rootId');
 }
 
 export function markerPath(key) {
@@ -126,7 +112,10 @@ export function writeMarker(path, obj) {
   }
 }
 
-export const COOLDOWN_MS = 30 * 60 * 1000;
+// Default cooldown, in ms — overridden per-config by `retrospective.cooldownMinutes` (see
+// parseRetrospectiveConfig). Kept as an export so callers still have a concrete fallback
+// constant available without re-deriving it from DEFAULT_COOLDOWN_MINUTES themselves.
+export const COOLDOWN_MS = DEFAULT_COOLDOWN_MINUTES * 60 * 1000;
 
 // Extracts the tool's JSON payload from a PostToolUse hook's tool_response field. The exact
 // delivered shape is not pinned down by the hooks docs for MCP tools, so this is deliberately
@@ -172,8 +161,14 @@ export function debugCapture(raw) {
 }
 
 export function buildNudge(roots) {
-  const ids = (roots || []).join(', ');
-  const first = (roots || [])[0] || '';
+  const list = (roots || []).filter(Boolean);
+  if (list.length === 0) {
+    return `Retrospective suggested — an implementation run reached terminal. ` +
+      `Consider running \`/session-retrospective\` to capture learnings before the session ends. ` +
+      `Skip if the feature still has items in progress, or if this was minor housekeeping.`;
+  }
+  const ids = list.join(', ');
+  const first = list[0];
   return `Retrospective suggested — an implementation run reached terminal (root(s): ${ids}). ` +
     `Consider running \`/session-retrospective ${first}\` to capture learnings before the session ends. ` +
     `Skip if the feature still has items in progress, or if this was minor housekeeping.`;

--- a/claude-plugins/task-orchestrator/hooks/retro-trigger.mjs
+++ b/claude-plugins/task-orchestrator/hooks/retro-trigger.mjs
@@ -1,26 +1,34 @@
 #!/usr/bin/env node
 // PostToolUse hook — detects when an implementation run reaches terminal, via advance_item
 // (direct transition or cascade) or complete_tree, and surfaces a retrospective nudge or a
-// hard dispatch directive, per the `retrospective.mode` config in .taskorchestrator/config.yaml.
+// hard dispatch directive, per the `retrospective` config in .taskorchestrator/config.yaml.
 //
 // Fail-open by design: any read/parse error, missing config, unparseable tool_response, or
 // unrecognized tool shape results in a silent `{}` on stdout and exit 0 — this hook must never
 // block a tool call.
+//
+// Substance gate: in `mode: dispatch`, a hard background dispatch only fires once the count of
+// items that reached terminal SINCE THE LAST retrospective directive (nudge or dispatch) clears
+// `dispatchThreshold` (default 3) — tracked in marker.terminalCount, accumulated across
+// LONE_TERMINAL calls and reset to 0 whenever any directive fires. Below threshold still emits
+// a nudge, never silence: nothing goes unreported, only the automatic background spawn is
+// reserved for substantial runs.
 
 import { readFileSync } from 'fs';
 import {
   findConfigContent,
-  parseRetrospectiveMode,
+  parseRetrospectiveConfig,
   parseProjectRootId,
   markerPath,
   readMarker,
   writeMarker,
-  COOLDOWN_MS,
   extractResponseJson,
   debugCapture,
   buildNudge,
   buildDispatch,
 } from './retro-lib.mjs';
+
+const MAX_ROOT_UUIDS = 50;
 
 function emitEmpty() {
   process.stdout.write('{}');
@@ -32,6 +40,13 @@ function emitContext(text) {
     hookSpecificOutput: { hookEventName: 'PostToolUse', additionalContext: text },
   }));
   process.exit(0);
+}
+
+// Keep only the most recent MAX_ROOT_UUIDS entries so the marker file can't grow unbounded
+// across a long-running session. `ids` comes from a Set spread, so insertion order (oldest
+// first) is preserved — slicing off the tail keeps the newest ones.
+function capRootUuids(ids) {
+  return ids.length > MAX_ROOT_UUIDS ? ids.slice(ids.length - MAX_ROOT_UUIDS) : ids;
 }
 
 try {
@@ -57,8 +72,10 @@ try {
   const toolResponse = hookInput.tool_response;
 
   const configContent = findConfigContent();
-  const mode = parseRetrospectiveMode(configContent);
-  if (mode === 'off') emitEmpty();
+  const config = parseRetrospectiveConfig(configContent);
+  if (config.mode === 'off') emitEmpty();
+
+  const cooldownMs = config.cooldownMinutes * 60 * 1000;
 
   const rootId = parseProjectRootId(configContent);
   const key = rootId || sessionId || 'unknown';
@@ -73,6 +90,7 @@ try {
   // and wait — a single leaf finishing isn't necessarily a run boundary), or neither.
   let kind = null;
   let roots = [];
+  let thisCallTerminalCount = 0;
 
   if (toolName.endsWith('complete_tree')) {
     const completed = resp?.summary?.completed;
@@ -83,11 +101,13 @@ try {
       if (ctRoots.length === 0) {
         // completed>0 but no identifiable root — don't emit a directive with an empty root
         // list (broken text). Record it like a lone-terminal signal so the Stop backstop can
-        // still catch it via its own rootId fallback.
+        // still catch it via its own pendingRoots/rootId fallback. Still counts toward
+        // substance so a later identifiable completion isn't under-counted.
         writeMarker(path, {
           ...marker,
           sawTerminal: true,
           lastTerminalAt: now,
+          terminalCount: (marker.terminalCount || 0) + completed,
           sessionId,
           rootId,
         });
@@ -95,6 +115,7 @@ try {
       }
       kind = 'PARENT_COMPLETION';
       roots = ctRoots;
+      thisCallTerminalCount = completed;
     }
   } else if (toolName.endsWith('advance_item')) {
     const results = Array.isArray(resp?.results) ? resp.results : [];
@@ -116,9 +137,20 @@ try {
       .filter(r => r.newRole === 'terminal' && !(Array.isArray(r.unblockedItems) && r.unblockedItems.length > 0))
       .map(r => r.itemId);
 
+    // Direct terminal results in this same batched call, regardless of unblockedItems — used
+    // only for substance counting below, never for `roots` (which stays scoped to cascade
+    // parents so the dispatch/nudge text's "what completed" scope is unchanged).
+    const directTerminals = results
+      .filter(r => r.newRole === 'terminal')
+      .map(r => r.itemId);
+
     if (cascadeTerminals.length) {
       kind = 'PARENT_COMPLETION';
-      roots = cascadeTerminals;
+      roots = [...new Set(cascadeTerminals)];
+      // Substance count: distinct itemIds reaching terminal in this call — the union of cascade
+      // terminals and any direct newRole === 'terminal' results in the same batch (e.g. several
+      // children going terminal plus one cascaded parent all count toward substance).
+      thisCallTerminalCount = new Set([...cascadeTerminals, ...directTerminals]).size;
     } else if (loneTerminalCandidates.length) {
       kind = 'LONE_TERMINAL';
       roots = loneTerminalCandidates;
@@ -129,34 +161,44 @@ try {
 
   if (kind === 'PARENT_COMPLETION') {
     const existingRoots = marker.rootUuids || [];
+    // Deliberately NOT removing this bypass: triggers are event-driven with no retry, so
+    // without it a second feature tree completing inside the cooldown window of the first
+    // would get no retrospective at all, not merely a late one. config-format.md promises one
+    // retrospective per run, not per time window.
     const newRun =
       !marker.handledAt ||
-      (now - marker.handledAt > COOLDOWN_MS) ||
+      (now - marker.handledAt > cooldownMs) ||
       roots.some(r => !existingRoots.includes(r));
 
     if (!newRun) emitEmpty();
 
+    const substance = (marker.terminalCount || 0) + thisCallTerminalCount;
+
     writeMarker(path, {
       ...marker,
       handledAt: now,
-      rootUuids: [...new Set([...existingRoots, ...roots])],
+      rootUuids: capRootUuids([...new Set([...existingRoots, ...roots])]),
       sawTerminal: false,
       pendingRoots: [],
+      terminalCount: 0,
       sessionId,
       rootId,
     });
 
-    const text = mode === 'dispatch' ? buildDispatch(roots, rootId) : buildNudge(roots);
+    const text = (config.mode === 'dispatch' && substance >= config.dispatchThreshold)
+      ? buildDispatch(roots, rootId)
+      : buildNudge(roots);
     emitContext(text);
   }
 
   // LONE_TERMINAL — record it so a subsequent cascade/parent completion in this run is
-  // recognized, but don't nudge/dispatch yet.
+  // recognized, but don't nudge/dispatch yet. Accumulates toward the substance gate.
   writeMarker(path, {
     ...marker,
     sawTerminal: true,
     lastTerminalAt: now,
     pendingRoots: [...new Set([...(marker.pendingRoots || []), ...roots])],
+    terminalCount: (marker.terminalCount || 0) + roots.length,
     sessionId,
     rootId,
   });

--- a/claude-plugins/task-orchestrator/hooks/session-start.mjs
+++ b/claude-plugins/task-orchestrator/hooks/session-start.mjs
@@ -4,6 +4,7 @@
 
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import { readSection, scalar } from './yaml-lite.mjs';
 
 // Locate config.yaml — check AGENT_CONFIG_DIR, then walk up from cwd to find
 // the project root containing .taskorchestrator/. This handles worktrees where
@@ -39,36 +40,11 @@ function findConfigPath() {
 function parseProjectBlock(configContent) {
   if (!configContent) return null;
 
-  let inProjectSection = false;
-  let rootId = null;
-  let name = null;
+  const section = readSection(configContent, 'project', { blockOnly: true });
+  if (!section) return null;
 
-  for (const line of configContent.split('\n')) {
-    const trimmed = line.trim();
-
-    if (/^project\s*:\s*$/.test(trimmed)) {
-      inProjectSection = true;
-      continue;
-    }
-
-    // Any other top-level (non-indented, non-empty) line ends the section.
-    if (inProjectSection && /^\S/.test(line)) {
-      inProjectSection = false;
-    }
-
-    if (inProjectSection) {
-      const rootIdMatch = trimmed.match(/^rootId\s*:\s*["']?([^"'#]+?)["']?\s*(#.*)?$/);
-      if (rootIdMatch) {
-        rootId = rootIdMatch[1].trim();
-        continue;
-      }
-      const nameMatch = trimmed.match(/^name\s*:\s*["']?([^"'#]+?)["']?\s*(#.*)?$/);
-      if (nameMatch) {
-        name = nameMatch[1].trim();
-        continue;
-      }
-    }
-  }
+  const rootId = scalar(section.lines, 'rootId');
+  const name = scalar(section.lines, 'name');
 
   if (!rootId) return null;
   return { rootId, name };

--- a/claude-plugins/task-orchestrator/hooks/tests/config-sync.test.mjs
+++ b/claude-plugins/task-orchestrator/hooks/tests/config-sync.test.mjs
@@ -1,0 +1,32 @@
+// Direct unit coverage for config-sync.mjs's parseRootId — previously only inferable through
+// session-start.mjs's subprocess tests (the two parsers are textually identical). Importing the
+// module must NOT trigger a live config sync as a side effect — config-sync.mjs guards its
+// `main()` invocation behind an entrypoint check (`process.argv[1] === this file`) specifically
+// so importing `parseRootId` here stays side-effect free.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseRootId } from '../config-sync.mjs';
+
+test('parseRootId: resolves rootId from a project: block', () => {
+  const content = 'project:\n  rootId: "abc-123"\n  name: "X"\n';
+  assert.equal(parseRootId(content), 'abc-123');
+});
+
+test('parseRootId: tolerates a column-0 comment above rootId', () => {
+  const content = [
+    'project:',
+    '# a stray column-0 comment sitting right above rootId',
+    '  rootId: "root-comment-check"',
+  ].join('\n');
+  assert.equal(parseRootId(content), 'root-comment-check');
+});
+
+test('parseRootId: null when project: block is absent', () => {
+  assert.equal(parseRootId('retrospective:\n  mode: nudge\n'), null);
+  assert.equal(parseRootId(null), null);
+});
+
+test('parseRootId: block-only — ignores an inline project: { ... } form', () => {
+  assert.equal(parseRootId('project: { rootId: abc }\n'), null);
+});

--- a/claude-plugins/task-orchestrator/hooks/tests/enforce-actor-attribution.test.mjs
+++ b/claude-plugins/task-orchestrator/hooks/tests/enforce-actor-attribution.test.mjs
@@ -1,0 +1,150 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const HOOK = fileURLToPath(new URL('../enforce-actor-attribution.mjs', import.meta.url));
+
+function writeConfig(dir, content) {
+  const cfgDir = join(dir, '.taskorchestrator');
+  mkdirSync(cfgDir, { recursive: true });
+  writeFileSync(join(cfgDir, 'config.yaml'), content, 'utf-8');
+}
+
+function runHook(dir, payload) {
+  return spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify(payload),
+    env: { ...process.env, AGENT_CONFIG_DIR: dir },
+    encoding: 'utf-8',
+    cwd: dir, // avoid the cwd-walk fallback finding this repo's real config.yaml
+  });
+}
+
+function tmpConfigDir() {
+  return mkdtempSync(join(tmpdir(), 'to-actor-attr-'));
+}
+
+test('actor_authentication absent -> allowed, silent exit 0', () => {
+  const dir = tmpConfigDir();
+  try {
+    writeConfig(dir, 'retrospective:\n  mode: nudge\n');
+    const res = runHook(dir, {
+      tool_name: 'mcp__mcp-task-orchestrator__advance_item',
+      tool_input: { transitions: [{ itemId: 'x', trigger: 'start' }] },
+    });
+    assert.equal(res.status, 0);
+    assert.equal(res.stdout, '');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('actor_authentication enabled, missing actor on advance_item -> denies', () => {
+  const dir = tmpConfigDir();
+  try {
+    writeConfig(dir, 'actor_authentication:\n  enabled: true\n');
+    const res = runHook(dir, {
+      tool_name: 'mcp__mcp-task-orchestrator__advance_item',
+      tool_input: { transitions: [{ itemId: 'x', trigger: 'start' }] },
+    });
+    assert.equal(res.status, 0);
+    const out = JSON.parse(res.stdout);
+    assert.equal(out.hookSpecificOutput.permissionDecision, 'deny');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('actor_authentication enabled, actor present -> allowed, silent exit 0', () => {
+  const dir = tmpConfigDir();
+  try {
+    writeConfig(dir, 'actor_authentication:\n  enabled: true\n');
+    const res = runHook(dir, {
+      tool_name: 'mcp__mcp-task-orchestrator__advance_item',
+      tool_input: { transitions: [{ itemId: 'x', trigger: 'start', actor: { id: 'a', kind: 'orchestrator' } }] },
+    });
+    assert.equal(res.status, 0);
+    assert.equal(res.stdout, '');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('actor_authentication enabled via inline {} form, missing actor on manage_notes upsert -> denies', () => {
+  const dir = tmpConfigDir();
+  try {
+    writeConfig(dir, 'actor_authentication: { enabled: true }\n');
+    const res = runHook(dir, {
+      tool_name: 'mcp__mcp-task-orchestrator__manage_notes',
+      tool_input: { operation: 'upsert', notes: [{ itemId: 'x', key: 'session-tracking', body: 'hi' }] },
+    });
+    assert.equal(res.status, 0);
+    const out = JSON.parse(res.stdout);
+    assert.equal(out.hookSpecificOutput.permissionDecision, 'deny');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('manage_notes with operation other than upsert is never enforced', () => {
+  const dir = tmpConfigDir();
+  try {
+    writeConfig(dir, 'actor_authentication:\n  enabled: true\n');
+    const res = runHook(dir, {
+      tool_name: 'mcp__mcp-task-orchestrator__manage_notes',
+      tool_input: { operation: 'delete', notes: [{ itemId: 'x', key: 'session-tracking' }] },
+    });
+    assert.equal(res.status, 0);
+    assert.equal(res.stdout, '');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('column-0 comment above enabled: true still resolves as enabled (parser bug fix)', () => {
+  const dir = tmpConfigDir();
+  try {
+    writeConfig(dir, [
+      'actor_authentication:',
+      '# a stray column-0 comment documenting enabled',
+      '  enabled: true',
+      '',
+    ].join('\n'));
+    const res = runHook(dir, {
+      tool_name: 'mcp__mcp-task-orchestrator__advance_item',
+      tool_input: { transitions: [{ itemId: 'x', trigger: 'start' }] },
+    });
+    assert.equal(res.status, 0);
+    const out = JSON.parse(res.stdout);
+    assert.equal(out.hookSpecificOutput.permissionDecision, 'deny');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('actor_authentication enabled via inline {} form with a trailing comment still enforces (fix M2)', () => {
+  const dir = tmpConfigDir();
+  try {
+    // The unsafe-direction M2 regression: an anchored inline regex fails this line entirely,
+    // readSection returns null, and enforcement goes silently OFF. It must still deny here.
+    writeConfig(dir, 'actor_authentication: { enabled: true } # trailing\n');
+    const res = runHook(dir, {
+      tool_name: 'mcp__mcp-task-orchestrator__advance_item',
+      tool_input: { transitions: [{ itemId: 'x', trigger: 'start' }] },
+    });
+    assert.equal(res.status, 0);
+    const out = JSON.parse(res.stdout);
+    assert.equal(out.hookSpecificOutput.permissionDecision, 'deny');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('fail-open: malformed stdin -> silent exit 0', () => {
+  const res = spawnSync(process.execPath, [HOOK], { input: '{not json', encoding: 'utf-8' });
+  assert.equal(res.status, 0);
+  assert.equal(res.stdout, '');
+});

--- a/claude-plugins/task-orchestrator/hooks/tests/plan-capture.test.mjs
+++ b/claude-plugins/task-orchestrator/hooks/tests/plan-capture.test.mjs
@@ -1,0 +1,32 @@
+// Direct unit coverage for plan-capture.mjs's parseRootId — previously only inferable through
+// session-start.mjs's subprocess tests (the two parsers are textually identical). Importing the
+// module must NOT trigger a synchronous stdin read as a side effect — plan-capture.mjs guards
+// its `main()` invocation behind an entrypoint check (`process.argv[1] === this file`)
+// specifically so importing `parseRootId` here stays side-effect free.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseRootId } from '../plan-capture.mjs';
+
+test('parseRootId: resolves rootId from a project: block', () => {
+  const content = 'project:\n  rootId: "abc-123"\n  name: "X"\n';
+  assert.equal(parseRootId(content), 'abc-123');
+});
+
+test('parseRootId: tolerates a column-0 comment above rootId', () => {
+  const content = [
+    'project:',
+    '# a stray column-0 comment sitting right above rootId',
+    '  rootId: "root-comment-check"',
+  ].join('\n');
+  assert.equal(parseRootId(content), 'root-comment-check');
+});
+
+test('parseRootId: null when project: block is absent', () => {
+  assert.equal(parseRootId('retrospective:\n  mode: nudge\n'), null);
+  assert.equal(parseRootId(null), null);
+});
+
+test('parseRootId: block-only — ignores an inline project: { ... } form', () => {
+  assert.equal(parseRootId('project: { rootId: abc }\n'), null);
+});

--- a/claude-plugins/task-orchestrator/hooks/tests/retro-ack.test.mjs
+++ b/claude-plugins/task-orchestrator/hooks/tests/retro-ack.test.mjs
@@ -1,0 +1,81 @@
+// Drives retro-ack.mjs as a subprocess. Marker isolation: retro-ack has no session_id to key
+// off of — with a `project:` block configured it acks exactly that rootId's marker; WITHOUT one
+// it acks every marker file in the shared directory (see retro-ack.mjs's module doc), which
+// would be unsafe to exercise here (it could ack a concurrently-running test's marker, or the
+// live marker for this repo's real root). So every test below configures a randomly-generated
+// fixture project rootId, keeping this hook's tests isolated the same way retro-backstop.test.mjs
+// isolates its rootId-keyed test — never exercising the ack-everything fallback path.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { markerPath, writeMarker, readMarker } from '../retro-lib.mjs';
+
+const HOOK = fileURLToPath(new URL('../retro-ack.mjs', import.meta.url));
+
+function writeConfig(dir, content) {
+  const cfgDir = join(dir, '.taskorchestrator');
+  mkdirSync(cfgDir, { recursive: true });
+  writeFileSync(join(cfgDir, 'config.yaml'), content, 'utf-8');
+}
+
+function runHook(agentConfigDir) {
+  return spawnSync(process.execPath, [HOOK], {
+    env: { ...process.env, AGENT_CONFIG_DIR: agentConfigDir },
+    encoding: 'utf-8',
+  });
+}
+
+function tmpConfigDir() {
+  return mkdtempSync(join(tmpdir(), 'to-retro-ack-'));
+}
+
+test('ackMarker resets terminalCount to 0 (fix H1), alongside sawTerminal/pendingRoots/handledAt', () => {
+  const dir = tmpConfigDir();
+  const rootId = `project-root-${randomUUID()}`;
+  writeConfig(dir, `project:\n  rootId: "${rootId}"\n`);
+  const marker = markerPath(rootId);
+  try {
+    writeMarker(marker, {
+      sawTerminal: true,
+      pendingRoots: ['root-1'],
+      terminalCount: 7,
+      rootUuids: ['root-1'],
+    });
+    const res = runHook(dir);
+    assert.equal(res.status, 0);
+    const after = readMarker(marker);
+    assert.equal(after.terminalCount, 0);
+    assert.equal(after.sawTerminal, false);
+    assert.deepEqual(after.pendingRoots, []);
+    assert.ok(typeof after.handledAt === 'number');
+    // rootUuids is untouched by ack — only substance/handled state resets.
+    assert.deepEqual(after.rootUuids, ['root-1']);
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ackMarker on an already-empty marker still resets terminalCount to 0, not undefined', () => {
+  const dir = tmpConfigDir();
+  const rootId = `project-root-${randomUUID()}`;
+  writeConfig(dir, `project:\n  rootId: "${rootId}"\n`);
+  const marker = markerPath(rootId);
+  try {
+    // No pre-existing marker file at all — readMarker() returns {} and ackMarker must still
+    // write a well-formed terminalCount: 0, not leave it absent/undefined.
+    const res = runHook(dir);
+    assert.equal(res.status, 0);
+    const after = readMarker(marker);
+    assert.equal(after.terminalCount, 0);
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/claude-plugins/task-orchestrator/hooks/tests/retro-backstop.test.mjs
+++ b/claude-plugins/task-orchestrator/hooks/tests/retro-backstop.test.mjs
@@ -1,0 +1,126 @@
+// Drives retro-backstop.mjs as a subprocess. Marker isolation: every test uses a randomly
+// generated fixture key (session_id, or a fixture project rootId when testing the rootId-keyed
+// path) with a dedicated temp config directory, so the shared marker file at
+// os.tmpdir()/task-orchestrator/retro-<key>.json is never the live marker for a real project.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { markerPath, writeMarker } from '../retro-lib.mjs';
+
+const HOOK = fileURLToPath(new URL('../retro-backstop.mjs', import.meta.url));
+
+function writeConfig(dir, content) {
+  const cfgDir = join(dir, '.taskorchestrator');
+  mkdirSync(cfgDir, { recursive: true });
+  writeFileSync(join(cfgDir, 'config.yaml'), content, 'utf-8');
+}
+
+function spawnHook(agentConfigDir, payload) {
+  return spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify(payload),
+    env: { ...process.env, AGENT_CONFIG_DIR: agentConfigDir },
+    encoding: 'utf-8',
+  });
+}
+
+function tmpConfigDir() {
+  return mkdtempSync(join(tmpdir(), 'to-retro-backstop-'));
+}
+
+test('never emits dispatch text, even in mode: dispatch', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, 'retrospective:\n  mode: dispatch\n');
+  const sessionId = `test-backstop-nudgeonly-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    writeMarker(marker, { sawTerminal: true, pendingRoots: ['root-1'] });
+    const res = spawnHook(dir, { session_id: sessionId });
+    assert.equal(res.status, 0);
+    const out = JSON.parse(res.stdout);
+    assert.equal(out.decision, 'block');
+    assert.ok(out.reason.includes('Retrospective suggested'));
+    assert.ok(!out.reason.includes('Retrospective dispatch'));
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('empty pendingRoots emits no project-anchor UUID, even with a project rootId configured', () => {
+  const dir = tmpConfigDir();
+  const rootId = `project-root-${randomUUID()}`;
+  writeConfig(dir, `project:\n  rootId: "${rootId}"\n\nretrospective:\n  mode: dispatch\n`);
+  const marker = markerPath(rootId); // key = rootId when a project rootId is configured
+  try {
+    writeMarker(marker, { sawTerminal: true, pendingRoots: [] });
+    const res = spawnHook(dir, { session_id: `test-backstop-emptyroots-${randomUUID()}` });
+    assert.equal(res.status, 0);
+    const out = JSON.parse(res.stdout);
+    assert.equal(out.decision, 'block');
+    assert.ok(!out.reason.includes(rootId), out.reason);
+    assert.ok(!out.reason.includes('root(s):'), out.reason);
+    assert.ok(out.reason.includes('`/session-retrospective`'), out.reason);
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('stop_hook_active short-circuits to {} regardless of marker state', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, 'retrospective:\n  mode: dispatch\n');
+  const sessionId = `test-backstop-loopguard-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    writeMarker(marker, { sawTerminal: true, pendingRoots: ['root-1'] });
+    const res = spawnHook(dir, { session_id: sessionId, stop_hook_active: true });
+    assert.equal(res.status, 0);
+    assert.equal(res.stdout.trim(), '{}');
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('sawTerminal falsy -> {} (nothing to escalate)', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, 'retrospective:\n  mode: dispatch\n');
+  const sessionId = `test-backstop-nothing-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    const res = spawnHook(dir, { session_id: sessionId });
+    assert.equal(res.status, 0);
+    assert.equal(res.stdout.trim(), '{}');
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('within cooldown -> {} (already handled recently)', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, 'retrospective:\n  mode: dispatch\n  cooldownMinutes: 30\n');
+  const sessionId = `test-backstop-cooldown-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    writeMarker(marker, { sawTerminal: true, pendingRoots: ['root-1'], handledAt: Date.now() });
+    const res = spawnHook(dir, { session_id: sessionId });
+    assert.equal(res.status, 0);
+    assert.equal(res.stdout.trim(), '{}');
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('fail-open: malformed stdin yields {} and exit 0', () => {
+  const res = spawnSync(process.execPath, [HOOK], { input: '{not valid json', encoding: 'utf-8' });
+  assert.equal(res.status, 0);
+  assert.equal(res.stdout.trim(), '{}');
+});

--- a/claude-plugins/task-orchestrator/hooks/tests/retro-config.test.mjs
+++ b/claude-plugins/task-orchestrator/hooks/tests/retro-config.test.mjs
@@ -1,0 +1,129 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseRetrospectiveConfig,
+  parseRetrospectiveMode,
+  parseProjectRootId,
+  buildNudge,
+  buildDispatch,
+  COOLDOWN_MS,
+} from '../retro-lib.mjs';
+
+test('parseRetrospectiveConfig: defaults when config content is absent', () => {
+  assert.deepEqual(parseRetrospectiveConfig(null), { mode: 'nudge', dispatchThreshold: 3, cooldownMinutes: 30 });
+  assert.deepEqual(parseRetrospectiveConfig(''), { mode: 'nudge', dispatchThreshold: 3, cooldownMinutes: 30 });
+});
+
+test('parseRetrospectiveConfig: defaults when the retrospective: block is absent', () => {
+  const cfg = parseRetrospectiveConfig('work_item_schemas:\n  foo: bar\n');
+  assert.deepEqual(cfg, { mode: 'nudge', dispatchThreshold: 3, cooldownMinutes: 30 });
+});
+
+test('parseRetrospectiveConfig: reads all three keys from a block', () => {
+  const content = [
+    'retrospective:',
+    '  mode: dispatch',
+    '  dispatchThreshold: 5',
+    '  cooldownMinutes: 10',
+  ].join('\n');
+  assert.deepEqual(parseRetrospectiveConfig(content), { mode: 'dispatch', dispatchThreshold: 5, cooldownMinutes: 10 });
+});
+
+test('parseRetrospectiveConfig: invalid dispatchThreshold falls back to the default of 3', () => {
+  assert.equal(
+    parseRetrospectiveConfig('retrospective:\n  dispatchThreshold: not-a-number\n').dispatchThreshold,
+    3,
+  );
+  assert.equal(parseRetrospectiveConfig('retrospective:\n  dispatchThreshold: -1\n').dispatchThreshold, 3);
+  assert.equal(parseRetrospectiveConfig('retrospective:\n  dispatchThreshold: 2.5\n').dispatchThreshold, 3);
+});
+
+test('parseRetrospectiveConfig: valid dispatchThreshold of 0 is honored (not treated as invalid)', () => {
+  assert.equal(parseRetrospectiveConfig('retrospective:\n  dispatchThreshold: 0\n').dispatchThreshold, 0);
+});
+
+test('parseRetrospectiveConfig: invalid cooldownMinutes falls back to the default of 30', () => {
+  assert.equal(
+    parseRetrospectiveConfig('retrospective:\n  cooldownMinutes: not-a-number\n').cooldownMinutes,
+    30,
+  );
+  assert.equal(parseRetrospectiveConfig('retrospective:\n  cooldownMinutes: 0\n').cooldownMinutes, 30);
+  assert.equal(parseRetrospectiveConfig('retrospective:\n  cooldownMinutes: -5\n').cooldownMinutes, 30);
+});
+
+test('parseRetrospectiveConfig: valid non-default cooldownMinutes is honored', () => {
+  assert.equal(parseRetrospectiveConfig('retrospective:\n  cooldownMinutes: 10\n').cooldownMinutes, 10);
+});
+
+test('parseRetrospectiveConfig: mode off stays off — never silently falls back to nudge', () => {
+  assert.equal(parseRetrospectiveConfig('retrospective:\n  mode: off\n').mode, 'off');
+});
+
+test('parseRetrospectiveConfig: unrecognized mode value falls back to nudge', () => {
+  assert.equal(parseRetrospectiveConfig('retrospective:\n  mode: bogus\n').mode, 'nudge');
+});
+
+test('parseRetrospectiveConfig: a column-0 comment above mode does not break the block', () => {
+  const content = [
+    'retrospective:',
+    '# comment describing the mode field',
+    '  mode: dispatch',
+  ].join('\n');
+  assert.equal(parseRetrospectiveConfig(content).mode, 'dispatch');
+});
+
+test('parseRetrospectiveConfig: inline {} form reads mode and dispatchThreshold', () => {
+  const cfg = parseRetrospectiveConfig('retrospective: { mode: dispatch, dispatchThreshold: 7 }\n');
+  assert.equal(cfg.mode, 'dispatch');
+  assert.equal(cfg.dispatchThreshold, 7);
+});
+
+test('parseRetrospectiveConfig: inline {} form with a trailing comment after the brace still reads mode (fix M2)', () => {
+  const cfg = parseRetrospectiveConfig('retrospective: { mode: dispatch }  # comment\n');
+  assert.equal(cfg.mode, 'dispatch');
+});
+
+test('parseRetrospectiveMode: thin wrapper matches parseRetrospectiveConfig().mode', () => {
+  const content = 'retrospective:\n  mode: dispatch\n';
+  assert.equal(parseRetrospectiveMode(content), parseRetrospectiveConfig(content).mode);
+  assert.equal(parseRetrospectiveMode(null), 'nudge');
+});
+
+test('parseProjectRootId: resolves rootId and tolerates a column-0 comment', () => {
+  const content = [
+    'project:',
+    '# a stray comment',
+    '  rootId: "abc-123"',
+    'retrospective:',
+    '  mode: nudge',
+  ].join('\n');
+  assert.equal(parseProjectRootId(content), 'abc-123');
+});
+
+test('parseProjectRootId: null when project: block is absent', () => {
+  assert.equal(parseProjectRootId('retrospective:\n  mode: nudge\n'), null);
+  assert.equal(parseProjectRootId(null), null);
+});
+
+test('buildNudge: empty roots renders a clean command with no argument and no root(s) fragment', () => {
+  const text = buildNudge([]);
+  assert.ok(!text.includes('root(s):'));
+  assert.ok(text.includes('`/session-retrospective`'));
+});
+
+test('buildNudge: non-empty roots renders the root list and the first root as the argument', () => {
+  const text = buildNudge(['aaa', 'bbb']);
+  assert.ok(text.includes('root(s): aaa, bbb'));
+  assert.ok(text.includes('`/session-retrospective aaa`'));
+});
+
+test('buildDispatch: includes roots and the ancestor rootId', () => {
+  const text = buildDispatch(['aaa'], 'root-1');
+  assert.ok(text.includes('aaa'));
+  assert.ok(text.includes('root-1'));
+  assert.ok(text.includes('Retrospective dispatch'));
+});
+
+test('COOLDOWN_MS default equals 30 minutes', () => {
+  assert.equal(COOLDOWN_MS, 30 * 60 * 1000);
+});

--- a/claude-plugins/task-orchestrator/hooks/tests/retro-trigger.test.mjs
+++ b/claude-plugins/task-orchestrator/hooks/tests/retro-trigger.test.mjs
@@ -1,0 +1,311 @@
+// Drives retro-trigger.mjs as a subprocess with fixture JSON on stdin. Marker isolation: every
+// test uses a fixture session_id (or a randomly-generated fixture rootId) with a dedicated temp
+// config directory, so the shared marker file at os.tmpdir()/task-orchestrator/retro-<key>.json
+// is never the live marker for a real project. Each test cleans up its own marker file.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { markerPath, writeMarker, readMarker } from '../retro-lib.mjs';
+
+const HOOK = fileURLToPath(new URL('../retro-trigger.mjs', import.meta.url));
+
+function writeConfig(dir, content) {
+  const cfgDir = join(dir, '.taskorchestrator');
+  mkdirSync(cfgDir, { recursive: true });
+  writeFileSync(join(cfgDir, 'config.yaml'), content, 'utf-8');
+}
+
+function spawnHook(agentConfigDir, payload, extra = {}) {
+  return spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify(payload),
+    env: { ...process.env, AGENT_CONFIG_DIR: agentConfigDir, ...extra.env },
+    encoding: 'utf-8',
+    cwd: extra.cwd,
+  });
+}
+
+function tmpConfigDir() {
+  return mkdtempSync(join(tmpdir(), 'to-retro-trigger-'));
+}
+
+test('below dispatchThreshold (mode dispatch) yields nudge text, not dispatch', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, 'retrospective:\n  mode: dispatch\n  dispatchThreshold: 3\n');
+  const sessionId = `test-trigger-below-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    const res = spawnHook(dir, {
+      session_id: sessionId,
+      tool_name: 'mcp__mcp-task-orchestrator__complete_tree',
+      tool_input: { rootId: 'aaaaaaaa-0000-0000-0000-000000000001' },
+      tool_response: { summary: { completed: 1 } },
+    });
+    assert.equal(res.status, 0);
+    const out = JSON.parse(res.stdout);
+    const text = out.hookSpecificOutput.additionalContext;
+    assert.ok(text.includes('Retrospective suggested'), text);
+    assert.ok(!text.includes('Retrospective dispatch'), text);
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('at/above dispatchThreshold (mode dispatch) yields dispatch text', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, 'retrospective:\n  mode: dispatch\n  dispatchThreshold: 3\n');
+  const sessionId = `test-trigger-above-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    const res = spawnHook(dir, {
+      session_id: sessionId,
+      tool_name: 'mcp__mcp-task-orchestrator__complete_tree',
+      tool_input: { rootId: 'aaaaaaaa-0000-0000-0000-000000000001' },
+      tool_response: { summary: { completed: 3 } },
+    });
+    assert.equal(res.status, 0);
+    const out = JSON.parse(res.stdout);
+    const text = out.hookSpecificOutput.additionalContext;
+    assert.ok(text.includes('Retrospective dispatch'), text);
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('advance_item PARENT_COMPLETION substance counts direct terminals + cascade terminals (fix M1)', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, 'retrospective:\n  mode: dispatch\n  dispatchThreshold: 3\n');
+  const sessionId = `test-trigger-m1-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    // A single batched advance_item call: 4 children go terminal directly, and one of those
+    // transitions cascades a parent to terminal too — 5 distinct itemIds reach terminal in this
+    // one call. Substance must be 5 (>= dispatchThreshold 3), not 1 (roots.length, the old bug).
+    const res = spawnHook(dir, {
+      session_id: sessionId,
+      tool_name: 'mcp__mcp-task-orchestrator__advance_item',
+      tool_input: {},
+      tool_response: {
+        results: [
+          { itemId: 'child-1', newRole: 'terminal', unblockedItems: [], cascadeEvents: [] },
+          { itemId: 'child-2', newRole: 'terminal', unblockedItems: [], cascadeEvents: [] },
+          { itemId: 'child-3', newRole: 'terminal', unblockedItems: [], cascadeEvents: [] },
+          {
+            itemId: 'child-4',
+            newRole: 'terminal',
+            unblockedItems: [],
+            cascadeEvents: [{ itemId: 'parent-1', targetRole: 'terminal', applied: true }],
+          },
+        ],
+      },
+    });
+    assert.equal(res.status, 0);
+    const out = JSON.parse(res.stdout);
+    const text = out.hookSpecificOutput.additionalContext;
+    // Substance (5) clears the threshold (3) -> hard dispatch, not a nudge.
+    assert.ok(text.includes('Retrospective dispatch'), text);
+    // `roots` stays scoped to cascade parents only — the dispatch text names the parent, not
+    // the four children directly (that scoping must be unchanged by the substance-count fix).
+    assert.ok(text.includes('parent-1'), text);
+    assert.ok(!text.includes('child-1'), text);
+    // Marker resets to 0 after a directive fires, same as any other PARENT_COMPLETION.
+    assert.equal(readMarker(marker).terminalCount, 0);
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('advance_item PARENT_COMPLETION below threshold with the M1 union still yields nudge, not dispatch', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, 'retrospective:\n  mode: dispatch\n  dispatchThreshold: 5\n');
+  const sessionId = `test-trigger-m1-below-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    // 1 direct terminal + 1 cascaded parent = substance 2, below dispatchThreshold 5.
+    const res = spawnHook(dir, {
+      session_id: sessionId,
+      tool_name: 'mcp__mcp-task-orchestrator__advance_item',
+      tool_input: {},
+      tool_response: {
+        results: [
+          {
+            itemId: 'child-1',
+            newRole: 'terminal',
+            unblockedItems: [],
+            cascadeEvents: [{ itemId: 'parent-1', targetRole: 'terminal', applied: true }],
+          },
+        ],
+      },
+    });
+    assert.equal(res.status, 0);
+    const out = JSON.parse(res.stdout);
+    const text = out.hookSpecificOutput.additionalContext;
+    assert.ok(text.includes('Retrospective suggested'), text);
+    assert.ok(!text.includes('Retrospective dispatch'), text);
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('trigger reads a non-default dispatchThreshold from config, not just the default of 3', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, 'retrospective:\n  mode: dispatch\n  dispatchThreshold: 7\n');
+  const sessionId = `test-trigger-nondefault-threshold-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    // completed: 6 would clear the default threshold (3) but not this config's 7 -> nudge.
+    let res = spawnHook(dir, {
+      session_id: sessionId,
+      tool_name: 'mcp__mcp-task-orchestrator__complete_tree',
+      tool_input: { rootId: 'root-nondefault' },
+      tool_response: { summary: { completed: 6 } },
+    });
+    let out = JSON.parse(res.stdout);
+    let text = out.hookSpecificOutput.additionalContext;
+    assert.ok(text.includes('Retrospective suggested'), text);
+    assert.ok(!text.includes('Retrospective dispatch'), text);
+
+    // A distinct root (the roots.some bypass, since the prior nudge already reset terminalCount
+    // to 0) clearing exactly 7 in one call -> dispatch, proving the hook reads 7 from config
+    // rather than silently defaulting to 3.
+    res = spawnHook(dir, {
+      session_id: sessionId,
+      tool_name: 'mcp__mcp-task-orchestrator__complete_tree',
+      tool_input: { rootId: 'root-nondefault-2' },
+      tool_response: { summary: { completed: 7 } },
+    });
+    out = JSON.parse(res.stdout);
+    text = out.hookSpecificOutput.additionalContext;
+    assert.ok(text.includes('Retrospective dispatch'), text);
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('terminalCount accumulates across LONE_TERMINAL calls and resets when a directive emits', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, 'retrospective:\n  mode: dispatch\n  dispatchThreshold: 3\n');
+  const sessionId = `test-trigger-accum-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    let res = spawnHook(dir, {
+      session_id: sessionId,
+      tool_name: 'mcp__mcp-task-orchestrator__advance_item',
+      tool_input: {},
+      tool_response: { results: [{ itemId: 'item-1', newRole: 'terminal', unblockedItems: [], cascadeEvents: [] }] },
+    });
+    assert.equal(res.stdout.trim(), '{}');
+    assert.equal(readMarker(marker).terminalCount, 1);
+
+    res = spawnHook(dir, {
+      session_id: sessionId,
+      tool_name: 'mcp__mcp-task-orchestrator__advance_item',
+      tool_input: {},
+      tool_response: { results: [{ itemId: 'item-2', newRole: 'terminal', unblockedItems: [], cascadeEvents: [] }] },
+    });
+    assert.equal(res.stdout.trim(), '{}');
+    assert.equal(readMarker(marker).terminalCount, 2);
+
+    // Substance = prior terminalCount (2) + this call's completed (1) = 3 >= threshold -> dispatch.
+    res = spawnHook(dir, {
+      session_id: sessionId,
+      tool_name: 'mcp__mcp-task-orchestrator__complete_tree',
+      tool_input: { rootId: 'root-final' },
+      tool_response: { summary: { completed: 1 } },
+    });
+    const out = JSON.parse(res.stdout);
+    assert.ok(out.hookSpecificOutput.additionalContext.includes('Retrospective dispatch'));
+    assert.equal(readMarker(marker).terminalCount, 0);
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the roots.some bypass still fires for a distinct root inside the cooldown window', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, 'retrospective:\n  mode: nudge\n');
+  const sessionId = `test-trigger-bypass-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    writeMarker(marker, { handledAt: Date.now(), rootUuids: ['root-A'], terminalCount: 0 });
+
+    // Same root again, inside the cooldown -> suppressed.
+    let res = spawnHook(dir, {
+      session_id: sessionId,
+      tool_name: 'mcp__mcp-task-orchestrator__complete_tree',
+      tool_input: { rootId: 'root-A' },
+      tool_response: { summary: { completed: 1 } },
+    });
+    assert.equal(res.stdout.trim(), '{}');
+
+    // A distinct root inside the same cooldown window -> the bypass fires, a directive emits.
+    res = spawnHook(dir, {
+      session_id: sessionId,
+      tool_name: 'mcp__mcp-task-orchestrator__complete_tree',
+      tool_input: { rootId: 'root-B' },
+      tool_response: { summary: { completed: 1 } },
+    });
+    const out = JSON.parse(res.stdout);
+    assert.ok(out.hookSpecificOutput.additionalContext.includes('Retrospective suggested'));
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('fail-open: malformed stdin yields {} and exit 0', () => {
+  const res = spawnSync(process.execPath, [HOOK], { input: '{not valid json', encoding: 'utf-8' });
+  assert.equal(res.status, 0);
+  assert.equal(res.stdout.trim(), '{}');
+});
+
+test('fail-open: unparseable tool_response yields {} and exit 0', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, 'retrospective:\n  mode: dispatch\n');
+  const sessionId = `test-trigger-failopen-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    const res = spawnHook(dir, {
+      session_id: sessionId,
+      tool_name: 'mcp__mcp-task-orchestrator__complete_tree',
+      tool_input: { rootId: 'root-x' },
+      tool_response: { totally: 'unexpected shape' },
+    });
+    assert.equal(res.status, 0);
+    assert.equal(res.stdout.trim(), '{}');
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('fail-open: no discoverable config still exits 0 and defaults to nudge (never crashes)', () => {
+  const emptyDir = tmpConfigDir();
+  const sessionId = `test-trigger-noconfig-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    const res = spawnHook(emptyDir, {
+      session_id: sessionId,
+      tool_name: 'mcp__mcp-task-orchestrator__complete_tree',
+      tool_input: { rootId: 'root-y' },
+      tool_response: { summary: { completed: 1 } },
+    }, { cwd: tmpdir() }); // cwd override: don't let the cwd-walk fallback find this repo's real config.yaml
+    assert.equal(res.status, 0);
+    const out = JSON.parse(res.stdout);
+    assert.ok(out.hookSpecificOutput.additionalContext.includes('Retrospective suggested'));
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(emptyDir, { recursive: true, force: true });
+  }
+});

--- a/claude-plugins/task-orchestrator/hooks/tests/session-start.test.mjs
+++ b/claude-plugins/task-orchestrator/hooks/tests/session-start.test.mjs
@@ -1,0 +1,84 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const HOOK = fileURLToPath(new URL('../session-start.mjs', import.meta.url));
+
+function writeConfig(dir, content) {
+  const cfgDir = join(dir, '.taskorchestrator');
+  mkdirSync(cfgDir, { recursive: true });
+  writeFileSync(join(cfgDir, 'config.yaml'), content, 'utf-8');
+}
+
+function runHook(agentConfigDir) {
+  return spawnSync(process.execPath, [HOOK], {
+    env: { ...process.env, AGENT_CONFIG_DIR: agentConfigDir },
+    encoding: 'utf-8',
+    cwd: agentConfigDir, // avoid the cwd-walk fallback finding this repo's real config.yaml
+  });
+}
+
+function tmpConfigDir() {
+  return mkdtempSync(join(tmpdir(), 'to-session-start-'));
+}
+
+test('no config discoverable -> base guidance only, no Project Scope section', () => {
+  const dir = tmpConfigDir();
+  try {
+    const res = runHook(dir);
+    assert.equal(res.status, 0);
+    const out = JSON.parse(res.stdout);
+    assert.ok(out.hookSpecificOutput.additionalContext.includes('Task Orchestrator — Session Context'));
+    assert.ok(!out.hookSpecificOutput.additionalContext.includes('## Project Scope'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('config present but no project: block -> not-project-scoped guidance', () => {
+  const dir = tmpConfigDir();
+  try {
+    writeConfig(dir, 'retrospective:\n  mode: nudge\n');
+    const res = runHook(dir);
+    const out = JSON.parse(res.stdout);
+    assert.ok(out.hookSpecificOutput.additionalContext.includes('not project-scoped'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('project block with a column-0 comment above rootId still resolves (parser bug fix)', () => {
+  const dir = tmpConfigDir();
+  try {
+    writeConfig(dir, [
+      'project:',
+      '# a stray column-0 comment sitting right above rootId',
+      '  rootId: "root-comment-fix-check"',
+      '  name: "Comment Fix Check"',
+      '',
+    ].join('\n'));
+    const res = runHook(dir);
+    assert.equal(res.status, 0);
+    const out = JSON.parse(res.stdout);
+    assert.ok(out.hookSpecificOutput.additionalContext.includes('root-comment-fix-check'));
+    assert.ok(out.hookSpecificOutput.additionalContext.includes('Comment Fix Check'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('project block with only rootId (no name) still resolves', () => {
+  const dir = tmpConfigDir();
+  try {
+    writeConfig(dir, 'project:\n  rootId: bare-root-id\n');
+    const res = runHook(dir);
+    const out = JSON.parse(res.stdout);
+    assert.ok(out.hookSpecificOutput.additionalContext.includes('bare-root-id'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/claude-plugins/task-orchestrator/hooks/tests/yaml-lite.test.mjs
+++ b/claude-plugins/task-orchestrator/hooks/tests/yaml-lite.test.mjs
@@ -1,0 +1,113 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readSection, scalar, inlineScalar } from '../yaml-lite.mjs';
+
+test('readSection: column-0 comment inside a block stays inside the section', () => {
+  const content = [
+    'retrospective:',
+    '# a stray column-0 comment describing mode',
+    '  mode: dispatch',
+    'work_item_schemas:',
+    '  foo: bar',
+  ].join('\n');
+  const section = readSection(content, 'retrospective');
+  assert.ok(section);
+  assert.equal(scalar(section.lines, 'mode'), 'dispatch');
+});
+
+test('readSection: blank lines stay inside the section', () => {
+  const content = [
+    'retrospective:',
+    '  mode: dispatch',
+    '',
+    '  dispatchThreshold: 5',
+    'project:',
+    '  rootId: xyz',
+  ].join('\n');
+  const section = readSection(content, 'retrospective');
+  assert.ok(section);
+  assert.equal(scalar(section.lines, 'dispatchThreshold'), '5');
+});
+
+test('readSection: inline {} form is captured separately from block lines', () => {
+  const content = 'retrospective: { mode: dispatch, dispatchThreshold: 5 }\n';
+  const section = readSection(content, 'retrospective');
+  assert.ok(section);
+  assert.equal(section.lines.length, 0);
+  assert.equal(inlineScalar(section.inline, 'mode'), 'dispatch');
+  assert.equal(inlineScalar(section.inline, 'dispatchThreshold'), '5');
+});
+
+test('readSection: inline {} form with a trailing comment still matches (fix M2)', () => {
+  const content = 'retrospective: { mode: dispatch }  # comment\n';
+  const section = readSection(content, 'retrospective');
+  assert.ok(section);
+  assert.equal(inlineScalar(section.inline, 'mode'), 'dispatch');
+});
+
+test('readSection: inline {} form with trailing content, non-retrospective key (fix M2)', () => {
+  const content = 'actor_authentication: { enabled: true } # trailing\n';
+  const section = readSection(content, 'actor_authentication');
+  assert.ok(section);
+  assert.equal(inlineScalar(section.inline, 'enabled'), 'true');
+});
+
+test('readSection: adjacent top-level key ends the section', () => {
+  const content = [
+    'project:',
+    '  rootId: abc-123',
+    'retrospective:',
+    '  mode: off',
+  ].join('\n');
+  const section = readSection(content, 'project', { blockOnly: true });
+  assert.ok(section);
+  assert.equal(scalar(section.lines, 'rootId'), 'abc-123');
+  // retrospective's mode must not have leaked into the project block.
+  assert.equal(scalar(section.lines, 'mode'), null);
+});
+
+test('readSection: absent block returns null', () => {
+  const content = 'project:\n  rootId: abc\n';
+  assert.equal(readSection(content, 'retrospective'), null);
+  assert.equal(readSection('', 'project'), null);
+  assert.equal(readSection(null, 'project'), null);
+});
+
+test('readSection: blockOnly ignores an inline form for that key', () => {
+  const content = 'project: { rootId: abc }\n';
+  assert.equal(readSection(content, 'project', { blockOnly: true }), null);
+});
+
+test('readSection: non-blockOnly still matches the block form', () => {
+  const content = 'actor_authentication:\n  enabled: true\n';
+  const section = readSection(content, 'actor_authentication');
+  assert.ok(section);
+  assert.equal(section.inline, null);
+  assert.equal(scalar(section.lines, 'enabled'), 'true');
+});
+
+test('scalar: strips quotes and trailing comments', () => {
+  const lines = ['  rootId: "abc-123"  # a uuid', '  name: bare-name'];
+  assert.equal(scalar(lines, 'rootId'), 'abc-123');
+  assert.equal(scalar(lines, 'name'), 'bare-name');
+});
+
+test('scalar: skips comment-only lines as candidates', () => {
+  const lines = ['  # rootId: should-not-match', '  rootId: real-value'];
+  assert.equal(scalar(lines, 'rootId'), 'real-value');
+});
+
+test('scalar: returns null when key is absent', () => {
+  assert.equal(scalar(['  other: value'], 'rootId'), null);
+});
+
+test('inlineScalar: bounded by comma or closing brace', () => {
+  const inline = ' mode: dispatch, dispatchThreshold: 5 ';
+  assert.equal(inlineScalar(inline, 'mode'), 'dispatch');
+  assert.equal(inlineScalar(inline, 'dispatchThreshold'), '5');
+});
+
+test('inlineScalar: returns null for an absent key or a null inline', () => {
+  assert.equal(inlineScalar(' mode: dispatch ', 'missing'), null);
+  assert.equal(inlineScalar(null, 'mode'), null);
+});

--- a/claude-plugins/task-orchestrator/hooks/yaml-lite.mjs
+++ b/claude-plugins/task-orchestrator/hooks/yaml-lite.mjs
@@ -1,0 +1,101 @@
+// Shared minimal-YAML section reader used by every plugin hook that reads
+// .taskorchestrator/config.yaml. Pure module — no I/O, no dependencies.
+//
+// This is NOT a general YAML parser. It only understands the narrow subset the plugin's
+// config.yaml uses: a handful of top-level `key:` blocks, each either a nested block of
+// `subkey: value` lines, or (for some keys) an inline `{ subkey: value, ... }` form.
+//
+// The bug this module fixes (six copies of it, one per hook): the idiom
+// `if (inSection && /^\S/.test(line)) inSection = false;` treats a column-0 `#` comment as
+// end-of-section, silently truncating block parsing when a comment happens to sit unindented
+// above (or inside) the value line it documents. Correct section exit is a line that is
+// column-0, non-blank, AND not a comment — blank lines and column-0 comments stay inside.
+
+/**
+ * Locate a top-level `name:` block or inline `name: { ... }` form.
+ *
+ * @param {string} content Full config.yaml text.
+ * @param {string} name Top-level key to find, e.g. "retrospective".
+ * @param {{ blockOnly?: boolean }} [opts]
+ *   blockOnly: when true, only the block form (`name:` alone on its line) is recognized — the
+ *   inline `{...}` form is ignored even if present. Mirrors `project:`'s original block-only
+ *   matching (session-start.mjs, config-sync.mjs, plan-capture.mjs never supported an inline
+ *   `project: { ... }` form, so this preserves that).
+ * @returns {{ inline: string|null, lines: string[] } | null}
+ *   `inline` holds the raw interior text of a matched `{ ... }` form (null for block form).
+ *   `lines` holds the raw (untrimmed) lines belonging to a matched block form (empty array for
+ *   inline form). Returns null when the section header isn't found at all.
+ */
+export function readSection(content, name, opts = {}) {
+  if (!content) return null;
+  const blockOnly = !!opts.blockOnly;
+
+  const blockHeaderRe = new RegExp(`^${name}\\s*:\\s*$`);
+  // Deliberately unanchored at the end (no trailing `\s*$`) — the six original per-hook
+  // parsers this module replaced were unanchored too, so an inline `{ ... }` form followed by
+  // a trailing `# comment` (or any other trailing content) still matches; only the leading
+  // `{...}` span is captured and anything after the closing brace is ignored.
+  const inlineHeaderRe = new RegExp(`^${name}\\s*:\\s*\\{(.*)\\}`);
+  const anyHeaderRe = new RegExp(`^${name}\\s*:`);
+
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (!anyHeaderRe.test(trimmed)) continue;
+
+    if (!blockOnly) {
+      const inlineMatch = trimmed.match(inlineHeaderRe);
+      if (inlineMatch) {
+        return { inline: inlineMatch[1], lines: [] };
+      }
+    }
+    if (blockHeaderRe.test(trimmed)) {
+      return { inline: null, lines: collectBlockLines(lines, i + 1) };
+    }
+    // Header matched `name:` but is neither block-only form nor (when allowed) inline-brace
+    // form — not a section we can read. Keep scanning in case the key appears again later.
+  }
+
+  return null;
+}
+
+// Collects lines belonging to a block starting right after the header line, stopping at the
+// first column-0, non-blank, non-comment line (or end of input).
+function collectBlockLines(lines, startIdx) {
+  const out = [];
+  for (let i = startIdx; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    if (trimmed === '') {
+      out.push(line);
+      continue;
+    }
+    const isColumnZero = /^\S/.test(line);
+    if (isColumnZero && !trimmed.startsWith('#')) break;
+    out.push(line);
+  }
+  return out;
+}
+
+// Extracts an unquoted, comment-stripped scalar value for `key: value` from a set of block
+// lines (as returned by readSection). Comment-only lines are skipped entirely — never treated
+// as a candidate match. Returns null if the key isn't present in the block.
+export function scalar(lines, key) {
+  const re = new RegExp(`^${key}\\s*:\\s*["']?([^"'#]+?)["']?\\s*(#.*)?$`);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('#')) continue;
+    const m = trimmed.match(re);
+    if (m) return m[1].trim();
+  }
+  return null;
+}
+
+// Same extraction as `scalar`, but for the interior text of an inline `{ key: value, ... }`
+// form. The value is bounded by the next comma or closing brace (or end of string).
+export function inlineScalar(inline, key) {
+  if (inline == null) return null;
+  const re = new RegExp(`${key}\\s*:\\s*["']?([^"',}#]+?)["']?\\s*(#[^,}]*)?\\s*(?=[,}]|$)`);
+  const m = inline.match(re);
+  return m ? m[1].trim() : null;
+}

--- a/claude-plugins/task-orchestrator/output-styles/schema-orchestrator.md
+++ b/claude-plugins/task-orchestrator/output-styles/schema-orchestrator.md
@@ -44,7 +44,7 @@ If you dispatch a subagent, its prompt must include entity IDs and full context 
 
 ## Retrospective
 
-When the retrospective hook fires — as PostToolUse context after `advance_item`/`complete_tree`, or as a Stop-hook directive — follow it: in `dispatch` mode, launch exactly the background retrospective agent it specifies (one per run, never more); in `nudge` mode, surface the suggestion to the user. Do not dispatch retrospectives from memory or prose — the hook is the single trigger. Configure via `retrospective.mode` in `.taskorchestrator/config.yaml` (`nudge` default | `dispatch` | `off`).
+When the retrospective hook fires — as PostToolUse context after `advance_item`/`complete_tree`, or as a Stop-hook directive — follow it: in `dispatch` mode, launch exactly the background retrospective agent it specifies (one per run, never more); in `nudge` mode, surface the suggestion to the user. In `dispatch` mode, a run below the configured `dispatchThreshold` (items terminal since the last directive) still arrives as a nudge, not a dispatch directive — treat it the same as `nudge` mode when that happens. Do not dispatch retrospectives from memory or prose — the hook is the single trigger. Configure via `retrospective.mode` in `.taskorchestrator/config.yaml` (`nudge` default | `dispatch` | `off`).
 
 ## Action Items
 

--- a/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
+++ b/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
@@ -86,7 +86,7 @@ Delegation prompts must include entity IDs and full context — subagents start 
 
 ## Retrospective
 
-When the retrospective hook fires — as PostToolUse context after `advance_item`/`complete_tree`, or as a Stop-hook directive — follow it: in `dispatch` mode, launch exactly the background retrospective agent it specifies (one per run, never more); in `nudge` mode, surface the suggestion to the user. Do not dispatch retrospectives from memory or prose — the hook is the single trigger. Configure via `retrospective.mode` in `.taskorchestrator/config.yaml` (`nudge` default | `dispatch` | `off`).
+When the retrospective hook fires — as PostToolUse context after `advance_item`/`complete_tree`, or as a Stop-hook directive — follow it: in `dispatch` mode, launch exactly the background retrospective agent it specifies (one per run, never more); in `nudge` mode, surface the suggestion to the user. In `dispatch` mode, a run below the configured `dispatchThreshold` (items terminal since the last directive) still arrives as a nudge, not a dispatch directive — treat it the same as `nudge` mode when that happens. Do not dispatch retrospectives from memory or prose — the hook is the single trigger. Configure via `retrospective.mode` in `.taskorchestrator/config.yaml` (`nudge` default | `dispatch` | `off`).
 
 ## Action Items
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
@@ -412,7 +412,9 @@ The `retrospective:` section is a top-level key alongside `work_item_schemas`, `
 
 ```yaml
 retrospective:
-  mode: nudge   # nudge (default) | dispatch | off | headless (reserved)
+  mode: nudge          # nudge (default) | dispatch | off | headless (reserved)
+  dispatchThreshold: 3 # items terminal since the last retrospective directive required to auto-spawn (default 3)
+  cooldownMinutes: 30  # minutes before the same run can trigger another directive (default 30)
 ```
 
 Default: `nudge` — applied when the `retrospective:` block or `mode` key is absent, or the value is unrecognized.
@@ -422,15 +424,19 @@ Default: `nudge` — applied when the `retrospective:` block or `mode` key is ab
 | Field | Required | Type | Notes |
 |-------|----------|------|-------|
 | `mode` | no | string | `nudge`, `dispatch`, `off`, or the reserved `headless`. Defaults to `nudge` |
+| `dispatchThreshold` | no | integer >= 0 | Only meaningful in `mode: dispatch`. Count of items that reached terminal since the last retrospective directive (nudge or dispatch) required before a hard background dispatch fires. Below this, the run still gets a nudge — it is never silent. Defaults to `3`; a non-integer or negative value falls back to the default. |
+| `cooldownMinutes` | no | number > 0 | Minutes before the same run can trigger another nudge/dispatch directive. Defaults to `30`; an invalid value falls back to the default. |
 
 ### Modes
 
 | Mode | Behavior |
 |------|----------|
 | `nudge` (default) | Hooks inject a suggestion to run `/session-retrospective` when an implementation run reaches terminal. The agent decides whether to act on it. |
-| `dispatch` | Hooks inject a directive that launches exactly one background retrospective agent per run — no suggestion, an instruction to act. |
+| `dispatch` | Hooks inject a directive that launches exactly one background retrospective agent, but only once the run's substance (items reached terminal since the last directive) clears `dispatchThreshold`. Below threshold, the hook still injects the `nudge` suggestion instead of staying silent — nothing goes unreported, only the automatic background spawn is reserved for substantial runs. |
 | `off` | Hooks stay silent — no retrospective suggestion or dispatch directive is injected. |
 | `headless` (reserved) | **Not implemented yet.** Intended for a future version where the hook spawns a detached `claude -p` retrospective session outside the current conversation. Today, setting `mode: headless` falls back to `nudge` behavior, same as any other unrecognized value. |
+
+**Backstop is always nudge-only.** The `Stop` hook (`retro-backstop.mjs`) — which escalates a lone terminal item that never got a `PARENT_COMPLETION` follow-up — always injects a nudge, regardless of configured mode. It fires on a signal that, by construction, is not a confirmed run boundary, so it never escalates to a hard dispatch even in `mode: dispatch`. When it has no identifiable root to scope the suggestion to, it omits the UUID argument entirely rather than falling back to the whole project — letting `/session-retrospective`'s own narrower fallback scan apply.
 
 ### Behavior
 


### PR DESCRIPTION
## Problem

With `retrospective.mode: dispatch`, the plugin's retrospective hooks auto-dispatched a background subagent far more often than an implementation-run boundary warranted — closing a single housekeeping item could spawn one. The original idea was to let the *agent* decide when a retrospective isn't worth running; a critical evaluation rejected that (the deciding agent is the one whose work would be critiqued, a silent skip is indistinguishable from a hook that never fired, and `retro-ack` is a leaky trace). The decision is instead computed **in the hook**, from facts.

## Change

- **Substance gate** — count items reaching terminal since the last retrospective (tracked in the existing marker file) and only auto-dispatch when it clears `dispatchThreshold` (default 3). Below threshold emits **nudge** text instead — never silence, so no run goes unsurfaced. Per-item `session-tracking` notes are gate-enforced regardless, so a deferred retrospective loses no data.
- **Backstop downgrade** — `retro-backstop` now always nudges, never hard-dispatches (it fires on a deferred lone-terminal flag, which by construction is not a run boundary), and no longer falls back to whole-project-anchor scope on empty `pendingRoots`.
- **Parser fix** — new `yaml-lite.mjs` shared section reader replaces **six** copy-pasted parsers whose `/^\S/` section-exit test wrongly treated a column-0 `#` comment inside a block as end-of-section. That latent bug could silently break `rootId` discovery (config-sync, plan-capture, session-start) and `actor_authentication.enabled` detection.
- **New config keys** — `retrospective.dispatchThreshold` and `cooldownMinutes` (absent → defaults; invalid → default, never throws).
- **`retro-ack` reset** — resets `terminalCount` so a completed retrospective does not leak accumulated substance into the next run.

### Explicitly *not* done

Removing the `roots.some(r => !existingRoots.includes(r))` cooldown bypass in `retro-trigger.mjs`. It looks like the culprit but is deliberate — triggers are event-driven with no retry, so without it a second feature tree completing shortly after the first gets no retrospective *ever*. Kept and covered by a test.

## Tests

First test coverage under `claude-plugins/` — **71 `node:test` cases**, zero dependencies. Covers the substance-gate boundary (asserts the persisted `terminalCount`, not just "some text emitted"), fail-open on malformed stdin / missing config / unparseable `tool_response`, parser equivalence across all six call sites, marker-file isolation, and the `advance_item` cascade+direct-terminal union. A CI step runs them and fails on an empty glob (so a moved test dir can't degrade to a green no-op).

```
node --test "claude-plugins/task-orchestrator/hooks/tests/*.test.mjs"
# 71 pass, 0 fail
```

## Review

Went through independent adversarial review (separate agent). Four findings — retro-ack substance leak, `advance_item` substance undercount, an inline-brace-plus-trailing-comment parser regression that failed *unsafe* for `actor_authentication`, and a CI empty-glob no-op — were all fixed and re-verified before this PR.

## Notes for reviewer

- Plugin content is cached — hook changes need a marketplace remove/re-add to take effect locally.
- User-visible behavior change: `dispatch` mode now narrows to "dispatch when the run is substantial, nudge below threshold." Documented in `config-format.md`.
- No plugin version bump (reserved for `/prepare-release`).

MCP item: `5c9287cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)