### PR TITLE
release: plugin v3.5.0 — substance-gated retrospective dispatch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "task-orchestrator",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "description": "Skills, hooks, and workflows for MCP Task Orchestrator. Schema-aware context, note-driven workflow, and session hooks.",
       "author": {
         "name": "Jeff Picklyk",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [Plugin 3.5.0] - 2026-07-23
+
+Plugin-only release — no server changes, no image rebuild. Server stays at 3.12.0.
+
+### Changed
+
+- **Retrospective dispatch is now gated by run substance.** In `dispatch` mode, the plugin
+  auto-launches a background retrospective only when the number of items reaching terminal since
+  the last retrospective meets `dispatchThreshold` (default 3); below the threshold it emits a
+  nudge instead of spawning an agent. Stops a single closed housekeeping item from triggering a
+  full retrospective run.
+- **Stop-hook backstop downgraded to nudge-only.** The end-of-turn backstop no longer hard-
+  dispatches a retrospective and no longer falls back to whole-project scope when it has no
+  specific root — eliminating the most expensive accidental firing.
+
+### Added
+
+- **New `retrospective` config keys:** `dispatchThreshold` (items reaching terminal since the last
+  retrospective required to auto-dispatch, default 3) and `cooldownMinutes` (default 30, replacing
+  the previously hardcoded value). Absent or invalid values fall back to defaults.
+
+### Fixed
+
+- **Config parser no longer mis-reads a comment as end-of-section.** A column-0 `#` comment inside
+  a `retrospective:`, `project:`, or `actor_authentication:` block previously ended the block
+  early, silently breaking `rootId` discovery and actor-authentication detection across six hooks.
+  Consolidated onto a shared section parser and covered by the plugin's first hook test suite (71
+  cases).
+- **Retrospective substance no longer leaks across runs.** `retro-ack` now resets the terminal
+  counter, so items closed during a retrospective can't accumulate and trigger a spurious dispatch
+  on the next run.
+
+### Plugin
+
+- Bumped plugin version to **3.5.0** — substance-gated retrospective dispatch, nudge-only Stop
+  backstop, and the six-hook section-exit parser fix.
+
 ## [3.12.0] - 2026-07-20
 
 ### Added

--- a/claude-plugins/CLAUDE.md
+++ b/claude-plugins/CLAUDE.md
@@ -10,7 +10,7 @@ removing and re-adding the marketplace in Claude Code. No version bump is needed
 
 | Plugin | Directory | Current Version |
 |--------|-----------|-----------------|
-| `task-orchestrator` | `claude-plugins/task-orchestrator/` | `3.4.0` |
+| `task-orchestrator` | `claude-plugins/task-orchestrator/` | `3.5.0` |
 
 > Updated automatically by `/prepare-release`. Do not bump manually.
 

--- a/claude-plugins/task-orchestrator/.claude-plugin/plugin.json
+++ b/claude-plugins/task-orchestrator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "task-orchestrator",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Claude Code integration for MCP Task Orchestrator — schema-aware context, note-driven workflow",
   "skills": "./skills",
   "hooks": "./hooks/hooks-config.json",


### PR DESCRIPTION
## Summary

Plugin-only release. Bumps the plugin **3.4.0 → 3.5.0** for the retrospective substance-gate work merged in #258. **No server changes** — `version.properties` stays at 3.12.0, no tag, no Docker rebuild, no GitHub Release.

- Retrospective dispatch now gated by run substance (`dispatchThreshold`, default 3) — a single closed housekeeping item no longer spawns a background retrospective.
- Stop-hook backstop downgraded to nudge-only; no more whole-project-scope fallback dispatch.
- New `retrospective` config keys: `dispatchThreshold`, `cooldownMinutes`.
- Fixed the six-hook column-0-comment section-exit parser bug; `retro-ack` now resets the terminal counter so substance can't leak across runs.

## Version

**Release type:** plugin-only
Plugin: 3.4.0 → 3.5.0 (minor)
Server: 3.12.0 (unchanged)

Files: `plugin.json`, `.claude-plugin/marketplace.json`, `claude-plugins/CLAUDE.md`, `CHANGELOG.md`.

Distribution: git-marketplace consumers pick this up from `main` via the normal plugin update flow (version bump in marketplace.json + plugin.json) — no marketplace re-add required.

Prepared with /prepare-release