### PR TITLE
feat: resource/credential leasing — traits declare resources, server enforces TTL leases at the work-phase gate (#261)

### DIFF
--- a/.claude/skills/feature-implementation/SKILL.md
+++ b/.claude/skills/feature-implementation/SKILL.md
@@ -84,6 +84,8 @@ advance_item(transitions=[{ itemId: "<uuid>", trigger: "start" }])
 ```
 
 Gate check: `feature-summary` must be filled. If gate rejects, fill the missing note and retry.
+If instead the response has `errorCode: "resource_unavailable"` (`errorKind: "transient"`), this
+is resource-lease contention, not a note gate failure — see Quick Reference below.
 
 Confirm `newRole: "work"` in the response before dispatching implementation subagents.
 
@@ -236,3 +238,8 @@ Confirm `newRole: "terminal"`. Run `get_context()` health check to verify no sta
 
 **Gate error pattern:** `"required notes not filled for <phase> phase: <keys>"`
 → Fill the listed notes, then retry `advance_item`.
+
+**Resource-lease contention pattern:** `applied: false`, `errorCode: "resource_unavailable"`,
+`errorKind: "transient"`, `contendedResources: [...]` on a `start` into work — a different
+failure mode than the gate error above. Do NOT fill notes or spin-retry; the resource is held by
+another item. Work a different item and retry later, or report contention upstream.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -152,6 +152,12 @@ materialization. Advance: `advance_item(trigger="start")`.
 The gate will reject advancement if required notes are missing. If rejected, fill
 the missing notes and retry.
 
+**Do not confuse this with resource-lease contention.** A queue→work `advance_item` can also
+fail with `applied: false`, `errorCode: "resource_unavailable"`, `errorKind: "transient"` — a
+resource a trait on this item declares (`resources:`) is currently held by another item. This
+is not a note gate failure: filling notes will not fix it. Work a different item and retry
+later (`retryAfterMs` is a hint), or report the contended key(s) to the user.
+
 ---
 
 ## Step 4 — Work Phase: Implementation

--- a/.taskorchestrator/config.yaml
+++ b/.taskorchestrator/config.yaml
@@ -175,6 +175,10 @@ traits:
 # See claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
 # → "Resources (Trait Dimension)" for the full field reference and merge semantics.
 #
+# WARNING: this file already has a live top-level `traits:` block above. Do NOT uncomment the
+# `traits:` line below as-is — a duplicate top-level key resolves last-wins and silently drops
+# every existing trait. Merge the example trait INTO the existing `traits:` block instead.
+#
 # resources:
 #   staging-db:
 #     description: "Single shared staging database — only one migration/test run at a time"

--- a/.taskorchestrator/config.yaml
+++ b/.taskorchestrator/config.yaml
@@ -169,3 +169,21 @@ traits:
         required: true
         description: "Session context — what was done, how it went, and anything the retrospective should know."
         guidance: "Record what happened during implementation. Structure: - **Outcome**: success | partial | failure - **Files changed**: list with brief rationale - **Deviations**: anything that differed from the specification or plan - **Friction**: tool errors, roundtrips, workarounds, API confusion (type + description) - **Gate interactions**: note fill attempts, gate failures encountered - **Observations**: anything worth tracking for process improvement - **Test results**: pass/fail counts, new tests added. Keep it factual and concise — this feeds the session retrospective."
+
+# Resource leasing — reference example only, NOT activated on this project's items.
+# Uncomment and adapt to declare a shared-resource registry and reference it from a trait.
+# See claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+# → "Resources (Trait Dimension)" for the full field reference and merge semantics.
+#
+# resources:
+#   staging-db:
+#     description: "Single shared staging database — only one migration/test run at a time"
+#     defaultTtlSeconds: 3600
+#
+# traits:
+#   needs-staging-slot:
+#     resources:
+#       - staging-db                # short form — bare key = mode: exclusive, registry default TTL
+#       # - key: github-deploy-token  # long form — explicit mode + ttlSeconds override
+#       #   mode: advisory
+#       #   ttlSeconds: 1800

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-admin callers who set it, WARN-logged when used). New `RESOURCE_LEASES_ENFORCED` env var
   (default `true`) is a deployment-wide kill switch, read per advance call rather than once at
   startup. `CORS_EXPOSE_HEADERS` now defaults to include `Retry-After`.
+- **Lease-interval history (audit log).** New append-only `resource_lease_history` table records one
+  row per lease hold interval — answering "who held resource R at time T" after a lease has already
+  been released, stolen, or force-released. Every acquire/refresh/release/steal/force-release write
+  is mirrored into history in the same transaction as the live-row write; `ResourceLeaseRepository`
+  gains `findHoldersAt` / `findRecentIntervals`, and `forceReleaseByKey` gains an optional `actorId`
+  parameter recorded on the closed interval. New REST route
+  `GET /api/v1/resources/leases/history?key=&at=&limit=` (holder/closer actor identity ADMIN-only,
+  `at` optional ISO-8601 instant, 400 on an unparseable value, `limit` default 100 max 500). No
+  pruning/retention in v1 — append-only, cardinality tracks lease events.
 
 ## [Plugin 3.5.1] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entry (`start` and `resume`) — no new MCP tool, no explicit acquire/release verb. `exclusive`
   resources take a TTL-bounded lease (default 3600s, max 86400s); contention rejects with a
   transient `resource_unavailable` error (MCP) or `409` + `Retry-After` (REST), disclosing the
-  contended keys only, never the current holder. `advisory` resources are audit-only.
+  contended keys only, never the current holder. `advisory` resources are audit-only. Lease
+  acquisition retries up to 5 times (40ms delay) on `SQLITE_BUSY`/`SQLITE_LOCKED` contention before
+  falling through to a transient DB-error response, so a losing writer in a genuine cross-connection
+  race gets a clean re-evaluation instead of a spurious failure.
 - **`credentialRefs` audit field.** `advance_item` transitions accept an optional `credentialRefs`
   array of opaque credential/resource labels (never secret values), persisted to
   `role_transitions.consumed_credentials` and surfaced read-only via `RoleTransitionDto.consumedCredentials`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Resource leasing.** Work items can now declare exclusive or advisory access to shared resources
+  (a staging slot, a test database, a deploy credential, a fleet-wide deployment mutex) via a new
+  `resources:` dimension on trait definitions, enforced as a gate inside `advance_item` at WORK
+  entry (`start` and `resume`) — no new MCP tool, no explicit acquire/release verb. `exclusive`
+  resources take a TTL-bounded lease (default 3600s, max 86400s); contention rejects with a
+  transient `resource_unavailable` error (MCP) or `409` + `Retry-After` (REST), disclosing the
+  contended keys only, never the current holder. `advisory` resources are audit-only.
+- **`credentialRefs` audit field.** `advance_item` transitions accept an optional `credentialRefs`
+  array of opaque credential/resource labels (never secret values), persisted to
+  `role_transitions.consumed_credentials` and surfaced read-only via `RoleTransitionDto.consumedCredentials`.
+  Once an item declares `resources:`, the field becomes a closed set validated against the
+  declared/registered keys, and declared keys are auto-recorded on work entry.
+- **Resource-lease read/recovery surfaces.** `get_context(itemId=...)` item mode gains a
+  `resourceLeases` block (mirroring `claimDetail`). New REST routes `GET /api/v1/resources/leases`
+  (list active leases; holder actor identity ADMIN-only) and
+  `DELETE /api/v1/resources/leases/{key}` (ADMIN-only force-release — the operator recovery path for
+  a crashed holder, without waiting out the TTL or disabling enforcement server-wide).
+- **Enforcement matrix and kill switch.** Both MCP and REST enforce the resource-lease gate by
+  default; REST additionally accepts an ADMIN-only `overrideResourceLeases` request flag (403 for
+  non-admin callers who set it, WARN-logged when used). New `RESOURCE_LEASES_ENFORCED` env var
+  (default `true`) is a deployment-wide kill switch, read per advance call rather than once at
+  startup. `CORS_EXPOSE_HEADERS` now defaults to include `Retry-After`.
+
 ## [Plugin 3.5.1] - 2026-07-23
 
 Plugin-only release — no server changes, no image rebuild. Server stays at 3.12.0.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,11 +91,12 @@ The optional `actor_authentication` config block adds JWKS-based identity verifi
 
 ## Trait System (Orchestration Signals)
 
-Traits are **composable orchestration signals** declared in `.taskorchestrator/config.yaml` under the `traits:` key. They are NOT merely note requirements. Each trait carries three dimensions:
+Traits are **composable orchestration signals** declared in `.taskorchestrator/config.yaml` under the `traits:` key. They are NOT merely note requirements. Each trait carries four dimensions:
 
 1. **Note requirements** -- notes with `key`, `role`, `required` that merge into an item's resolved schema and enforce gates
 2. **Guidance** -- `guidance` text on each note telling agents HOW to fill it (context, constraints, structure)
 3. **Skill routing** -- optional `skill` pointer (e.g., `skill: "migration-review"`) that routes evaluation to a specialized skill
+4. **Resources** -- optional `resources:` list declaring shared-resource requirements (`exclusive` or `advisory` mode) enforced as a lease gate at WORK entry, independent of the note-requirement dimension. See `claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md` -> "Resources (Trait Dimension)" for declaration syntax, merge semantics, and the leaf-task-types-only rule.
 
 **Resolution flow:** `ToolExecutionContext.resolveSchema(item)` merges trait notes from two sources:
 - `defaultTraits` on the schema type definition (always applied to items of that type)
@@ -214,7 +215,7 @@ Add to `gradle/libs.versions.toml` (`[versions]` + `[libraries]`), then referenc
 - `CORS_ALLOWED_ORIGINS` — comma-separated origins; empty = no CORS
 - `CORS_ALLOWED_METHODS` — default: `GET,POST,PATCH,PUT,DELETE,OPTIONS`
 - `CORS_ALLOWED_HEADERS` — default: `Authorization,Content-Type,If-Match`
-- `CORS_EXPOSE_HEADERS` — default: `ETag,Last-Event-ID`
+- `CORS_EXPOSE_HEADERS` — default: `ETag,Last-Event-ID,Retry-After`
 - `CORS_MAX_AGE_SECONDS` — default: `3600`
 - `API_SSE_BUFFER_SIZE` — SSE ring-buffer size for Last-Event-ID replay (default: `1000`)
 - `API_ALLOW_QUERY_TOKEN_FOR_SSE` — allow `?token=` auth on SSE endpoint (default: `false`)
@@ -222,6 +223,7 @@ Add to `gradle/libs.versions.toml` (`[versions]` + `[libraries]`), then referenc
 - `API_REDACT_NOTE_ATTRIBUTION` — default `true`; when `true` non-admin callers see no actor/verification on notes/transitions
 - `API_REDACT_ACTOR_PROOF` — default `true`; when `true` actor.proof redacted unless ADMIN + `?include=proof`
 - `API_WARN_ON_CLAIMED_ADVANCE` — default `true`; WARN when REST API caller advances a claimed item
+- `RESOURCE_LEASES_ENFORCED` — default `true`; only the literal `false` disables the resource-lease gate (acquisition only — releases always run). Read per `advance_item`/advance-route call (not once at startup), so a change takes effect on the next call, not after a restart
 
 **Migration files:** `current/src/main/resources/db/migration/`
 

--- a/claude-plugins/task-orchestrator/hooks/subagent-start.mjs
+++ b/claude-plugins/task-orchestrator/hooks/subagent-start.mjs
@@ -36,7 +36,9 @@ const output = {
     hookEventName: "SubagentStart",
     additionalContext: `## Agent-Owned-Phase Protocol
 
-**You own exactly ONE phase.** Enter it with \`advance_item(transitions=[{itemId: "<your-item-UUID>", trigger: "start"}])\`, do the work, and fill the phase's required notes via \`manage_notes(operation="upsert", ...)\` — each upsert response returns the next note's guidance. If the item is already in your phase (\`applied: false\`), call \`get_context(itemId=...)\` once for guidance instead.
+**You own exactly ONE phase.** Enter it with \`advance_item(transitions=[{itemId: "<your-item-UUID>", trigger: "start"}])\`, do the work, and fill the phase's required notes via \`manage_notes(operation="upsert", ...)\` — each upsert response returns the next note's guidance. If the item is already in your phase (\`applied: false\`, no \`errorCode\`), call \`get_context(itemId=...)\` once for guidance instead.
+
+**If \`advance_item\` instead fails with \`errorCode: "resource_unavailable"\` (\`errorKind: "transient"\`), do NOT treat it as already-in-phase and do NOT retry.** A shared resource this item declares is currently held by another item. Stop immediately and report the contended resource key(s) (\`contendedResources\`) back to the orchestrator — do not proceed as if you had entered work phase, and do not spin-retry the same call.
 
 **Never call \`advance_item\` again after entering your phase, and never use \`trigger: "complete"\`** — the orchestrator owns all subsequent transitions.
 

--- a/claude-plugins/task-orchestrator/output-styles/ralph-iteration.md
+++ b/claude-plugins/task-orchestrator/output-styles/ralph-iteration.md
@@ -46,6 +46,7 @@ These are explicit overrides — even if other parts of your context (memory, pr
 | A required note couldn't be filled (insufficient info, requires external input, schema requires content you can't author) | `gate-blocked` |
 | Tool error, build failure, claim failure, unexpected condition | `error` |
 | All claim candidates were already claimed by other actors | `skip` |
+| `advance_item` rejected with transient `resource_unavailable` (another item holds a declared resource lease) | `skip` — release nothing manually (the claim TTL handles it); do NOT spin-retry the same item |
 | Item is already in terminal role at claim time (race) | `skip` |
 | No items match the filter | `no-item` |
 

--- a/claude-plugins/task-orchestrator/output-styles/schema-orchestrator.md
+++ b/claude-plugins/task-orchestrator/output-styles/schema-orchestrator.md
@@ -28,7 +28,7 @@ Whether you implement inline or dispatch a subagent is your call per the work �
 ## Workflow Principles
 
 1. **Materialize before implement** — MCP work items must exist before any implementation or dispatch.
-2. **Agent-owned phases** — if you delegate, the subagent enters its phase (one `advance_item(start)`), fills that phase's required notes, and returns; the orchestrator owns all subsequent transitions. Skills referenced by a note's `skillPointer` provide the evaluation framework for whoever fills it.
+2. **Agent-owned phases** — if you delegate, the subagent enters its phase (one `advance_item(start)`), fills that phase's required notes, and returns; the orchestrator owns all subsequent transitions. Skills referenced by a note's `skillPointer` provide the evaluation framework for whoever fills it. **A queue→work `advance_item` can fail transiently** with `errorCode: "resource_unavailable"` (a resource-bearing trait's lease is held elsewhere) — distinct from a gate block; do not fill more notes or retry immediately, work a different item and retry later (see `/status-progression`).
 3. **Atomic creation** — use `create_work_tree` for hierarchy; avoid multi-call sequences.
 4. **Include the item UUID in every delegation** — subagents start fresh with no ambient context.
 5. **Know current state** — query MCP before deciding; `role="work"` filters resolve to all work-phase statuses.

--- a/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
+++ b/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
@@ -50,7 +50,7 @@ Review applies only when the item's schema declares review-phase notes; otherwis
 ## Workflow Principles
 
 1. **Materialize before implement** — all MCP work items must exist before dispatching agents
-2. **Agent-owned phases** — implementation agents enter their assigned phase (one `advance_item(start)` call), fill its required notes, and return. The orchestrator owns all subsequent transitions: advance, inspect `newRole`, dispatch the next agent. Skills referenced by `skillPointer` provide the evaluation framework for whoever fills the note
+2. **Agent-owned phases** — implementation agents enter their assigned phase (one `advance_item(start)` call), fill its required notes, and return. The orchestrator owns all subsequent transitions: advance, inspect `newRole`, dispatch the next agent. Skills referenced by `skillPointer` provide the evaluation framework for whoever fills the note. **A queue→work `advance_item` can fail transiently** with `errorCode: "resource_unavailable"` (a resource-bearing trait's lease is held elsewhere) — distinct from a gate block; do not fill more notes or retry immediately, work a different item and retry later (see `/status-progression`)
 3. **Atomic creation** — `create_work_tree` for hierarchy; avoid multi-call sequences
 4. **Include the item UUID in every delegation**
 5. **Know current state** — query MCP before deciding; `role="work"` filters resolve to all work-phase statuses

--- a/claude-plugins/task-orchestrator/scripts/ralph-loop.mjs
+++ b/claude-plugins/task-orchestrator/scripts/ralph-loop.mjs
@@ -702,7 +702,9 @@ Outcomes (signaled by RALPH_OUTCOME marker in iteration agent stdout):
   terminal       Item reached terminal role per its schema
   gate-blocked   Required notes couldn't be filled autonomously
   error          Tool error, build failure, budget cap hit
-  skip           Already-terminal, claim contention, or filter mismatch
+  skip           Already-terminal, claim contention, resource-lease contention
+                 (advance_item errorCode=resource_unavailable -- claim released,
+                 iteration moves to a different item), or filter mismatch
   no-item        No claimable items match filter -- queue drained
 
 Compose with /loop for autonomous cadence:

--- a/claude-plugins/task-orchestrator/skills/configure-server/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/configure-server/SKILL.md
@@ -9,8 +9,14 @@ argument-hint: "[optional: 'recommended', 'http', 'stdio', 'bearer', or a change
 Decides **how the MCP Task Orchestrator container is launched and reached**: transport, REST API mode,
 port publishing, config mount, and config-sync. This is a runtime/deployment concern, distinct from
 `quick-start` (first-time onboarding narrative) and `manage-schemas` (workflow gates/traits/
-`actor_authentication` content inside `.taskorchestrator/config.yaml`). If the user wants schema or
-gate changes, redirect to `/manage-schemas` instead of proceeding here.
+`resources:`/`actor_authentication` content inside `.taskorchestrator/config.yaml`). If the user wants
+schema or gate changes — including resource-lease declarations — redirect to `/manage-schemas` instead
+of proceeding here.
+
+One operator escape hatch worth knowing when launching the container: `RESOURCE_LEASES_ENFORCED=false`
+(env, default true) disables resource-lease gate enforcement server-wide — a kill switch for lease
+contention incidents, same gate-policy category as `DEGRADED_MODE_POLICY`. Configuring which resources
+exist and which traits declare them stays in `/manage-schemas`; this skill only knows the switch.
 
 The full fragment catalog (exact env tuples, loopback caveat, Windows/MSYS caveat, `.mcp.json` shapes)
 lives in `references/runtime-config.md` — this skill's job is the **decision flow** and **rendering**,

--- a/claude-plugins/task-orchestrator/skills/create-item/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/create-item/SKILL.md
@@ -127,6 +127,8 @@ Only assign traits that exist in the config. If no `traits:` section exists, ski
 
 If multiple traits apply, combine them: `traits: "needs-migration-review,needs-api-compat-review"`
 
+**Resource-bearing traits (informational):** if a chosen trait's config entry carries its own `resources:` list, note this to the user — items with that trait will acquire an exclusive lease on the named resource key(s) when they enter work phase, and `advance_item(start)` can transiently fail with `resource_unavailable` if another item currently holds it. No extra action is needed here; this is just so the choice isn't a surprise later.
+
 ---
 
 ## Step 5 — Create the item(s)

--- a/claude-plugins/task-orchestrator/skills/dependency-manager/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/dependency-manager/SKILL.md
@@ -225,6 +225,17 @@ For each blocker, determine what must happen:
 
 If any blocker is itself blocked, offer to recurse: "The blocker is also blocked. Would you like to diagnose that item too?"
 
+**Not every "why can't this start" is a dependency.** This skill diagnoses `BLOCKED`-role items
+and unsatisfied `BLOCKS` edges only. A separate, unrelated cause can produce a similar symptom:
+`advance_item` rejecting a `start`/`resume` transition with `errorCode: "resource_unavailable"`
+(`errorKind: "transient"`) — a shared resource the item declares via a `resources:` trait is
+currently held by another item. That item's role does **not** change to `blocked`; it stays in
+its current role (typically `queue`) and the transition simply fails transiently. If
+`query_dependencies` shows no incoming edges yet the item still won't advance, suspect resource
+contention instead — check the `advance_item` error for `errorCode`/`contendedResources`, or
+inspect `get_context(itemId=...)` → `resourceLeases` for the item's declared/held keys. Do not
+treat this as a dependency problem; retrying the dependency diagnosis will not help.
+
 After the diagnosis, link to the resolution path:
 - To advance the blocking item: use `/status-progression` with its UUID
 - To fill missing notes on the blocker first: use `manage_notes(operation="upsert")` to fill required notes

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
@@ -41,7 +41,7 @@ Check if `.taskorchestrator/config.yaml` exists by reading it.
 
 **If the file exists:** Read and parse it. Proceed to Step 3.
 
-> **Note:** `project:` is a recognized top-level key alongside `work_item_schemas`, `traits`, and `actor_authentication` — it anchors this repo to a project root item and is read only by other skills (`quick-start`, `/adopt-project-scope`), never by this skill. Do not treat it as unknown, and never drop or rewrite it — every write operation in Step 3 (CREATE/EDIT/DELETE) must carry it through unchanged. See `references/config-format.md` → Project Scoping for its fields.
+> **Note:** `project:` is a recognized top-level key alongside `work_item_schemas`, `traits`, `resources`, and `actor_authentication` — it anchors this repo to a project root item and is read only by other skills (`quick-start`, `/adopt-project-scope`), never by this skill. Do not treat it as unknown, and never drop or rewrite it — every write operation in Step 3 (CREATE/EDIT/DELETE) must carry it through unchanged. See `references/config-format.md` → Project Scoping for its fields. (`resources:` is the optional shared-resource registry — see `references/config-format.md` → "Resources (Trait Dimension)"; it must be preserved the same way.)
 
 ---
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
@@ -282,7 +282,8 @@ types if you want audit visibility without the lock.
 
 ### Interaction with `credentialRefs`
 
-Once an item declares `resources:` (or the server's registry is non-empty), the `credentialRefs`
+Once an item declares at least one resource via its traits' `resources:` (registry state alone
+does not trigger this — an item declaring nothing keeps the open rung-1 behavior), the `credentialRefs`
 field on that item's `advance_item` transitions becomes a **closed set** — each supplied ref must
 name a declared/registered key, or the transition is rejected with a validation error naming the
 unrecognized ref and the known-key list. Declared keys (both `exclusive`, once acquired, and

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
@@ -41,6 +41,17 @@ traits:
         description: "Security review"
         skill: "security-review"
         guidance: "Evaluate input validation, injection risks, access control..."
+    resources:                  # Optional — resources this trait's items need at WORK entry (see below)
+      - staging-db               # short form: bare key = mode: exclusive, no ttlSeconds override
+      - key: github-deploy-token  # long form: explicit mode + ttlSeconds
+        mode: advisory
+        ttlSeconds: 1800
+
+resources:                      # Optional top-level registry — describes keys, does not declare usage
+  staging-db:
+    description: "Single shared staging database — only one migration/test run at a time"
+    defaultTtlSeconds: 3600
+    maxHolders: 1                # values > 1 are rejected at config load ("not yet supported")
 ```
 
 ---
@@ -169,6 +180,118 @@ traits:
       - {key: implementation-notes, role: review, required: false}  # dropped — key collides with base
       - {key: review-checklist, role: review, required: true}       # added
 ```
+
+---
+
+## Resources (Trait Dimension)
+
+A trait can declare `resources:` — a list of shared-resource requirements enforced by the server as
+a **gate at WORK entry** (`advance_item(trigger="start")` from queue, and `trigger="resume"` from
+blocked — both re-enter WORK). This is independent of the note-requirement dimension: a trait can
+carry notes, resources, both, or neither.
+
+### Declaration forms
+
+```yaml
+traits:
+  needs-staging-slot:
+    resources:
+      - staging-db                     # short form — bare string
+      - key: github-deploy-token       # long form — explicit fields
+        mode: advisory                 # exclusive (default) | advisory
+        ttlSeconds: 1800                # optional; overrides the registry default for this trait
+```
+
+| Field | Required | Default | Notes |
+|-------|----------|---------|-------|
+| `key` | yes | — | Resource key. Same charset as `credentialRefs`: `^[a-z0-9][a-z0-9\-_./]*$`, max 128 chars. An invalid key is warned-and-skipped (that one entry only — not fatal to the config load). |
+| `mode` | no | `exclusive` | `exclusive` — server takes a lease at WORK entry; contention rejects the transition. `advisory` — no lease, no lock; the key is recorded into the transition's `consumedCredentials` audit trail only. |
+| `ttlSeconds` | no | registry's `defaultTtlSeconds`, else `3600` | Bounds: clamped to `[1, 86400]`. |
+
+### The optional top-level `resources:` registry
+
+```yaml
+resources:
+  staging-db:
+    description: "Human-readable note — what this key protects"
+    defaultTtlSeconds: 3600    # bounds 1-86400; out-of-range or non-numeric warns and falls back to 3600
+    maxHolders: 1              # v1 only supports 1 — see below
+```
+
+The registry is optional metadata: TTL defaults and a human-readable description for a key. A trait
+can reference a key that has **no** registry entry at all — see "Undeclared keys" below. `maxHolders`
+values greater than `1` are a **load error**: the whole registry entry is skipped (not clamped) with
+a warning containing the literal text `maxHolders > 1 not yet supported` — storage is
+semaphore-ready for a future multi-holder release, but v1 admission is capped at exactly 1 regardless
+of what a config author writes here. A `maxHolders` value less than `1` is warned-and-clamped to `1`
+(entry still created, unlike the `> 1` case). Reserved budget fields (`budgetLimit`,
+`budgetWindowSeconds`) are parsed and warned as "reserved for future use" but never stored on either
+the registry entry or a trait's resource requirement.
+
+### Merge semantics — read this before combining traits
+
+Resource requirements merge differently from notes in three specific ways — do not assume the note
+merge rules (`Trait Merge Semantics` above) apply here.
+
+1. **Union across traits, never dropped.** Unlike notes (where a base-schema key always wins and a
+   colliding trait note is silently dropped), two traits declaring the *same resource key* both
+   contribute — the merge is a union, deduplicated by key. Nothing is ever silently lost to a
+   collision the way a duplicate note key would be.
+2. **On a mode conflict for the same key, `exclusive` wins.** If one trait declares a key
+   `advisory` and another (applied to the same item) declares it `exclusive`, the merged result is
+   `exclusive` — the stricter declaration always wins, regardless of application order. `ttlSeconds`
+   for a duplicate key keeps the **first-seen** value in trait-application order (base schema's
+   `default_traits` first, then per-item `traits`); a later trait's `ttlSeconds` for an
+   already-recorded key is ignored.
+3. **The registry layers in the OPPOSITE direction from every other per-root setting — read this
+   twice.** Every other per-root-honorable setting in this document (schemas, traits, `note_limits`,
+   `status_labels`) is **per-root-wins**: a project's own config overrides the global floor for that
+   project. The `resources:` **registry** inverts this: on a key collision between a per-root
+   registry entry and the global registry entry, **the global entry wins**, and the collision is
+   logged. Rationale: a resource key is a **server-global lock/lease namespace** — a real shared
+   credential or staging slot is a singleton across the whole server, so one project must not be
+   able to silently redefine another project's shared key's TTL or holder cap by pushing its own
+   per-root config. (The *trait declarations themselves* — which resources a trait requires — still
+   follow the normal per-root-wins layering; only the registry's global-wins inversion is special.)
+
+### Undeclared keys — warn and honor, never skip
+
+A trait can declare a resource key with **no matching registry entry** (in either layer). This is
+**not** an error and does **not** disable enforcement — the key is warned (`"undeclared resource"`
+in the log) and enforced anyway using default TTL (3600s). The registry is fail-open (an absent
+entry never widens or weakens the lock); the lock itself is fail-closed (absence of registry
+metadata never skips enforcement). Known residual risk: two projects that happen to pick the same
+generic key name (e.g. `db`) for two genuinely different resources will falsely serialize against
+each other. Mitigate with a naming convention that scopes keys to your project
+(`proj-a/staging-db` rather than `staging-db`) — the config loader also warns when one key is
+declared by three or more traits/schemas (fan-out), which is a useful early signal for this exact
+collision.
+
+### LEAF TASK TYPES ONLY for exclusive resources — a hard rule, not a suggestion
+
+**Declare `mode: exclusive` resources on leaf task-level schemas only — never on a container/feature
+schema (`lifecycle: manual` or `permanent` root containers, or any type with children).** The lease
+is held for the ENTIRE time the declaring item sits in WORK. A feature container commonly stays in
+WORK for the full duration of its child tree's implementation — hours to days. If a container-level
+schema (or a container item's own `traits`) declares an exclusive resource, that resource is locked
+for the container's whole WORK lifetime, not just for whichever child task actually needs it —
+starving every other item that needs the same key for as long as the feature is in flight. This is
+almost never the intended effect. Put the exclusive declaration on the leaf task type/trait that
+actually performs the resource-touching work; use `advisory` (or no declaration at all) on container
+types if you want audit visibility without the lock.
+
+### Interaction with `credentialRefs`
+
+Once an item declares `resources:` (or the server's registry is non-empty), the `credentialRefs`
+field on that item's `advance_item` transitions becomes a **closed set** — each supplied ref must
+name a declared/registered key, or the transition is rejected with a validation error naming the
+unrecognized ref and the known-key list. Declared keys (both `exclusive`, once acquired, and
+`advisory`) are **auto-recorded** into `consumedCredentials` on work entry — you do not need to
+repeat them in `credentialRefs`. Items that declare no resources are unaffected — `credentialRefs`
+there stays an open, format-only-validated field (rung-1 behavior, unchanged). See
+[`api-reference.md`](../../../../../current/docs/api-reference.md) for the full `credentialRefs`
+validation contract and [`workflow-guide.md`](../../../../../current/docs/workflow-guide.md#11-resource-leasing)
+for the contention/retry model and the full guarantees-vs-non-guarantees statement.
 
 ---
 
@@ -500,15 +623,29 @@ server's config back before editing, rather than pushing over it. `current` (alr
 returned) both proceed as before. `force: true` (or `?force=true`) bypasses the guard when a
 deliberate revert or overwrite is intended.
 
-**Per-root honorable settings.** `note_limits` and `status_labels` are layered the same way as
-schemas/traits: a per-root document that **explicitly** sets `note_limits.mode` or a trigger under
-`status_labels` wins for that root; a per-root document that **omits the key entirely** falls
-through to the global value, unchanged. `status_labels` falls through **per trigger** — a per-root
-map that only overrides `start` still defers to the global config for `complete`, `block`, etc.
-(and a trigger explicitly mapped to `null` in the per-root doc means "no label for this trigger",
-which is different from the trigger being absent). A pushed document's response (`manage_project_config`
-push, or `PUT /roots/{rootId}/config`) reports which top-level keys it contains that are NOT honored
-per-root in an additive `ignoredSections` field.
+**Per-root honorable settings.** `note_limits`, `status_labels`, and `resources` are layered the
+same way as schemas/traits: a per-root document that **explicitly** sets `note_limits.mode`, a
+trigger under `status_labels`, or the `resources` top-level key wins for that root; a per-root
+document that **omits the key entirely** falls through to the global value, unchanged.
+`status_labels` falls through **per trigger** — a per-root map that only overrides `start` still
+defers to the global config for `complete`, `block`, etc. (and a trigger explicitly mapped to
+`null` in the per-root doc means "no label for this trigger", which is different from the trigger
+being absent). A pushed document's response (`manage_project_config` push, or
+`PUT /roots/{rootId}/config`) reports which top-level keys it contains that are NOT honored per-root
+in an additive `ignoredSections` field.
+
+> **`resources` is the one exception to "per-root wins" in this list — read it separately.** Every
+> other honored section above (schemas, traits, `note_limits`, `status_labels`) resolves
+> per-root-wins: the project's own config beats the global floor. The `resources:` **registry**
+> specifically inverts this — on a key collision, the **global** registry entry wins over a
+> per-root one, because a resource key is a server-wide lock namespace, not a per-project setting.
+> This applies only to the registry entries (`resources: <key>: {...}`), not to which resources a
+> trait declares — trait resource declarations still layer per-root-wins like every other trait
+> field. See "Resources (Trait Dimension)" above for the full merge semantics and the rationale.
+>
+> Also unlike every other validation failure documented in this file (which degrades gracefully to
+> a default), a registry entry with `maxHolders > 1` is dropped entirely rather than clamped — see
+> "Resources (Trait Dimension)" above.
 
 **Global-only settings.** `actor_authentication` is **not** part of the per-root layer — the
 resolver reads it only from the global file. A per-root document may carry it, but it is ignored

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/delete-workflow.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/delete-workflow.md
@@ -42,7 +42,7 @@ Remove the schema key and all its entries from the appropriate section (`work_it
 work_item_schemas:
 ```
 
-**Preserve all other top-level keys verbatim.** Deleting a schema must not touch `project`, `actor_authentication`, `note_limits`, `traits`, or any other top-level key — carry them through exactly as read rather than reconstructing the file from a parsed model.
+**Preserve all other top-level keys verbatim.** Deleting a schema must not touch `project`, `actor_authentication`, `note_limits`, `traits`, `resources`, or any other top-level key — carry them through exactly as read rather than reconstructing the file from a parsed model.
 
 Write the updated file back.
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/edit-workflow.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/edit-workflow.md
@@ -95,7 +95,7 @@ Require explicit confirmation before applying.
 
 ## Write Back
 
-**Preserve all other top-level keys verbatim.** Only the schema being edited may change — carry through `project`, `actor_authentication`, `note_limits`, `traits`, and any other top-level key exactly as read. Do not regenerate the whole file from a parsed-and-reserialized model; splice the edited schema back into the existing text rather than reconstructing the file from scratch.
+**Preserve all other top-level keys verbatim.** Only the schema being edited may change — carry through `project`, `actor_authentication`, `note_limits`, `traits`, `resources`, and any other top-level key exactly as read. Do not regenerate the whole file from a parsed-and-reserialized model; splice the edited schema back into the existing text rather than reconstructing the file from scratch.
 
 Write the modified config back to `.taskorchestrator/config.yaml`. Show a diff-style summary of what changed:
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/example-schemas.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/example-schemas.md
@@ -195,3 +195,38 @@ traits:
 ```
 
 Apply traits at item creation: `manage_items(operation="create", items=[{..., traits: "needs-migration-review"}])` or via schema-level `default_traits`. Most schemas in this project apply `session-tracked` (and often `delegated`) via `default_traits` rather than per-item, since nearly every item needs session tracking for `/session-retrospective`; `needs-task-review` is the opt-in trait that layers a review phase onto `feature-task`.
+
+## Resources Example — trait `resources:` + registry
+
+Traits can also declare shared-resource requirements enforced as a gate at WORK entry (see
+"Resources (Trait Dimension)" in `config-format.md` for the full merge/precedence rules). This
+example locks a shared staging database for the duration of a deploy task's work phase, while
+recording (but not locking) a deploy credential for audit purposes:
+
+```yaml
+traits:
+  needs-staging-deploy:
+    notes:
+      - key: deploy-plan
+        role: queue
+        required: true
+        description: "What gets deployed and the rollback plan."
+        guidance: "State the target environment, the change being deployed, and how to roll back if it fails."
+    resources:
+      - key: staging-db           # exclusive (default) — only one deploy task holds this at a time
+        mode: exclusive
+      - key: deploy-credential    # advisory — recorded in consumedCredentials, never locks
+        mode: advisory
+
+resources:
+  staging-db:
+    description: "Shared staging database — exclusive during deploy verification"
+    defaultTtlSeconds: 3600
+    maxHolders: 1
+```
+
+Apply `needs-staging-deploy` on a **leaf task type** (e.g. `deploy-task`), never on a feature
+container — a container commonly sits in WORK for the whole duration of its child tree, which would
+lock `staging-db` far longer than any single deploy actually needs it (see the leaf-task-types-only
+rule in `config-format.md`). A second item entering WORK while `staging-db` is held gets a transient
+`resource_unavailable` rejection with a retry hint — not a gate-style "write more notes" error.

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/validate-workflow.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/validate-workflow.md
@@ -30,6 +30,7 @@ Parse the file. If YAML is invalid, report the parse error with line number (if 
 - `did_loose_kid_match` (if present) must be a boolean
 - `did_allowlist` and `did_pattern` are mutually exclusive — error if both are set
 - DID-trust mode (non-empty `did_allowlist` or non-null `did_pattern`) is mutually exclusive with static-JWKS mode (`oidc_discovery`/`jwks_uri`/`jwks_path`) — error if both are configured
+- `resources` is an optional top-level key — recognized, not schema-related; if present, must be a mapping of resource key → `{ description?, defaultTtlSeconds?, maxHolders? }`. Do not flag as unknown. See `references/config-format.md` → "Resources (Trait Dimension)"
 - No other top-level keys expected (warn if found)
 
 ### 3. Schema Entry Structure

--- a/claude-plugins/task-orchestrator/skills/ralph/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/ralph/SKILL.md
@@ -176,6 +176,16 @@ The iteration agent emits `RALPH_OUTCOME: {...}` as its final message. The loop 
 | `skip` | Counter —; no counter changes; loop continues |
 | `no-item` | Loop exits cleanly (queue empty) |
 
+**`skip` includes resource-lease contention.** When `advance_item` rejects a transition into WORK
+with `errorCode: "resource_unavailable"` (transient — a shared resource the item declares via a
+`resources:` trait is currently held by another item), the iteration prompt releases its claim on
+that item and emits `skip` naming the contended key, rather than retrying the same item or treating
+it as an error. This is deliberate: a `resource_unavailable` rejection is expected contention, not a
+failure of this iteration, and the lock is not going to free up within the iteration's own lifetime
+— the next iteration should pick a *different* item, not spin against the same lock. See
+[Workflow Guide §11 — Resource Leasing](../../../../current/docs/workflow-guide.md#11-resource-leasing)
+for the full contention/retry model.
+
 The script's own exit code:
 | Code | Meaning |
 |---|---|

--- a/claude-plugins/task-orchestrator/skills/ralph/iteration-prompt.md
+++ b/claude-plugins/task-orchestrator/skills/ralph/iteration-prompt.md
@@ -72,6 +72,27 @@ If `/schema-workflow` cannot complete because a required note can't be filled (y
 RALPH_OUTCOME: {"status": "gate-blocked", "itemId": "<uuid>", "reason": "<which note key, why it can't be filled>"}
 ```
 
+**If `advance_item` rejects a transition into WORK with `errorCode: "resource_unavailable"`** (a
+shared resource the item declares — via a `resources:` trait — is currently held by another item;
+`errorKind` is `"transient"`, distinct from a gate block), this is **not** a gate-blocked or error
+condition — it is expected contention, and the claimed item did not do anything wrong. Do NOT retry
+`advance_item` on the same item; the lock will not free up within this iteration's lifetime, and
+spin-retrying just burns budget against a lock this iteration cannot control. Instead:
+
+1. Release the claim on this item: `claim_item(releases=[{"itemId": "<uuid>"}], actor={...})`.
+2. Emit the skip outcome, naming the contended resource key(s) from the failure's
+   `contendedResources` field:
+
+```
+RALPH_OUTCOME: {"status": "skip", "itemId": "<uuid>", "reason": "resource_unavailable: <contendedResources>"}
+```
+
+The loop driver treats `skip` as a neutral outcome — no circuit-breaker penalty — and the next
+iteration will claim a *different* item (this one stays unclaimed and claimable again once you
+release it). If every candidate the loop encounters is contended on the same key, that is a signal
+for the human operator to inspect `GET /api/v1/resources/leases` or `get_context(itemId=...)`, not
+something this iteration should try to resolve by waiting.
+
 If a tool fails, build breaks unexpectedly, or any other condition prevents progress:
 
 ```

--- a/claude-plugins/task-orchestrator/skills/schema-workflow/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/schema-workflow/SKILL.md
@@ -111,6 +111,13 @@ The response confirms the transition:
 **If the gate rejects:** The response lists which notes are missing. Fill them (Step 2),
 then retry. Do not call `get_context` first — `advance_item` already told you what's needed.
 
+**If the response instead has `applied: false` with `errorCode: "resource_unavailable"`
+(`errorKind: "transient"`):** this is NOT a note-gate rejection — do not fill more notes and
+do not retry the same call. A shared resource this item declares via a `resources:` trait is
+currently held by another item entering WORK. Report the contended `contendedResources` key(s)
+(and `retryAfterMs` if present) back to the orchestrator/user rather than spin-retrying; see
+`/status-progression` → "resource_unavailable" for the full recovery pattern.
+
 ### Step 4 — Repeat or finish
 
 After advancing, check whether the new phase has its own required notes:
@@ -188,6 +195,12 @@ phases. Begin filling queue-phase notes immediately, then follow the progression
 
 **Gate rejection:** `advance_item` returns `applied: false` with the missing note keys.
 Fill them and retry — no need for a separate `get_context` call.
+
+**Resource-lease contention:** `advance_item` returns `applied: false` with
+`errorCode: "resource_unavailable"` and `errorKind: "transient"` instead of missing notes —
+distinct from a gate rejection. Do not fill notes in response to this; it means another item
+currently holds a resource this item's traits declare. Wait (`retryAfterMs` is a hint) or work
+a different item; never spin-retry the same `advance_item` call.
 
 **Wrong phase notes:** If you try to upsert a note with a `role` that doesn't match the
 item's current role, the note is still created (notes are not phase-locked), but it won't

--- a/claude-plugins/task-orchestrator/skills/status-progression/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/status-progression/SKILL.md
@@ -171,6 +171,33 @@ If any required notes across queue, work, or review phases are unfilled, the gat
 
 ---
 
+**Problem: `advance_item` fails with `errorCode: "resource_unavailable"`**
+
+Cause: The item declares a shared resource (via a `resources:` trait, `mode: exclusive`) that
+another item currently holds — a real resource-lease conflict, not a note-schema gate failure.
+`errorKind` is `"transient"`, distinct from the gate-block/ownership/policy error codes above.
+
+**Do NOT treat this like a gate failure — do not "fill in more notes" and do not spin-retry the
+same `advance_item` call.** The fix is to wait (`retryAfterMs` names a backoff hint) or work a
+different item; retrying immediately will almost always fail again since the response never
+discloses when — only that — the key is contended. `contendedResources` names the contended key(s)
+only; the current holder's identity is never included in this response by design.
+
+Solution:
+1. Report the contended key(s) to the user/operator rather than retrying silently.
+2. To diagnose who holds it: `get_context(itemId="<uuid>")` → `resourceLeases` block (shows
+   `holderItemId`/`acquiredByActorId`/`expiresAt` for the contended key), or the REST route
+   `GET /api/v1/resources/leases` for a fleet-wide view (`ADMIN` capability needed to see the
+   holder's actor identity).
+3. If the holder is confirmed stale/crashed, an operator can force-release via
+   `DELETE /api/v1/resources/leases/{key}` (`ADMIN` capability) rather than waiting out the TTL.
+4. Otherwise, move on to a different item and revisit this one later.
+
+See [Workflow Guide §11 — Resource Leasing](../../../../current/docs/workflow-guide.md#11-resource-leasing)
+for the full contention/retry model and the guarantees-vs-non-guarantees statement.
+
+---
+
 **Problem: Parent item cascaded unexpectedly**
 
 Cause: Cascade is by design. When the first child of a container starts (queue → work), the container cascades to work automatically. When the last child reaches terminal, the container cascades to terminal automatically.

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1031,9 +1031,11 @@ Each backlink entry represents another item that holds a dependency edge pointin
 gate enforcement, cascade detection, and unblock reporting. Supports batch transitions.
 
 This tool and the REST `POST /items/{id}/advance` route share a single advance pipeline
-(`AdvanceService`): ownership pre-check → resolve → validate → required-note gate → apply → cascade
-detection → unblock detection. The MCP path enforces claim ownership; the REST path bypasses it (see
-`api-rest.md`). Both enforce the same note gates and report the same cascade/unblock results.
+(`AdvanceService`): ownership pre-check → resolve → validate → required-note gate → resource-lease
+gate → apply → cascade detection → unblock detection. The MCP path enforces claim ownership; the
+REST path bypasses it (see `api-rest.md`). Both enforce the same note gates and the same
+resource-lease gate (REST accepts an ADMIN-only override for the lease gate; MCP does not), and
+report the same cascade/unblock results.
 
 #### Key Parameters
 
@@ -1056,6 +1058,7 @@ Provide **either** a `transitions` array **or** the singular `itemId` + `trigger
 | `trigger` | string | Yes | One of: `start`, `complete`, `block`, `hold`, `resume`, `cancel`, `reopen`. Only `UserTrigger` values are accepted — `cascade` is system-internal and is rejected at the API boundary. |
 | `summary` | string | No | Optional annotation stored on the transition record |
 | `actor` | object | No | Optional actor claim — see Actor Attribution section |
+| `credentialRefs` | string or array of strings | No | Opaque audit labels for credentials/resources this transition consumed — never secret values. A bare string is coerced to a one-element array. Max 8 entries, each 1-128 chars matching `^[a-z0-9][a-z0-9\-_./]*$`. See **Resource-lease gate** below for the closed-set rule that applies once the item declares `resources:`. |
 
 Each transition element may include an optional `actor` object:
 - `id` (required string): Identifier for the actor making this transition
@@ -1198,6 +1201,61 @@ All cascade types are recorded in `cascadeEvents`.
 
 **Ownership / policy rejection.** When a transition is rejected because another agent holds a live claim, or by `degradedModePolicy=reject`, the failed result carries structured fields alongside `error`: `errorKind`, `errorCode` (`not_claim_holder` or `rejected_by_policy`), and — for ownership rejections — `contendedItemId`.
 
+**Resource-lease gate.** When an item's resolved traits declare `resources:` (see
+[`config-format.md`](../../claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md)),
+entering the `work` role — via **both** `start` (queue→work) and `resume` (blocked→work) — acquires
+an exclusive lease per `mode: exclusive` resource key the item declares, atomically (all keys or
+none). `mode: advisory` keys never lock; they are recorded into `consumedCredentials` (below) for
+audit visibility only. The lease is released on every exit from `work` (`complete`, `cancel`,
+`block`/`hold`, `reopen`, or a terminal cascade) and is not re-validated while the item stays in
+`work` — it is a precondition captured at entry, not a continuously-checked invariant. Items that
+declare no resources are entirely unaffected (zero extra queries, byte-identical behavior).
+
+*Contention.* When an exclusive key is already held, the transition is rejected as **transient**,
+not gate-blocked — the fix is to wait and retry (or work a different item), not to write more notes:
+
+```json
+{
+  "results": [
+    {
+      "itemId": "uuid",
+      "trigger": "start",
+      "applied": false,
+      "error": "Resource lease contended: staging-db",
+      "errorKind": "transient",
+      "errorCode": "resource_unavailable",
+      "retryAfterMs": 30000,
+      "contendedResources": ["staging-db"]
+    }
+  ],
+  "summary": { "total": 1, "succeeded": 0, "failed": 1 }
+}
+```
+
+`contendedResources` names the contended keys only. **The current holder's identity is never
+disclosed on this path** — no item id, no actor id — by the same tiered-disclosure principle
+`claim_item`'s `already_claimed` outcome follows. Diagnose a specific stuck lease via
+`get_context(itemId=...)` (below) or, for operators, `GET /api/v1/resources/leases` (REST, `ADMIN`
+capability for holder actor identity — see `api-rest.md`).
+
+*`credentialRefs` becomes a closed set.* Once an item declares `resources:` (or the server's
+`resources:` registry is non-empty), each supplied `credentialRefs` entry must name a
+declared/registered key — an unrecognized ref is rejected before anything is persisted. Declared
+resource keys (both the exclusive keys just acquired and any advisory keys) are **auto-recorded**
+into the persisted transition's `consumedCredentials`, unioned with any caller-supplied
+`credentialRefs` — you do not need to repeat a declared key yourself. Items with no declared
+resources keep the open, format-only-validated behavior of the plain `credentialRefs` field
+(unchanged from its baseline behavior).
+
+A start-cascade into `work` acquires leases the same way; on contention the cascade event is
+recorded with `applied: false`, `resourceBlocked: true`, and `contendedResources` — the **child's
+own transition still succeeds**, only the parent's automatic promotion is deferred.
+
+See [Workflow Guide §11 — Resource Leasing](workflow-guide.md#11-resource-leasing) for the full
+guarantees-vs-non-guarantees statement (no fairness/queueing, crash recovery via TTL or ADMIN
+force-release, item-keyed exclusivity, single-DB arbiter, opaque-labels-never-secrets) and the
+`exclusive` vs `advisory` modeling guidance.
+
 ---
 
 ### get_next_status
@@ -1335,6 +1393,37 @@ Each entry in the `schema` array is keys-only: `key`, `role`, `required`, `exist
 | `claimExpiresAt` | ISO 8601 UTC | TTL-based expiry (DB-computed). Passive: the claim is not auto-released; expired claims are filtered at read time. |
 | `originalClaimedAt` | ISO 8601 UTC | First claim timestamp by the current agent. Preserved across re-claims (heartbeats). Reset when a different agent claims the item. |
 | `isExpired` | boolean | `true` when `claimExpiresAt` is in the past at the time of the query |
+
+**`resourceLeases`** (array, optional) — present only when the item declares at least one
+`resources:` requirement (via its resolved traits) or actively holds at least one lease; omitted
+entirely otherwise (zero payload for the common case). Item mode is the sanctioned holder-identity
+diagnostic for resource leases, mirroring `claimDetail` above:
+
+```json
+{
+  "resourceLeases": [
+    {
+      "key": "staging-db",
+      "mode": "exclusive",
+      "held": true,
+      "holderItemId": "uuid",
+      "acquiredByActorId": "agent-worker-42",
+      "expiresAt": "2026-07-25T13:00:00Z"
+    },
+    { "key": "deploy-credential", "mode": "advisory", "held": false }
+  ]
+}
+```
+
+One entry per key the item either declares or currently holds (union of both sets). `mode` is
+`"exclusive"` or `"advisory"` from the resolved trait requirement; for a key the item still holds a
+lease on but no longer declares (trait removed while the lease is active), `mode` defaults to
+`"advisory"` (the least presumptuous fallback). `held` is `true` only when **this item's own** lease
+is active for that key. `holderItemId`/`acquiredByActorId`/`expiresAt` are present only when *some*
+lease is currently active for that key (self lease takes priority for an undeclared-but-held key;
+otherwise the current holder across all items) — omitted for a declared-but-unheld key with no
+active lease anywhere. See [Workflow Guide §11](workflow-guide.md#11-resource-leasing) for the
+exclusive/advisory modeling guidance and the full guarantees statement.
 
 **Response (session-resume mode).**
 

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1238,8 +1238,9 @@ disclosed on this path** — no item id, no actor id — by the same tiered-disc
 `get_context(itemId=...)` (below) or, for operators, `GET /api/v1/resources/leases` (REST, `ADMIN`
 capability for holder actor identity — see `api-rest.md`).
 
-*`credentialRefs` becomes a closed set.* Once an item declares `resources:` (or the server's
-`resources:` registry is non-empty), each supplied `credentialRefs` entry must name a
+*`credentialRefs` becomes a closed set.* Once an item declares at least one resource via its
+traits' `resources:` (registry state alone does not trigger this), each supplied `credentialRefs`
+entry must name a
 declared/registered key — an unrecognized ref is rejected before anything is persisted. Declared
 resource keys (both the exclusive keys just acquired and any advisory keys) are **auto-recorded**
 into the persisted transition's `consumedCredentials`, unioned with any caller-supplied

--- a/current/docs/api-rest.md
+++ b/current/docs/api-rest.md
@@ -738,8 +738,9 @@ This route runs the **same advance pipeline as the MCP `advance_item` tool**, un
 `credentialRefs`: opaque audit labels for credentials/resources this transition consumed — max 8
 entries, each 1-128 chars matching `^[a-z0-9][a-z0-9\-_./]*$`. Validated with the identical
 `CredentialRefValidation` object the MCP `advance_item` tool uses, so the two surfaces reject the
-same inputs. **Closed-set rule:** once the target item declares `resources:` (via traits) or the
-server has a non-empty `resources:` registry, each supplied ref must name a declared/registered key
+same inputs. **Closed-set rule:** once the target item declares at least one resource via its traits'
+`resources:` (registry state alone does not trigger this), each supplied ref must name a
+declared/registered key
 — an unrecognized ref is rejected with `400 validation_error` naming the ref and the known-key list.
 Items with no declared resources are unaffected (an open, format-only check, unchanged from rung 1).
 Declared exclusive/advisory keys are auto-recorded into `consumedCredentials` on work entry — you do

--- a/current/docs/api-rest.md
+++ b/current/docs/api-rest.md
@@ -560,6 +560,29 @@ caller; it carries no more information than an item ID already readable via `GET
 { "resourceKey": "staging-db", "releasedCount": 1 }
 ```
 
+### ResourceLeaseIntervalDto (see §14)
+
+```json
+{
+  "resourceKey": "staging-db",
+  "holderItemId": "<uuid>",
+  "acquiredByActorId": "agent-worker-42",  // ADMIN callers only — omitted (not null) otherwise
+  "acquiredAt": "ISO-8601",
+  "expiresAt": "ISO-8601",
+  "releasedAt": "ISO-8601",                // null (omitted) while the interval is still open
+  "releaseReason": "released",             // "released" | "expired" | "force_released"; null while open
+  "releasedByActorId": "admin-token-id"    // ADMIN callers only; null for a passive "expired" close
+}
+```
+
+One row per lease hold INTERVAL, not per lease event — append-only, never pruned in v1. See §14.
+
+### ResourceLeaseHistoryResponseDto
+
+```json
+{ "intervals": [<ResourceLeaseIntervalDto>] }
+```
+
 ### SSE / ApiEvent
 
 ```json
@@ -1009,7 +1032,30 @@ server-wide" into a one-call fix.
 
 Every successful force-release is WARN-logged with the acting principal's token id, the key, and the
 released count — sufficient to attribute the action to a specific bearer token from server logs
-alone, without needing to correlate against the response body.
+alone, without needing to correlate against the response body. The acting principal's token id is
+also threaded through to `released_by_actor_id` on the closed history interval(s) — see below.
+
+### GET /api/v1/resources/leases/history
+
+Append-only lease-interval audit log — answers "who held resource R at time T" after a lease has
+already been released, stolen, or force-released, which `GET /resources/leases` (current holders
+only) cannot. Requires `READ`.
+
+**Query parameters** (all optional):
+- `key` — restrict to one resource key. Same validation as `{key}` on the DELETE route above (400
+  `validation_error` on mismatch).
+- `at` — an ISO-8601 instant. When present, returns every interval held at that instant (per
+  `acquiredAt <= at < coalesce(releasedAt, expiresAt)`), open or closed. **400 `validation_error`**
+  if the value does not parse as an instant. When absent, returns the most recent intervals
+  (open or closed), newest-first by `acquiredAt`.
+- `limit` — max rows, default `100`, clamped to `[1, 500]`.
+
+**Response `200 OK`:** `ResourceLeaseHistoryResponseDto` → `{ "intervals": [<ResourceLeaseIntervalDto>] }`.
+`acquiredByActorId` / `releasedByActorId` are present per-entry only for callers with `ADMIN`
+capability — same inline redaction rule `GET /resources/leases` applies to `acquiredByActorId`.
+
+No pruning/retention in v1 — the table is append-only and grows with lease-event cardinality
+(documented, accepted behavior; see `current/src/main/resources/db/migration/V16__Resource_Lease_History.sql`).
 
 ---
 

--- a/current/docs/api-rest.md
+++ b/current/docs/api-rest.md
@@ -229,10 +229,11 @@ All error responses use:
 | `scope_forbidden` | 403 | Item exists but is outside the caller's scope |
 | `field_not_patchable` | 400 | PATCH attempted on a server-owned field |
 | `cycle_detected` | 400 | Dependency would create a cycle |
-| `unsupported_media_type` | 415 | Wrong `Content-Type` for PATCH (see §22) |
+| `unsupported_media_type` | 415 | Wrong `Content-Type` for PATCH (see §23) |
 | `etag_mismatch` | 412 | `If-Match` header does not match current ETag |
 | `unauthenticated` | 401 | No authenticated principal (missing/invalid token) |
 | `verification_failed` | 401 | JWKS verification failed under `reject` policy |
+| `insufficient_capability` | 403 | Caller's token lacks a capability required by the request itself (distinct from `scope_forbidden`'s root-scope check) — e.g. a non-ADMIN caller sets `overrideResourceLeases: true` on `POST /items/{id}/advance`, or calls `DELETE /api/v1/resources/leases/{key}` without `ADMIN` |
 | `transition_failed` | 422 | Role transition rejected (invalid trigger, gate failure, dependency blocker) |
 | `resource_unavailable` | 409 | Resource-lease gate contention on `POST /items/{id}/advance` into WORK — transient, retryable. Carries a `Retry-After` header and `details.contendedResources`/`details.retryAfterMs`. Never discloses the current holder. |
 | `db_error` | 500 | Database query failed |
@@ -716,7 +717,7 @@ Supports `Idempotency-Key` header.
 
 JSON Merge Patch update. Requires `WRITE_ITEMS`, `If-Match`, and `Content-Type: application/merge-patch+json` (or `application/json`).
 
-**Request body:** A partial JSON object following RFC 7396 merge-patch semantics (see §22).
+**Request body:** A partial JSON object following RFC 7396 merge-patch semantics (see §23).
 
 **Tags deviation:** In PATCH, `tags` must be a comma-separated **string** (not a JSON array). Example: `"tags": "feature,auth"`. Sending a JSON array in PATCH → `400 validation_error`.
 

--- a/current/docs/api-rest.md
+++ b/current/docs/api-rest.md
@@ -31,17 +31,18 @@ ongoing fleet or multi-project work.
 11. [Endpoints — Notes (Read)](#11-endpoints--notes-read)
 12. [Endpoints — Notes (Write)](#12-endpoints--notes-write)
 13. [Endpoints — Dependencies](#13-endpoints--dependencies)
-14. [Endpoints — Transitions (Audit)](#14-endpoints--transitions-audit)
-15. [Endpoints — Search](#15-endpoints--search)
-16. [Endpoints — Config / Schema Discovery](#16-endpoints--config--schema-discovery)
-17. [Endpoints — Project Config (Per-Root)](#17-endpoints--project-config-per-root)
-18. [Endpoints — Plan Documents (Per-Root)](#18-endpoints--plan-documents-per-root)
-19. [Endpoints — Service Meta](#19-endpoints--service-meta)
-20. [Server-Sent Events (SSE)](#20-server-sent-events-sse)
-21. [Audit Model](#21-audit-model)
-22. [Merge Patch Semantics](#22-merge-patch-semantics)
-23. [Status-Graph Caveat](#23-status-graph-caveat)
-24. [Known Limitations](#24-known-limitations)
+14. [Endpoints — Resource Leases](#14-endpoints--resource-leases)
+15. [Endpoints — Transitions (Audit)](#15-endpoints--transitions-audit)
+16. [Endpoints — Search](#16-endpoints--search)
+17. [Endpoints — Config / Schema Discovery](#17-endpoints--config--schema-discovery)
+18. [Endpoints — Project Config (Per-Root)](#18-endpoints--project-config-per-root)
+19. [Endpoints — Plan Documents (Per-Root)](#19-endpoints--plan-documents-per-root)
+20. [Endpoints — Service Meta](#20-endpoints--service-meta)
+21. [Server-Sent Events (SSE)](#21-server-sent-events-sse)
+22. [Audit Model](#22-audit-model)
+23. [Merge Patch Semantics](#23-merge-patch-semantics)
+24. [Status-Graph Caveat](#24-status-graph-caveat)
+25. [Known Limitations](#25-known-limitations)
 
 ---
 
@@ -184,10 +185,10 @@ Config/schema endpoints (`/config`, `/config/schemas`, etc.) use a fingerprint-b
 - Stable across reads when the config has not changed
 - `If-None-Match` → `304` when fingerprint matches
 
-The per-root project config endpoints (§17, `/roots/{rootId}/config`) use the SAME `"cfg-<fingerprint>"`
+The per-root project config endpoints (§18, `/roots/{rootId}/config`) use the SAME `"cfg-<fingerprint>"`
 format, but the fingerprint is a SHA-256 over the stored `configYaml`'s raw UTF-8 bytes (see
 `SQLiteProjectConfigRepository.computeFingerprint`) rather than the global config file. `PUT` additionally
-accepts `If-Match` for optimistic-concurrency writes (see §17).
+accepts `If-Match` for optimistic-concurrency writes (see §18).
 
 ---
 
@@ -228,11 +229,12 @@ All error responses use:
 | `scope_forbidden` | 403 | Item exists but is outside the caller's scope |
 | `field_not_patchable` | 400 | PATCH attempted on a server-owned field |
 | `cycle_detected` | 400 | Dependency would create a cycle |
-| `unsupported_media_type` | 415 | Wrong `Content-Type` for PATCH (see §21) |
+| `unsupported_media_type` | 415 | Wrong `Content-Type` for PATCH (see §22) |
 | `etag_mismatch` | 412 | `If-Match` header does not match current ETag |
 | `unauthenticated` | 401 | No authenticated principal (missing/invalid token) |
 | `verification_failed` | 401 | JWKS verification failed under `reject` policy |
 | `transition_failed` | 422 | Role transition rejected (invalid trigger, gate failure, dependency blocker) |
+| `resource_unavailable` | 409 | Resource-lease gate contention on `POST /items/{id}/advance` into WORK — transient, retryable. Carries a `Retry-After` header and `details.contendedResources`/`details.retryAfterMs`. Never discloses the current holder. |
 | `db_error` | 500 | Database query failed |
 
 ---
@@ -344,9 +346,17 @@ For REST API writes, `id` is always `"api:<tokenId>"` and `kind` is always `"ext
   "statusLabel": "string|null",
   "occurredAt": "ISO-8601",
   "actor": null,        // redacted unless ADMIN
-  "verification": null  // redacted unless ADMIN
+  "verification": null, // redacted unless ADMIN
+  "consumedCredentials": ["vault:prod-db-password"] // nullable; omitted when empty
 }
 ```
+
+`consumedCredentials` is the audit trail of opaque credential/resource-lease labels this transition
+consumed — caller-supplied `credentialRefs` from the advance request, unioned with any keys the
+resource-lease gate auto-derived (held exclusive leases + advisory-mode declarations) when the item
+declares `resources:`. **Not subject to `API_REDACT_NOTE_ATTRIBUTION`** — unlike `actor`/`verification`
+on this same DTO, it is visible to any caller with `READ` capability, regardless of `ADMIN` status;
+the field's purpose is external verifiability, so it is deliberately not redacted.
 
 ### DependenciesDto
 
@@ -472,7 +482,7 @@ Note: `"<previousRole>"` is a literal sentinel string — dashboards must resolv
 }
 ```
 
-**ProjectConfigResponseDto** (see §17):
+**ProjectConfigResponseDto** (see §18):
 ```json
 {
   "rootId": "550e8400-e29b-41d4-a716-446655440000",
@@ -486,12 +496,12 @@ Note: `"<previousRole>"` is a literal sentinel string — dashboards must resolv
 ```
 `configYaml` is populated on `GET` only (omitted on `PUT`). `warning` is populated only when the
 root's `type` is not `"project"` (non-fatal — the push still succeeds). `relation` is populated on
-`GET` only, and only when `?fingerprint=` was supplied — see §17. `ignoredSections` is populated on
+`GET` only, and only when `?fingerprint=` was supplied — see §18. `ignoredSections` is populated on
 `PUT` only, and only when the pushed document contains top-level keys the per-root resolution layer
 does not honor (e.g. `actor_authentication`, which stays global-only) — omitted entirely when empty.
-See §17 for the full list of honored per-root keys.
+See §18 for the full list of honored per-root keys.
 
-**PlanDocumentResponseDto** (see §18):
+**PlanDocumentResponseDto** (see §19):
 ```json
 {
   "id": "550e8400-e29b-41d4-a716-446655440000",
@@ -509,15 +519,45 @@ See §17 for the full list of honored per-root keys.
 is `"adopted"`; null while `"pending"`, and null again if the adopting item is later deleted
 (`ON DELETE SET NULL` — the document's own `status` does not revert).
 
-**PlanDocumentSummaryDto** — one row of `PlanDocumentListResponseDto.plans` (see §18); same shape as
+**PlanDocumentSummaryDto** — one row of `PlanDocumentListResponseDto.plans` (see §19); same shape as
 `PlanDocumentResponseDto` minus `body`, which is never included in list responses.
 
-**PlanDocumentListResponseDto** (see §18):
+**PlanDocumentListResponseDto** (see §19):
 ```json
 {
   "rootId": "550e8400-e29b-41d4-a716-446655440000",
   "plans": [<PlanDocumentSummaryDto>]
 }
+```
+
+### ResourceLeaseDto (see §14)
+
+```json
+{
+  "resourceKey": "staging-db",
+  "holderItemId": "<uuid>",
+  "acquiredByActorId": "agent-worker-42",  // ADMIN callers only — omitted (not null) otherwise
+  "acquiredAt": "ISO-8601",
+  "expiresAt": "ISO-8601",
+  "originalAcquiredAt": "ISO-8601"
+}
+```
+
+`acquiredByActorId` is present only when the caller has `ADMIN` capability; non-admin `READ` callers
+receive the object without this field at all (server-wide `explicitNulls=false` — omitted, not
+serialized as `null`). `holderItemId` (the exclusivity subject — see §14) is visible to any `READ`
+caller; it carries no more information than an item ID already readable via `GET /items/{id}`.
+
+### ResourceLeaseListResponseDto
+
+```json
+{ "leases": [<ResourceLeaseDto>] }
+```
+
+### ResourceLeaseReleaseResponseDto
+
+```json
+{ "resourceKey": "staging-db", "releasedCount": 1 }
 ```
 
 ### SSE / ApiEvent
@@ -653,7 +693,7 @@ Supports `Idempotency-Key` header.
 
 JSON Merge Patch update. Requires `WRITE_ITEMS`, `If-Match`, and `Content-Type: application/merge-patch+json` (or `application/json`).
 
-**Request body:** A partial JSON object following RFC 7396 merge-patch semantics (see §21).
+**Request body:** A partial JSON object following RFC 7396 merge-patch semantics (see §22).
 
 **Tags deviation:** In PATCH, `tags` must be a comma-separated **string** (not a JSON array). Example: `"tags": "feature,auth"`. Sending a JSON array in PATCH → `400 validation_error`.
 
@@ -684,18 +724,84 @@ Cascade delete (removes item and all descendants, notes, and dependencies). Requ
 
 Trigger a role transition. Requires `ADVANCE`.
 
-This route runs the **same advance pipeline as the MCP `advance_item` tool**, unified behind `AdvanceService`: resolve → validate dependencies → **required-note gate** → apply → cascade detection → unblock detection. Previously the REST path skipped the gate, cascades, and unblock detection; those are now enforced and reported.
+This route runs the **same advance pipeline as the MCP `advance_item` tool**, unified behind `AdvanceService`: resolve → validate dependencies → **required-note gate** → **resource-lease gate** → apply → cascade detection → unblock detection. Previously the REST path skipped the gate, cascades, and unblock detection; those are now enforced and reported.
 
 **Request body:**
 ```json
 {
-  "trigger": "start|complete|block|hold|resume|cancel|reopen"
+  "trigger": "start|complete|block|hold|resume|cancel|reopen",
+  "credentialRefs": ["vault:prod-db-password"],     // optional; audit labels, never secret values
+  "overrideResourceLeases": false                    // optional; ADMIN-only, see below
 }
 ```
+
+`credentialRefs`: opaque audit labels for credentials/resources this transition consumed — max 8
+entries, each 1-128 chars matching `^[a-z0-9][a-z0-9\-_./]*$`. Validated with the identical
+`CredentialRefValidation` object the MCP `advance_item` tool uses, so the two surfaces reject the
+same inputs. **Closed-set rule:** once the target item declares `resources:` (via traits) or the
+server has a non-empty `resources:` registry, each supplied ref must name a declared/registered key
+— an unrecognized ref is rejected with `400 validation_error` naming the ref and the known-key list.
+Items with no declared resources are unaffected (an open, format-only check, unchanged from rung 1).
+Declared exclusive/advisory keys are auto-recorded into `consumedCredentials` on work entry — you do
+not need to repeat them.
+
+`overrideResourceLeases`: **ADMIN-only.** When `true`, skips the resource-lease gate for this
+transition entirely — no lease is taken, the gate is bypassed, not satisfied. A non-admin caller
+setting this field to `true` gets **`403 insufficient_capability`**, checked before the item is even
+loaded — the flag is never silently ignored. A successful override is WARN-logged (principal token
+id, item id, trigger) and the persisted transition's `summary` is stamped `"(resource leases
+overridden)"`. Omitted, `null`, or `false` are indistinguishable — the gate stays enforced.
 
 **Claimed-item behavior:** The REST API bypasses MCP claim ownership — a claimed item advances successfully even if a different MCP agent holds the claim. A WARN is emitted to the server log (`API_WARN_ON_CLAIMED_ADVANCE=false` to suppress). The response does NOT disclose `claimedBy` (tiered-disclosure principle).
 
 **Note-gate enforcement:** When the item's schema declares required notes, the gate is enforced exactly as in MCP — a `start` requires the current phase's required notes; a `complete` requires all required notes across every phase. An advance that leaves a required note unfilled is **rejected with `422 gate_blocked`** (it no longer silently advances). The missing notes are returned in `details.missingNotes`.
+
+**Resource-lease gate — the ownership/lease asymmetry.** REST bypasses MCP claim *ownership* for
+every caller unconditionally (see above), but it does **not** bypass the resource-lease gate the
+same way: leases stay enforced for every REST caller by default, and only an explicit ADMIN
+`overrideResourceLeases: true` opts out. The rationale: a claim is one agent's own bookkeeping, which
+an operator may reasonably overrule; a lease protects a shared *external* resource, which operator
+authority over the item does not make safe to double-acquire. This is the single most surprising
+behavior on this route — read it twice if you're building an operator dashboard.
+
+Entry into WORK is gated on **both** the `start` and `resume` triggers (`resume` re-enters WORK from
+BLOCKED and re-resolves/re-acquires leases against config as it stands at resume time — it is not
+exempt just because the note gate's `start`/`complete` check is). `complete`, `cancel`, `block`,
+`hold`, and `reopen` never acquire; every trigger that leaves WORK releases held leases inside the
+same transition (best-effort — a release failure is WARN-logged and never fails the transition; the
+lease TTL is the backstop).
+
+**Contention response (`409 resource_unavailable`):**
+```json
+{
+  "error": "resource_unavailable",
+  "message": "Resource lease contended: staging-db",
+  "details": {
+    "targetRole": "work",
+    "contendedResources": ["staging-db"],
+    "retryAfterMs": 30000
+  }
+}
+```
+A `Retry-After` response header accompanies the body — whole seconds, **rounded up** from
+`retryAfterMs` with a floor of 1, so a client never retries before the lease can possibly have
+expired. `CORS_EXPOSE_HEADERS` includes `Retry-After` by default (see `fleet-deployment.md`) so
+browser-based dashboards behind CORS can read it directly; `details.retryAfterMs` is present as a
+fallback regardless. **No holder identity is ever disclosed** on this path — neither the holding
+item's id nor its actor. Use `GET /api/v1/resources/leases` (§14, `ADMIN` capability for actor
+identity) to diagnose a stuck lease, or `get_context(itemId=...)` on the MCP side.
+
+An item that declares no resources (no `resources:` trait, whether or not a registry exists) can
+never produce `resource_unavailable` — the gate short-circuits before any lease-repository query, so
+non-adopters see byte-identical behavior to the feature's absence.
+
+**Known REST/MCP parity gap:** a start-cascade suppressed by resource contention is recorded in
+`cascadeEvents` with `"applied": false` (same as a gate-blocked cascade), but — unlike the MCP
+surface, which adds `resourceBlocked`/`contendedResources` to the cascade JSON — the REST
+`CascadeEventDto` does not yet carry those fields. A REST caller currently cannot distinguish a
+resource-suppressed cascade from any other unapplied one by field alone; this is flagged as a small
+additive follow-up, not a blocking gap (the child item's own transition still fully succeeds either
+way).
 
 **Response `200 OK`:** `AdvanceResponseDto`
 ```json
@@ -728,7 +834,10 @@ The `cascadeEvents`, `unblockedItems`, and `expectedNotes` fields are **additive
 
 **Responses:**
 - `200 OK` → `AdvanceResponseDto`
-- `400 validation_error` — invalid trigger string
+- `400 validation_error` — invalid trigger string, or a `credentialRefs` entry fails format/closed-set validation
+- `403 insufficient_capability` — `overrideResourceLeases: true` sent by a non-ADMIN caller
+- `409 resource_unavailable` — resource-lease gate contention; `Retry-After` header + `details.contendedResources`/`details.retryAfterMs` (see above)
+- `409 not_claim_holder` — pre-existing, defensive-only on this route (REST bypasses claim ownership by default — see "Claimed-item behavior" above); not expected to occur in normal REST usage
 - `422 gate_blocked` — a required-note gate failed; `details.missingNotes` lists the unfilled required notes
 - `422 transition_blocked` — a dependency blocker prevents the transition; `details.blockers` lists the blocking edges
 - `422 transition_failed` — invalid state transition (resolution/apply failure)
@@ -863,7 +972,47 @@ Scope check: both `fromItemId` and `toItemId` of the edge must be accessible to 
 
 ---
 
-## 14. Endpoints — Transitions (Audit)
+## 14. Endpoints — Resource Leases
+
+Server-wide primitive backing the resource-lease gate on `POST /items/{id}/advance` (§10) and the
+`resources:` trait dimension (see `config-format.md`). **Cross-project, not per-root** — unlike
+every other `/api/v1` resource in this document, these routes carry no `rootId` scoping; a lease key
+is a server-wide namespace (see the "global-wins" registry precedence note in `config-format.md`).
+
+### GET /api/v1/resources/leases
+
+Lists all currently active (unexpired) resource leases. Requires `READ`.
+
+**Response `200 OK`:** `ResourceLeaseListResponseDto` → `{ "leases": [<ResourceLeaseDto>] }`.
+`acquiredByActorId` is present per-entry only for callers with `ADMIN` capability — non-admin `READ`
+callers see every other field (including `holderItemId`, which is not considered sensitive; see
+`ResourceLeaseDto` in §8). No pagination — lease cardinality is bounded by design (one row per
+declared resource key per active holder, TTL-bounded), not a user-facing high-cardinality collection.
+
+### DELETE /api/v1/resources/leases/{key}
+
+Force-releases the active lease(s) held on `{key}`. Requires `ADMIN`. This is the operator recovery
+path for a crashed holder — it turns "wait out the TTL (up to 24h) or disable enforcement
+server-wide" into a one-call fix.
+
+**Path parameter:** `{key}` — validated against `^[a-z0-9][a-z0-9\-_./]*$`, max 128 chars, checked
+**before** any repository access.
+
+**Responses:**
+- `200 OK` → `ResourceLeaseReleaseResponseDto` → `{ "resourceKey": "...", "releasedCount": 1 }`
+- `400 validation_error` — `{key}` fails the pattern/length check
+- `403 insufficient_capability` — caller lacks `ADMIN`
+- `404 not_found` — no active lease exists on `{key}` (idempotent-safe: a repeat call after a
+  successful release returns `404`, not a second `200`)
+- `500 db_error` — repository failure
+
+Every successful force-release is WARN-logged with the acting principal's token id, the key, and the
+released count — sufficient to attribute the action to a specific bearer token from server logs
+alone, without needing to correlate against the response body.
+
+---
+
+## 15. Endpoints — Transitions (Audit)
 
 All require `READ`. `actor` and `verification` fields are redacted (null) for non-admin callers; admin callers see them subject to `API_REDACT_NOTE_ATTRIBUTION` and `API_REDACT_ACTOR_PROOF` env vars. Proof requires `ADMIN` + `?include=proof`.
 
@@ -887,7 +1036,7 @@ Scope-filtered: scoped tokens only see transitions for items within their scope 
 
 ---
 
-## 15. Endpoints — Search
+## 16. Endpoints — Search
 
 All require `READ`.
 
@@ -921,7 +1070,7 @@ Returns up to 50 hits. `noteKey` is populated on every hit (note-body search alw
 
 ---
 
-## 16. Endpoints — Config / Schema Discovery
+## 17. Endpoints — Config / Schema Discovery
 
 All require `READ`. All config endpoints emit a fingerprint-based ETag (`"cfg-<fingerprint>"`) and support `If-None-Match` → `304 Not Modified`.
 
@@ -963,11 +1112,11 @@ Structural role-transition graph across all schema types.
 
 **Response:** `200 OK` → `StatusGraphDto`
 
-See §22 for the important caveat about what the status graph does and does not reflect.
+See §23 for the important caveat about what the status graph does and does not reflect.
 
 ---
 
-## 17. Endpoints — Project Config (Per-Root)
+## 18. Endpoints — Project Config (Per-Root)
 
 Per-root config YAML documents pushed by a client (or the fail-open SessionStart config-sync hook,
 in a later phase) and layered over the global `.taskorchestrator/config.yaml` on every
@@ -1005,10 +1154,12 @@ fingerprint guard (guard 6 below).
 7. Optional `If-Match` (see below), evaluated against the CURRENT stored fingerprint
 
 On success, the parsed document's top-level keys are checked against the honored allowlist —
-`work_item_schemas`, `note_schemas`, `traits`, `project`, `note_limits`, `status_labels` — and any
-other key present (e.g. `actor_authentication`, which stays global-only — see
+`work_item_schemas`, `note_schemas`, `traits`, `project`, `note_limits`, `status_labels`,
+`resources` — and any other key present (e.g. `actor_authentication`, which stays global-only — see
 [`config-format.md`](../../claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md))
 is reported in the response's `ignoredSections` array so a push is never silently partial.
+`resources` is honored with an inverted precedence versus the other six keys — global wins on a
+registry key collision, not per-root — see "Per-root honorable settings" in `config-format.md`.
 
 **Responses:**
 - `200 OK` → `ProjectConfigResponseDto` (no `configYaml` field on this verb; `ignoredSections`
@@ -1051,7 +1202,7 @@ Removes the stored config row for `{rootId}`. Requires `WRITE_CONFIG`.
 
 ---
 
-## 18. Endpoints — Plan Documents (Per-Root)
+## 19. Endpoints — Plan Documents (Per-Root)
 
 Per-root plan documents — free-floating planning docs an agent stashes ahead of adoption into a
 real WorkItem. See [`PlanDocumentService`](../src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/PlanDocumentService.kt)
@@ -1107,7 +1258,7 @@ Lists metadata-only summaries (never the body) for every document under `{rootId
 
 ---
 
-## 19. Endpoints — Service Meta
+## 20. Endpoints — Service Meta
 
 ### GET /api/v1/info
 
@@ -1149,7 +1300,7 @@ Requires `READ`. Returns server metadata and the caller's resolved capabilities.
 
 ---
 
-## 20. Server-Sent Events (SSE)
+## 21. Server-Sent Events (SSE)
 
 ### GET /api/v1/events
 
@@ -1197,7 +1348,7 @@ Ktor's `sse {}` handler runs inside the response-body phase — after the HTTP 2
 
 ---
 
-## 21. Audit Model
+## 22. Audit Model
 
 All write endpoints (POST, PATCH, PUT, DELETE) synthesize an actor server-side from the authenticated principal. Client-supplied `actor.*` fields in the request body are **silently dropped** — callers cannot override audit attribution.
 
@@ -1218,7 +1369,7 @@ All write endpoints (POST, PATCH, PUT, DELETE) synthesize an actor server-side f
 
 ---
 
-## 22. Merge Patch Semantics
+## 23. Merge Patch Semantics
 
 `PATCH /items/{id}` implements [RFC 7396 JSON Merge Patch](https://datatracker.ietf.org/doc/html/rfc7396).
 
@@ -1238,7 +1389,7 @@ All write endpoints (POST, PATCH, PUT, DELETE) synthesize an actor server-side f
 
 ---
 
-## 23. Status-Graph Caveat
+## 24. Status-Graph Caveat
 
 `GET /config/status-graph` returns the **structural** (schema-defined) transition graph — which triggers are valid for each role per type.
 
@@ -1254,7 +1405,7 @@ The `"<previousRole>"` sentinel in `blocked.resume` is a literal string — reso
 
 ---
 
-## 24. Known Limitations
+## 25. Known Limitations
 
 **SSE dependency-event scoping depends on a warm ancestor cache.** Live root-filtering and `Last-Event-ID` replay are both correctly root-scoped — ring-buffer entries carry `affectedRoots` metadata and the replay path applies the same root-intersection filter as the live fan-out. One residual caveat remains for dependency events: `dependency.added` / `dependency.removed` resolve their affected roots from an in-memory ancestor cache populated by prior item create/update writes. On a cache miss (e.g., a dependency change with no preceding item write on that subtree during the connection's lifetime), the event falls back to an unscoped broadcast. This is a deliberate tradeoff; root-scoped subscribers that require exact dependency-event scoping should re-fetch state rather than relying solely on the event stream.
 

--- a/current/docs/api/openapi.yaml
+++ b/current/docs/api/openapi.yaml
@@ -481,6 +481,54 @@ components:
         releasedCount:
           type: integer
 
+    ResourceLeaseIntervalDto:
+      type: object
+      required: [resourceKey, holderItemId, acquiredAt, expiresAt]
+      description: >-
+        One row per lease hold interval (append-only, never pruned in v1) — see the
+        resource_lease_history table.
+      properties:
+        resourceKey:
+          type: string
+        holderItemId:
+          type: string
+          format: uuid
+        acquiredByActorId:
+          type: string
+          nullable: true
+          description: Present only for callers with ADMIN capability; omitted (not null) otherwise.
+        acquiredAt:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time
+        releasedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Null while the interval is still open.
+        releaseReason:
+          type: string
+          nullable: true
+          enum: [released, expired, force_released]
+          description: Null while the interval is still open.
+        releasedByActorId:
+          type: string
+          nullable: true
+          description: >-
+            Present only for callers with ADMIN capability; omitted (not null) otherwise. Null for a
+            passive "expired" close (no explicit release action performed it).
+
+    ResourceLeaseHistoryResponseDto:
+      type: object
+      required: [intervals]
+      properties:
+        intervals:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResourceLeaseIntervalDto"
+
     MissingNoteDto:
       type: object
       required: [key, description]
@@ -1654,6 +1702,53 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorDto"
+
+  /resources/leases/history:
+    get:
+      summary: Lease-interval audit history (who held resource R at time T)
+      operationId: listResourceLeaseHistory
+      tags: [resources]
+      description: >-
+        Append-only lease-interval audit log — answers "who held resource R at time T" after a
+        lease has already been released, stolen, or force-released, which the current-holders-only
+        /resources/leases list cannot. No pruning/retention in v1.
+      parameters:
+        - name: key
+          in: query
+          required: false
+          schema:
+            type: string
+            pattern: '^[a-z0-9][a-z0-9\-_./]*$'
+            maxLength: 128
+        - name: at
+          in: query
+          required: false
+          description: >-
+            ISO-8601 instant. When present, returns every interval held at that instant
+            (acquiredAt <= at < coalesce(releasedAt, expiresAt)). When absent, returns the most
+            recent intervals, newest-first.
+          schema:
+            type: string
+            format: date-time
+        - name: limit
+          in: query
+          required: false
+          description: Default 100, clamped to [1, 500].
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: >-
+            Matching intervals. acquiredByActorId / releasedByActorId are present per-entry only
+            for ADMIN callers (omitted, not null, for others).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceLeaseHistoryResponseDto"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
   /transitions:
     get:

--- a/current/docs/api/openapi.yaml
+++ b/current/docs/api/openapi.yaml
@@ -227,6 +227,16 @@ components:
           $ref: "#/components/schemas/ActorClaimDto"
         verification:
           $ref: "#/components/schemas/VerificationDto"
+        consumedCredentials:
+          type: array
+          nullable: true
+          items:
+            type: string
+          description: >-
+            Opaque audit labels for credentials/resources this transition consumed — caller-supplied
+            credentialRefs unioned with any resource-lease keys the gate auto-derived. Omitted/null
+            when empty. NOT subject to API_REDACT_NOTE_ATTRIBUTION — visible to any READ caller,
+            unlike actor/verification on this same DTO.
 
     DependenciesDto:
       type: object
@@ -406,6 +416,69 @@ components:
         trigger:
           type: string
           enum: [start, complete, block, hold, resume, cancel, reopen]
+        credentialRefs:
+          type: array
+          nullable: true
+          items:
+            type: string
+            pattern: '^[a-z0-9][a-z0-9\-_./]*$'
+          maxItems: 8
+          description: >-
+            Opaque audit labels for credentials/resources consumed by this transition (never secret
+            values). Each entry 1-128 chars matching the pattern. Once the target item declares
+            resources: (traits) or the server registry is non-empty, each ref must name a
+            declared/registered key (closed set) — an unrecognized ref returns 400 validation_error.
+            Declared resource keys are auto-recorded on work entry; you do not need to repeat them.
+        overrideResourceLeases:
+          type: boolean
+          nullable: true
+          default: false
+          description: >-
+            ADMIN-only. When true, skips the resource-lease gate for this transition (no lease taken,
+            gate bypassed not satisfied). A non-ADMIN caller setting this to true receives 403
+            insufficient_capability before the item is even loaded. WARN-logged; stamps
+            "(resource leases overridden)" on the persisted transition's summary.
+
+    ResourceLeaseDto:
+      type: object
+      required: [resourceKey, holderItemId, acquiredAt, expiresAt, originalAcquiredAt]
+      properties:
+        resourceKey:
+          type: string
+        holderItemId:
+          type: string
+          format: uuid
+        acquiredByActorId:
+          type: string
+          nullable: true
+          description: Present only for callers with ADMIN capability; omitted (not null) otherwise.
+        acquiredAt:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time
+        originalAcquiredAt:
+          type: string
+          format: date-time
+
+    ResourceLeaseListResponseDto:
+      type: object
+      required: [leases]
+      properties:
+        leases:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResourceLeaseDto"
+
+    ResourceLeaseReleaseResponseDto:
+      type: object
+      required: [resourceKey, releasedCount]
+      properties:
+        resourceKey:
+          type: string
+        releasedCount:
+          type: integer
 
     MissingNoteDto:
       type: object
@@ -1120,7 +1193,8 @@ paths:
       tags: [items]
       description: |
         Runs the SAME advance pipeline as the MCP advance_item tool (resolve → validate →
-        required-note gate → apply → cascade → unblock), unified behind AdvanceService.
+        required-note gate → resource-lease gate → apply → cascade → unblock), unified behind
+        AdvanceService.
 
         Bypasses MCP claim ownership — a claimed item advances successfully regardless of
         which MCP agent holds the claim. Response does NOT include claimedBy. WARN is logged
@@ -1130,6 +1204,12 @@ paths:
         is rejected with 422 (error code "gate_blocked") and the missing notes in details.missingNotes,
         rather than silently advancing. The response includes cascadeEvents, unblockedItems, and
         expectedNotes (additive — older clients can ignore the new fields).
+
+        Resource-lease gate ALSO enforced on both start and resume (both re-enter WORK) — unlike
+        claim ownership above, this gate is NOT bypassed for ordinary callers; only an explicit
+        ADMIN overrideResourceLeases:true opts out (403 for non-admin callers who set it). Contention
+        returns 409 resource_unavailable with a Retry-After header — never the current holder's
+        identity. An item with no declared resources can never produce this response.
       parameters:
         - $ref: "#/components/parameters/itemId"
       requestBody:
@@ -1153,6 +1233,26 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          description: >-
+            Two independent discriminants share this status, both defensive on the REST path since
+            REST bypasses claim ownership by default (see the ownership/lease asymmetry above):
+            error="resource_unavailable" — resource lease contended; details.contendedResources lists
+            the contended keys and details.retryAfterMs the suggested backoff (echoed as a Retry-After
+            header, whole seconds, rounded up); no holder identity disclosed, use
+            GET /api/v1/resources/leases (ADMIN) to diagnose. Only reachable for items that declare
+            resources: via traits. error="not_claim_holder" — a different agent holds a live claim on
+            the item (not expected to occur on the REST path, which bypasses ownership enforcement,
+            but defensively mapped).
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Present only for resource_unavailable. Whole seconds until the contended lease can possibly free up (rounded up, floor 1).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorDto"
         "422":
           description: >-
             Transition rejected. error="gate_blocked" with details.missingNotes when a required-note
@@ -1497,6 +1597,62 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+
+  /resources/leases:
+    get:
+      summary: List active resource leases
+      operationId: listResourceLeases
+      tags: [resources]
+      description: >-
+        Cross-project, server-wide — not root-scoped, unlike the rest of this API. Backs the
+        resource-lease gate on POST /items/{id}/advance and the resources: trait dimension.
+      responses:
+        "200":
+          description: >-
+            Active leases. acquiredByActorId is present per-entry only for ADMIN callers
+            (omitted, not null, for others).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceLeaseListResponseDto"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /resources/leases/{key}:
+    delete:
+      summary: Force-release a resource lease (operator recovery)
+      operationId: forceReleaseResourceLease
+      tags: [resources]
+      description: >-
+        ADMIN only. Recovers a lease stuck by a crashed holder without waiting out the TTL (up to
+        24h) or disabling enforcement server-wide. WARN-logged with the acting principal's token id.
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-z0-9][a-z0-9\-_./]*$'
+            maxLength: 128
+      responses:
+        "200":
+          description: Released
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceLeaseReleaseResponseDto"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: No active lease exists on this key (idempotent-safe — a repeat call 404s, not a second 200)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorDto"
 
   /transitions:
     get:

--- a/current/docs/api/openapi.yaml
+++ b/current/docs/api/openapi.yaml
@@ -425,9 +425,10 @@ components:
           maxItems: 8
           description: >-
             Opaque audit labels for credentials/resources consumed by this transition (never secret
-            values). Each entry 1-128 chars matching the pattern. Once the target item declares
-            resources: (traits) or the server registry is non-empty, each ref must name a
-            declared/registered key (closed set) — an unrecognized ref returns 400 validation_error.
+            values). Each entry 1-128 chars matching the pattern. Once the target item declares at
+            least one resource via its traits (registry state alone does not trigger this), each
+            ref must name a declared/registered key (closed set) — an unrecognized ref returns 400
+            validation_error.
             Declared resource keys are auto-recorded on work entry; you do not need to repeat them.
         overrideResourceLeases:
           type: boolean

--- a/current/docs/fleet-deployment.md
+++ b/current/docs/fleet-deployment.md
@@ -8,7 +8,8 @@ For single-agent or local-dev setups, the defaults are appropriate and this guid
 - [REST API Reference](api-rest.md) — HTTP endpoint docs, DTOs, error codes, SSE
 - [API Reference — `claim_item`](api-reference.md#claim_item) — tool spec: parameters, outcome codes, examples
 - [Workflow Guide §10 — Claim Mechanism](workflow-guide.md#10-claim-mechanism-for-multi-agent-fleets) — agent-side lifecycle, heartbeat pattern, discovery
-- This guide — operator-side: identity policy, capacity, disclosure, observability
+- [Workflow Guide §11 — Resource Leasing](workflow-guide.md#11-resource-leasing) — agent-side model: exclusive vs advisory, contention/retry, guarantees vs non-guarantees
+- This guide — operator-side: identity policy, capacity, disclosure, observability, resource-lease TTL/runbook
 
 ---
 
@@ -87,7 +88,7 @@ API_ALLOW_UNAUTHENTICATED=true
 | `CORS_ALLOWED_ORIGINS` | browser clients | _(none)_ | Comma-separated allowed origins. Empty = no cross-origin access. |
 | `CORS_ALLOWED_METHODS` | CORS enabled | `GET,POST,PATCH,PUT,DELETE,OPTIONS` | Comma-separated methods. |
 | `CORS_ALLOWED_HEADERS` | CORS enabled | `Authorization,Content-Type,If-Match` | Comma-separated request headers. |
-| `CORS_EXPOSE_HEADERS` | CORS enabled | `ETag,Last-Event-ID` | Response headers JS may read. |
+| `CORS_EXPOSE_HEADERS` | CORS enabled | `ETag,Last-Event-ID,Retry-After` | Response headers JS may read. `Retry-After` is exposed by default so browser dashboards can read the resource-lease contention backoff hint directly off `POST /items/{id}/advance`'s `409` response (see Resource Leasing below) without falling back to the `details.retryAfterMs` body field. |
 | `CORS_MAX_AGE_SECONDS` | CORS enabled | `3600` | Preflight cache duration. |
 | `API_SSE_BUFFER_SIZE` | SSE in use | `1000` | Ring-buffer size for Last-Event-ID replay. |
 | `API_ALLOW_QUERY_TOKEN_FOR_SSE` | SSE + browser | `false` | Allow `?token=` auth for SSE (browser EventSource workaround). |
@@ -95,6 +96,7 @@ API_ALLOW_UNAUTHENTICATED=true
 | `API_REDACT_NOTE_ATTRIBUTION` | always | `true` | When `true`, non-admin callers see no `actor`/`verification` on notes/transitions. |
 | `API_REDACT_ACTOR_PROOF` | always | `true` | When `true`, `actor.proof` is redacted even from admin callers unless `?include=proof`. |
 | `API_WARN_ON_CLAIMED_ADVANCE` | always | `true` | Log WARN when API caller advances a claimed item. |
+| `RESOURCE_LEASES_ENFORCED` | always | `true` | Deployment-wide kill switch for the resource-lease gate (see Resource Leasing below). Only the literal `false` (case-insensitive) disables it — any other value, including unset, leaves enforcement on. Disables **acquisition only**; releases always run regardless. Unlike every other flag in this table, this is read **per advance call**, not once at process start — `AdvanceService` is constructed fresh per `advance_item`/`POST .../advance` invocation, so flipping this var takes effect on the very next call, no restart required. |
 
 ### Bearer token secret file
 
@@ -637,6 +639,87 @@ The server intentionally restricts where `claimedBy` identity is visible. This d
 | `get_context()` health-check | `claimSummary: { active, expired }` globally — counts only |
 
 `get_context(itemId)` is the operator diagnostic tool. All other surfaces use count-only or boolean signals.
+
+---
+
+## Resource Leasing
+
+Resource leasing is a **separate primitive from `claim_item`**, deliberately: a claim leases a work
+*item* to a single actor; a resource lease serializes access to a shared *external* resource
+(a staging slot, a test database, a deploy credential, a fleet-wide deployment mutex) across
+whichever items declare it. An agent can hold a work-item claim and one or more resource leases
+simultaneously — the two systems do not interact, and one released is not implicitly released
+alongside the other. See [Workflow Guide §11](workflow-guide.md#11-resource-leasing) for the
+agent-facing model (declaration modes, contention/retry discipline, the full guarantees/non-
+guarantees statement) and
+[`config-format.md`](../../claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md)
+for the `resources:` trait/registry YAML syntax. This section covers the operator-facing runbook.
+
+### Item-keyed holder model
+
+The exclusivity subject is the **holding work item**, not the actor that triggered acquisition
+(`acquired_by_actor_id` is audit metadata only, nullable). This is deliberate: actor identity is
+optional and often self-reported or shared across processes (ten worker processes all reporting
+`actor.id: "orchestrator"` would otherwise all be treated as "the same holder," reproducing the
+exact multi-instance credential-collision failure this feature exists to prevent). Practical
+consequence for operators: **you cannot release a lease by matching on actor identity** — the only
+release paths are (1) the holding item's own transition out of WORK, (2) TTL expiry, or (3) an
+explicit `DELETE /api/v1/resources/leases/{key}` force-release. There is no "kick this actor's
+leases" operation.
+
+### TTL guidance
+
+Default TTL is **3600 seconds** (1 hour), configurable per resource key up to a hard maximum of
+**86400 seconds** (24 hours) via the registry's `defaultTtlSeconds`, or per-declaration via a
+trait's `ttlSeconds` (precedence: `requirement.ttlSeconds` > `registry.defaultTtlSeconds` > 3600,
+clamped to `[1, 86400]`). This is a materially longer default than the work-item claim TTL (900s) —
+size it to the resource, not the item: a resource lease should comfortably outlast the WORK phase
+of the item holding it, since there is no lease heartbeat/renewal call (unlike `claim_item`, which
+agents heartbeat explicitly). A lease that expires while the holding item is still legitimately in
+WORK does not get cleaned up automatically — the item keeps working, but a contending item could
+then acquire the "expired" key out from under it (a lost-exclusivity edge case; size TTL generously
+enough that this is a non-event in practice).
+
+| Resource type | Guidance |
+|---|---|
+| Fast single-step operation (e.g. a schema migration against a shared test DB) | Default (3600s) is comfortable headroom |
+| Multi-hour feature work touching a shared staging slot | Size `ttlSeconds` to 2-3x your realistic worst-case WORK duration |
+| Fleet-wide deployment mutex | Size to the deployment window, not the calendar — a stuck deploy should free the mutex well before an operator would otherwise notice |
+
+### Force-release runbook
+
+When a holder crashes or hangs mid-WORK, the lease sits until TTL expiry unless an operator
+intervenes:
+
+```bash
+curl -X DELETE https://orchestrator.internal:3001/api/v1/resources/leases/staging-db \
+  -H "Authorization: Bearer <admin-token>"
+```
+
+Requires `ADMIN` capability. Responses: `200` with `{ resourceKey, releasedCount }` on success;
+`404 not_found` if no active lease exists on that key (idempotent-safe — a repeat call after a
+successful release 404s rather than double-counting); `400 validation_error` if `{key}` fails the
+`^[a-z0-9][a-z0-9\-_./]*$` / 128-char check. Every successful force-release is WARN-logged with the
+acting principal's token id — check server logs to attribute the override after the fact. There is
+**no equivalent MCP tool/verb** — force-release is REST-only, by design (see Non-Goals in the
+implementation plan: no MCP acquire/release/renew verbs).
+
+**Diagnosing before you force-release:** `GET /api/v1/resources/leases` (`READ` capability; add
+`ADMIN` to see `acquiredByActorId`) lists every active lease with its `holderItemId` and
+`expiresAt`. Cross-reference `holderItemId` against `get_context(itemId=<that-uuid>)` (MCP) to
+confirm the holder is actually dead (stale `roleChangedAt`, no recent transitions) before force-
+releasing — a live holder that gets force-released will simply lose its lease silently; there is no
+notification back to the holder.
+
+### Enforcement kill switch
+
+`RESOURCE_LEASES_ENFORCED=false` (see the env var table above) disables **acquisition** fleet-wide
+without a restart — releases keep running regardless, so no lease is ever stranded by flipping the
+switch. Use this as an emergency valve if the gate itself is suspected of misbehaving (e.g.
+falsely rejecting every WORK entry) — it degrades the deployment to rung-1/rung-2 behavior
+(the audit field and the lease table both still exist and are still readable/force-releasable via
+REST) without requiring a config edit or redeploy. Re-enable by unsetting the var or setting it to
+anything other than the literal `false` — takes effect on the next `advance_item`/advance-route call.
 
 ---
 

--- a/current/docs/fleet-deployment.md
+++ b/current/docs/fleet-deployment.md
@@ -700,9 +700,13 @@ Requires `ADMIN` capability. Responses: `200` with `{ resourceKey, releasedCount
 `404 not_found` if no active lease exists on that key (idempotent-safe — a repeat call after a
 successful release 404s rather than double-counting); `400 validation_error` if `{key}` fails the
 `^[a-z0-9][a-z0-9\-_./]*$` / 128-char check. Every successful force-release is WARN-logged with the
-acting principal's token id — check server logs to attribute the override after the fact. There is
-**no equivalent MCP tool/verb** — force-release is REST-only, by design (see Non-Goals in the
-implementation plan: no MCP acquire/release/renew verbs).
+acting principal's token id — check server logs to attribute the override after the fact. The same
+token id is also threaded through to `releasedByActorId` on the closed `resource_lease_history`
+interval(s) for that key (`releaseReason: "force_released"`), so the override is attributable from
+`GET /api/v1/resources/leases/history?key=<key>` (`ADMIN` capability for actor identity) even after
+server logs have rotated — see [Workflow Guide §11, "Lease-interval history"](workflow-guide.md#11-resource-leasing)
+and [`api-rest.md`](api-rest.md) §14. There is **no equivalent MCP tool/verb** — force-release is
+REST-only, by design (see Non-Goals in the implementation plan: no MCP acquire/release/renew verbs).
 
 **Diagnosing before you force-release:** `GET /api/v1/resources/leases` (`READ` capability; add
 `ADMIN` to see `acquiredByActorId`) lists every active lease with its `holderItemId` and

--- a/current/docs/workflow-guide.md
+++ b/current/docs/workflow-guide.md
@@ -1161,6 +1161,22 @@ invariant, and not fairness. Read this section before relying on it for anything
   the implementation plan) — treat `resource_unavailable` as a normal, expected outcome to handle in
   your retry loop, not a bug.
 
+### Lease-interval history (audit)
+
+Every lease acquire/refresh/release/steal/force-release also writes to an append-only
+`resource_lease_history` table — one row per hold INTERVAL, not per event — answering "who held
+resource `R` at time `T`" after the fact, which the live `resource_leases` table (current holder
+only) cannot: it still has the answer once a lease has already been released, stolen by another
+item, or force-released by an operator. Query it via
+`GET /api/v1/resources/leases/history?key=&at=&limit=` (see [`api-rest.md`](./api-rest.md) §14) —
+omit `at` for a recent-activity feed (newest-first, default 100 rows, max 500); pass `at` as an
+ISO-8601 instant to ask "who held this at exactly this moment" (an open interval is bounded by its
+own `expiresAt`, so a crashed holder's interval reads as "not held" once its TTL lapses, even though
+the operator hasn't force-released it yet). Holder/closer actor identity is ADMIN-only, same
+redaction rule as the live list. History rows carry no foreign key to the holder work item and
+deliberately survive its deletion — this is an audit trail, not a live-state mirror. There is no
+pruning or retention policy in v1: the table is append-only and grows with lease-event cardinality.
+
 ---
 
 ## Quick Reference

--- a/current/docs/workflow-guide.md
+++ b/current/docs/workflow-guide.md
@@ -1038,6 +1038,131 @@ get_context(itemId="uuid")
 
 ---
 
+## 11. Resource Leasing
+
+Resource leasing lets a work item declare — via **traits** — that it needs exclusive or advisory
+access to a named shared resource (a staging slot, a test database, a deploy credential, a
+fleet-wide deployment mutex) before it enters the `work` phase. The server enforces this as a
+**gate inside `advance_item`**, the same call agents already use to advance — there is no separate
+acquire/release verb and no new MCP tool.
+
+> Full config syntax (`resources:` on a trait, the optional top-level registry, merge semantics,
+> the leaf-task-types-only rule) is in
+> [`config-format.md`](../../claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md).
+> This section covers the runtime behavior and operating discipline.
+
+### What it is (and isn't)
+
+A trait can declare one or more `resources:` — each a short opaque key (e.g. `staging-db`,
+`github-deploy-token`) with a **mode**:
+
+- **`exclusive`** (default) — the server takes a lease on the key when the item enters WORK (via
+  `start` or `resume` — both re-enter WORK). At most one item holds an exclusive key at a time in
+  v1 (the storage is semaphore-ready for `maxHolders > 1` later; admission is capped at 1 today). A
+  second item entering WORK while the key is held gets rejected — see Contention below.
+- **`advisory`** — no lease, no lock, no contention possible. The key is recorded into the
+  transition's `consumedCredentials` audit trail (alongside any caller-supplied `credentialRefs`)
+  purely for visibility — "this item touched this resource" — without serializing anything.
+
+**The single biggest modeling mistake to avoid:** `exclusive` means *"this item's work phase must
+not overlap another item's work phase for this key"* — reserve it for genuinely single-occupancy
+resources (a staging slot only one deployment can hold, a test DB only one suite can migrate at a
+time, a fleet-wide "one deployment in flight" mutex). A credential that is safe for several agents
+to *use concurrently* (most read-only API tokens, most service credentials with their own
+rate-limit budget) should be declared `advisory`, not `exclusive` — tagging it `exclusive` just
+because it's "a credential" needlessly serializes unrelated work. Use `advisory` for "record that
+this item touched this credential"; reserve `exclusive` for "this item must have this resource to
+itself."
+
+### Contention and retry discipline
+
+When an item enters WORK and an exclusive key it declares is already held, `advance_item` rejects
+the transition with a **transient** error, not a gate block:
+
+```json
+{
+  "itemId": "uuid",
+  "trigger": "start",
+  "applied": false,
+  "error": "Resource lease contended: staging-db",
+  "errorKind": "transient",
+  "errorCode": "resource_unavailable",
+  "retryAfterMs": 30000,
+  "contendedResources": ["staging-db"]
+}
+```
+
+This is deliberately shaped differently from a gate-blocked failure (`missingNotes` / write-more-notes)
+because the fix is different: **wait and retry, or work a different item** — not "fill in more
+context." `contendedResources` names the contended keys only; **the current holder's identity is
+never disclosed** on this path, by design (see Guarantees below). Agents and Ralph-style loop
+workers should treat `resource_unavailable` the same way they treat `already_claimed` from
+`claim_item`: release any claim on the item and move to a different item, never spin-retry the same
+item against the same lock.
+
+On the REST surface, the same contention maps to `409 resource_unavailable` with a `Retry-After`
+header (whole seconds, rounded up) — see [`api-rest.md`](./api-rest.md) §10/§14.
+
+An item that declares **no** `resources:` can never produce `resource_unavailable` — the check
+short-circuits before any lease-repository access, so the overwhelmingly common case (items with no
+resource traits) pays zero extra cost and sees byte-identical behavior to a deployment without this
+feature at all.
+
+### Guarantees vs non-guarantees
+
+Resource leasing gives you a real exclusivity guarantee at a specific moment, not a continuous
+invariant, and not fairness. Read this section before relying on it for anything safety-critical.
+
+**What it DOES guarantee:**
+- **A precondition at WORK entry, not a continuous invariant.** At the instant an item's `start`/`resume`
+  transition acquires an exclusive key, no other item holds that key. The lease is **not**
+  re-checked or re-validated for the remainder of the item's time in WORK — it holds the key until
+  it leaves WORK (complete, cancel, block/hold, reopen, or the TTL elapses), full stop. Both exit
+  paths release leases: `advance_item` (and the equivalent REST advance route) release inline on
+  every WORK exit, and `complete_tree` — which applies completions/cancellations directly rather
+  than through `advance_item` — independently releases leases on the same "leaving WORK" condition,
+  so a batch completion via `complete_tree` does not orphan leases until TTL expiry.
+- **The exclusivity subject is the work item, not the actor.** Leases are keyed on `holder_item_id`,
+  not on `acquired_by_actor_id` (audit metadata only). This makes the guarantee independent of actor
+  identity quality — it holds the same whether or not `actor_authentication` is configured, and
+  regardless of how many processes share a self-reported actor id like `"orchestrator"`.
+- **A single-DB arbiter.** Admission is enforced by one SQLite transaction (count-guard + insert, or
+  refresh) against the `resource_leases` table. There is no distributed coordination — this is not
+  a substitute for a distributed lock service across multiple database instances.
+- **Keys are opaque labels, never secrets.** A resource key (`staging-db`, `github-deploy-token`) is
+  a name, not a value — no credential material is ever stored by this feature. This is enforced by
+  construction (the key/label charset is deliberately narrow), not by redaction — labels are
+  intentionally NOT hidden from readers, since external verifiability is the point.
+
+**What it does NOT guarantee:**
+- **No fairness, no queueing, no waiting acquire.** A contended item is rejected immediately with
+  `resource_unavailable` — it does not wait in line. Whichever retry happens to land after the
+  holder releases wins; there is no FIFO ordering across contending items. If you need fair
+  ordering, build it in your retry/dispatch logic, not in this feature.
+- **Crash recovery is TTL expiry or an explicit ADMIN force-release — nothing automatic beyond
+  that.** If a holder crashes mid-WORK, the lease sits until its TTL elapses (default 3600s,
+  operator-configurable up to a max of 86400s per resource) or an operator calls
+  `DELETE /api/v1/resources/leases/{key}` (ADMIN capability — see
+  [`fleet-deployment.md`](./fleet-deployment.md)). There is no background reaper/sweeper process
+  actively watching for crashed holders.
+- **Identity governs early release, not exclusion.** Because leases are item-keyed (not
+  actor-keyed), *any* successful transition that moves the holding item out of WORK releases the
+  lease — there is no per-actor "only the acquiring actor can release" check. This is a deliberate
+  simplification, not an oversight: the exclusivity guarantee above is about the item, not about who
+  is allowed to touch it.
+- **The kill switch is read per request, not once at startup.** `RESOURCE_LEASES_ENFORCED=false`
+  disables acquisition (releases still always run) — and because the pipeline is constructed fresh
+  per `advance_item`/`POST .../advance` call, flipping this env var takes effect on the **next
+  call**, not after a server restart. Do not assume the usual "env vars need a restart" convention
+  applies here.
+- **No selector-level awareness.** `get_next_item` and `claim_item`'s selector mode do not know
+  about resource contention — they can still hand an agent an item that will immediately reject with
+  `resource_unavailable` on `start`. This is a known, deliberately deferred gap (see Non-Goals in
+  the implementation plan) — treat `resource_unavailable` as a normal, expected outcome to handle in
+  your retry loop, not a bug.
+
+---
+
 ## Quick Reference
 
 ### Common Call Patterns
@@ -1064,3 +1189,6 @@ get_context(itemId="uuid")
 | Diagnose stalled claim            | `get_context(itemId="uuid")` — returns `claimDetail` with `claimedBy` |
 | Filter next item by tag           | `get_next_item(tags="task-implementation", priority="high")` |
 | FIFO queue drain                  | `get_next_item(orderBy="oldest")` |
+| Record a consumed credential/resource | `advance_item(transitions=[{itemId, trigger:"start", credentialRefs:["vault:prod-db-password"]}])` |
+| Diagnose a stuck resource lease   | `get_context(itemId="uuid")` — `resourceLeases` block; or `GET /api/v1/resources/leases` (ADMIN sees holder actor) |
+| Force-release a stuck lease (operator) | `DELETE /api/v1/resources/leases/{key}` (ADMIN capability) |

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceService.kt
@@ -183,6 +183,10 @@ class AdvanceService(
      * @param degradedModePolicy the deployment's degraded-mode policy.
      * @param enforceOwnership when true, the claim-ownership pre-check runs (MCP); when false it is
      *   skipped entirely (REST) — the transition proceeds regardless of claim state.
+     * @param credentialRefs optional audit list of opaque credential/secret labels consumed by this
+     *   transition (never raw secret material). Defaults to empty — additive, no behavior change
+     *   when omitted. Caller (MCP tool / REST route) is responsible for format validation before
+     *   calling [advance]; this service persists the list as-is.
      * @return [AdvanceOutcome.Success] with a structured [AdvanceResult], or
      *   [AdvanceOutcome.Failure] with a structured [AdvanceFailure].
      */
@@ -193,7 +197,8 @@ class AdvanceService(
         actorClaim: ActorClaim?,
         verification: VerificationResult?,
         degradedModePolicy: DegradedModePolicy,
-        enforceOwnership: Boolean
+        enforceOwnership: Boolean,
+        credentialRefs: List<String> = emptyList()
     ): AdvanceOutcome {
         val previousRole = item.role
         val itemSchema = schemaResolver(item)
@@ -266,7 +271,8 @@ class AdvanceService(
                 roleTransitionRepository,
                 actorClaim = actorClaim,
                 verification = verification,
-                roleChangedAt = dbNow
+                roleChangedAt = dbNow,
+                consumedCredentials = credentialRefs
             )
         if (!applyResult.success || applyResult.item == null) {
             return AdvanceOutcome.Failure(

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceService.kt
@@ -3,12 +3,18 @@ package io.github.jpicklyk.mcptask.current.application.service
 import io.github.jpicklyk.mcptask.current.domain.model.ActorClaim
 import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceDefinition
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceMode
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceRequirement
 import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.VerificationResult
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
 import io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseAcquireResult
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseReleaseResult
 import io.github.jpicklyk.mcptask.current.domain.repository.NoteRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.domain.repository.RoleTransitionRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
@@ -55,6 +61,33 @@ sealed class AdvanceFailure {
         val missingNotes: List<NoteSchemaEntry>
     ) : AdvanceFailure()
 
+    /**
+     * A required EXCLUSIVE resource lease could not be acquired for a transition entering
+     * [Role.WORK] — another work item currently holds at least one of the item's declared
+     * resources (or the lease store hit a transient write conflict).
+     *
+     * Deliberately a SIBLING of [GateBlocked], not a variant of it: a gate block is a permanent
+     * rejection the caller fixes by writing notes, whereas this is a TRANSIENT rejection the caller
+     * fixes by waiting. Callers map it to a retryable error shape (MCP `resource_unavailable` with
+     * `errorKind=transient`, REST 409 + `Retry-After`).
+     *
+     * **No holder identity is carried here.** Learning which item or actor holds a contended
+     * resource is an operator-only capability exposed through `GET /api/v1/resources/leases`
+     * (ADMIN-gated) — never through an advance rejection, which any agent can trigger by probing.
+     *
+     * @property message human-readable summary naming the contended resource keys.
+     * @property targetRole the role the transition would have moved to (always [Role.WORK]).
+     * @property contendedResources every contended resource key, not just the first.
+     * @property retryAfterMs backoff hint in milliseconds (soonest lease expiry), or null when the
+     *   store could not compute one.
+     */
+    data class ResourceLeaseUnavailable(
+        val message: String,
+        val targetRole: Role,
+        val contendedResources: List<String>,
+        val retryAfterMs: Long?
+    ) : AdvanceFailure()
+
     /** The persistence step failed (DB error during apply). */
     data class ApplyFailed(
         val message: String
@@ -71,6 +104,12 @@ sealed class AdvanceFailure {
  * @property gateBlocked true when a terminal cascade was suppressed because the parent had
  *   unfilled required notes; in that case [applied] is false and [gateMissingNotes] is populated.
  * @property gateMissingNotes structured required notes missing on the parent (only when [gateBlocked]).
+ * @property resourceBlocked true when a START cascade into [Role.WORK] was suppressed because the
+ *   parent's EXCLUSIVE resource leases are held by another item; [applied] is false and
+ *   [contendedResources] is populated. Mirrors the [gateBlocked] suppression shape. The CHILD's own
+ *   advance still succeeded — only the parent's auto-start was skipped.
+ * @property contendedResources contended resource keys on the parent (only when [resourceBlocked]);
+ *   never carries holder identity.
  */
 data class AdvanceCascadeEvent(
     val itemId: java.util.UUID,
@@ -80,7 +119,9 @@ data class AdvanceCascadeEvent(
     val applied: Boolean,
     val statusLabel: String? = null,
     val gateBlocked: Boolean = false,
-    val gateMissingNotes: List<NoteSchemaEntry> = emptyList()
+    val gateMissingNotes: List<NoteSchemaEntry> = emptyList(),
+    val resourceBlocked: Boolean = false,
+    val contendedResources: List<String> = emptyList()
 )
 
 /** A downstream item that became fully unblocked as a result of the primary advance. */
@@ -135,6 +176,9 @@ data class AdvanceResult(
  * 2. **Resolve** — trigger + current role → target role (review-phase-aware).
  * 3. **Validate** — dependency-constraint check.
  * 4. **Gate check** — required-note enforcement for start/complete via [GatePredicate].
+ * 4.5 **Resource-lease gate** — for transitions ENTERING [Role.WORK] only, acquires the item's
+ *    declared EXCLUSIVE resource leases (see [resourceRequirementsResolver]). Short-circuits with
+ *    ZERO lease-store access when the item declares no resources, so non-adopters pay nothing.
  * 5. **Apply** — persist the role change + audit row atomically (single inner transaction).
  * 6. **Cascade detection** — terminal / start / reopen cascades, each applied in its OWN
  *    transaction boundary (the cascade applies are never wrapped in one outer transaction).
@@ -155,6 +199,20 @@ data class AdvanceResult(
  * @property statusLabelService resolves config-driven status labels per trigger.
  * @property schemaResolver resolves the trait-merged [WorkItemSchema] for an item (or null).
  *   Provided by the caller so the service does not depend on `ToolExecutionContext`.
+ * @property resourceLeaseRepository lease store used by the step-4.5 resource gate and by the
+ *   WORK-exit release paths. Null (the default) means no lease wiring is available — the resource
+ *   gate then logs an error and proceeds if an item somehow declares resources, which cannot happen
+ *   with the default [resourceRequirementsResolver].
+ * @property resourceRequirementsResolver resolves an item's declared resource requirements
+ *   (trait-merged, schema-free-safe — see `ToolExecutionContext.resolveResourceRequirements`).
+ *   Injected in the same style as [schemaResolver]; defaults to "no requirements", which keeps the
+ *   whole resource path dormant for callers that do not wire it.
+ * @property resourceRegistryResolver resolves the effective `resources:` registry for a root, used
+ *   for TTL defaults and for the credentialRefs membership check. Defaults to an empty registry.
+ * @property resourceLeasesEnforced deployment kill switch, read from the `RESOURCE_LEASES_ENFORCED`
+ *   environment variable at CONSTRUCTION time (see [resourceLeasesEnforcedFromEnv]) — never deep in
+ *   the pipeline. When false, step 4.5 and the start-cascade acquisition are skipped entirely;
+ *   releases still run, because releasing a lease is always safe.
  */
 class AdvanceService(
     private val workItemRepository: WorkItemRepository,
@@ -162,7 +220,11 @@ class AdvanceService(
     private val dependencyRepository: DependencyRepository,
     private val noteRepository: NoteRepository,
     private val statusLabelService: StatusLabelService,
-    private val schemaResolver: suspend (WorkItem) -> WorkItemSchema?
+    private val schemaResolver: suspend (WorkItem) -> WorkItemSchema?,
+    private val resourceLeaseRepository: ResourceLeaseRepository? = null,
+    private val resourceRequirementsResolver: suspend (WorkItem) -> List<ResourceRequirement> = { emptyList() },
+    private val resourceRegistryResolver: suspend (java.util.UUID?) -> Map<String, ResourceDefinition> = { emptyMap() },
+    private val resourceLeasesEnforced: Boolean = true
 ) {
     private val handler = RoleTransitionHandler()
     private val cascadeDetector = CascadeDetector()
@@ -170,6 +232,37 @@ class AdvanceService(
     companion object {
         private val logger = LoggerFactory.getLogger(AdvanceService::class.java)
         private const val MAX_CASCADES = 100
+
+        /** Environment variable name for the deployment-wide resource-lease kill switch. */
+        const val RESOURCE_LEASES_ENFORCED_ENV = "RESOURCE_LEASES_ENFORCED"
+
+        /** Fallback lease TTL when neither the requirement nor the registry specifies one. */
+        const val DEFAULT_RESOURCE_TTL_SECONDS = 3600
+
+        /** Inclusive lower bound applied to a resolved lease TTL. */
+        const val MIN_RESOURCE_TTL_SECONDS = 1
+
+        /** Inclusive upper bound (24h) applied to a resolved lease TTL. */
+        const val MAX_RESOURCE_TTL_SECONDS = 86400
+
+        /**
+         * Backoff hint surfaced when the lease store returns
+         * [LeaseAcquireResult.DBError] — its KDoc documents that a lost cross-transaction race can
+         * surface as a DB error rather than a [LeaseAcquireResult.Contended], with no computable
+         * expiry, so callers treat it as transient with a fixed default.
+         */
+        const val LEASE_DB_ERROR_RETRY_AFTER_MS = 1000L
+
+        /**
+         * Reads the [RESOURCE_LEASES_ENFORCED_ENV] kill switch. Enforcement is ON by default; only
+         * the literal string "false" (case-insensitive) disables it, matching the
+         * `API_WARN_ON_CLAIMED_ADVANCE` / `API_REDACT_*` convention in `AppConfig`.
+         *
+         * Call this at AdvanceService CONSTRUCTION sites and pass the result in — the pipeline
+         * itself never touches the environment.
+         */
+        fun resourceLeasesEnforcedFromEnv(env: (String) -> String? = System::getenv): Boolean =
+            env(RESOURCE_LEASES_ENFORCED_ENV)?.lowercase() != "false"
     }
 
     /**
@@ -185,8 +278,18 @@ class AdvanceService(
      *   skipped entirely (REST) — the transition proceeds regardless of claim state.
      * @param credentialRefs optional audit list of opaque credential/secret labels consumed by this
      *   transition (never raw secret material). Defaults to empty — additive, no behavior change
-     *   when omitted. Caller (MCP tool / REST route) is responsible for format validation before
-     *   calling [advance]; this service persists the list as-is.
+     *   when omitted. Caller (MCP tool / REST route) is responsible for FORMAT validation before
+     *   calling [advance]; this service adds a SET-MEMBERSHIP check (and the derived resource keys)
+     *   only for items that actually declare resources — see step 4.5.
+     * @param enforceResourceLeases when true (the default), the step-4.5 resource-lease gate and
+     *   the start-cascade lease acquisition run. **Deliberately INDEPENDENT of [enforceOwnership].**
+     *   The REST route passes `enforceOwnership = false` but `enforceResourceLeases = true`: claim
+     *   ownership is an *agent's* bookkeeping that an operator may legitimately override, whereas a
+     *   resource lease protects a shared EXTERNAL resource (a credential, a staging environment)
+     *   whose contention an operator cannot make safe by asserting authority. Only an explicit
+     *   ADMIN-only `overrideResourceLeases` request flag lowers this to false on the REST path; MCP
+     *   always passes true. The deployment-wide [resourceLeasesEnforced] kill switch is ANDed with
+     *   this parameter — either one being false disables the gate.
      * @return [AdvanceOutcome.Success] with a structured [AdvanceResult], or
      *   [AdvanceOutcome.Failure] with a structured [AdvanceFailure].
      */
@@ -198,7 +301,8 @@ class AdvanceService(
         verification: VerificationResult?,
         degradedModePolicy: DegradedModePolicy,
         enforceOwnership: Boolean,
-        credentialRefs: List<String> = emptyList()
+        credentialRefs: List<String> = emptyList(),
+        enforceResourceLeases: Boolean = true
     ): AdvanceOutcome {
         val previousRole = item.role
         val itemSchema = schemaResolver(item)
@@ -257,6 +361,22 @@ class AdvanceService(
             if (gateFailure != null) return AdvanceOutcome.Failure(gateFailure)
         }
 
+        // 4.5 Resource-lease gate — ONLY for transitions entering WORK.
+        //
+        // targetRole (not the trigger) is the correct discriminator: it covers "start" QUEUE->WORK
+        // AND "resume" BLOCKED->WORK, which the note gate above deliberately does not (its
+        // trigger == "start" || "complete" condition is left untouched).
+        val leaseGateActive = enforceResourceLeases && resourceLeasesEnforced
+        val effectiveCredentialRefs =
+            if (targetRole == Role.WORK && leaseGateActive) {
+                when (val gate = runResourceLeaseGate(item, targetRole, actorClaim, credentialRefs)) {
+                    is ResourceGateOutcome.Rejected -> return AdvanceOutcome.Failure(gate.failure)
+                    is ResourceGateOutcome.Proceed -> gate.credentialRefs
+                }
+            } else {
+                credentialRefs
+            }
+
         // 5. Apply — routes through applyTransition (atomic role change + audit row).
         // roleChangedAt is sourced from the DB clock for consistency with range-filter queries.
         val effectiveLabel = resolution.statusLabel ?: configLabel
@@ -272,7 +392,7 @@ class AdvanceService(
                 actorClaim = actorClaim,
                 verification = verification,
                 roleChangedAt = dbNow,
-                consumedCredentials = credentialRefs
+                consumedCredentials = effectiveCredentialRefs
             )
         if (!applyResult.success || applyResult.item == null) {
             return AdvanceOutcome.Failure(
@@ -281,6 +401,13 @@ class AdvanceService(
         }
         val appliedItem = applyResult.item
 
+        // 5.5 Release on EVERY exit from WORK — one condition covers complete, cancel, block, hold,
+        // and reopen-out-of-work. Releasing is unconditional on the kill switch: a lease acquired
+        // while enforcement was on must still be released after it is turned off.
+        if (previousRole == Role.WORK && targetRole != Role.WORK) {
+            releaseLeases(item.id, "work-exit ($trigger)")
+        }
+
         // 6. Cascade detection — each cascade apply is its OWN transaction boundary (inside
         //    applyTransition/cascadeTransition); detection and apply are intentionally split.
         val cascadeEvents = mutableListOf<AdvanceCascadeEvent>()
@@ -288,12 +415,12 @@ class AdvanceService(
             targetRole == Role.TERMINAL -> detectAndApplyTerminalCascades(appliedItem, trigger, cascadeEvents)
             targetRole == Role.WORK -> {
                 val startEvents = cascadeDetector.detectStartCascades(appliedItem, workItemRepository)
-                applyCascadeEvents(startEvents, "Auto-cascaded from child start", cascadeEvents)
+                applyCascadeEvents(startEvents, "Auto-cascaded from child start", cascadeEvents, leaseGateActive)
             }
         }
         if (trigger == "reopen" && targetRole == Role.QUEUE) {
             val reopenEvents = cascadeDetector.detectReopenCascades(appliedItem, workItemRepository, schemaResolver)
-            applyCascadeEvents(reopenEvents, "Auto-cascaded from child reopen", cascadeEvents)
+            applyCascadeEvents(reopenEvents, "Auto-cascaded from child reopen", cascadeEvents, leaseGateActive)
         }
 
         // 7. Unblock detection.
@@ -355,6 +482,174 @@ class AdvanceService(
                 "Gate check failed: required notes not filled: $missingKeys"
             }
         return AdvanceFailure.GateBlocked(message, targetRole, missingEntries)
+    }
+
+    /** Result of the step-4.5 resource gate: proceed (with derived refs) or reject the advance. */
+    private sealed class ResourceGateOutcome {
+        /** Leases acquired (or none needed); [credentialRefs] is the final audit list to persist. */
+        data class Proceed(
+            val credentialRefs: List<String>
+        ) : ResourceGateOutcome()
+
+        data class Rejected(
+            val failure: AdvanceFailure
+        ) : ResourceGateOutcome()
+    }
+
+    /**
+     * Step 4.5 — the resource-lease gate for a transition entering [Role.WORK].
+     *
+     * Order of operations:
+     * 1. Resolve the item's declared requirements. **If there are none, return immediately with the
+     *    caller's refs untouched — zero lease-repository access, zero registry resolution.** This is
+     *    the common path for every item that does not use resources, and it must stay free.
+     * 2. Resolve the registry (TTL defaults + the known-key set).
+     * 3. Tighten `credentialRefs` validation: reject any caller-supplied ref outside
+     *    `declared keys ∪ registry keys`. Only reachable when the item declares a resource or the
+     *    registry is non-empty, so non-adopters keep rung-1 behavior (format validation only).
+     * 4. Acquire all EXCLUSIVE keys in one all-or-nothing call. ADVISORY keys are never locked.
+     * 5. Derive the final `consumedCredentials`: derived keys (exclusive, then advisory) first, then
+     *    any caller-supplied extras, deduped.
+     *
+     * The acquire IS the snapshot of the item's requirements for its whole work phase — requirements
+     * are never re-resolved mid-work. A `resume` out of BLOCKED re-enters WORK and therefore
+     * re-resolves and re-acquires against the config as it stands at resume time, which is the
+     * intended behavior (the item lost its leases when it exited WORK into BLOCKED).
+     */
+    private suspend fun runResourceLeaseGate(
+        item: WorkItem,
+        targetRole: Role,
+        actorClaim: ActorClaim?,
+        credentialRefs: List<String>
+    ): ResourceGateOutcome {
+        // (1) Short-circuit: no declared resources → nothing to lock, nothing to derive.
+        val requirements = resourceRequirementsResolver(item)
+        if (requirements.isEmpty()) return ResourceGateOutcome.Proceed(credentialRefs)
+
+        // (2) Registry: TTL defaults and the set of server-known keys.
+        val registry = resourceRegistryResolver(item.rootId)
+
+        // (3) Membership tightening — declared keys plus every registered key.
+        val knownKeys = requirements.mapTo(mutableSetOf()) { it.key } + registry.keys
+        val unknownRef = credentialRefs.firstOrNull { it !in knownKeys }
+        if (unknownRef != null) {
+            return ResourceGateOutcome.Rejected(
+                AdvanceFailure.ValidationFailed(
+                    "credentialRefs entry '$unknownRef' is not a resource declared by this item or " +
+                        "registered in the server's resources: registry. Known keys: " +
+                        knownKeys.sorted().joinToString(),
+                    emptyList()
+                )
+            )
+        }
+
+        val exclusiveKeys = requirements.filter { it.mode == ResourceMode.EXCLUSIVE }.map { it.key }
+        val advisoryKeys = requirements.filter { it.mode == ResourceMode.ADVISORY }.map { it.key }
+
+        // (4) Acquire the EXCLUSIVE set. Actor id is audit metadata ONLY — exclusivity is keyed on
+        // the holder ITEM in the repository, so a shared or self-reported actor id cannot widen or
+        // narrow the guarantee.
+        if (exclusiveKeys.isNotEmpty()) {
+            val leaseRepo = resourceLeaseRepository
+            if (leaseRepo == null) {
+                logger.error(
+                    "Item {} declares {} exclusive resource(s) {} but no ResourceLeaseRepository is wired " +
+                        "into AdvanceService — the resource gate is being SKIPPED. This is a wiring bug at " +
+                        "the AdvanceService construction site, not a runtime condition.",
+                    item.id,
+                    exclusiveKeys.size,
+                    exclusiveKeys
+                )
+            } else {
+                val leaseRequests =
+                    requirements
+                        .filter { it.mode == ResourceMode.EXCLUSIVE }
+                        .map { it.key to resolveTtlSeconds(it, registry) }
+                when (val acquire = leaseRepo.acquireAll(item.id, actorClaim?.id, leaseRequests)) {
+                    is LeaseAcquireResult.Success -> {} // proceed
+                    is LeaseAcquireResult.Contended ->
+                        return ResourceGateOutcome.Rejected(
+                            AdvanceFailure.ResourceLeaseUnavailable(
+                                message =
+                                    "Cannot enter work phase: resource(s) currently held by another work item: " +
+                                        acquire.contendedKeys.joinToString(),
+                                targetRole = targetRole,
+                                contendedResources = acquire.contendedKeys,
+                                retryAfterMs = acquire.retryAfterMs
+                            )
+                        )
+                    is LeaseAcquireResult.DBError -> {
+                        logger.warn(
+                            "Resource lease acquire failed for item {} on keys {}: {}",
+                            item.id,
+                            exclusiveKeys,
+                            acquire.cause.message
+                        )
+                        return ResourceGateOutcome.Rejected(
+                            AdvanceFailure.ResourceLeaseUnavailable(
+                                message =
+                                    "Cannot enter work phase: transient contention in the resource lease store " +
+                                        "for resource(s): " + exclusiveKeys.joinToString() + ". Retry shortly.",
+                                targetRole = targetRole,
+                                contendedResources = exclusiveKeys,
+                                retryAfterMs = LEASE_DB_ERROR_RETRY_AFTER_MS
+                            )
+                        )
+                    }
+                }
+            }
+        }
+
+        // (5) Derivation: derived keys first (exclusive, then advisory), caller extras appended.
+        // Deduped, order-preserving. The MAX_ENTRIES cap in CredentialRefValidation constrains
+        // CALLER input only — server-derived keys are trusted and are never truncated.
+        return ResourceGateOutcome.Proceed((exclusiveKeys + advisoryKeys + credentialRefs).distinct())
+    }
+
+    /**
+     * Resolves a lease TTL: the requirement's own override wins, then the registry entry's
+     * `defaultTtlSeconds`, then [DEFAULT_RESOURCE_TTL_SECONDS]. The result is clamped to
+     * [MIN_RESOURCE_TTL_SECONDS]..[MAX_RESOURCE_TTL_SECONDS] so a hostile or stale config value can
+     * neither produce a non-positive TTL (which the lease store rejects) nor pin a resource for
+     * longer than a day.
+     */
+    private fun resolveTtlSeconds(
+        requirement: ResourceRequirement,
+        registry: Map<String, ResourceDefinition>
+    ): Int {
+        val raw =
+            requirement.ttlSeconds
+                ?: registry[requirement.key]?.defaultTtlSeconds
+                ?: DEFAULT_RESOURCE_TTL_SECONDS
+        return raw.coerceIn(MIN_RESOURCE_TTL_SECONDS, MAX_RESOURCE_TTL_SECONDS)
+    }
+
+    /**
+     * Releases every lease held by [itemId], logging and CONTINUING on failure.
+     *
+     * A release failure must never fail a transition that already persisted: the role change is
+     * committed by this point, and the lease TTL is the backstop that frees the resource anyway.
+     * [reason] is log context naming the release path (work exit vs. cascade).
+     */
+    private suspend fun releaseLeases(
+        itemId: java.util.UUID,
+        reason: String
+    ) {
+        val leaseRepo = resourceLeaseRepository ?: return
+        when (val release = leaseRepo.releaseAllForItem(itemId)) {
+            is LeaseReleaseResult.Success ->
+                if (release.releasedCount > 0) {
+                    logger.debug("Released {} resource lease(s) for item {} on {}", release.releasedCount, itemId, reason)
+                }
+            is LeaseReleaseResult.DBError ->
+                logger.warn(
+                    "Failed to release resource leases for item {} on {}: {}. The transition is NOT failed; " +
+                        "the lease TTL remains the backstop.",
+                    itemId,
+                    reason,
+                    release.cause.message
+                )
+        }
     }
 
     /**
@@ -436,6 +731,12 @@ class AdvanceService(
                 )
             )
 
+            // A cascaded ancestor that was itself in WORK has now left WORK — release its leases on
+            // the same log-and-continue policy as the primary work-exit path.
+            if (cascadeApply.success && event.currentRole == Role.WORK && event.targetRole != Role.WORK) {
+                releaseLeases(event.itemId, "terminal-cascade work-exit")
+            }
+
             if (!cascadeApply.success || cascadeApply.item == null) break
 
             // Continue up the tree: re-detect from the newly-cascaded parent.
@@ -456,11 +757,24 @@ class AdvanceService(
     /**
      * Apply a list of pre-detected cascade events (start cascade, reopen cascade). Each apply runs
      * in its own transaction via [RoleTransitionHandler.cascadeTransition].
+     *
+     * Resource handling mirrors the primary transition, keyed on the cascade's target role:
+     * - **Into WORK** (start cascades): the parent's own EXCLUSIVE leases are acquired BEFORE the
+     *   cascade is applied. On contention the cascade event is SUPPRESSED — recorded with
+     *   `applied = false`, `resourceBlocked = true` and the contended keys, exactly mirroring the
+     *   `gateBlocked` suppression shape used for terminal cascades. The child's own advance, which
+     *   already succeeded, is unaffected: a parent that cannot take the resource simply stays queued.
+     * - **Out of WORK** (reopen cascades from a working parent): leases are released after a
+     *   successful apply, log-and-continue.
+     *
+     * @param leaseGateActive false when either the caller passed `enforceResourceLeases = false` or
+     *   the deployment kill switch is off; acquisition is skipped, releases still run.
      */
     private suspend fun applyCascadeEvents(
         events: List<CascadeEvent>,
         reason: String,
-        out: MutableList<AdvanceCascadeEvent>
+        out: MutableList<AdvanceCascadeEvent>,
+        leaseGateActive: Boolean
     ) {
         for (event in events) {
             val parentItem =
@@ -468,6 +782,25 @@ class AdvanceService(
                     is Result.Success -> parentResult.data
                     is Result.Error -> continue
                 }
+
+            // Resource gate for a cascade INTO work: suppress this cascade on contention.
+            if (event.targetRole == Role.WORK && leaseGateActive) {
+                val contended = acquireForCascadeIntoWork(parentItem)
+                if (contended.isNotEmpty()) {
+                    out.add(
+                        AdvanceCascadeEvent(
+                            itemId = event.itemId,
+                            title = parentItem.title,
+                            previousRole = event.currentRole,
+                            targetRole = event.targetRole,
+                            applied = false,
+                            resourceBlocked = true,
+                            contendedResources = contended
+                        )
+                    )
+                    continue
+                }
+            }
 
             val cascadeApply =
                 handler.cascadeTransition(
@@ -489,6 +822,52 @@ class AdvanceService(
                     statusLabel = cascadeApply.item?.statusLabel
                 )
             )
+
+            if (cascadeApply.success && event.currentRole == Role.WORK && event.targetRole != Role.WORK) {
+                releaseLeases(event.itemId, "cascade work-exit")
+            }
+        }
+    }
+
+    /**
+     * Attempts to acquire [parentItem]'s EXCLUSIVE leases ahead of a cascade into [Role.WORK].
+     *
+     * @return the contended keys (empty when the acquire succeeded, when the parent declares no
+     *   exclusive resources, or when no lease repository is wired) — a non-empty result means the
+     *   caller must suppress the cascade.
+     */
+    private suspend fun acquireForCascadeIntoWork(parentItem: WorkItem): List<String> {
+        val requirements = resourceRequirementsResolver(parentItem)
+        if (requirements.isEmpty()) return emptyList()
+
+        val exclusive = requirements.filter { it.mode == ResourceMode.EXCLUSIVE }
+        if (exclusive.isEmpty()) return emptyList()
+
+        val leaseRepo = resourceLeaseRepository ?: return emptyList()
+        val registry = resourceRegistryResolver(parentItem.rootId)
+        val leaseRequests = exclusive.map { it.key to resolveTtlSeconds(it, registry) }
+
+        // Cascades have no actor by construction (see RoleTransitionHandler.cascadeTransition),
+        // so the lease's audit actor is null here.
+        return when (val acquire = leaseRepo.acquireAll(parentItem.id, null, leaseRequests)) {
+            is LeaseAcquireResult.Success -> emptyList()
+            is LeaseAcquireResult.Contended -> {
+                logger.info(
+                    "Start cascade into work suppressed for item {}: resource(s) {} held by another item",
+                    parentItem.id,
+                    acquire.contendedKeys
+                )
+                acquire.contendedKeys
+            }
+            is LeaseAcquireResult.DBError -> {
+                logger.warn(
+                    "Start cascade into work suppressed for item {}: lease store error on keys {}: {}",
+                    parentItem.id,
+                    exclusive.map { it.key },
+                    acquire.cause.message
+                )
+                exclusive.map { it.key }
+            }
         }
     }
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceService.kt
@@ -505,8 +505,9 @@ class AdvanceService(
      *    the common path for every item that does not use resources, and it must stay free.
      * 2. Resolve the registry (TTL defaults + the known-key set).
      * 3. Tighten `credentialRefs` validation: reject any caller-supplied ref outside
-     *    `declared keys ∪ registry keys`. Only reachable when the item declares a resource or the
-     *    registry is non-empty, so non-adopters keep rung-1 behavior (format validation only).
+     *    `declared keys ∪ registry keys`. Only reachable when the item declares at least one
+     *    resource — step (1) short-circuits before this regardless of registry state, so
+     *    non-adopters keep rung-1 behavior (format validation only).
      * 4. Acquire all EXCLUSIVE keys in one all-or-nothing call. ADVISORY keys are never locked.
      * 5. Derive the final `consumedCredentials`: derived keys (exclusive, then advisory) first, then
      *    any caller-supplied extras, deduped.
@@ -758,14 +759,18 @@ class AdvanceService(
      * Apply a list of pre-detected cascade events (start cascade, reopen cascade). Each apply runs
      * in its own transaction via [RoleTransitionHandler.cascadeTransition].
      *
-     * Resource handling mirrors the primary transition, keyed on the cascade's target role:
-     * - **Into WORK** (start cascades): the parent's own EXCLUSIVE leases are acquired BEFORE the
-     *   cascade is applied. On contention the cascade event is SUPPRESSED — recorded with
+     * Resource handling mirrors the primary transition, keyed on the cascade's target role. Both
+     * cascade kinds applied here — start and reopen — target [Role.WORK] (a reopen cascade re-enters
+     * WORK from a TERMINAL parent; it does not leave WORK), so only one path is ever reachable:
+     * - **Into WORK** (start or reopen cascades): the parent's own EXCLUSIVE leases are acquired
+     *   BEFORE the cascade is applied. On contention the cascade event is SUPPRESSED — recorded with
      *   `applied = false`, `resourceBlocked = true` and the contended keys, exactly mirroring the
      *   `gateBlocked` suppression shape used for terminal cascades. The child's own advance, which
      *   already succeeded, is unaffected: a parent that cannot take the resource simply stays queued.
-     * - **Out of WORK** (reopen cascades from a working parent): leases are released after a
-     *   successful apply, log-and-continue.
+     *
+     * The release call below is defensive and currently unreachable — no event this method applies
+     * ever has `targetRole != WORK` — but it is kept in case a future cascade kind routed through
+     * this method does exit WORK; releasing an item with no leases is always a safe no-op.
      *
      * @param leaseGateActive false when either the caller passed `enforceResourceLeases = false` or
      *   the deployment kill switch is off; acquisition is skipped, releases still run.
@@ -823,6 +828,9 @@ class AdvanceService(
                 )
             )
 
+            // Defensive and currently unreachable: every event this method applies targets WORK (see
+            // the KDoc above), so `event.targetRole != Role.WORK` is never true here. Kept as a
+            // safety net for a future cascade kind that DOES exit WORK.
             if (cascadeApply.success && event.currentRole == Role.WORK && event.targetRole != Role.WORK) {
                 releaseLeases(event.itemId, "cascade work-exit")
             }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/CredentialRefValidation.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/CredentialRefValidation.kt
@@ -1,0 +1,63 @@
+package io.github.jpicklyk.mcptask.current.application.service
+
+/**
+ * Shared validation rules for the optional `credentialRefs` audit field accepted by the MCP
+ * `advance_item` tool and the REST `POST /items/{id}/advance` route. Both call sites route
+ * through [validate] so the two surfaces enforce byte-for-byte identical rules.
+ *
+ * Entries are opaque credential/secret *labels* (e.g. "vault/prod-db-password", "github-pat-ci")
+ * recorded on the `role_transitions` audit row — never the credential value itself. Callers must
+ * never pass raw secret material here; this field is deliberately not redacted on read (see
+ * TransitionRoutes.kt) because the labels themselves are not sensitive.
+ */
+object CredentialRefValidation {
+    /** Maximum number of credentialRefs entries accepted per transition. */
+    const val MAX_ENTRIES = 8
+
+    /** Maximum length (inclusive) of a single credentialRefs entry. */
+    const val MAX_LENGTH = 128
+
+    /** Lowercase-slug-like label pattern: starts alphanumeric, then alphanumeric/-/_/./ allowed. */
+    val ENTRY_PATTERN: Regex = Regex("^[a-z0-9][a-z0-9\\-_./]*$")
+
+    /** Outcome of validating a candidate `credentialRefs` list. */
+    sealed class Result {
+        data class Valid(
+            val values: List<String>
+        ) : Result()
+
+        /**
+         * @property index the offending entry's position in the list, or -1 when the violation is
+         *   about the list as a whole (e.g. too many entries).
+         * @property reason a human-readable description of the violation, without any index prefix
+         *   — callers compose the final message since the two call sites format it differently.
+         */
+        data class Invalid(
+            val index: Int,
+            val reason: String
+        ) : Result()
+    }
+
+    /**
+     * Validates [values] against the shared rules: at most [MAX_ENTRIES] entries, each 1..[MAX_LENGTH]
+     * characters matching [ENTRY_PATTERN]. Returns the first violation encountered (list-size check
+     * first, then per-entry checks in order).
+     */
+    fun validate(values: List<String>): Result {
+        if (values.size > MAX_ENTRIES) {
+            return Result.Invalid(-1, "must not contain more than $MAX_ENTRIES entries (found ${values.size})")
+        }
+        values.forEachIndexed { index, value ->
+            if (value.isEmpty() || value.length > MAX_LENGTH) {
+                return Result.Invalid(index, "must be 1-$MAX_LENGTH characters (found length ${value.length})")
+            }
+            if (!ENTRY_PATTERN.matches(value)) {
+                return Result.Invalid(
+                    index,
+                    "'$value' does not match required pattern ^[a-z0-9][a-z0-9\\-_./]*$"
+                )
+            }
+        }
+        return Result.Valid(values)
+    }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NoteSchemaService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/NoteSchemaService.kt
@@ -1,6 +1,8 @@
 package io.github.jpicklyk.mcptask.current.application.service
 
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceDefinition
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceRequirement
 import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
 
@@ -119,6 +121,22 @@ interface WorkItemSchemaService {
      * Default implementation returns `"warn"` (schema-free / unconfigured mode).
      */
     fun getNoteLimitsMode(): String = "warn"
+
+    /**
+     * Returns the resource requirements declared for trait [traitName] (its `resources:` list under
+     * `traits.<traitName>.resources:`), or an empty list when the trait declares no `resources:` key
+     * or the trait itself is undefined.
+     *
+     * Default implementation returns an empty list (schema-free / unconfigured mode).
+     */
+    fun getTraitResources(traitName: String): List<ResourceRequirement> = emptyList()
+
+    /**
+     * Returns the top-level `resources:` registry, keyed by resource key.
+     *
+     * Default implementation returns an empty map (schema-free / unconfigured mode).
+     */
+    fun getResourceRegistry(): Map<String, ResourceDefinition> = emptyMap()
 }
 
 /**

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushService.kt
@@ -243,7 +243,7 @@ class ProjectConfigPushService(
          * so a push is never silently partial.
          */
         private val HONORED_TOP_LEVEL_SECTIONS =
-            setOf("work_item_schemas", "note_schemas", "traits", "project", "note_limits", "status_labels")
+            setOf("work_item_schemas", "note_schemas", "traits", "project", "note_limits", "status_labels", "resources")
     }
 }
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandler.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/RoleTransitionHandler.kt
@@ -684,6 +684,9 @@ class RoleTransitionHandler {
      *   pass the DB-side current time (via [WorkItemRepository.dbNow]) to keep this
      *   timestamp consistent with DB-clock-based range filter queries. Defaults to
      *   [Instant.now] for backward compatibility with existing unit tests.
+     * @param consumedCredentials Optional audit list of opaque credential/secret labels consumed
+     *   by this transition (never raw secret material). Defaults to empty — additive, no behavior
+     *   change when omitted. Cascade transitions always pass the default (empty).
      */
     suspend fun applyTransition(
         item: WorkItem,
@@ -695,7 +698,8 @@ class RoleTransitionHandler {
         roleTransitionRepository: RoleTransitionRepository,
         actorClaim: ActorClaim? = null,
         verification: VerificationResult? = null,
-        roleChangedAt: Instant = Instant.now()
+        roleChangedAt: Instant = Instant.now(),
+        consumedCredentials: List<String> = emptyList()
     ): TransitionApplyResult {
         val previousRole = item.role
 
@@ -754,7 +758,8 @@ class RoleTransitionHandler {
                                 trigger = trigger,
                                 summary = summary,
                                 actorClaim = actorClaim,
-                                verification = verification
+                                verification = verification,
+                                consumedCredentials = consumedCredentials
                             )
                         when (val createResult = roleTransitionRepository.create(transition)) {
                             is Result.Success -> {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContext.kt
@@ -13,6 +13,9 @@ import io.github.jpicklyk.mcptask.current.application.service.StatusLabelService
 import io.github.jpicklyk.mcptask.current.application.service.WorkTreeExecutor
 import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceDefinition
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceMode
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceRequirement
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
 import io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
@@ -166,6 +169,92 @@ class ToolExecutionContext(
      * Returns false when no schema matches (schema-free mode — skip REVIEW).
      */
     suspend fun resolveHasReviewPhase(item: WorkItem): Boolean = resolveSchema(item)?.hasReviewPhase() ?: false
+
+    /**
+     * Resolves the effective [ResourceRequirement] list for [item]'s traits — the config/domain
+     * layer only; nothing here acquires or enforces a lease (a follow-on task consumes this list to
+     * do that).
+     *
+     * Trait list = `(base schema's defaultTraits, if a schema resolves) + PropertiesHelper.extractTraits(item.properties)`,
+     * deduplicated preserving order — the exact same trait set [mergeTraits] uses for note merging.
+     * Deliberately reuses [resolveBaseSchemaWithSource] ONLY for its `defaultTraits`, tolerating a
+     * null base schema: an item with no resolvable schema (schema-free type/tags) is NOT exempt from
+     * resource resolution — its `properties`-carried traits are still honored, so a schema-free item
+     * can still declare (and later have leased) a resource.
+     *
+     * Per trait, resource requirements are layered exactly like trait notes ([mergeTraits]): the
+     * ALREADY-fetched per-root [snapshotFor] snapshot's `traitResources[name]` wins over the global
+     * [NoteSchemaService.getTraitResources]; a trait absent from both layers contributes nothing (no
+     * warning — an unknown trait is already warned about by [mergeTraits] when notes are resolved).
+     *
+     * Merge across traits is a UNION of keys (a requirement is never dropped for being a duplicate):
+     * on a duplicate key, [ResourceMode.EXCLUSIVE] wins over [ResourceMode.ADVISORY] regardless of
+     * which trait declared which mode, and `ttlSeconds` keeps the FIRST-seen (in trait-iteration
+     * order) non-null value — a later trait's ttl override for the same key is ignored once one is
+     * already recorded.
+     */
+    suspend fun resolveResourceRequirements(item: WorkItem): List<ResourceRequirement> {
+        val service = noteSchemaService()
+        val snapshot = snapshotFor(item.rootId)
+        val baseSchema = resolveBaseSchemaWithSource(item, snapshot, service)?.first
+        val defaultTraits = baseSchema?.defaultTraits ?: emptyList()
+        val itemTraits = PropertiesHelper.extractTraits(item.properties)
+        val allTraits = (defaultTraits + itemTraits).distinct()
+
+        if (allTraits.isEmpty()) return emptyList()
+
+        val merged = LinkedHashMap<String, ResourceRequirement>()
+        for (traitName in allTraits) {
+            val perRootRequirements = snapshot?.traitResources?.get(traitName)
+            val requirements = perRootRequirements ?: service.getTraitResources(traitName)
+            for (requirement in requirements) {
+                val existing = merged[requirement.key]
+                if (existing == null) {
+                    merged[requirement.key] = requirement
+                } else if (existing.mode != ResourceMode.EXCLUSIVE && requirement.mode == ResourceMode.EXCLUSIVE) {
+                    merged[requirement.key] = existing.copy(mode = ResourceMode.EXCLUSIVE)
+                }
+                // else: keep the first-seen entry as-is — first-seen wins for ttlSeconds, and the
+                // mode is already EXCLUSIVE (nothing beats it) or unchanged ADVISORY-vs-ADVISORY.
+            }
+        }
+        return merged.values.toList()
+    }
+
+    /**
+     * Resolves the effective resource registry (top-level `resources:`) visible to [rootId].
+     *
+     * ## GLOBAL WINS on collision — the inverse of trait/note layering
+     *
+     * Every other per-root resolver in this class has the per-root layer win over the global layer
+     * (a project's own config is treated as more specific). This resolver inverts that: it starts
+     * from [rootId]'s per-root registry, then OVERWRITES any colliding key with the GLOBAL entry.
+     * Rationale: a resource key is a lock/lease NAMESPACE that is server-global by construction (the
+     * whole point of `exclusive` mode is coordinating holders across possibly-different projects
+     * sharing the same server) — a per-root redefinition of a globally-known key would otherwise
+     * silently fork the namespace two ways depending on which config layer a caller consulted. A
+     * collision (the same key present in both layers) is logged as a warning; the global definition
+     * is used either way. A null [rootId] or no wired [perRootConfigService] simply yields the global
+     * registry unchanged (no per-root entries to start from).
+     */
+    suspend fun resolveResourceRegistry(rootId: UUID?): Map<String, ResourceDefinition> {
+        val perRootRegistry = snapshotFor(rootId)?.resourceRegistry ?: emptyMap()
+        val globalRegistry = noteSchemaService().getResourceRegistry()
+
+        val merged = LinkedHashMap<String, ResourceDefinition>(perRootRegistry)
+        for ((key, definition) in globalRegistry) {
+            if (merged.containsKey(key)) {
+                logger.warn(
+                    "Resource registry key '{}' is defined in both per-root and global config for root '{}'; " +
+                        "global definition wins",
+                    key,
+                    rootId
+                )
+            }
+            merged[key] = definition
+        }
+        return merged
+    }
 
     /**
      * Layered `note_limits.mode` resolution: [rootId]'s per-root config wins when it explicitly

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt
@@ -4,6 +4,7 @@ import io.github.jpicklyk.mcptask.current.application.service.RoleTransitionHand
 import io.github.jpicklyk.mcptask.current.application.tools.*
 import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseReleaseResult
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.modelcontextprotocol.kotlin.sdk.types.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
@@ -451,6 +452,8 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
                 continue
             }
 
+            releaseLeasesOnWorkExit(item, resolution.targetRole, context)
+
             completedCount++
             resultsList.add(
                 buildJsonObject {
@@ -576,6 +579,8 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
             return
         }
 
+        releaseLeasesOnWorkExit(item, resolution.targetRole, context)
+
         onComplete()
         resultsList.add(
             buildJsonObject {
@@ -609,6 +614,34 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
             }
         val filledKeys = notes.filter { it.body.isNotBlank() }.map { it.key }.toSet()
         return allRequired.filter { it.key !in filledKeys }.map { it.key }
+    }
+
+    /**
+     * Releases [item]'s resource leases when a `complete_tree`-applied transition exits WORK.
+     *
+     * `complete_tree` applies transitions via [RoleTransitionHandler.applyTransition] directly,
+     * bypassing [io.github.jpicklyk.mcptask.current.application.service.AdvanceService]'s own
+     * WORK-exit release (`AdvanceService.releaseLeases`, step 5.5). Without this call, an item
+     * completed through `complete_tree` while holding leases would orphan them until their TTL
+     * expires. A release failure must NEVER fail the completion — the TTL is the backstop that
+     * frees the resource anyway, mirroring [AdvanceService]'s log-and-continue release policy.
+     */
+    private suspend fun releaseLeasesOnWorkExit(
+        item: WorkItem,
+        targetRole: Role,
+        context: ToolExecutionContext
+    ) {
+        if (item.role != Role.WORK || targetRole == Role.WORK) return
+        when (val release = context.repositoryProvider.resourceLeaseRepository().releaseAllForItem(item.id)) {
+            is LeaseReleaseResult.Success -> {}
+            is LeaseReleaseResult.DBError ->
+                logger.warn(
+                    "Failed to release resource leases for item {} on complete_tree work-exit: {}. " +
+                        "The completion is NOT failed; the lease TTL remains the backstop.",
+                    item.id,
+                    release.cause.message
+                )
+        }
     }
 
     override fun userSummary(

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -7,6 +7,7 @@ import io.github.jpicklyk.mcptask.current.application.service.CredentialRefValid
 import io.github.jpicklyk.mcptask.current.application.service.buildExpectedNotesJson
 import io.github.jpicklyk.mcptask.current.application.service.computePhaseNoteContext
 import io.github.jpicklyk.mcptask.current.application.tools.*
+import io.github.jpicklyk.mcptask.current.domain.model.ErrorKind
 import io.github.jpicklyk.mcptask.current.domain.model.ToolError
 import io.github.jpicklyk.mcptask.current.domain.model.UserTrigger
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
@@ -57,6 +58,10 @@ into a one-element array. If `transitions` is present the singular fields are ig
 - start: required notes for the current phase must be filled before advancing
 - complete: all required notes across all phases must be filled
 
+**Resource-lease gate:** transitions entering the work phase acquire an exclusive lease per resource
+declared by the item's traits; contention rejects with transient `resource_unavailable` +
+`retryAfterMs` + `contendedResources` (holder never disclosed). Leases release on every work exit.
+
 **Batch actor constraint:** all transitions in a call must either all omit `actor` or all use the same
 `actor.id`; cascade-triggered transitions always have a null actor.
         """.trimIndent()
@@ -87,7 +92,9 @@ into a one-element array. If `transitions` is present the singular fields are ig
                                         "kind (required: orchestrator|subagent|user|external), parent?, proof? }), " +
                                         "credentialRefs? (audit labels of credentials this transition consumed — " +
                                         "opaque labels, never secret values; string or string array, max 8, " +
-                                        "each 1-128 chars matching ^[a-z0-9][a-z0-9\\-_./]*$) }"
+                                        "each 1-128 chars matching ^[a-z0-9][a-z0-9\\-_./]*$; must name a " +
+                                        "declared/registered resource key when any exist; declared keys are " +
+                                        "auto-recorded on work entry) }"
                                 )
                             )
                         }
@@ -451,10 +458,17 @@ into a one-element array. If `transitions` is present the singular fields are ig
                     dependencyRepository = context.dependencyRepository(),
                     noteRepository = context.noteRepository(),
                     statusLabelService = context.rootAwareStatusLabelService(item.rootId, trigger),
-                    schemaResolver = { context.resolveSchema(it) }
+                    schemaResolver = { context.resolveSchema(it) },
+                    resourceLeaseRepository = context.repositoryProvider.resourceLeaseRepository(),
+                    resourceRequirementsResolver = { context.resolveResourceRequirements(it) },
+                    resourceRegistryResolver = { context.resolveResourceRegistry(it) },
+                    resourceLeasesEnforced = AdvanceService.resourceLeasesEnforcedFromEnv()
                 )
 
             // Delegate the full pipeline to the per-item AdvanceService above.
+            // MCP ALWAYS enforces resource leases — there is no tool-level override. An operator
+            // who must bypass a lease uses the ADMIN-gated REST surface (an `overrideResourceLeases`
+            // advance, or DELETE /api/v1/resources/leases/{key}), both of which are logged at WARN.
             val outcome =
                 advanceService.advance(
                     item = item,
@@ -464,7 +478,8 @@ into a one-element array. If `transitions` is present the singular fields are ig
                     verification = verification,
                     degradedModePolicy = context.degradedModePolicy,
                     enforceOwnership = true,
-                    credentialRefs = credentialRefs
+                    credentialRefs = credentialRefs,
+                    enforceResourceLeases = true
                 )
 
             val advanceResult =
@@ -493,6 +508,13 @@ into a one-element array. If `transitions` is present the singular fields are ig
                         if (event.gateBlocked) {
                             put("gateBlocked", JsonPrimitive(true))
                             put("missingNotes", NoteSchemaJsonHelpers.buildMissingNotesArray(event.gateMissingNotes))
+                        }
+                        if (event.resourceBlocked) {
+                            put("resourceBlocked", JsonPrimitive(true))
+                            put(
+                                "contendedResources",
+                                JsonArray(event.contendedResources.map { JsonPrimitive(it) })
+                            )
                         }
                         event.statusLabel?.let { put("statusLabel", JsonPrimitive(it)) }
                     }
@@ -607,6 +629,11 @@ into a one-element array. If `transitions` is present the singular fields are ig
      * error JSON shapes (preserved byte-for-byte from the pre-unification inline logic):
      * - Ownership rejection → structured `not_claim_holder` error (+ `contendedItemId`)
      * - Policy rejection → structured `rejected_by_policy` error
+     * - Resource-lease contention → structured `resource_unavailable` error with
+     *   `errorKind=transient`, `retryAfterMs`, and a `contendedResources` array of key strings.
+     *   **No holder identity** (`contendedItemId` is deliberately left null, and no actor id
+     *   appears anywhere in the payload) — an agent that can trigger an advance must not be able to
+     *   enumerate who holds a resource; that is ADMIN-only via `GET /api/v1/resources/leases`.
      * - Validation failure → `error` + `blockers` array
      * - Gate block → `error` + `missingNotes` array
      * - Resolution / apply failure → plain `error` string
@@ -630,6 +657,18 @@ into a one-element array. If `transitions` is present the singular fields are ig
                     itemId,
                     trigger,
                     ToolError.permanent(code = "rejected_by_policy", message = failure.reason)
+                )
+            is AdvanceFailure.ResourceLeaseUnavailable ->
+                buildStructuredErrorResult(
+                    itemId,
+                    trigger,
+                    ToolError(
+                        kind = ErrorKind.TRANSIENT,
+                        code = "resource_unavailable",
+                        message = failure.message,
+                        retryAfterMs = failure.retryAfterMs
+                    ),
+                    contendedResources = failure.contendedResources
                 )
             is AdvanceFailure.ResolutionFailed ->
                 buildErrorResult(itemId, trigger, failure.message)
@@ -684,13 +723,18 @@ into a one-element array. If `transitions` is present the singular fields are ig
     /**
      * Builds a per-transition error result with structured [ToolError] fields.
      *
-     * Adds `kind`, `errorCode`, and `contendedItemId` alongside the legacy `error` string so
-     * agents can make programmatic retry decisions on ownership rejections and policy rejections.
+     * Adds `kind`, `errorCode`, `retryAfterMs`, and `contendedItemId` alongside the legacy `error`
+     * string so agents can make programmatic retry decisions on ownership rejections, policy
+     * rejections, and resource-lease contention.
+     *
+     * @param contendedResources contended resource KEYS for a `resource_unavailable` rejection.
+     *   Keys only — the holding item and actor are never disclosed here.
      */
     private fun buildStructuredErrorResult(
         itemId: UUID,
         trigger: String,
-        toolError: ToolError
+        toolError: ToolError,
+        contendedResources: List<String> = emptyList()
     ): JsonObject =
         buildJsonObject {
             put("itemId", JsonPrimitive(itemId.toString()))
@@ -699,6 +743,10 @@ into a one-element array. If `transitions` is present the singular fields are ig
             put("error", JsonPrimitive(toolError.message))
             put("errorKind", JsonPrimitive(toolError.kind.toJsonString()))
             put("errorCode", JsonPrimitive(toolError.code))
+            toolError.retryAfterMs?.let { put("retryAfterMs", JsonPrimitive(it)) }
             toolError.contendedItemId?.let { put("contendedItemId", JsonPrimitive(it.toString())) }
+            if (contendedResources.isNotEmpty()) {
+                put("contendedResources", JsonArray(contendedResources.map { JsonPrimitive(it) }))
+            }
         }
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -3,6 +3,7 @@ package io.github.jpicklyk.mcptask.current.application.tools.workflow
 import io.github.jpicklyk.mcptask.current.application.service.AdvanceFailure
 import io.github.jpicklyk.mcptask.current.application.service.AdvanceOutcome
 import io.github.jpicklyk.mcptask.current.application.service.AdvanceService
+import io.github.jpicklyk.mcptask.current.application.service.CredentialRefValidation
 import io.github.jpicklyk.mcptask.current.application.service.buildExpectedNotesJson
 import io.github.jpicklyk.mcptask.current.application.service.computePhaseNoteContext
 import io.github.jpicklyk.mcptask.current.application.tools.*
@@ -83,7 +84,10 @@ into a one-element array. If `transitions` is present the singular fields are ig
                                 JsonPrimitive(
                                     "Array of transition objects: { itemId (required, UUID or hex prefix), " +
                                         "trigger (required), summary?, actor? ({ id (required), " +
-                                        "kind (required: orchestrator|subagent|user|external), parent?, proof? }) }"
+                                        "kind (required: orchestrator|subagent|user|external), parent?, proof? }), " +
+                                        "credentialRefs? (audit labels of credentials this transition consumed — " +
+                                        "opaque labels, never secret values; string or string array, max 8, " +
+                                        "each 1-128 chars matching ^[a-z0-9][a-z0-9\\-_./]*$) }"
                                 )
                             )
                         }
@@ -152,6 +156,20 @@ into a one-element array. If `transitions` is present the singular fields are ig
         }
     }
 
+    /**
+     * Parses a `credentialRefs` JSON value into a `List<String>`: a bare string is coerced to a
+     * one-element list; a JSON array is accepted only if every element is a string. Returns null
+     * for any other shape (wrong type, non-string array element) so the caller can raise a
+     * shape-specific validation error.
+     */
+    private fun parseCredentialRefsElement(element: JsonElement): List<String>? =
+        when (element) {
+            is JsonArray ->
+                element.map { (it as? JsonPrimitive)?.takeIf { p -> p.isString }?.content ?: return null }
+            is JsonPrimitive -> if (element.isString) listOf(element.content) else null
+            else -> null
+        }
+
     override fun validateParams(params: JsonElement) {
         val normalized = normalizeParams(params)
         val normalizedObj = normalized as? JsonObject
@@ -190,6 +208,27 @@ into a one-element array. If `transitions` is present the singular fields are ig
                     "transitions[$index].trigger '${triggerPrim.content}' is not a valid trigger. " +
                         "Valid triggers: $validTriggers"
                 )
+
+            // Optional credentialRefs: a bare string or an array of strings, validated against the
+            // shared rules in CredentialRefValidation. Malformed shape or a rule violation fails
+            // validateParams up front — nothing is persisted for ANY transition in the batch.
+            val credentialRefsElement = obj["credentialRefs"]
+            if (credentialRefsElement != null && credentialRefsElement !is JsonNull) {
+                val parsed =
+                    parseCredentialRefsElement(credentialRefsElement)
+                        ?: throw ToolValidationException(
+                            "transitions[$index].credentialRefs must be a string or an array of strings"
+                        )
+                when (val result = CredentialRefValidation.validate(parsed)) {
+                    is CredentialRefValidation.Result.Invalid ->
+                        throw ToolValidationException(
+                            "transitions[$index].credentialRefs" +
+                                (if (result.index >= 0) "[${result.index}]" else "") +
+                                " ${result.reason}"
+                        )
+                    is CredentialRefValidation.Result.Valid -> {} // ok
+                }
+            }
         }
 
         // Validate that all transitions share the same actor presence and actor.id.
@@ -358,6 +397,17 @@ into a one-element array. If `transitions` is present the singular fields are ig
                     if (it.isString && it.content.isNotBlank()) it.content else null
                 }
 
+            // credentialRefs already validated (shape + rules) in validateParams; re-parse here to
+            // thread the resolved list into AdvanceService. Absent/null field -> empty list (no
+            // behavior change).
+            val credentialRefsElement = obj["credentialRefs"]
+            val credentialRefs =
+                if (credentialRefsElement != null && credentialRefsElement !is JsonNull) {
+                    parseCredentialRefsElement(credentialRefsElement) ?: emptyList()
+                } else {
+                    emptyList()
+                }
+
             // Extract optional actor claim
             val actorResult = parseActorClaim(obj["actor"] as? JsonObject, context)
             val actorClaim =
@@ -413,7 +463,8 @@ into a one-element array. If `transitions` is present the singular fields are ig
                     actorClaim = actorClaim,
                     verification = verification,
                     degradedModePolicy = context.degradedModePolicy,
-                    enforceOwnership = true
+                    enforceOwnership = true,
+                    credentialRefs = credentialRefs
                 )
 
             val advanceResult =

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
@@ -3,6 +3,7 @@ package io.github.jpicklyk.mcptask.current.application.tools.workflow
 import io.github.jpicklyk.mcptask.current.application.service.buildExpectedNotesJson
 import io.github.jpicklyk.mcptask.current.application.service.computePhaseNoteContext
 import io.github.jpicklyk.mcptask.current.application.tools.*
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceMode
 import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.modelcontextprotocol.kotlin.sdk.types.ToolAnnotations
@@ -239,6 +240,31 @@ session-resume, neither → health-check); explicit `mode` takes precedence.
                 JsonArray(emptyList())
             }
 
+        // Resource lease disclosure inputs — declared resources (from traits) plus any leases this
+        // item actively holds. Items that declare no resources skip the lease repository entirely
+        // (the overwhelmingly common path pays zero lease queries); a lease held by an item whose
+        // declarations were since removed from config is not surfaced here — TTL reclaims it.
+        val declaredResources = context.resolveResourceRequirements(item)
+        val declaredKeys = declaredResources.map { it.key }
+        val heldLeaseByKey =
+            if (declaredKeys.isNotEmpty()) {
+                context.repositoryProvider
+                    .resourceLeaseRepository()
+                    .findActiveForItem(item.id)
+                    .associateBy { it.resourceKey }
+            } else {
+                emptyMap()
+            }
+        val anyHolderByKey =
+            if (declaredKeys.isNotEmpty()) {
+                context.repositoryProvider
+                    .resourceLeaseRepository()
+                    .findActiveByKeys(declaredKeys)
+                    .associateBy { it.resourceKey }
+            } else {
+                emptyMap()
+            }
+
         val data =
             buildJsonObject {
                 put("mode", JsonPrimitive("item"))
@@ -281,6 +307,36 @@ session-resume, neither → health-check); explicit `mode` takes precedence.
                             val isExpired = item.claimExpiresAt != null && !item.claimExpiresAt.isAfter(dbNowInstant)
                             put("isExpired", JsonPrimitive(isExpired))
                         }
+                    )
+                }
+                // Resource lease disclosure — item mode is the sanctioned holder-identity diagnostic
+                // for resource leases too, mirroring claimDetail above. Omitted entirely when the
+                // item neither declares nor holds any resource (zero payload for the common case).
+                if (declaredResources.isNotEmpty() || heldLeaseByKey.isNotEmpty()) {
+                    val requirementByKey = declaredResources.associateBy { it.key }
+                    val allKeys = (declaredKeys + heldLeaseByKey.keys).distinct()
+                    put(
+                        "resourceLeases",
+                        JsonArray(
+                            allKeys.map { key ->
+                                val requirement = requirementByKey[key]
+                                val ownLease = heldLeaseByKey[key]
+                                // For declared keys, holder identity comes from the all-holders lookup
+                                // above; for a held-but-no-longer-declared key (trait removed while the
+                                // lease is still active), fall back to the item's own lease record.
+                                val anyLease = anyHolderByKey[key] ?: ownLease
+                                buildJsonObject {
+                                    put("key", JsonPrimitive(key))
+                                    put("mode", JsonPrimitive((requirement?.mode ?: ResourceMode.ADVISORY).name.lowercase()))
+                                    put("held", JsonPrimitive(ownLease != null))
+                                    anyLease?.let { lease ->
+                                        put("holderItemId", JsonPrimitive(lease.holderItemId.toString()))
+                                        lease.acquiredByActorId?.let { actorId -> put("acquiredByActorId", JsonPrimitive(actorId)) }
+                                        put("expiresAt", JsonPrimitive(lease.expiresAt.toString()))
+                                    }
+                                }
+                            }
+                        )
                     )
                 }
             }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ResourceDefinition.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ResourceDefinition.kt
@@ -1,0 +1,37 @@
+package io.github.jpicklyk.mcptask.current.domain.model
+
+/**
+ * Registry entry for a shared external resource (credential, environment, etc.), declared under
+ * the top-level `resources:` key in `.taskorchestrator/config.yaml`:
+ *
+ * ```yaml
+ * resources:
+ *   staging-db-credential:
+ *     description: "Shared staging database credential"
+ *     defaultTtlSeconds: 1800
+ *     maxHolders: 1
+ * ```
+ *
+ * This is the server-global lock namespace: a resource `key` referenced by a trait's
+ * [ResourceRequirement] resolves its default TTL and description against this registry — see
+ * [io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext.resolveResourceRegistry]
+ * for the per-root/global layering (global wins on key collision, the inverse of trait-note
+ * layering, since the lock namespace itself is server-global).
+ *
+ * @property key Resource identifier. Must match `^[a-z0-9][a-z0-9\-_./]*$`, max 128 characters — see
+ *   [io.github.jpicklyk.mcptask.current.infrastructure.config.YamlSchemaParser].
+ * @property description Human-readable description of the resource.
+ * @property defaultTtlSeconds Default lease TTL in seconds used when a trait's [ResourceRequirement]
+ *   doesn't override it with its own `ttlSeconds`. Valid range enforced at config load: 1..86400
+ *   (24h) — an out-of-range or non-numeric YAML value is a load warning, and the entry falls back to
+ *   3600s rather than being rejected outright.
+ * @property maxHolders Maximum concurrent holders. v1 only supports exactly 1 (single-holder
+ *   exclusive lock) — a config value greater than 1 is a load ERROR (the entry is skipped, not
+ *   clamped) since fan-in lease semantics are not yet implemented.
+ */
+data class ResourceDefinition(
+    val key: String,
+    val description: String = "",
+    val defaultTtlSeconds: Int = 3600,
+    val maxHolders: Int = 1
+)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ResourceLease.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ResourceLease.kt
@@ -1,0 +1,60 @@
+package io.github.jpicklyk.mcptask.current.domain.model
+
+import io.github.jpicklyk.mcptask.current.domain.validation.ValidationException
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * A server-enforced TTL lease held by a WorkItem on a shared external resource (see
+ * [ResourceRequirement] / [ResourceDefinition]).
+ *
+ * Backed by `resource_leases` (see
+ * [io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ResourceLeasesTable] /
+ * `V15__Resource_Leases.sql`). "Active" (not expired) is a lazy, read-time notion — see
+ * [io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository] KDoc — this type
+ * itself carries no `isActive` flag; callers compare [expiresAt] against the DB clock, or rely on
+ * repository methods that already filter to active rows.
+ *
+ * @property id Stable identifier for this lease row.
+ * @property resourceKey The resource namespace key this lease holds (matches
+ *   [ResourceDefinition.key] / [ResourceRequirement.key]).
+ * @property holderItemId The WorkItem holding this lease. FK `ON DELETE CASCADE` — deleting the
+ *   holder releases its leases automatically.
+ * @property acquiredByActorId Opaque actor identifier that performed the acquisition, if known.
+ *   Audit-only; never used for lease-ownership decisions (ownership is by [holderItemId]).
+ * @property acquiredAt When the current lease term began. Refreshed on same-holder re-acquire.
+ * @property expiresAt TTL-based expiry, computed DB-side. A lease with `expiresAt <= dbNow()` is
+ *   treated as absent by every repository read path (lazy expiry — no background sweep).
+ * @property originalAcquiredAt Timestamp of the FIRST acquisition of this (resourceKey, holderItemId)
+ *   pair — preserved across same-holder re-acquires/refreshes; reset only when a different holder
+ *   acquires the key after the prior lease lapsed. Mirrors [WorkItem.originalClaimedAt].
+ * @property version Optimistic-concurrency / audit counter, incremented on each write to this row.
+ */
+data class ResourceLease(
+    val id: UUID = UUID.randomUUID(),
+    val resourceKey: String,
+    val holderItemId: UUID,
+    val acquiredByActorId: String? = null,
+    val acquiredAt: Instant,
+    val expiresAt: Instant,
+    val originalAcquiredAt: Instant,
+    val version: Int = 0,
+) {
+    init {
+        validate()
+    }
+
+    /**
+     * Coherence checks mirroring [WorkItem]'s claim-field invariant style (see
+     * `WorkItem.validate()`): timestamps must be internally ordered.
+     */
+    fun validate() {
+        if (resourceKey.isBlank()) throw ValidationException("resourceKey must not be blank")
+        if (acquiredAt.isAfter(expiresAt)) {
+            throw ValidationException("acquiredAt must not be after expiresAt")
+        }
+        if (originalAcquiredAt.isAfter(acquiredAt)) {
+            throw ValidationException("originalAcquiredAt must not be after acquiredAt")
+        }
+    }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ResourceLeaseInterval.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ResourceLeaseInterval.kt
@@ -1,0 +1,45 @@
+package io.github.jpicklyk.mcptask.current.domain.model
+
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * An append-only audit record of one resource-lease HOLD INTERVAL — answers "who held resource R
+ * at time T" (see `resource_lease_history` /
+ * [io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ResourceLeaseHistoryTable]).
+ *
+ * Unlike [ResourceLease] (the live, mutable "current holder" row), this type is immutable audit
+ * history: one row per hold interval, appended on acquire and closed exactly once — never deleted
+ * or otherwise mutated after closing. [holderItemId] carries NO foreign key — the row must remain
+ * readable after the holder work item is deleted.
+ *
+ * An interval is "held at" instant `T` iff `acquiredAt <= T < coalesce(releasedAt, expiresAt)` —
+ * see [io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository.findHoldersAt].
+ *
+ * @property id Stable identifier for this history row.
+ * @property resourceKey The resource namespace key held during this interval.
+ * @property holderItemId The WorkItem that held the key during this interval. No FK — may
+ *   reference a since-deleted work item.
+ * @property acquiredByActorId Opaque actor identifier that acquired this interval, if known.
+ * @property acquiredAt When this hold interval began.
+ * @property expiresAt TTL-based expiry as of the last write to this row. Refreshed in place on a
+ *   same-holder re-acquire while the interval is open; frozen at its final value once closed.
+ * @property releasedAt When this interval closed. Null while the interval is OPEN.
+ * @property releaseReason Why the interval closed: `"released"` (normal release), `"expired"`
+ *   (stolen by a different holder after TTL lapse), or `"force_released"` (ADMIN override). Null
+ *   while open.
+ * @property releasedByActorId Opaque actor identifier that performed the closing action —
+ *   populated for `"released"` / `"force_released"`; null for a passive `"expired"` close, since
+ *   the STEALING holder's acquire caused the close, not an explicit release action.
+ */
+data class ResourceLeaseInterval(
+    val id: UUID = UUID.randomUUID(),
+    val resourceKey: String,
+    val holderItemId: UUID,
+    val acquiredByActorId: String? = null,
+    val acquiredAt: Instant,
+    val expiresAt: Instant,
+    val releasedAt: Instant? = null,
+    val releaseReason: String? = null,
+    val releasedByActorId: String? = null,
+)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ResourceRequirement.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/ResourceRequirement.kt
@@ -1,0 +1,40 @@
+package io.github.jpicklyk.mcptask.current.domain.model
+
+/**
+ * Declares a shared external resource (credential, environment, etc.) that a trait requires.
+ *
+ * Declared per-trait in `.taskorchestrator/config.yaml` under `traits.<name>.resources:`, in either
+ * short form (a bare key string, `EXCLUSIVE` mode, no ttl override) or long form (a map with `key`,
+ * optional `mode`, optional `ttlSeconds`) — see
+ * [io.github.jpicklyk.mcptask.current.infrastructure.config.YamlSchemaParser.parseRoot].
+ *
+ * This type carries only the *declaration*; nothing in this task enforces it. Enforcement (a
+ * server-side TTL lease acquired at work-phase entry for [ResourceMode.EXCLUSIVE] requirements) is
+ * implemented by a follow-on task and layers on top of
+ * [io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext.resolveResourceRequirements].
+ *
+ * @property key Resource identifier. Matched against the optional top-level `resources:` registry
+ *   ([ResourceDefinition]) to resolve a default TTL and description; also the lease/lock namespace
+ *   key used by future enforcement. Referencing a key absent from the registry is not an error — it
+ *   is enforced with built-in defaults (see the "undeclared resource" warning emitted by the parser).
+ * @property mode [ResourceMode.EXCLUSIVE] (default) is intended for a server-enforced TTL lease
+ *   acquired at work-phase entry (enforcement implemented by a follow-on task, not this one);
+ *   [ResourceMode.ADVISORY] is audit-only and is never enforced, only recorded.
+ * @property ttlSeconds Optional override of the resolved [ResourceDefinition.defaultTtlSeconds] for
+ *   this specific trait's requirement. Null means "use the registry default" (or the parser's
+ *   built-in default of 3600s when the key isn't registered).
+ */
+data class ResourceRequirement(
+    val key: String,
+    val mode: ResourceMode = ResourceMode.EXCLUSIVE,
+    val ttlSeconds: Int? = null
+)
+
+/**
+ * Enforcement mode for a [ResourceRequirement].
+ *
+ * - [EXCLUSIVE]: server-enforced single-holder TTL lease acquired at work-phase entry (enforcement
+ *   implemented by a follow-on task).
+ * - [ADVISORY]: audit-only — recorded but never enforced or leased.
+ */
+enum class ResourceMode { EXCLUSIVE, ADVISORY }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/RoleTransition.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/model/RoleTransition.kt
@@ -18,7 +18,12 @@ data class RoleTransition(
     val summary: String? = null,
     val transitionedAt: Instant = Instant.now(),
     val actorClaim: ActorClaim? = null,
-    val verification: VerificationResult? = null
+    val verification: VerificationResult? = null,
+    /**
+     * Opaque credential/secret labels consumed by this transition (e.g. "vault:prod-db-password",
+     * "github-pat-ci") — never raw secret material. Optional audit trail; empty when not supplied.
+     */
+    val consumedCredentials: List<String> = emptyList()
 ) {
     companion object {
         val VALID_TRIGGERS = setOf("start", "complete", "block", "hold", "resume", "cancel", "reopen", "cascade")

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/ResourceLeaseRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/ResourceLeaseRepository.kt
@@ -1,6 +1,8 @@
 package io.github.jpicklyk.mcptask.current.domain.repository
 
 import io.github.jpicklyk.mcptask.current.domain.model.ResourceLease
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceLeaseInterval
+import java.time.Instant
 import java.util.UUID
 
 /**
@@ -107,8 +109,14 @@ interface ResourceLeaseRepository {
      *
      * Authorization is the CALLER's responsibility — this layer performs no permission checks; the
      * REST surface gates this behind the ADMIN capability.
+     *
+     * @param actorId Optional opaque actor identifier of the acting principal, recorded as
+     *   `released_by_actor_id` on every closed [ResourceLeaseInterval] history row (audit-only).
      */
-    suspend fun forceReleaseByKey(resourceKey: String): LeaseReleaseResult
+    suspend fun forceReleaseByKey(
+        resourceKey: String,
+        actorId: String? = null
+    ): LeaseReleaseResult
 
     /** Returns the active (non-expired) leases among [keys], across all holders. */
     suspend fun findActiveByKeys(keys: List<String>): List<ResourceLease>
@@ -118,4 +126,25 @@ interface ResourceLeaseRepository {
 
     /** Returns every active (non-expired) lease in the table, across all keys and holders. */
     suspend fun findAllActive(): List<ResourceLease>
+
+    /**
+     * Returns every [ResourceLeaseInterval] (open or closed) that was held at instant [at] —
+     * i.e. `acquiredAt <= at < coalesce(releasedAt, expiresAt)` — optionally restricted to
+     * [resourceKey]. Ordered newest-first by [ResourceLeaseInterval.acquiredAt]. Answers "who held
+     * resource R at time T" for post-incident diagnosis; see the `resource_lease_history` table.
+     */
+    suspend fun findHoldersAt(
+        resourceKey: String?,
+        at: Instant
+    ): List<ResourceLeaseInterval>
+
+    /**
+     * Returns the most recent [ResourceLeaseInterval] rows (open or closed), newest-first by
+     * [ResourceLeaseInterval.acquiredAt], optionally restricted to [resourceKey] and capped at
+     * [limit] rows. Backs the no-`at` "recent activity" view.
+     */
+    suspend fun findRecentIntervals(
+        resourceKey: String?,
+        limit: Int
+    ): List<ResourceLeaseInterval>
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/ResourceLeaseRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/ResourceLeaseRepository.kt
@@ -1,0 +1,112 @@
+package io.github.jpicklyk.mcptask.current.domain.repository
+
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceLease
+import java.util.UUID
+
+/**
+ * Outcome of [ResourceLeaseRepository.acquireAll].
+ *
+ * Acquisition is all-or-nothing across every requested key: if any key is held by a different
+ * item, NOTHING is written for this call — not even for the keys that were free — and every
+ * contended key (not just the first one found) is reported back in [Contended.contendedKeys] so
+ * the caller can surface a complete picture in a single round trip.
+ */
+sealed class LeaseAcquireResult {
+    /** Every requested key was acquired (or refreshed, for keys already held by [holderItemId]). */
+    data class Success(
+        val leases: List<ResourceLease>
+    ) : LeaseAcquireResult()
+
+    /**
+     * At least one requested key is actively held by a different item. [contendedKeys] lists ALL
+     * such keys (not just the first). [retryAfterMs] is the soonest time (in milliseconds, computed
+     * against the DB clock) until any of the contended leases expires — a hint for backoff, not a
+     * guarantee the key will be free at that instant.
+     */
+    data class Contended(
+        val contendedKeys: List<String>,
+        val retryAfterMs: Long
+    ) : LeaseAcquireResult()
+
+    /** An unexpected database exception occurred; the operation did not complete. */
+    data class DBError(
+        val cause: Exception
+    ) : LeaseAcquireResult()
+}
+
+/** Outcome of [ResourceLeaseRepository.releaseAllForItem] / [ResourceLeaseRepository.forceReleaseByKey]. */
+sealed class LeaseReleaseResult {
+    /** The delete succeeded; [releasedCount] rows were removed (0 if none matched — not an error). */
+    data class Success(
+        val releasedCount: Int
+    ) : LeaseReleaseResult()
+
+    /** An unexpected database exception occurred; the operation did not complete. */
+    data class DBError(
+        val cause: Exception
+    ) : LeaseReleaseResult()
+}
+
+/**
+ * Persists server-enforced TTL leases on shared external resources (see
+ * [io.github.jpicklyk.mcptask.current.domain.model.ResourceRequirement] /
+ * [io.github.jpicklyk.mcptask.current.domain.model.ResourceDefinition] and
+ * [io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ResourceLeasesTable]).
+ *
+ * This is the storage + concurrency primitive only — no gate enforcement and no MCP tool surface.
+ * A follow-on task wires `acquireAll` / `releaseAllForItem` into the work-phase-entry gate.
+ *
+ * ## "Active" is a lazy, read-time notion
+ *
+ * There is no background expiry sweep. A lease row with `expires_at <= dbNow()` is treated as
+ * ABSENT by every read path here (`findActive*`) and as FREE (stealable) by [acquireAll]'s
+ * per-key holder-count check. Expired rows are simply overwritten in place on the next acquire for
+ * that key (or left as harmless stale rows until then) — callers never observe an expired lease
+ * through this interface.
+ *
+ * ## Isolation from claims
+ *
+ * Acquiring or releasing leases must NEVER touch other items' lease rows, or the `work_items`
+ * claim columns (`claimed_by` / `claimed_at` / `claim_expires_at` / `original_claimed_at`). A
+ * lease and a claim on the same item are independent lifecycles.
+ */
+interface ResourceLeaseRepository {
+    /**
+     * Atomically acquires (or, for a key already held by [holderItemId], refreshes) a lease on
+     * every key in [requirements]. All-or-nothing: if any key is actively held by a DIFFERENT
+     * item, no writes occur for this call and [LeaseAcquireResult.Contended] lists every contended
+     * key. A same-holder re-acquire extends `expiresAt`/refreshes `acquiredAt` while preserving the
+     * original `originalAcquiredAt`; a fresh acquire (or one following the prior holder's lease
+     * expiring) sets all three timestamps together.
+     *
+     * @param holderItemId The WorkItem acquiring the leases.
+     * @param actorId Optional opaque actor identifier recorded on each acquired/refreshed row
+     *   (audit-only — see [ResourceLease.acquiredByActorId]).
+     * @param requirements Pre-resolved `(resourceKey, ttlSeconds)` pairs — TTL resolution
+     *   (registry default vs. per-requirement override) is the caller's responsibility; this method
+     *   performs no config lookups.
+     */
+    suspend fun acquireAll(
+        holderItemId: UUID,
+        actorId: String?,
+        requirements: List<Pair<String, Int>>
+    ): LeaseAcquireResult
+
+    /** Releases every active or expired lease row held by [holderItemId]. Never touches other items' rows. */
+    suspend fun releaseAllForItem(holderItemId: UUID): LeaseReleaseResult
+
+    /**
+     * Force-releases every row (any holder) for [resourceKey] — an administrative override for
+     * unsticking a resource without waiting out its TTL. Not used by normal acquire/release flow.
+     */
+    suspend fun forceReleaseByKey(resourceKey: String): LeaseReleaseResult
+
+    /** Returns the active (non-expired) leases among [keys], across all holders. */
+    suspend fun findActiveByKeys(keys: List<String>): List<ResourceLease>
+
+    /** Returns every active (non-expired) lease held by [holderItemId]. */
+    suspend fun findActiveForItem(holderItemId: UUID): List<ResourceLease>
+
+    /** Returns every active (non-expired) lease in the table, across all keys and holders. */
+    suspend fun findAllActive(): List<ResourceLease>
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/ResourceLeaseRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/domain/repository/ResourceLeaseRepository.kt
@@ -84,7 +84,13 @@ interface ResourceLeaseRepository {
      *   (audit-only — see [ResourceLease.acquiredByActorId]).
      * @param requirements Pre-resolved `(resourceKey, ttlSeconds)` pairs — TTL resolution
      *   (registry default vs. per-requirement override) is the caller's responsibility; this method
-     *   performs no config lookups.
+     *   performs no config lookups. Each `ttlSeconds` must be positive.
+     *
+     * Concurrency note: under a genuine cross-transaction race on the same key, the losing writer
+     * may surface as [LeaseAcquireResult.DBError] (SQLite write-conflict) rather than
+     * [LeaseAcquireResult.Contended] — mutual exclusion still holds, but `retryAfterMs` is not
+     * available on that path. Callers should treat a `DBError` from this method as transient and
+     * retry with a default backoff.
      */
     suspend fun acquireAll(
         holderItemId: UUID,
@@ -98,6 +104,9 @@ interface ResourceLeaseRepository {
     /**
      * Force-releases every row (any holder) for [resourceKey] — an administrative override for
      * unsticking a resource without waiting out its TTL. Not used by normal acquire/release flow.
+     *
+     * Authorization is the CALLER's responsibility — this layer performs no permission checks; the
+     * REST surface gates this behind the ADMIN capability.
      */
     suspend fun forceReleaseByKey(resourceKey: String): LeaseReleaseResult
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/AppConfig.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/AppConfig.kt
@@ -71,7 +71,7 @@ data class AppConfig(
         // Default lists for CORS — mirror CorsConfig.configureCors.
         internal val DEFAULT_CORS_METHODS = listOf("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS")
         internal val DEFAULT_CORS_HEADERS = listOf("Authorization", "Content-Type", "If-Match")
-        internal val DEFAULT_CORS_EXPOSE_HEADERS = listOf("ETag", "Last-Event-ID")
+        internal val DEFAULT_CORS_EXPOSE_HEADERS = listOf("ETag", "Last-Event-ID", "Retry-After")
 
         /**
          * Reads the environment once and returns a typed snapshot.

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/PerRootConfigService.kt
@@ -1,6 +1,8 @@
 package io.github.jpicklyk.mcptask.current.infrastructure.config
 
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceDefinition
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceRequirement
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
 import io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
@@ -73,7 +75,9 @@ class PerRootConfigService(
         val traits: Map<String, List<NoteSchemaEntry>>,
         val noteLimitsModeExplicit: String?,
         val statusLabels: Map<String, String?>?,
-        val fingerprint: String
+        val fingerprint: String,
+        val traitResources: Map<String, List<ResourceRequirement>> = emptyMap(),
+        val resourceRegistry: Map<String, ResourceDefinition> = emptyMap()
     )
 
     /**
@@ -90,7 +94,9 @@ class PerRootConfigService(
             traits = parsed.traits,
             noteLimitsModeExplicit = parsed.noteLimitsModeExplicit,
             statusLabels = parsed.statusLabels,
-            fingerprint = fingerprint
+            fingerprint = fingerprint,
+            traitResources = parsed.traitResources,
+            resourceRegistry = parsed.resourceRegistry
         )
     }
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlNoteSchemaService.kt
@@ -2,6 +2,8 @@ package io.github.jpicklyk.mcptask.current.infrastructure.config
 
 import io.github.jpicklyk.mcptask.current.application.service.WorkItemSchemaService
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceDefinition
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceRequirement
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
 import io.github.jpicklyk.mcptask.current.infrastructure.security.sha256Hex
 import org.slf4j.LoggerFactory
@@ -94,6 +96,10 @@ class YamlWorkItemSchemaService(
     override fun getAllSchemas(): Map<String, WorkItemSchema> = workItemSchemas
 
     override fun getAllTraits(): Map<String, List<NoteSchemaEntry>> = traitDefs
+
+    override fun getTraitResources(traitName: String): List<ResourceRequirement> = loadResult.traitResources[traitName] ?: emptyList()
+
+    override fun getResourceRegistry(): Map<String, ResourceDefinition> = loadResult.resourceRegistry
 
     /**
      * Returns the configured `note_limits.mode` ("warn" or "reject"), defaulting to "warn"

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlSchemaParser.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlSchemaParser.kt
@@ -2,6 +2,9 @@ package io.github.jpicklyk.mcptask.current.infrastructure.config
 
 import io.github.jpicklyk.mcptask.current.domain.model.LifecycleMode
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceDefinition
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceMode
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceRequirement
 import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
 import org.slf4j.LoggerFactory
@@ -38,6 +41,35 @@ internal object YamlSchemaParser {
     /** Recognized `note_limits.mode` values. */
     private val VALID_NOTE_LIMITS_MODES = setOf("warn", "reject")
 
+    /** Resource keys (`traits.<name>.resources[].key` / top-level `resources:` keys) must match this shape. */
+    private val RESOURCE_KEY_REGEX = Regex("^[a-z0-9][a-z0-9\\-_./]*$")
+
+    /** Max length for a resource key — see [RESOURCE_KEY_REGEX]. */
+    private const val RESOURCE_KEY_MAX_LENGTH = 128
+
+    /** Fallback TTL (seconds) for a resource with no registry entry and no per-requirement override. */
+    const val DEFAULT_RESOURCE_TTL_SECONDS = 3600
+
+    /** Valid inclusive bounds for [ResourceDefinition.defaultTtlSeconds]. */
+    private const val MIN_RESOURCE_TTL_SECONDS = 1
+    private const val MAX_RESOURCE_TTL_SECONDS = 86400
+
+    /** A resource key declared by at least this many traits triggers a fan-out warning. */
+    private const val RESOURCE_FANOUT_WARNING_THRESHOLD = 3
+
+    /** Recognized `traits.<name>.resources[].mode` values, matched case-insensitively. */
+    private val VALID_RESOURCE_MODES =
+        mapOf(
+            "exclusive" to ResourceMode.EXCLUSIVE,
+            "advisory" to ResourceMode.ADVISORY,
+        )
+
+    /**
+     * Budget-related keys reserved for future use. If present on a `resources:` entry (registry or
+     * per-trait), they are parsed-and-warned but never stored — see [warnReservedBudgetKeys].
+     */
+    private val RESERVED_BUDGET_KEYS = setOf("budgetLimit", "budgetWindowSeconds")
+
     /**
      * Result of parsing a config root map: schemas (keyed by type/tag), traits, warnings, and the
      * note-limits mode. Per-tag note lists are read via `workItemSchemas[tag]?.notes` — there is no
@@ -57,6 +89,12 @@ internal object YamlSchemaParser {
      *   [io.github.jpicklyk.mcptask.current.infrastructure.config.YamlStatusLabelService]'s
      *   "explicit null clears the label" semantics — only an ABSENT key in this map falls through to
      *   another layer).
+     * @property traitResources per-trait resource requirements, parsed from `traits.<name>.resources:`
+     *   (short form: a list of bare key strings; long form: a list of maps with `key`, optional
+     *   `mode`, optional `ttlSeconds`). A trait with no `resources:` key is absent from this map
+     *   entirely (not mapped to an empty list).
+     * @property resourceRegistry the top-level `resources:` registry, keyed by resource key. Empty
+     *   when the document has no top-level `resources:` section.
      */
     data class ParsedConfig(
         val workItemSchemas: Map<String, WorkItemSchema>,
@@ -64,7 +102,9 @@ internal object YamlSchemaParser {
         val warnings: List<String>,
         val noteLimitsMode: String = DEFAULT_NOTE_LIMITS_MODE,
         val noteLimitsModeExplicit: String? = null,
-        val statusLabels: Map<String, String?>? = null
+        val statusLabels: Map<String, String?>? = null,
+        val traitResources: Map<String, List<ResourceRequirement>> = emptyMap(),
+        val resourceRegistry: Map<String, ResourceDefinition> = emptyMap()
     )
 
     /**
@@ -88,6 +128,8 @@ internal object YamlSchemaParser {
         val parsedNoteLimitsMode = parseNoteLimitsMode(root, warnings)
         val noteLimitsModeExplicit = if (root.containsKey("note_limits")) parsedNoteLimitsMode else null
         val parsedStatusLabels = parseStatusLabels(root, warnings)
+        val resourceRegistry = parseResourceRegistry(root, warnings)
+        val traitResources = parseTraitResources(root, resourceRegistry, warnings)
 
         val base =
             when {
@@ -106,7 +148,9 @@ internal object YamlSchemaParser {
             warnings = warnings,
             noteLimitsMode = parsedNoteLimitsMode,
             noteLimitsModeExplicit = noteLimitsModeExplicit,
-            statusLabels = parsedStatusLabels
+            statusLabels = parsedStatusLabels,
+            traitResources = traitResources,
+            resourceRegistry = resourceRegistry
         )
     }
 
@@ -204,6 +248,249 @@ internal object YamlSchemaParser {
                     parseEntry(raw, "trait:$traitName", index, warnings)
                 }
             traitName to entries
+        }
+    }
+
+    /**
+     * Parses the top-level `resources:` registry into a key→[ResourceDefinition] map. A malformed
+     * section (present but not a map) is warned-and-ignored, matching every other top-level-section
+     * parse in this object — never fails the whole config load. Individual malformed/invalid
+     * entries are warned-and-skipped the same way: the rest of the registry still loads.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun parseResourceRegistry(
+        root: Map<String, Any>,
+        warnings: MutableList<String>
+    ): Map<String, ResourceDefinition> {
+        val raw = root["resources"] ?: return emptyMap()
+        val rawMap =
+            raw as? Map<String, Any> ?: run {
+                warnings.add("Top-level 'resources' section is not a map; ignoring")
+                return emptyMap()
+            }
+
+        val registry = mutableMapOf<String, ResourceDefinition>()
+        for ((key, rawValue) in rawMap) {
+            if (!isValidResourceKey(key)) {
+                warnings.add(
+                    "Resource registry key '$key' is invalid (must match '${RESOURCE_KEY_REGEX.pattern}', " +
+                        "max $RESOURCE_KEY_MAX_LENGTH chars); skipping"
+                )
+                continue
+            }
+
+            val entryMap = rawValue as? Map<String, Any>
+            if (entryMap == null) {
+                warnings.add("Resource registry entry '$key' is not a map; skipping")
+                continue
+            }
+
+            warnReservedBudgetKeys(entryMap, "Resource registry entry '$key'", warnings)
+
+            val description = entryMap["description"] as? String ?: ""
+
+            val maxHoldersRaw = entryMap["maxHolders"]
+            val maxHolders =
+                when (maxHoldersRaw) {
+                    null -> 1
+                    is Number -> maxHoldersRaw.toInt()
+                    else -> {
+                        warnings.add(
+                            "Resource registry entry '$key' has non-numeric 'maxHolders' value '$maxHoldersRaw'; defaulting to 1"
+                        )
+                        1
+                    }
+                }
+            if (maxHolders > 1) {
+                warnings.add("Resource registry entry '$key': maxHolders > 1 not yet supported; skipping entry")
+                continue
+            }
+            if (maxHolders < 1) {
+                warnings.add("Resource registry entry '$key' has maxHolders '$maxHolders' below 1; defaulting to 1")
+            }
+
+            val ttlRaw = entryMap["defaultTtlSeconds"]
+            val defaultTtlSeconds =
+                when (ttlRaw) {
+                    null -> DEFAULT_RESOURCE_TTL_SECONDS
+                    is Number -> {
+                        val ttl = ttlRaw.toInt()
+                        if (ttl in MIN_RESOURCE_TTL_SECONDS..MAX_RESOURCE_TTL_SECONDS) {
+                            ttl
+                        } else {
+                            warnings.add(
+                                "Resource registry entry '$key' has defaultTtlSeconds '$ttl' out of bounds " +
+                                    "($MIN_RESOURCE_TTL_SECONDS..$MAX_RESOURCE_TTL_SECONDS); defaulting to ${DEFAULT_RESOURCE_TTL_SECONDS}s"
+                            )
+                            DEFAULT_RESOURCE_TTL_SECONDS
+                        }
+                    }
+                    else -> {
+                        warnings.add(
+                            "Resource registry entry '$key' has non-numeric 'defaultTtlSeconds' value '$ttlRaw'; " +
+                                "defaulting to ${DEFAULT_RESOURCE_TTL_SECONDS}s"
+                        )
+                        DEFAULT_RESOURCE_TTL_SECONDS
+                    }
+                }
+
+            registry[key] =
+                ResourceDefinition(
+                    key = key,
+                    description = description,
+                    defaultTtlSeconds = defaultTtlSeconds,
+                    maxHolders = maxHolders.coerceAtLeast(1)
+                )
+        }
+        return registry
+    }
+
+    /**
+     * Parses per-trait `resources:` lists into a trait-name→[ResourceRequirement] map (traits with
+     * no `resources:` key are absent from the result, not mapped to an empty list), then emits two
+     * cross-trait warnings against the already-parsed [registry]:
+     *  - a requirement referencing a key absent from [registry] ("undeclared resource") — warned but
+     *    still honored with built-in defaults, never dropped;
+     *  - a resource key declared by [RESOURCE_FANOUT_WARNING_THRESHOLD] or more traits ("fan-out").
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun parseTraitResources(
+        root: Map<String, Any>,
+        registry: Map<String, ResourceDefinition>,
+        warnings: MutableList<String>
+    ): Map<String, List<ResourceRequirement>> {
+        val traitsRaw = root["traits"] as? Map<String, Any> ?: return emptyMap()
+
+        val result = mutableMapOf<String, List<ResourceRequirement>>()
+        val keyCounts = mutableMapOf<String, Int>()
+
+        for ((traitName, rawValue) in traitsRaw) {
+            val rawMap = rawValue as? Map<String, Any> ?: continue
+            val resourcesRaw = rawMap["resources"] ?: continue
+
+            val requirements = parseResourceRequirementList(resourcesRaw, traitName, warnings)
+            if (requirements.isEmpty()) continue
+
+            result[traitName] = requirements
+            for (req in requirements) {
+                keyCounts[req.key] = (keyCounts[req.key] ?: 0) + 1
+                if (req.key !in registry) {
+                    warnings.add(
+                        "Trait '$traitName' references undeclared resource '${req.key}'; enforcing with defaults " +
+                            "(ttl ${DEFAULT_RESOURCE_TTL_SECONDS}s)"
+                    )
+                }
+            }
+        }
+
+        keyCounts
+            .filterValues { it >= RESOURCE_FANOUT_WARNING_THRESHOLD }
+            .forEach { (key, count) ->
+                warnings.add("Resource '$key' is declared by $count traits (fan-out); contention is likely")
+            }
+
+        return result
+    }
+
+    /**
+     * Parses a single trait's `resources:` value, which must be a list. Supports both short form
+     * (bare key strings, coerced to [ResourceMode.EXCLUSIVE] with no ttl override) and long form
+     * (maps with `key`, optional `mode` — case-insensitive, unknown values warn and fall back to
+     * EXCLUSIVE — and optional `ttlSeconds`). A non-list value or an unrecognized list-element shape
+     * is warned-and-skipped at that granularity (element or whole section), never fatal.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun parseResourceRequirementList(
+        resourcesRaw: Any,
+        traitName: String,
+        warnings: MutableList<String>
+    ): List<ResourceRequirement> {
+        val list =
+            resourcesRaw as? List<Any?> ?: run {
+                warnings.add("Trait '$traitName' has a malformed 'resources' section (expected a list); skipping")
+                return emptyList()
+            }
+
+        val result = mutableListOf<ResourceRequirement>()
+        for ((index, rawEntry) in list.withIndex()) {
+            when (rawEntry) {
+                is String -> {
+                    if (!isValidResourceKey(rawEntry)) {
+                        warnings.add("Trait '$traitName' resources[$index] has invalid key '$rawEntry'; skipping")
+                        continue
+                    }
+                    result.add(ResourceRequirement(key = rawEntry))
+                }
+
+                is Map<*, *> -> {
+                    val entryMap = rawEntry as Map<String, Any>
+                    val key = entryMap["key"] as? String
+                    if (key == null) {
+                        warnings.add("Trait '$traitName' resources[$index] is missing required field 'key'; skipping")
+                        continue
+                    }
+                    if (!isValidResourceKey(key)) {
+                        warnings.add("Trait '$traitName' resources[$index] has invalid key '$key'; skipping")
+                        continue
+                    }
+
+                    warnReservedBudgetKeys(entryMap, "Trait '$traitName' resources[$index] (key='$key')", warnings)
+
+                    val modeRaw = entryMap["mode"] as? String
+                    val mode =
+                        if (modeRaw == null) {
+                            ResourceMode.EXCLUSIVE
+                        } else {
+                            VALID_RESOURCE_MODES[modeRaw.lowercase()] ?: run {
+                                warnings.add(
+                                    "Trait '$traitName' resources[$index] (key='$key') has unknown mode '$modeRaw'; " +
+                                        "defaulting to exclusive"
+                                )
+                                ResourceMode.EXCLUSIVE
+                            }
+                        }
+
+                    val ttlRaw = entryMap["ttlSeconds"]
+                    val ttlSeconds =
+                        when (ttlRaw) {
+                            null -> null
+                            is Number -> ttlRaw.toInt()
+                            else -> {
+                                warnings.add(
+                                    "Trait '$traitName' resources[$index] (key='$key') has non-numeric 'ttlSeconds' " +
+                                        "value '$ttlRaw'; ignoring"
+                                )
+                                null
+                            }
+                        }
+
+                    result.add(ResourceRequirement(key = key, mode = mode, ttlSeconds = ttlSeconds))
+                }
+
+                else -> {
+                    warnings.add("Trait '$traitName' resources[$index] is neither a string nor a map; skipping")
+                }
+            }
+        }
+        return result
+    }
+
+    private fun isValidResourceKey(key: String): Boolean = key.length in 1..RESOURCE_KEY_MAX_LENGTH && RESOURCE_KEY_REGEX.matches(key)
+
+    /**
+     * Warns (without storing) when [entryMap] contains any of [RESERVED_BUDGET_KEYS] — these fields
+     * are reserved for a future budget-enforcement feature and are intentionally not modeled by
+     * [ResourceDefinition]/[ResourceRequirement] yet.
+     */
+    private fun warnReservedBudgetKeys(
+        entryMap: Map<String, Any>,
+        context: String,
+        warnings: MutableList<String>
+    ) {
+        for (budgetKey in RESERVED_BUDGET_KEYS) {
+            if (entryMap.containsKey(budgetKey)) {
+                warnings.add("$context uses '$budgetKey', which is reserved for future use; ignoring")
+            }
         }
     }
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/ResourceLeaseHistoryTable.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/ResourceLeaseHistoryTable.kt
@@ -1,0 +1,38 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database.schema
+
+import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
+import org.jetbrains.exposed.v1.core.java.javaUUID
+import org.jetbrains.exposed.v1.javatime.timestamp
+
+/**
+ * Append-only audit history of resource-lease hold intervals — answers "who held resource R at
+ * time T" (see [io.github.jpicklyk.mcptask.current.domain.model.ResourceLeaseInterval]). Mirrors
+ * `V16__Resource_Lease_History.sql` exactly.
+ *
+ * Deliberately carries NO foreign key on [holderItemId] to `WorkItemsTable` — see the migration
+ * header for the full rationale. In short: this table is an audit trail that must survive both
+ * `ON DELETE CASCADE` of the live [ResourceLeasesTable] rows and deletion of the holder work item
+ * itself, so [holderItemId] may reference a work item that no longer exists.
+ *
+ * One row per hold INTERVAL, not per lease event — [acquiredAt] marks when the interval opened;
+ * [releasedAt] / [releaseReason] mark when and why it closed (both null while the interval is
+ * open). A same-holder TTL refresh extends [expiresAt] on the OPEN row in place rather than
+ * opening a new interval; stealing an expired lease closes the prior holder's interval
+ * (`released_at` = its own prior `expires_at`, `release_reason` = "expired") before a new interval
+ * opens for the new holder — see `SQLiteResourceLeaseRepository.acquireAll`.
+ */
+object ResourceLeaseHistoryTable : UUIDTable("resource_lease_history") {
+    val resourceKey = text("resource_key")
+    val holderItemId = javaUUID("holder_item_id")
+    val acquiredByActorId = text("acquired_by_actor_id").nullable()
+    val acquiredAt = timestamp("acquired_at")
+    val expiresAt = timestamp("expires_at")
+    val releasedAt = timestamp("released_at").nullable()
+    val releaseReason = text("release_reason").nullable()
+    val releasedByActorId = text("released_by_actor_id").nullable()
+
+    init {
+        index(isUnique = false, resourceKey, acquiredAt)
+        index(isUnique = false, releasedAt)
+    }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/ResourceLeasesTable.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/ResourceLeasesTable.kt
@@ -1,0 +1,47 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database.schema
+
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
+import org.jetbrains.exposed.v1.core.java.javaUUID
+import org.jetbrains.exposed.v1.javatime.timestamp
+
+/**
+ * Server-enforced TTL lease store for shared external resources (see
+ * [io.github.jpicklyk.mcptask.current.domain.model.ResourceRequirement] /
+ * [io.github.jpicklyk.mcptask.current.domain.model.ResourceDefinition]). Mirrors
+ * `V15__Resource_Leases.sql` exactly.
+ *
+ * `(resource_key, holder_item_id)` is unique — deliberately NOT unique on [resourceKey] alone, so
+ * a future fan-in ("semaphore", `maxHolders > 1`) enforcement mode can store multiple concurrent
+ * holder rows for the same key without a schema change. v1 enforcement still only ever allows a
+ * single active holder per key (checked in application code, not by this constraint — see
+ * `SQLiteResourceLeaseRepository.acquireAll`). Follows [PlanDocumentsTable]'s style: BLOB id
+ * default, a plain unique-index pair rather than an inline `UNIQUE` column.
+ *
+ * [acquiredAt] / [expiresAt] / [originalAcquiredAt] are declared via [timestamp] exactly like
+ * [WorkItemsTable]'s `claimedAt` / `claimExpiresAt` / `originalClaimedAt` claim columns — both
+ * store ISO-8601 TEXT under SQLite (see `V5__Add_Claim_Fields.sql` and `V15__Resource_Leases.sql`
+ * for the underlying column type rationale).
+ *
+ * [budgetLimit] / [budgetUsed] / [budgetWindowSeconds] are reserved for a future rate-budget
+ * enforcement mode — unused by the current repository surface, always null for now.
+ */
+object ResourceLeasesTable : UUIDTable("resource_leases") {
+    val resourceKey = text("resource_key")
+    val holderItemId = javaUUID("holder_item_id")
+    val acquiredByActorId = text("acquired_by_actor_id").nullable()
+    val acquiredAt = timestamp("acquired_at")
+    val expiresAt = timestamp("expires_at")
+    val originalAcquiredAt = timestamp("original_acquired_at")
+    val budgetLimit = integer("budget_limit").nullable()
+    val budgetUsed = integer("budget_used").nullable()
+    val budgetWindowSeconds = integer("budget_window_seconds").nullable()
+    val version = integer("version").default(0)
+
+    init {
+        foreignKey(holderItemId to WorkItemsTable.id, onDelete = ReferenceOption.CASCADE)
+        uniqueIndex(resourceKey, holderItemId)
+        index(isUnique = false, resourceKey)
+        index(isUnique = false, expiresAt)
+    }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/RoleTransitionsTable.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/RoleTransitionsTable.kt
@@ -22,6 +22,9 @@ object RoleTransitionsTable : UUIDTable("role_transitions") {
     val verificationVerifier = text("verification_verifier").nullable()
     val verificationReason = text("verification_reason").nullable()
 
+    /** JSON array of opaque credential/secret labels consumed by this transition (V14); null when omitted. */
+    val consumedCredentials = text("consumed_credentials").nullable()
+
     init {
         foreignKey(itemId to WorkItemsTable.id, onDelete = ReferenceOption.CASCADE)
         index(isUnique = false, itemId)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/management/DirectDatabaseSchemaManager.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/management/DirectDatabaseSchemaManager.kt
@@ -4,6 +4,7 @@ import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.Depende
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.NotesTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.PlanDocumentsTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ProjectConfigTable
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ResourceLeaseHistoryTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ResourceLeasesTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.RoleTransitionsTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.WorkItemsTable
@@ -20,17 +21,20 @@ import org.slf4j.LoggerFactory
  * Table dependency graph:
  * 1. WorkItemsTable (no external dependencies, self-referencing parentId)
  * 2. ResourceLeasesTable (depends on WorkItemsTable — holder_item_id, CASCADE)
- * 3. ProjectConfigTable (depends on WorkItemsTable)
- * 4. PlanDocumentsTable (depends on WorkItemsTable, two FKs — root_item_id and adopted_by_item_id)
- * 5. NotesTable (depends on WorkItemsTable)
- * 6. DependenciesTable (depends on WorkItemsTable)
- * 7. RoleTransitionsTable (depends on WorkItemsTable)
+ * 3. ResourceLeaseHistoryTable (NO dependency on WorkItemsTable — holder_item_id is deliberately
+ *    FK-less so the audit trail survives holder deletion; see V16__Resource_Lease_History.sql.
+ *    Positioned after ResourceLeasesTable for readability only, not FK ordering.)
+ * 4. ProjectConfigTable (depends on WorkItemsTable)
+ * 5. PlanDocumentsTable (depends on WorkItemsTable, two FKs — root_item_id and adopted_by_item_id)
+ * 6. NotesTable (depends on WorkItemsTable)
+ * 7. DependenciesTable (depends on WorkItemsTable)
+ * 8. RoleTransitionsTable (depends on WorkItemsTable)
  *
  * Virtual tables (FTS5, follow their backing tables):
- * 8. work_items_fts_trigram (external-content over WorkItemsTable)
- * 9. work_items_fts_text    (external-content over WorkItemsTable)
- * 10. notes_fts_trigram     (external-content over NotesTable)
- * 11. notes_fts_text        (external-content over NotesTable)
+ * 9. work_items_fts_trigram (external-content over WorkItemsTable)
+ * 10. work_items_fts_text   (external-content over WorkItemsTable)
+ * 11. notes_fts_trigram     (external-content over NotesTable)
+ * 12. notes_fts_text        (external-content over NotesTable)
  *
  * Triggers (registered after their backing tables):
  * - work_items_cycle_check, work_items_cycle_check_update (cycle detection on parent_id)
@@ -45,6 +49,7 @@ class DirectDatabaseSchemaManager : DatabaseSchemaManager {
         arrayOf(
             WorkItemsTable,
             ResourceLeasesTable,
+            ResourceLeaseHistoryTable,
             ProjectConfigTable,
             PlanDocumentsTable,
             NotesTable,

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/management/DirectDatabaseSchemaManager.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/schema/management/DirectDatabaseSchemaManager.kt
@@ -4,6 +4,7 @@ import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.Depende
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.NotesTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.PlanDocumentsTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ProjectConfigTable
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ResourceLeasesTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.RoleTransitionsTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.WorkItemsTable
 import org.jetbrains.exposed.v1.core.vendors.H2Dialect
@@ -18,17 +19,18 @@ import org.slf4j.LoggerFactory
  *
  * Table dependency graph:
  * 1. WorkItemsTable (no external dependencies, self-referencing parentId)
- * 2. ProjectConfigTable (depends on WorkItemsTable)
- * 3. PlanDocumentsTable (depends on WorkItemsTable, two FKs — root_item_id and adopted_by_item_id)
- * 4. NotesTable (depends on WorkItemsTable)
- * 5. DependenciesTable (depends on WorkItemsTable)
- * 6. RoleTransitionsTable (depends on WorkItemsTable)
+ * 2. ResourceLeasesTable (depends on WorkItemsTable — holder_item_id, CASCADE)
+ * 3. ProjectConfigTable (depends on WorkItemsTable)
+ * 4. PlanDocumentsTable (depends on WorkItemsTable, two FKs — root_item_id and adopted_by_item_id)
+ * 5. NotesTable (depends on WorkItemsTable)
+ * 6. DependenciesTable (depends on WorkItemsTable)
+ * 7. RoleTransitionsTable (depends on WorkItemsTable)
  *
  * Virtual tables (FTS5, follow their backing tables):
- * 6. work_items_fts_trigram (external-content over WorkItemsTable)
- * 7. work_items_fts_text    (external-content over WorkItemsTable)
- * 8. notes_fts_trigram      (external-content over NotesTable)
- * 9. notes_fts_text         (external-content over NotesTable)
+ * 8. work_items_fts_trigram (external-content over WorkItemsTable)
+ * 9. work_items_fts_text    (external-content over WorkItemsTable)
+ * 10. notes_fts_trigram     (external-content over NotesTable)
+ * 11. notes_fts_text        (external-content over NotesTable)
  *
  * Triggers (registered after their backing tables):
  * - work_items_cycle_check, work_items_cycle_check_update (cycle detection on parent_id)
@@ -42,6 +44,7 @@ class DirectDatabaseSchemaManager : DatabaseSchemaManager {
     private val tables =
         arrayOf(
             WorkItemsTable,
+            ResourceLeasesTable,
             ProjectConfigTable,
             PlanDocumentsTable,
             NotesTable,

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/DefaultRepositoryProvider.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/DefaultRepositoryProvider.kt
@@ -5,6 +5,7 @@ import io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.NoteRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.PlanDocumentRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.RoleTransitionRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
@@ -26,6 +27,7 @@ class DefaultRepositoryProvider(
     private val roleTransitionRepo by lazy { SQLiteRoleTransitionRepository(databaseManager) }
     private val projectConfigRepo by lazy { SQLiteProjectConfigRepository(databaseManager) }
     private val planDocumentRepo by lazy { SQLitePlanDocumentRepository(databaseManager) }
+    private val resourceLeaseRepo by lazy { SQLiteResourceLeaseRepository(databaseManager) }
     private val workTreeExecutorInstance by lazy { SQLiteWorkTreeService(databaseManager, workItemRepo, noteRepo, planDocumentRepo) }
 
     override fun workItemRepository(): WorkItemRepository = workItemRepo
@@ -39,6 +41,8 @@ class DefaultRepositoryProvider(
     override fun projectConfigRepository(): ProjectConfigRepository = projectConfigRepo
 
     override fun planDocumentRepository(): PlanDocumentRepository = planDocumentRepo
+
+    override fun resourceLeaseRepository(): ResourceLeaseRepository = resourceLeaseRepo
 
     override fun database(): org.jetbrains.exposed.v1.jdbc.Database? = databaseManager.getDatabase()
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/RepositoryProvider.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/RepositoryProvider.kt
@@ -5,6 +5,7 @@ import io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.NoteRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.PlanDocumentRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.RoleTransitionRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
 
@@ -24,6 +25,8 @@ interface RepositoryProvider {
     fun projectConfigRepository(): ProjectConfigRepository
 
     fun planDocumentRepository(): PlanDocumentRepository
+
+    fun resourceLeaseRepository(): ResourceLeaseRepository
 
     fun database(): org.jetbrains.exposed.v1.jdbc.Database?
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteResourceLeaseRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteResourceLeaseRepository.kt
@@ -1,0 +1,273 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.repository
+
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceLease
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseAcquireResult
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseReleaseResult
+import io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository
+import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ResourceLeasesTable
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.VarCharColumnType
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greater
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.java.UUIDColumnType
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
+import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+/**
+ * SQLite implementation of [ResourceLeaseRepository], backed by [ResourceLeasesTable].
+ *
+ * Storage + concurrency primitive only — no gate enforcement, no MCP tool surface (see the
+ * interface KDoc). Mirrors [SQLiteWorkItemRepository.claim]'s transaction/DB-clock discipline:
+ * every timestamp compared or written for lease-freshness decisions is DB-side (`datetime('now')`
+ * in raw SQL, or an [Instant] read from the DB clock via [dbNow] for typed Exposed comparisons) —
+ * never [Instant.now].
+ */
+class SQLiteResourceLeaseRepository(
+    private val databaseManager: DatabaseManager
+) : ResourceLeaseRepository {
+    private val logger = LoggerFactory.getLogger(SQLiteResourceLeaseRepository::class.java)
+
+    /**
+     * v1 hard cap on concurrent active holders per resource key. Matches
+     * [io.github.jpicklyk.mcptask.current.domain.model.ResourceDefinition.maxHolders]'s own
+     * config-load-time hard cap (a config value > 1 is rejected as a load ERROR — see that
+     * property's KDoc). This repository does not read config; a future fan-in ("semaphore")
+     * enforcement mode would resolve the caller's actual `maxHolders` and compare against that
+     * instead of this constant — the table's `(resource_key, holder_item_id)` unique index (see
+     * `V15__Resource_Leases.sql`) is already shaped to support that without a schema change.
+     */
+    private val maxHoldersPerKey = 1
+
+    /**
+     * Return the database server's current wall-clock time as an [Instant].
+     *
+     * Self-contained twin of [SQLiteWorkItemRepository.dbNow] — see that method's KDoc for the
+     * full string-parsing rationale (SQLite's `CURRENT_TIMESTAMP` has no timezone suffix and is in
+     * UTC; naive `rs.getTimestamp()` would apply the JVM's local zone offset and drift). Used only
+     * to obtain a DB-clock [Instant] for typed Exposed `expiresAt greater now` comparisons in the
+     * `findActive*` read paths — mutating SQL in this class uses `datetime('now')` directly instead.
+     */
+    private suspend fun dbNow(): Instant =
+        try {
+            suspendTransaction(db = databaseManager.getDatabase()) {
+                exec("SELECT CURRENT_TIMESTAMP") { rs ->
+                    if (rs.next()) rs.getString(1)?.let { parseDbTimestamp(it) } else null
+                }
+            } ?: Instant.now()
+        } catch (e: Exception) {
+            logger.warn("Failed to fetch DB-side current time, falling back to JVM clock: ${e.message}")
+            Instant.now()
+        }
+
+    private fun parseDbTimestamp(raw: String): Instant {
+        val isoCandidate = raw.replace(" ", "T")
+        val tzPattern = Regex("([+-]\\d{2}(:\\d{2})?|Z)$")
+        val tzMatch = tzPattern.find(isoCandidate)
+        return if (tzMatch != null) {
+            val tz = tzMatch.value
+            val normalized =
+                if (tz.startsWith("Z") || tz.contains(":")) {
+                    isoCandidate
+                } else {
+                    isoCandidate.dropLast(tz.length) + tz + ":00"
+                }
+            OffsetDateTime.parse(normalized, DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant()
+        } else {
+            LocalDateTime
+                .parse(isoCandidate, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                .toInstant(ZoneOffset.UTC)
+        }
+    }
+
+    override suspend fun acquireAll(
+        holderItemId: UUID,
+        actorId: String?,
+        requirements: List<Pair<String, Int>>
+    ): LeaseAcquireResult =
+        try {
+            if (requirements.isEmpty()) {
+                LeaseAcquireResult.Success(emptyList())
+            } else {
+                // Sort lexicographically for deterministic contention reporting across calls.
+                // SQLite's single-writer model already serializes the whole transaction below, so
+                // this ordering is not required for correctness here — only for predictable
+                // diagnostics when the same requirement set is retried.
+                val sortedRequirements = requirements.sortedBy { it.first }
+
+                suspendTransaction(db = databaseManager.getDatabase()) {
+                    val uuidType = UUIDColumnType()
+                    val keyType = VarCharColumnType(255)
+                    val actorType = VarCharColumnType(500)
+                    val ttlOffsetType = VarCharColumnType(50)
+
+                    // Pre-pass: check EVERY key for contention before writing anything. This pre-pass
+                    // and the writes below run in the SAME transaction — SQLite's single-writer model
+                    // means no other transaction can insert a competing row in between, so there is no
+                    // TOCTOU window despite the check-then-write shape.
+                    val contendedKeys = mutableListOf<String>()
+                    for ((key, _) in sortedRequirements) {
+                        var activeOtherHolders = 0L
+                        exec(
+                            """
+                            SELECT COUNT(*) FROM resource_leases
+                             WHERE resource_key = ?
+                               AND holder_item_id != ?
+                               AND expires_at > datetime('now')
+                            """.trimIndent(),
+                            args = listOf(keyType to key, uuidType to holderItemId)
+                        ) { rs -> if (rs.next()) activeOtherHolders = rs.getLong(1) }
+
+                        if (activeOtherHolders >= maxHoldersPerKey) {
+                            contendedKeys += key
+                        }
+                    }
+
+                    if (contendedKeys.isNotEmpty()) {
+                        // retryAfterMs: milliseconds (computed entirely DB-side via julianday
+                        // arithmetic — never the JVM clock) until the SOONEST of the contending
+                        // leases expires, across every contended key.
+                        var retryAfterMs = 0L
+                        exec(
+                            """
+                            SELECT CAST(ROUND((julianday(MIN(expires_at)) - julianday('now')) * 86400000) AS INTEGER)
+                              FROM resource_leases
+                             WHERE resource_key IN (${contendedKeys.joinToString(",") { "?" }})
+                               AND holder_item_id != ?
+                               AND expires_at > datetime('now')
+                            """.trimIndent(),
+                            args = contendedKeys.map { keyType to it } + listOf(uuidType to holderItemId)
+                        ) { rs ->
+                            if (rs.next()) {
+                                val value = rs.getLong(1)
+                                if (!rs.wasNull() && value > 0) retryAfterMs = value
+                            }
+                        }
+                        return@suspendTransaction LeaseAcquireResult.Contended(contendedKeys, retryAfterMs)
+                    }
+
+                    // No contention for any key — upsert every requested key's own row.
+                    // Same-holder re-acquire (a row already exists for this (resource_key,
+                    // holder_item_id) pair, active OR expired) refreshes acquired_at/expires_at and
+                    // preserves original_acquired_at by simply omitting it from the DO UPDATE SET —
+                    // untouched columns keep their prior value under SQLite upsert semantics. A fresh
+                    // acquire (no existing row for this pair — including the case where a DIFFERENT
+                    // holder's now-expired row exists for the same key) inserts all three timestamps
+                    // together.
+                    val leases = mutableListOf<ResourceLease>()
+                    for ((key, ttlSeconds) in sortedRequirements) {
+                        val ttlOffset = "+$ttlSeconds"
+                        exec(
+                            """
+                            INSERT INTO resource_leases
+                                (id, resource_key, holder_item_id, acquired_by_actor_id,
+                                 acquired_at, expires_at, original_acquired_at, version)
+                            VALUES
+                                (randomblob(16), ?, ?, ?, datetime('now'), datetime('now', ? || ' seconds'), datetime('now'), 0)
+                            ON CONFLICT(resource_key, holder_item_id) DO UPDATE SET
+                                acquired_by_actor_id = excluded.acquired_by_actor_id,
+                                acquired_at = datetime('now'),
+                                expires_at = datetime('now', ? || ' seconds'),
+                                version = resource_leases.version + 1
+                            """.trimIndent(),
+                            args =
+                                listOf(
+                                    keyType to key,
+                                    uuidType to holderItemId,
+                                    actorType to actorId,
+                                    ttlOffsetType to ttlOffset,
+                                    ttlOffsetType to ttlOffset,
+                                )
+                        )
+
+                        val row =
+                            ResourceLeasesTable
+                                .selectAll()
+                                .where { (ResourceLeasesTable.resourceKey eq key) and (ResourceLeasesTable.holderItemId eq holderItemId) }
+                                .single()
+                        leases += toResourceLease(row)
+                    }
+
+                    LeaseAcquireResult.Success(leases)
+                }
+            }
+        } catch (e: Exception) {
+            logger.error("Failed to acquire resource leases for holder $holderItemId: ${e.message}", e)
+            LeaseAcquireResult.DBError(e)
+        }
+
+    override suspend fun releaseAllForItem(holderItemId: UUID): LeaseReleaseResult =
+        try {
+            suspendTransaction(db = databaseManager.getDatabase()) {
+                val count = ResourceLeasesTable.deleteWhere { ResourceLeasesTable.holderItemId eq holderItemId }
+                LeaseReleaseResult.Success(count)
+            }
+        } catch (e: Exception) {
+            logger.error("Failed to release resource leases for holder $holderItemId: ${e.message}", e)
+            LeaseReleaseResult.DBError(e)
+        }
+
+    override suspend fun forceReleaseByKey(resourceKey: String): LeaseReleaseResult =
+        try {
+            suspendTransaction(db = databaseManager.getDatabase()) {
+                val count = ResourceLeasesTable.deleteWhere { ResourceLeasesTable.resourceKey eq resourceKey }
+                LeaseReleaseResult.Success(count)
+            }
+        } catch (e: Exception) {
+            logger.error("Failed to force-release resource leases for key $resourceKey: ${e.message}", e)
+            LeaseReleaseResult.DBError(e)
+        }
+
+    override suspend fun findActiveByKeys(keys: List<String>): List<ResourceLease> {
+        if (keys.isEmpty()) return emptyList()
+        val now = dbNow()
+        return suspendTransaction(db = databaseManager.getDatabase()) {
+            ResourceLeasesTable
+                .selectAll()
+                .where { (ResourceLeasesTable.resourceKey inList keys) and (ResourceLeasesTable.expiresAt greater now) }
+                .map { toResourceLease(it) }
+        }
+    }
+
+    override suspend fun findActiveForItem(holderItemId: UUID): List<ResourceLease> {
+        val now = dbNow()
+        return suspendTransaction(db = databaseManager.getDatabase()) {
+            ResourceLeasesTable
+                .selectAll()
+                .where { (ResourceLeasesTable.holderItemId eq holderItemId) and (ResourceLeasesTable.expiresAt greater now) }
+                .map { toResourceLease(it) }
+        }
+    }
+
+    override suspend fun findAllActive(): List<ResourceLease> {
+        val now = dbNow()
+        return suspendTransaction(db = databaseManager.getDatabase()) {
+            ResourceLeasesTable
+                .selectAll()
+                .where { ResourceLeasesTable.expiresAt greater now }
+                .map { toResourceLease(it) }
+        }
+    }
+
+    private fun toResourceLease(row: ResultRow): ResourceLease =
+        ResourceLease(
+            id = row[ResourceLeasesTable.id].value,
+            resourceKey = row[ResourceLeasesTable.resourceKey],
+            holderItemId = row[ResourceLeasesTable.holderItemId],
+            acquiredByActorId = row[ResourceLeasesTable.acquiredByActorId],
+            acquiredAt = row[ResourceLeasesTable.acquiredAt],
+            expiresAt = row[ResourceLeasesTable.expiresAt],
+            originalAcquiredAt = row[ResourceLeasesTable.originalAcquiredAt],
+            version = row[ResourceLeasesTable.version],
+        )
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteResourceLeaseRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteResourceLeaseRepository.kt
@@ -1,21 +1,33 @@
 package io.github.jpicklyk.mcptask.current.infrastructure.repository
 
 import io.github.jpicklyk.mcptask.current.domain.model.ResourceLease
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceLeaseInterval
 import io.github.jpicklyk.mcptask.current.domain.repository.LeaseAcquireResult
 import io.github.jpicklyk.mcptask.current.domain.repository.LeaseReleaseResult
 import io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ResourceLeaseHistoryTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ResourceLeasesTable
+import kotlinx.coroutines.delay
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.VarCharColumnType
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greater
 import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.core.java.UUIDColumnType
+import org.jetbrains.exposed.v1.core.lessEq
+import org.jetbrains.exposed.v1.core.neq
+import org.jetbrains.exposed.v1.core.or
+import org.jetbrains.exposed.v1.jdbc.andWhere
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
+import org.jetbrains.exposed.v1.jdbc.update
 import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.time.LocalDateTime
@@ -48,6 +60,12 @@ class SQLiteResourceLeaseRepository(
      * `V15__Resource_Leases.sql`) is already shaped to support that without a schema change.
      */
     private val maxHoldersPerKey = 1
+
+    private companion object {
+        /** Bounded retries for SQLITE_BUSY / SQLITE_LOCKED contention on [acquireAll]. */
+        const val ACQUIRE_LOCK_RETRIES = 5
+        const val ACQUIRE_LOCK_RETRY_DELAY_MS = 40L
+    }
 
     /**
      * Return the database server's current wall-clock time as an [Instant].
@@ -99,6 +117,43 @@ class SQLiteResourceLeaseRepository(
             "ttlSeconds must be positive for every requirement: " +
                 requirements.filter { it.second <= 0 }.joinToString { "${it.first}=${it.second}" }
         }
+        // Bounded retry on SQLite lock contention (SQLITE_BUSY on file databases,
+        // SQLITE_LOCKED_SHAREDCACHE on shared-cache connections): the losing writer of a genuine
+        // cross-connection race gets a clean rollback from suspendTransaction, so retrying is safe
+        // and lets it re-evaluate — typically landing on Contended (with retryAfterMs) instead of
+        // surfacing a raw DBError. Exhausting the attempts falls through to the DBError path,
+        // which callers already treat as transient per the interface KDoc.
+        var lastLockException: Exception? = null
+        repeat(ACQUIRE_LOCK_RETRIES) { attempt ->
+            try {
+                return acquireAllOnce(holderItemId, actorId, requirements)
+            } catch (e: Exception) {
+                if (!isSqliteLockContention(e)) throw e
+                lastLockException = e
+                logger.debug("acquireAll lock contention (attempt ${attempt + 1}/$ACQUIRE_LOCK_RETRIES), retrying")
+                delay(ACQUIRE_LOCK_RETRY_DELAY_MS)
+            }
+        }
+        logger.error("Failed to acquire resource leases for holder $holderItemId after $ACQUIRE_LOCK_RETRIES lock-contention retries")
+        return LeaseAcquireResult.DBError(lastLockException ?: IllegalStateException("lock contention"))
+    }
+
+    /** Walks the cause chain for a SQLite busy/locked result code — the only retryable failures. */
+    private fun isSqliteLockContention(e: Throwable?): Boolean {
+        var cause = e
+        while (cause != null) {
+            val msg = cause.message ?: ""
+            if (msg.contains("SQLITE_BUSY") || msg.contains("SQLITE_LOCKED")) return true
+            cause = cause.cause
+        }
+        return false
+    }
+
+    private suspend fun acquireAllOnce(
+        holderItemId: UUID,
+        actorId: String?,
+        requirements: List<Pair<String, Int>>
+    ): LeaseAcquireResult {
         return try {
             if (requirements.isEmpty()) {
                 LeaseAcquireResult.Success(emptyList())
@@ -171,6 +226,31 @@ class SQLiteResourceLeaseRepository(
                     val leases = mutableListOf<ResourceLease>()
                     for ((key, ttlSeconds) in sortedRequirements) {
                         val ttlOffset = "+$ttlSeconds"
+
+                        // History bookkeeping happens on the SAME row lookups the live upsert below
+                        // is about to overwrite — read the pre-write state now, before it changes.
+                        // See recordHistoryOnAcquire's KDoc for the three cases this distinguishes.
+                        val ownRow =
+                            ResourceLeasesTable
+                                .selectAll()
+                                .where { (ResourceLeasesTable.resourceKey eq key) and (ResourceLeasesTable.holderItemId eq holderItemId) }
+                                .singleOrNull()
+                        // Not .singleOrNull(): the live table's uniqueness is scoped to (resource_key,
+                        // holder_item_id), so a fresh acquire/steal never deletes a prior holder's
+                        // now-stale row — a key can accumulate more than one expired other-holder row
+                        // across repeated steals. All of them are guaranteed expired here (the
+                        // contention pre-pass above already rejected any ACTIVE other holder).
+                        val staleOtherRows =
+                            if (ownRow == null) {
+                                ResourceLeasesTable
+                                    .selectAll()
+                                    .where {
+                                        (ResourceLeasesTable.resourceKey eq key) and (ResourceLeasesTable.holderItemId neq holderItemId)
+                                    }.toList()
+                            } else {
+                                emptyList()
+                            }
+
                         exec(
                             """
                             INSERT INTO resource_leases
@@ -200,20 +280,114 @@ class SQLiteResourceLeaseRepository(
                                 .where { (ResourceLeasesTable.resourceKey eq key) and (ResourceLeasesTable.holderItemId eq holderItemId) }
                                 .single()
                         leases += toResourceLease(row)
+
+                        recordHistoryOnAcquire(
+                            key = key,
+                            holderItemId = holderItemId,
+                            actorId = actorId,
+                            ownRowExisted = ownRow != null,
+                            staleOtherRows = staleOtherRows,
+                            liveRow = row,
+                        )
                     }
 
                     LeaseAcquireResult.Success(leases)
                 }
             }
         } catch (e: Exception) {
+            // Lock contention propagates to acquireAll's bounded retry; everything else is terminal.
+            if (isSqliteLockContention(e)) throw e
             logger.error("Failed to acquire resource leases for holder $holderItemId: ${e.message}", e)
             LeaseAcquireResult.DBError(e)
+        }
+    }
+
+    /**
+     * Writes the `resource_lease_history` side of a single-key acquire, in the SAME transaction as
+     * the live-row upsert `acquireAll` just performed for [key]. Three cases, distinguished by the
+     * pre-write state captured before the live upsert ran:
+     *
+     * 1. **Refresh** ([ownRowExisted] true) — the OPEN history interval for `(key, holderItemId)`
+     *    has its `expiresAt` extended in place. If none is open (the bootstrap gap for a lease that
+     *    predates V16 — see the migration header), a new interval opens instead.
+     * 2. **Steal** ([ownRowExisted] false, [staleOtherRows] non-empty) — every OTHER holder row
+     *    still on this key (necessarily expired, or `acquireAll`'s contention pre-pass would have
+     *    rejected this call — there can be more than one, since a steal never deletes the row it
+     *    supersedes) has its OPEN history interval closed with `releaseReason = "expired"` at its
+     *    own last-known `expiresAt` (read from the live row BEFORE it was overwritten —
+     *    authoritative regardless of whether history was already in sync; a no-op for any stale row
+     *    with no open interval to close). A new interval then opens for the new holder.
+     * 3. **Fresh** ([ownRowExisted] false, [staleOtherRows] empty) — a never-before-seen (or
+     *    previously fully released) key: a new interval simply opens.
+     *
+     * [liveRow] is the freshly-upserted `resource_leases` row, read back after the write — its
+     * `acquiredAt` / `expiresAt` (both DB-computed) are reused verbatim for the history row so the
+     * two tables can never disagree on the interval's timestamps.
+     */
+    private fun recordHistoryOnAcquire(
+        key: String,
+        holderItemId: UUID,
+        actorId: String?,
+        ownRowExisted: Boolean,
+        staleOtherRows: List<ResultRow>,
+        liveRow: ResultRow,
+    ) {
+        val liveAcquiredAt = liveRow[ResourceLeasesTable.acquiredAt]
+        val liveExpiresAt = liveRow[ResourceLeasesTable.expiresAt]
+
+        fun openNewInterval() {
+            ResourceLeaseHistoryTable.insert {
+                it[id] = UUID.randomUUID()
+                it[resourceKey] = key
+                it[ResourceLeaseHistoryTable.holderItemId] = holderItemId
+                it[acquiredByActorId] = actorId
+                it[acquiredAt] = liveAcquiredAt
+                it[expiresAt] = liveExpiresAt
+            }
+        }
+
+        if (ownRowExisted) {
+            val updated =
+                ResourceLeaseHistoryTable.update({
+                    (ResourceLeaseHistoryTable.resourceKey eq key) and
+                        (ResourceLeaseHistoryTable.holderItemId eq holderItemId) and
+                        ResourceLeaseHistoryTable.releasedAt.isNull()
+                }) {
+                    it[expiresAt] = liveExpiresAt
+                }
+            if (updated == 0) openNewInterval()
+        } else {
+            staleOtherRows.forEach { stale ->
+                val staleHolderId = stale[ResourceLeasesTable.holderItemId]
+                val staleExpiresAt = stale[ResourceLeasesTable.expiresAt]
+                ResourceLeaseHistoryTable.update({
+                    (ResourceLeaseHistoryTable.resourceKey eq key) and
+                        (ResourceLeaseHistoryTable.holderItemId eq staleHolderId) and
+                        ResourceLeaseHistoryTable.releasedAt.isNull()
+                }) {
+                    it[releasedAt] = staleExpiresAt
+                    it[releaseReason] = "expired"
+                }
+            }
+            openNewInterval()
         }
     }
 
     override suspend fun releaseAllForItem(holderItemId: UUID): LeaseReleaseResult =
         try {
             suspendTransaction(db = databaseManager.getDatabase()) {
+                val uuidType = UUIDColumnType()
+                // Close every OPEN interval this holder has, across all its keys. releasedAt is
+                // stamped DB-side (datetime('now')) — never the JVM clock, matching every other
+                // write in this class.
+                exec(
+                    """
+                    UPDATE resource_lease_history
+                       SET released_at = datetime('now'), release_reason = 'released'
+                     WHERE holder_item_id = ? AND released_at IS NULL
+                    """.trimIndent(),
+                    args = listOf(uuidType to holderItemId)
+                )
                 val count = ResourceLeasesTable.deleteWhere { ResourceLeasesTable.holderItemId eq holderItemId }
                 LeaseReleaseResult.Success(count)
             }
@@ -222,9 +396,24 @@ class SQLiteResourceLeaseRepository(
             LeaseReleaseResult.DBError(e)
         }
 
-    override suspend fun forceReleaseByKey(resourceKey: String): LeaseReleaseResult =
+    override suspend fun forceReleaseByKey(
+        resourceKey: String,
+        actorId: String?
+    ): LeaseReleaseResult =
         try {
             suspendTransaction(db = databaseManager.getDatabase()) {
+                val keyType = VarCharColumnType(255)
+                val actorType = VarCharColumnType(500)
+                // Close every OPEN interval on this key, regardless of holder. released_by_actor_id
+                // records the acting principal (the REST route threads its tokenId through).
+                exec(
+                    """
+                    UPDATE resource_lease_history
+                       SET released_at = datetime('now'), release_reason = 'force_released', released_by_actor_id = ?
+                     WHERE resource_key = ? AND released_at IS NULL
+                    """.trimIndent(),
+                    args = listOf(actorType to actorId, keyType to resourceKey)
+                )
                 val count = ResourceLeasesTable.deleteWhere { ResourceLeasesTable.resourceKey eq resourceKey }
                 LeaseReleaseResult.Success(count)
             }
@@ -264,6 +453,42 @@ class SQLiteResourceLeaseRepository(
         }
     }
 
+    override suspend fun findHoldersAt(
+        resourceKey: String?,
+        at: Instant
+    ): List<ResourceLeaseInterval> =
+        suspendTransaction(db = databaseManager.getDatabase()) {
+            // Held at `at` iff acquiredAt <= at < coalesce(releasedAt, expiresAt) — expressed as an
+            // OR over the open/closed shapes since Exposed has no direct coalesce() comparison here.
+            val heldAt =
+                (ResourceLeaseHistoryTable.acquiredAt lessEq at) and
+                    (
+                        (ResourceLeaseHistoryTable.releasedAt.isNull() and (ResourceLeaseHistoryTable.expiresAt greater at)) or
+                            (ResourceLeaseHistoryTable.releasedAt.isNotNull() and (ResourceLeaseHistoryTable.releasedAt greater at))
+                    )
+            val conditions = mutableListOf(heldAt)
+            if (resourceKey != null) conditions.add(ResourceLeaseHistoryTable.resourceKey eq resourceKey)
+
+            ResourceLeaseHistoryTable
+                .selectAll()
+                .where { conditions.reduce { acc, op -> acc and op } }
+                .orderBy(ResourceLeaseHistoryTable.acquiredAt, SortOrder.DESC)
+                .map { toInterval(it) }
+        }
+
+    override suspend fun findRecentIntervals(
+        resourceKey: String?,
+        limit: Int
+    ): List<ResourceLeaseInterval> =
+        suspendTransaction(db = databaseManager.getDatabase()) {
+            var query = ResourceLeaseHistoryTable.selectAll()
+            if (resourceKey != null) query = query.andWhere { ResourceLeaseHistoryTable.resourceKey eq resourceKey }
+            query
+                .orderBy(ResourceLeaseHistoryTable.acquiredAt, SortOrder.DESC)
+                .limit(limit)
+                .map { toInterval(it) }
+        }
+
     private fun toResourceLease(row: ResultRow): ResourceLease =
         ResourceLease(
             id = row[ResourceLeasesTable.id].value,
@@ -274,5 +499,18 @@ class SQLiteResourceLeaseRepository(
             expiresAt = row[ResourceLeasesTable.expiresAt],
             originalAcquiredAt = row[ResourceLeasesTable.originalAcquiredAt],
             version = row[ResourceLeasesTable.version],
+        )
+
+    private fun toInterval(row: ResultRow): ResourceLeaseInterval =
+        ResourceLeaseInterval(
+            id = row[ResourceLeaseHistoryTable.id].value,
+            resourceKey = row[ResourceLeaseHistoryTable.resourceKey],
+            holderItemId = row[ResourceLeaseHistoryTable.holderItemId],
+            acquiredByActorId = row[ResourceLeaseHistoryTable.acquiredByActorId],
+            acquiredAt = row[ResourceLeaseHistoryTable.acquiredAt],
+            expiresAt = row[ResourceLeaseHistoryTable.expiresAt],
+            releasedAt = row[ResourceLeaseHistoryTable.releasedAt],
+            releaseReason = row[ResourceLeaseHistoryTable.releaseReason],
+            releasedByActorId = row[ResourceLeaseHistoryTable.releasedByActorId],
         )
 }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteResourceLeaseRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteResourceLeaseRepository.kt
@@ -94,8 +94,12 @@ class SQLiteResourceLeaseRepository(
         holderItemId: UUID,
         actorId: String?,
         requirements: List<Pair<String, Int>>
-    ): LeaseAcquireResult =
-        try {
+    ): LeaseAcquireResult {
+        require(requirements.all { it.second > 0 }) {
+            "ttlSeconds must be positive for every requirement: " +
+                requirements.filter { it.second <= 0 }.joinToString { "${it.first}=${it.second}" }
+        }
+        return try {
             if (requirements.isEmpty()) {
                 LeaseAcquireResult.Success(emptyList())
             } else {
@@ -205,6 +209,7 @@ class SQLiteResourceLeaseRepository(
             logger.error("Failed to acquire resource leases for holder $holderItemId: ${e.message}", e)
             LeaseAcquireResult.DBError(e)
         }
+    }
 
     override suspend fun releaseAllForItem(holderItemId: UUID): LeaseReleaseResult =
         try {

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteRoleTransitionRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteRoleTransitionRepository.kt
@@ -9,6 +9,9 @@ import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.domain.repository.RoleTransitionRepository
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.RoleTransitionsTable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
@@ -49,6 +52,10 @@ class SQLiteRoleTransitionRepository(
                 it[RoleTransitionsTable.verificationStatus] = transition.verification?.status?.toJsonString()
                 it[RoleTransitionsTable.verificationVerifier] = transition.verification?.verifier
                 it[RoleTransitionsTable.verificationReason] = transition.verification?.reason
+                it[RoleTransitionsTable.consumedCredentials] =
+                    transition.consumedCredentials.takeIf { creds -> creds.isNotEmpty() }?.let { creds ->
+                        Json.encodeToString(ListSerializer(String.serializer()), creds)
+                    }
             }
             Result.Success(transition)
         }
@@ -158,6 +165,19 @@ class SQLiteRoleTransitionRepository(
                     null
                 }
             }
+        val consumedCredentials: List<String> =
+            row[RoleTransitionsTable.consumedCredentials]?.let { raw ->
+                try {
+                    Json.decodeFromString(ListSerializer(String.serializer()), raw)
+                } catch (e: Exception) {
+                    logger.warn(
+                        "RoleTransition {}: invalid consumedCredentials JSON '{}'; defaulting to empty list",
+                        transitionId,
+                        raw
+                    )
+                    emptyList<String>()
+                }
+            } ?: emptyList()
         return RoleTransition(
             id = transitionId,
             itemId = row[RoleTransitionsTable.itemId],
@@ -169,7 +189,8 @@ class SQLiteRoleTransitionRepository(
             summary = row[RoleTransitionsTable.summary],
             transitionedAt = row[RoleTransitionsTable.transitionedAt],
             actorClaim = actorClaim,
-            verification = verification
+            verification = verification,
+            consumedCredentials = consumedCredentials
         )
     }
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/cors/CorsConfig.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/cors/CorsConfig.kt
@@ -12,7 +12,7 @@ import io.ktor.server.plugins.cors.CORSConfig
  *   Empty / unset = no cross-origin requests allowed (all preflight returns 403).
  * - `CORS_ALLOWED_METHODS` — comma-separated HTTP methods. Default: GET, POST, PATCH, PUT, DELETE, OPTIONS.
  * - `CORS_ALLOWED_HEADERS` — comma-separated request headers. Default: Authorization, Content-Type, If-Match.
- * - `CORS_EXPOSE_HEADERS` — comma-separated response headers exposed to JS. Default: ETag, Last-Event-ID.
+ * - `CORS_EXPOSE_HEADERS` — comma-separated response headers exposed to JS. Default: ETag, Last-Event-ID, Retry-After.
  * - `CORS_MAX_AGE_SECONDS` — preflight cache duration in seconds. Default: 3600.
  *
  * Design decisions:

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/dto/Dtos.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/dto/Dtos.kt
@@ -90,6 +90,12 @@ data class RoleTransitionDto(
     val occurredAt: String,
     val actor: ActorClaimDto?,
     val verification: VerificationDto?,
+    /**
+     * Opaque credential/secret labels consumed by this transition (e.g. "vault:prod-db-password"),
+     * never raw secret material. Omitted (null) when empty. Deliberately NOT subject to attribution
+     * redaction — the labels themselves are not sensitive.
+     */
+    val consumedCredentials: List<String>? = null,
 )
 
 /** DTO for the combined dependencies view of a work item. */
@@ -331,6 +337,13 @@ data class DependencyCreateDto(
 @Serializable
 data class AdvanceRequestDto(
     val trigger: String,
+    /**
+     * Optional audit list of opaque credential/secret labels consumed by this transition (e.g.
+     * "vault:prod-db-password"), never raw secret material. Validated with the same rules as the
+     * MCP `advance_item` tool's `credentialRefs` field (see [io.github.jpicklyk.mcptask.current.application.service.CredentialRefValidation]).
+     * Omitted/null preserves existing behavior (no credentialRefs recorded).
+     */
+    val credentialRefs: List<String>? = null,
 )
 
 /**

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/dto/Dtos.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/dto/Dtos.kt
@@ -560,3 +560,29 @@ data class ResourceLeaseReleaseResponseDto(
     val resourceKey: String,
     val releasedCount: Int,
 )
+
+/**
+ * DTO for one append-only lease hold interval (see
+ * [io.github.jpicklyk.mcptask.current.domain.model.ResourceLeaseInterval]).
+ *
+ * `acquiredByActorId` / `releasedByActorId` are holder/closer identity — included only for callers
+ * with `admin` capability, same inline redaction rule the live `GET /resources/leases` route
+ * applies to `ResourceLeaseDto.acquiredByActorId`.
+ */
+@Serializable
+data class ResourceLeaseIntervalDto(
+    val resourceKey: String,
+    val holderItemId: String,
+    val acquiredByActorId: String? = null,
+    val acquiredAt: String,
+    val expiresAt: String,
+    val releasedAt: String? = null,
+    val releaseReason: String? = null,
+    val releasedByActorId: String? = null,
+)
+
+/** Response DTO for `GET /api/v1/resources/leases/history`. */
+@Serializable
+data class ResourceLeaseHistoryResponseDto(
+    val intervals: List<ResourceLeaseIntervalDto>,
+)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/dto/Dtos.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/dto/Dtos.kt
@@ -344,6 +344,21 @@ data class AdvanceRequestDto(
      * Omitted/null preserves existing behavior (no credentialRefs recorded).
      */
     val credentialRefs: List<String>? = null,
+    /**
+     * Operator escape hatch: when `true`, skips the resource-lease gate for a transition entering
+     * the work phase, letting the advance proceed even though another item holds one of this item's
+     * declared exclusive resources.
+     *
+     * **Requires [io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiCapability.ADMIN].**
+     * A non-admin principal that sends `true` is REJECTED with 403 rather than silently ignored — a
+     * caller that believes it bypassed the gate but did not must never proceed as if it had.
+     * Omitted/null (the default) leaves the gate enforced, so existing request bodies are unchanged.
+     *
+     * Note the asymmetry with claim ownership: the REST surface bypasses claim ownership for every
+     * caller by design (operators override an agent's bookkeeping), but a resource lease protects a
+     * shared EXTERNAL resource and stays enforced unless an admin explicitly opts out here.
+     */
+    val overrideResourceLeases: Boolean? = null,
 )
 
 /**

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/dto/Dtos.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/dto/Dtos.kt
@@ -513,3 +513,35 @@ data class PlanDocumentListResponseDto(
     val rootId: String,
     val plans: List<PlanDocumentSummaryDto>,
 )
+
+/**
+ * DTO for a single active resource lease row (see
+ * [io.github.jpicklyk.mcptask.current.domain.model.ResourceLease]).
+ *
+ * `acquiredByActorId` is holder-identity — included only for callers with `admin` capability;
+ * non-admin callers get it redacted to null by the route handler (mirrors [NoteDto]'s
+ * attribution redaction, applied via [io.github.jpicklyk.mcptask.current.interfaces.api.v1.redaction.AttributionRedactor]-style
+ * gating rather than that class itself, since resource leases have no note/verification shape).
+ */
+@Serializable
+data class ResourceLeaseDto(
+    val resourceKey: String,
+    val holderItemId: String,
+    val acquiredByActorId: String? = null,
+    val acquiredAt: String,
+    val expiresAt: String,
+    val originalAcquiredAt: String,
+)
+
+/** Response DTO for `GET /api/v1/resources/leases`. */
+@Serializable
+data class ResourceLeaseListResponseDto(
+    val leases: List<ResourceLeaseDto>,
+)
+
+/** Response DTO for `DELETE /api/v1/resources/leases/{key}` on a successful force-release. */
+@Serializable
+data class ResourceLeaseReleaseResponseDto(
+    val resourceKey: String,
+    val releasedCount: Int,
+)

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/events/EventPublishingRepositoryProvider.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/events/EventPublishingRepositoryProvider.kt
@@ -9,6 +9,7 @@ import io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.NoteRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.PlanDocumentRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.ProjectConfigRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.domain.repository.RoleTransitionRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
@@ -357,6 +358,9 @@ class EventPublishingRepositoryProvider(
     override fun projectConfigRepository(): ProjectConfigRepository = delegate.projectConfigRepository()
 
     override fun planDocumentRepository(): PlanDocumentRepository = delegate.planDocumentRepository()
+
+    // No event publishing for resource leases — pure pass-through decorator.
+    override fun resourceLeaseRepository(): ResourceLeaseRepository = delegate.resourceLeaseRepository()
 
     override fun database() = delegate.database()
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/mapping/Mappers.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/mapping/Mappers.kt
@@ -6,6 +6,7 @@ import io.github.jpicklyk.mcptask.current.domain.model.Dependency
 import io.github.jpicklyk.mcptask.current.domain.model.DependencyType
 import io.github.jpicklyk.mcptask.current.domain.model.Note
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceLease
 import io.github.jpicklyk.mcptask.current.domain.model.RoleTransition
 import io.github.jpicklyk.mcptask.current.domain.model.VerificationResult
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
@@ -18,6 +19,7 @@ import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.ExpectedNoteDto
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.ItemDto
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.MissingNoteDto
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.NoteDto
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.ResourceLeaseDto
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.RoleTransitionDto
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.UnblockedItemDto
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.VerificationDto
@@ -284,3 +286,24 @@ fun AdvanceResult.toDto(existingNoteKeys: Set<String>): AdvanceResponseDto {
         expectedNotes = expectedNotes,
     )
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ResourceLeaseMapper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Maps a [ResourceLease] domain entity to a [ResourceLeaseDto].
+ *
+ * The caller is responsible for redacting `acquiredByActorId` for non-admin callers (see
+ * `ResourceLeaseRoutes` — the route handler nulls it out before responding) — this function
+ * always includes it when present.
+ */
+fun ResourceLease.toDto(): ResourceLeaseDto =
+    ResourceLeaseDto(
+        resourceKey = resourceKey,
+        holderItemId = holderItemId.toString(),
+        acquiredByActorId = acquiredByActorId,
+        acquiredAt = acquiredAt.toString(),
+        expiresAt = expiresAt.toString(),
+        originalAcquiredAt = originalAcquiredAt.toString(),
+    )

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/mapping/Mappers.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/mapping/Mappers.kt
@@ -210,6 +210,7 @@ fun RoleTransition.toDto(): RoleTransitionDto =
         occurredAt = transitionedAt.toString(),
         actor = actorClaim?.toDto(),
         verification = verification?.toDto(),
+        consumedCredentials = consumedCredentials.takeIf { it.isNotEmpty() },
     )
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/mapping/Mappers.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/mapping/Mappers.kt
@@ -7,6 +7,7 @@ import io.github.jpicklyk.mcptask.current.domain.model.DependencyType
 import io.github.jpicklyk.mcptask.current.domain.model.Note
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
 import io.github.jpicklyk.mcptask.current.domain.model.ResourceLease
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceLeaseInterval
 import io.github.jpicklyk.mcptask.current.domain.model.RoleTransition
 import io.github.jpicklyk.mcptask.current.domain.model.VerificationResult
 import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
@@ -20,6 +21,7 @@ import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.ItemDto
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.MissingNoteDto
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.NoteDto
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.ResourceLeaseDto
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.ResourceLeaseIntervalDto
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.RoleTransitionDto
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.UnblockedItemDto
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.VerificationDto
@@ -306,4 +308,23 @@ fun ResourceLease.toDto(): ResourceLeaseDto =
         acquiredAt = acquiredAt.toString(),
         expiresAt = expiresAt.toString(),
         originalAcquiredAt = originalAcquiredAt.toString(),
+    )
+
+/**
+ * Maps a [ResourceLeaseInterval] domain entity to a [ResourceLeaseIntervalDto].
+ *
+ * The caller is responsible for redacting `acquiredByActorId` / `releasedByActorId` for non-admin
+ * callers (see `ResourceLeaseRoutes` — the route handler nulls them out before responding) — this
+ * function always includes them when present.
+ */
+fun ResourceLeaseInterval.toDto(): ResourceLeaseIntervalDto =
+    ResourceLeaseIntervalDto(
+        resourceKey = resourceKey,
+        holderItemId = holderItemId.toString(),
+        acquiredByActorId = acquiredByActorId,
+        acquiredAt = acquiredAt.toString(),
+        expiresAt = expiresAt.toString(),
+        releasedAt = releasedAt?.toString(),
+        releaseReason = releaseReason,
+        releasedByActorId = releasedByActorId,
     )

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemWriteRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemWriteRoutes.kt
@@ -24,6 +24,7 @@ import io.github.jpicklyk.mcptask.current.interfaces.api.v1.audit.ApiAuditBridge
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiCapability
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiPrincipalKey
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.enforceScopeForItem
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.hasCapability
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.requireCapability
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.AdvanceRequestDto
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.ErrorDto
@@ -109,6 +110,11 @@ private fun errorCaptured(
  *   advance that fails a required-note gate is now REJECTED instead of silently advancing.
  * - [AdvanceFailure.ValidationFailed] → **422** `transition_blocked`, with the dependency blockers.
  * - [AdvanceFailure.ResolutionFailed] / [AdvanceFailure.ApplyFailed] → **422** `transition_failed`.
+ * - [AdvanceFailure.ResourceLeaseUnavailable] → **409** `resource_unavailable`, with a
+ *   `Retry-After` header (whole seconds, rounded UP from the millisecond hint so a client never
+ *   retries early) and `details.contendedResources` / `details.retryAfterMs`. 409 rather than 422:
+ *   the request is well-formed and will succeed once the holder finishes. The response carries
+ *   resource KEYS only — never the holding item or actor.
  * - [AdvanceFailure.PolicyRejected] → **401** `verification_failed` (defensive — ownership is not
  *   enforced on the REST path, so this is not expected to occur here).
  * - [AdvanceFailure.OwnershipRejected] → **409** `not_claim_holder` (defensive — same caveat).
@@ -164,6 +170,28 @@ private suspend fun respondAdvanceFailure(
             call.respond(
                 HttpStatusCode.UnprocessableEntity,
                 ErrorDto("transition_blocked", failure.message, details),
+            )
+        }
+        is AdvanceFailure.ResourceLeaseUnavailable -> {
+            // Round UP to whole seconds: Retry-After has second granularity, and rounding down
+            // would tell the client to retry before the lease can possibly have expired.
+            failure.retryAfterMs?.let { ms ->
+                call.response.header(HttpHeaders.RetryAfter, ((ms + 999) / 1000).coerceAtLeast(1).toString())
+            }
+            val details =
+                buildJsonObject {
+                    put("targetRole", JsonPrimitive(failure.targetRole.name.lowercase()))
+                    put(
+                        "contendedResources",
+                        kotlinx.serialization.json.buildJsonArray {
+                            failure.contendedResources.forEach { add(JsonPrimitive(it)) }
+                        },
+                    )
+                    failure.retryAfterMs?.let { put("retryAfterMs", JsonPrimitive(it)) }
+                }
+            call.respond(
+                HttpStatusCode.Conflict,
+                ErrorDto("resource_unavailable", failure.message, details),
             )
         }
         is AdvanceFailure.ResolutionFailed ->
@@ -736,6 +764,21 @@ fun Route.itemWriteRoutes(
                 is CredentialRefValidation.Result.Valid -> {} // ok
             }
 
+            // Optional ADMIN-only resource-lease override. Sent by a non-admin principal this is a
+            // hard 403, never a silent no-op: an operator who thinks they bypassed the lease and
+            // did not would go on to touch a resource another item is actively holding.
+            val overrideResourceLeases = advanceDto.overrideResourceLeases == true
+            if (overrideResourceLeases && !hasCapability(call, ApiCapability.ADMIN)) {
+                call.respond(
+                    HttpStatusCode.Forbidden,
+                    ErrorDto(
+                        "insufficient_capability",
+                        "overrideResourceLeases requires the admin capability",
+                    ),
+                )
+                return@post
+            }
+
             val itemResult = workItemRepo.getById(id)
             if (itemResult is Result.Error) {
                 call.respond(HttpStatusCode.NotFound, ErrorDto("not_found", "Item $id not found"))
@@ -764,17 +807,42 @@ fun Route.itemWriteRoutes(
                 )
             }
 
+            // A lease override is always audited: it is the one way an exclusive resource can be
+            // entered by two items at once, so it must be reconstructible from logs alone. The
+            // transition summary carries the same fact into the durable role_transitions row.
+            if (overrideResourceLeases) {
+                writeLogger.warn(
+                    "Resource-lease override: admin principal tokenId='{}' bypassed the resource gate for " +
+                        "itemId={}, trigger={}. Another work item may hold this item's exclusive resources.",
+                    principal.tokenId,
+                    id,
+                    advanceDto.trigger,
+                )
+            }
+            val transitionSummary = if (overrideResourceLeases) "(resource leases overridden)" else null
+
             // Build the synthesized actor for the transition audit trail (server-side only)
             val actorClaim = ApiAuditBridge.toActorClaim(principal)
             val verification = ApiAuditBridge.toVerificationResult(principal)
 
             // Delegate to the shared AdvanceService — the SAME pipeline the MCP advance_item tool
-            // uses (resolve → validate → required-note gate → apply → cascade → unblock). The schema
-            // resolver mirrors AdvanceItemTool's trait-merged resolution. enforceOwnership = false:
-            // the REST API bypasses claim ownership entirely (plan §2 — API callers are operators,
-            // not fleet agents). The advance SUCCEEDS even when the item is claimed by a different
-            // MCP agent, while the synthesized API actor is still recorded on the role_transitions
-            // row for audit. Unlike the prior userTransition() path, the gate is now ENFORCED.
+            // uses (resolve → validate → required-note gate → resource-lease gate → apply → cascade
+            // → unblock). The schema resolver mirrors AdvanceItemTool's trait-merged resolution.
+            //
+            // The two enforcement flags are DELIBERATELY ASYMMETRIC:
+            //
+            //  * enforceOwnership = false — the REST API bypasses claim ownership entirely (plan §2
+            //    — API callers are operators, not fleet agents). The advance SUCCEEDS even when the
+            //    item is claimed by a different MCP agent, while the synthesized API actor is still
+            //    recorded on the role_transitions row for audit. A claim is one agent's bookkeeping,
+            //    and an operator is entitled to overrule it.
+            //  * enforceResourceLeases = true (unless an ADMIN explicitly sent overrideResourceLeases)
+            //    — a resource lease protects a shared EXTERNAL resource (a credential, a staging
+            //    environment). Operator authority cannot make two concurrent holders of a single
+            //    credential safe, so this gate is NOT waived by virtue of being an operator; it takes
+            //    an explicit, admin-gated, WARN-logged opt-out per request.
+            //
+            // Unlike the prior userTransition() path, the required-note gate is now ENFORCED.
             // statusLabelService is bound to THIS item's rootId via the SAME root-aware factory
             // AdvanceItemTool uses, so REST advances stamp identical (config-driven, per-root)
             // status labels instead of applying none at all (bug 80e48e55).
@@ -790,18 +858,23 @@ fun Route.itemWriteRoutes(
                             userTrigger.triggerString,
                         ),
                     schemaResolver = { schemaResolutionContext.resolveSchema(it) },
+                    resourceLeaseRepository = repositoryProvider.resourceLeaseRepository(),
+                    resourceRequirementsResolver = { schemaResolutionContext.resolveResourceRequirements(it) },
+                    resourceRegistryResolver = { schemaResolutionContext.resolveResourceRegistry(it) },
+                    resourceLeasesEnforced = AdvanceService.resourceLeasesEnforcedFromEnv(),
                 )
 
             val outcome =
                 advanceService.advance(
                     item = item,
                     trigger = userTrigger.triggerString,
-                    summary = null,
+                    summary = transitionSummary,
                     actorClaim = actorClaim,
                     verification = verification,
                     degradedModePolicy = degradedModePolicy,
                     enforceOwnership = false,
                     credentialRefs = credentialRefs,
+                    enforceResourceLeases = !overrideResourceLeases,
                 )
 
             val advanceResult =

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemWriteRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ItemWriteRoutes.kt
@@ -3,6 +3,7 @@ package io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes
 import io.github.jpicklyk.mcptask.current.application.service.AdvanceFailure
 import io.github.jpicklyk.mcptask.current.application.service.AdvanceOutcome
 import io.github.jpicklyk.mcptask.current.application.service.AdvanceService
+import io.github.jpicklyk.mcptask.current.application.service.CredentialRefValidation
 import io.github.jpicklyk.mcptask.current.application.service.IdempotencyCache
 import io.github.jpicklyk.mcptask.current.application.service.ItemHierarchyValidator
 import io.github.jpicklyk.mcptask.current.application.service.StatusLabelService
@@ -720,6 +721,21 @@ fun Route.itemWriteRoutes(
                     return@post
                 }
 
+            // Optional credentialRefs: same shared rules as the MCP advance_item tool
+            // (CredentialRefValidation) — a violation fails the request before anything is persisted.
+            val credentialRefs = advanceDto.credentialRefs ?: emptyList()
+            when (val credentialRefsResult = CredentialRefValidation.validate(credentialRefs)) {
+                is CredentialRefValidation.Result.Invalid -> {
+                    val suffix = if (credentialRefsResult.index >= 0) "[${credentialRefsResult.index}]" else ""
+                    call.respond(
+                        HttpStatusCode.BadRequest,
+                        ErrorDto("validation_error", "credentialRefs$suffix ${credentialRefsResult.reason}"),
+                    )
+                    return@post
+                }
+                is CredentialRefValidation.Result.Valid -> {} // ok
+            }
+
             val itemResult = workItemRepo.getById(id)
             if (itemResult is Result.Error) {
                 call.respond(HttpStatusCode.NotFound, ErrorDto("not_found", "Item $id not found"))
@@ -785,6 +801,7 @@ fun Route.itemWriteRoutes(
                     verification = verification,
                     degradedModePolicy = degradedModePolicy,
                     enforceOwnership = false,
+                    credentialRefs = credentialRefs,
                 )
 
             val advanceResult =

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ResourceLeaseRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ResourceLeaseRoutes.kt
@@ -7,6 +7,7 @@ import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiPrincipalKey
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.hasCapability
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.requireCapability
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.ErrorDto
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.ResourceLeaseHistoryResponseDto
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.ResourceLeaseListResponseDto
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.ResourceLeaseReleaseResponseDto
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.mapping.toDto
@@ -18,12 +19,16 @@ import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
 import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.time.format.DateTimeParseException
 
 private val resourceLeaseLogger = LoggerFactory.getLogger("ResourceLeaseRoutes")
 
 /** Lowercase-slug-like resource key pattern, matching [io.github.jpicklyk.mcptask.current.domain.model.ResourceDefinition.key]. */
 private val RESOURCE_KEY_PATTERN = Regex("^[a-z0-9][a-z0-9\\-_./]*$")
 private const val RESOURCE_KEY_MAX_LENGTH = 128
+private const val HISTORY_DEFAULT_LIMIT = 100
+private const val HISTORY_MAX_LIMIT = 500
 
 /**
  * Registers the operator-facing resource-lease read/force-release routes under
@@ -44,7 +49,16 @@ private const val RESOURCE_KEY_MAX_LENGTH = 128
  *   the repository layer, but this operator surface treats "nothing to release" as not-found), 200
  *   with `{resourceKey, releasedCount}` otherwise. Every successful force-release is logged at WARN
  *   naming the acting principal and the key — this bypasses normal TTL-based mutual exclusion, so it
- *   must be auditable from logs alone.
+ *   must be auditable from logs alone. The acting principal's token id is also threaded through as
+ *   `released_by_actor_id` on the closed `resource_lease_history` interval(s) — see
+ *   `GET /resources/leases/history` below.
+ * - `GET    /resources/leases/history` — append-only lease-interval audit log, answering "who held
+ *   resource R at time T" ([ApiCapability.READ]). Optional `key` (validated like the DELETE route's
+ *   `{key}`, 400 on mismatch), `at` (ISO-8601 instant — when present, returns every interval held at
+ *   that instant; 400 `validation_error` if unparseable), and `limit` (default 100, clamped to
+ *   [1, 500]). Without `at`, returns the most recent intervals (open or closed), newest-first.
+ *   `acquiredByActorId` / `releasedByActorId` are ADMIN-only, same inline redaction as the list
+ *   route above.
  *
  * **No scope enforcement:** resource leases are a cross-project, server-wide concurrency primitive
  * (unlike per-root items/config/plans) — there is no `rootId` to scope against, so only capability
@@ -86,14 +100,14 @@ fun Route.resourceLeaseRoutes(repositoryProvider: RepositoryProvider) {
                     return@delete
                 }
 
-                when (val result = leaseRepo.forceReleaseByKey(key)) {
+                val principal = call.attributes.getOrNull(ApiPrincipalKey)
+                when (val result = leaseRepo.forceReleaseByKey(key, principal?.tokenId)) {
                     is LeaseReleaseResult.Success -> {
                         if (result.releasedCount == 0) {
                             call.respond(HttpStatusCode.NotFound, ErrorDto("not_found", "No active lease found for key '$key'"))
                             return@delete
                         }
 
-                        val principal = call.attributes.getOrNull(ApiPrincipalKey)
                         resourceLeaseLogger.warn(
                             "Operator force-release: {} lease row(s) released for resourceKey='{}' by principal tokenId='{}'",
                             result.releasedCount,
@@ -111,6 +125,54 @@ fun Route.resourceLeaseRoutes(repositoryProvider: RepositoryProvider) {
                         call.respond(HttpStatusCode.InternalServerError, ErrorDto("db_error", "Failed to force-release lease"))
                     }
                 }
+            }
+        }
+
+        // ─── GET /resources/leases/history ─────────────────────────────────────
+        requireCapability(ApiCapability.READ) {
+            get("/history") {
+                val isAdmin = hasCapability(call, ApiCapability.ADMIN)
+
+                val key = call.request.queryParameters["key"]
+                if (key != null && (key.isBlank() || key.length > RESOURCE_KEY_MAX_LENGTH || !RESOURCE_KEY_PATTERN.matches(key))) {
+                    call.respond(
+                        HttpStatusCode.BadRequest,
+                        ErrorDto(
+                            "validation_error",
+                            "key must be 1-$RESOURCE_KEY_MAX_LENGTH characters matching " +
+                                "^[a-z0-9][a-z0-9\\-_./]*$",
+                        ),
+                    )
+                    return@get
+                }
+
+                val atParam = call.request.queryParameters["at"]
+                val at =
+                    if (atParam != null) {
+                        try {
+                            Instant.parse(atParam)
+                        } catch (e: DateTimeParseException) {
+                            call.respond(
+                                HttpStatusCode.BadRequest,
+                                ErrorDto("validation_error", "at must be a valid ISO-8601 instant"),
+                            )
+                            return@get
+                        }
+                    } else {
+                        null
+                    }
+
+                val limit =
+                    (call.request.queryParameters["limit"]?.toIntOrNull() ?: HISTORY_DEFAULT_LIMIT)
+                        .coerceIn(1, HISTORY_MAX_LIMIT)
+
+                val found = if (at != null) leaseRepo.findHoldersAt(key, at) else leaseRepo.findRecentIntervals(key, limit)
+                val intervals =
+                    found.take(limit).map { interval ->
+                        val dto = interval.toDto()
+                        if (isAdmin) dto else dto.copy(acquiredByActorId = null, releasedByActorId = null)
+                    }
+                call.respond(HttpStatusCode.OK, ResourceLeaseHistoryResponseDto(intervals = intervals))
             }
         }
     }

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ResourceLeaseRoutes.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ResourceLeaseRoutes.kt
@@ -1,0 +1,117 @@
+package io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes
+
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseReleaseResult
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiCapability
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiPrincipalKey
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.hasCapability
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.requireCapability
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.ErrorDto
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.ResourceLeaseListResponseDto
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.dto.ResourceLeaseReleaseResponseDto
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.mapping.toDto
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import org.slf4j.LoggerFactory
+
+private val resourceLeaseLogger = LoggerFactory.getLogger("ResourceLeaseRoutes")
+
+/** Lowercase-slug-like resource key pattern, matching [io.github.jpicklyk.mcptask.current.domain.model.ResourceDefinition.key]. */
+private val RESOURCE_KEY_PATTERN = Regex("^[a-z0-9][a-z0-9\\-_./]*$")
+private const val RESOURCE_KEY_MAX_LENGTH = 128
+
+/**
+ * Registers the operator-facing resource-lease read/force-release routes under
+ * `/api/v1/resources/leases`.
+ *
+ * Endpoints:
+ * - `GET    /resources/leases`      — list every currently active (non-expired) lease across all
+ *   keys and holders ([ApiCapability.READ]). `acquiredByActorId` (holder-identity) is included only
+ *   for callers with [ApiCapability.ADMIN]; non-admin callers get it omitted, mirroring the
+ *   [io.github.jpicklyk.mcptask.current.interfaces.api.v1.redaction.AttributionRedactor] admin-gating
+ *   pattern used for note attribution (leases have no note/verification shape, so that class itself
+ *   isn't reused — the same admin-only rule is applied inline here instead).
+ * - `DELETE /resources/leases/{key}` — administrative override: force-releases every row (any
+ *   holder) for `{key}`, bypassing its TTL ([ApiCapability.ADMIN] — never granted by [ApiCapability.READ]
+ *   alone). `{key}` is validated against the same resource-key pattern used at config-parse time
+ *   (`^[a-z0-9][a-z0-9\-_./]*$`, max 128 chars) before touching the repository (400 on mismatch).
+ *   Returns 404 when no active lease was released (`releasedCount == 0` is not itself an error at
+ *   the repository layer, but this operator surface treats "nothing to release" as not-found), 200
+ *   with `{resourceKey, releasedCount}` otherwise. Every successful force-release is logged at WARN
+ *   naming the acting principal and the key — this bypasses normal TTL-based mutual exclusion, so it
+ *   must be auditable from logs alone.
+ *
+ * **No scope enforcement:** resource leases are a cross-project, server-wide concurrency primitive
+ * (unlike per-root items/config/plans) — there is no `rootId` to scope against, so only capability
+ * checks apply here.
+ *
+ * **REST-only:** registered on the authenticated `/api/v1` pipeline only, like the other
+ * `/api/v1/resources` routes — never reachable on the unauthenticated `/mcp` transport.
+ */
+fun Route.resourceLeaseRoutes(repositoryProvider: RepositoryProvider) {
+    val leaseRepo = repositoryProvider.resourceLeaseRepository()
+
+    route("/resources/leases") {
+        // ─── GET /resources/leases ─────────────────────────────────────────────
+        requireCapability(ApiCapability.READ) {
+            get {
+                val isAdmin = hasCapability(call, ApiCapability.ADMIN)
+                val leases =
+                    leaseRepo.findAllActive().map { lease ->
+                        val dto = lease.toDto()
+                        if (isAdmin) dto else dto.copy(acquiredByActorId = null)
+                    }
+                call.respond(HttpStatusCode.OK, ResourceLeaseListResponseDto(leases = leases))
+            }
+        }
+
+        // ─── DELETE /resources/leases/{key} ────────────────────────────────────
+        requireCapability(ApiCapability.ADMIN) {
+            delete("/{key}") {
+                val key = call.parameters["key"]
+                if (key.isNullOrBlank() || key.length > RESOURCE_KEY_MAX_LENGTH || !RESOURCE_KEY_PATTERN.matches(key)) {
+                    call.respond(
+                        HttpStatusCode.BadRequest,
+                        ErrorDto(
+                            "validation_error",
+                            "resourceKey must be 1-$RESOURCE_KEY_MAX_LENGTH characters matching " +
+                                "^[a-z0-9][a-z0-9\\-_./]*$",
+                        ),
+                    )
+                    return@delete
+                }
+
+                when (val result = leaseRepo.forceReleaseByKey(key)) {
+                    is LeaseReleaseResult.Success -> {
+                        if (result.releasedCount == 0) {
+                            call.respond(HttpStatusCode.NotFound, ErrorDto("not_found", "No active lease found for key '$key'"))
+                            return@delete
+                        }
+
+                        val principal = call.attributes.getOrNull(ApiPrincipalKey)
+                        resourceLeaseLogger.warn(
+                            "Operator force-release: {} lease row(s) released for resourceKey='{}' by principal tokenId='{}'",
+                            result.releasedCount,
+                            key,
+                            principal?.tokenId ?: "unknown",
+                        )
+
+                        call.respond(
+                            HttpStatusCode.OK,
+                            ResourceLeaseReleaseResponseDto(resourceKey = key, releasedCount = result.releasedCount),
+                        )
+                    }
+                    is LeaseReleaseResult.DBError -> {
+                        resourceLeaseLogger.warn("DELETE /resources/leases/{} DB error: {}", key, result.cause.message)
+                        call.respond(HttpStatusCode.InternalServerError, ErrorDto("db_error", "Failed to force-release lease"))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/interfaces/mcp/CurrentMcpServer.kt
@@ -43,6 +43,7 @@ import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.noteRoutes
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.noteWriteRoutes
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.planDocumentRoutes
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.projectConfigRoutes
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.resourceLeaseRoutes
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.searchRoutes
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.serviceRoutes
 import io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes.transitionRoutes
@@ -528,6 +529,8 @@ internal fun Application.installRestApiRoutes(
             // plan_documents store: per-root plan document read/write —
             // converges on the same PlanDocumentService the manage_plan_documents MCP tool uses.
             planDocumentRoutes(effectiveProvider)
+            // Operator resource-lease read + force-release — cross-project, server-wide (no rootId scope).
+            resourceLeaseRoutes(effectiveProvider)
         }
         // Phase 6: real-time SSE event stream — registered OUTSIDE the ApiBearerAuth block (as a
         // sibling `route("/api/v1/events")`) so the ApiBearerAuth plugin does NOT intercept it. The

--- a/current/src/main/resources/db/migration/V14__Add_Consumed_Credentials.sql
+++ b/current/src/main/resources/db/migration/V14__Add_Consumed_Credentials.sql
@@ -1,0 +1,14 @@
+-- V14: Add consumed_credentials audit field to role_transitions
+--
+-- Adds an optional JSON-array-of-strings column recording which credential/secret *labels*
+-- (opaque references such as "vault:prod-db-password" or "github-pat-ci" — never raw secret
+-- material) a transition consumed. Populated by the `advance_item` MCP tool's optional
+-- `credentialRefs` parameter and the REST advance route's equivalent field; NULL when omitted
+-- (the overwhelming majority of transitions). See RoleTransitionsTable.kt / RoleTransition.kt /
+-- SQLiteRoleTransitionRepository.kt for the Exposed table, domain model, and JSON
+-- serialize/deserialize round-trip.
+--
+-- Follows the V5__Add_Claim_Fields.sql convention: a simple additive ALTER TABLE ADD COLUMN
+-- (SQLite has no ALTER COLUMN; this migration never needs one since the column is new).
+
+ALTER TABLE role_transitions ADD COLUMN consumed_credentials TEXT DEFAULT NULL;

--- a/current/src/main/resources/db/migration/V15__Resource_Leases.sql
+++ b/current/src/main/resources/db/migration/V15__Resource_Leases.sql
@@ -1,0 +1,61 @@
+-- V15: Resource leases store — server-enforced TTL leases for shared external resources
+--
+-- Adds `resource_leases`, the storage primitive backing trait-declared resource requirements
+-- (see ResourceRequirement / ResourceDefinition in domain/model, and the `resources:` registry
+-- in `.taskorchestrator/config.yaml`). This migration builds ONLY the storage + repository layer
+-- — no gate enforcement and no MCP tool surface are wired up here (follow-on task).
+--
+-- Time values (acquired_at, expires_at, original_acquired_at) are stored as ISO-8601 TEXT (SQLite
+-- TEXT affinity), matching the V5__Add_Claim_Fields.sql convention for work_items' claim columns
+-- (claimed_at / claim_expires_at / original_claimed_at) — the exact same three-timestamp shape,
+-- reused here for the lease lifecycle. All lease timestamps are written DB-side via datetime('now',
+-- ...) — never the JVM clock — for the same skew-avoidance reason documented on WorkItemRepository.dbNow().
+--
+-- Pure CREATE TABLE — no ALTER COLUMN, no table recreation. Follows the V12__Plan_Documents.sql
+-- style: BLOB id with a randomblob(16) default, a plain (non-inline-UNIQUE) column pair plus a
+-- separate CREATE UNIQUE INDEX statement for the uniqueness constraint.
+--
+-- ## Semaphore-ready design (deliberately NOT unique on resource_key alone)
+--
+-- v1 enforcement only ever supports a single holder per key (ResourceDefinition.maxHolders is
+-- hard-capped to 1 at config-load time — see ResourceDefinition KDoc). Even so, this table's
+-- uniqueness constraint is deliberately scoped to the PAIR (resource_key, holder_item_id) rather
+-- than resource_key alone:
+--   - It lets the SAME item re-acquire (refresh) its own lease on a key it already holds, via an
+--     UPSERT keyed on the pair, without first deleting the row.
+--   - It leaves room for a future fan-in (maxHolders > 1, "semaphore") enforcement mode to store
+--     multiple concurrent-holder rows for the same resource_key without a schema change — only the
+--     application-layer holder-count check (`COUNT(*) WHERE resource_key = ? AND expires_at > now`)
+--     would need to compare against maxHolders instead of the current hardcoded 1.
+--
+-- `original_acquired_at` mirrors work_items.original_claimed_at: preserved across same-holder
+-- re-acquires (TTL refresh), reset only when a different item acquires the key after the prior
+-- lease lapsed.
+--
+-- budget_limit / budget_used / budget_window_seconds are reserved columns for a future rate-budget
+-- enforcement mode (e.g. "N acquisitions per rolling window") — unused by this task's repository
+-- surface (acquireAll / releaseAllForItem / forceReleaseByKey / findActive*), always NULL for now.
+
+CREATE TABLE resource_leases (
+    id                     BLOB PRIMARY KEY DEFAULT (randomblob(16)),
+    resource_key           TEXT NOT NULL,
+    holder_item_id         BLOB NOT NULL REFERENCES work_items(id) ON DELETE CASCADE,
+    acquired_by_actor_id   TEXT NULL,
+    acquired_at            TEXT NOT NULL,
+    expires_at             TEXT NOT NULL,
+    original_acquired_at   TEXT NOT NULL,
+    budget_limit           INTEGER DEFAULT NULL,
+    budget_used            INTEGER DEFAULT NULL,
+    budget_window_seconds  INTEGER DEFAULT NULL,
+    version                INTEGER NOT NULL DEFAULT 0
+);
+
+-- Semaphore-ready uniqueness: one row per (resource_key, holder_item_id) pair, NOT per resource_key
+-- alone — see the header comment above.
+CREATE UNIQUE INDEX idx_resource_leases_key_holder ON resource_leases(resource_key, holder_item_id);
+
+-- Supports the per-key active-holder count check in acquireAll.
+CREATE INDEX idx_resource_leases_resource_key ON resource_leases(resource_key);
+
+-- Supports lazy-expiry scans (findAllActive / findActiveByKeys) and future TTL-sweep tooling.
+CREATE INDEX idx_resource_leases_expires_at ON resource_leases(expires_at);

--- a/current/src/main/resources/db/migration/V16__Resource_Lease_History.sql
+++ b/current/src/main/resources/db/migration/V16__Resource_Lease_History.sql
@@ -1,0 +1,56 @@
+-- V16: Resource lease history — append-only audit log of lease hold intervals
+--
+-- Adds `resource_lease_history`, answering "who held resource R at time T" — the audit shape
+-- needed to diagnose a foreign-timestamp incident after a lease has already been released or
+-- stolen. `resource_leases` (V15) only ever reflects the CURRENT holder (if any); this table
+-- accumulates one row per hold INTERVAL and is never pruned in v1 (append-only — no retention
+-- policy yet; cardinality tracks lease events, not resource count).
+--
+-- ## Deliberately NO foreign key on holder_item_id
+--
+-- Unlike `resource_leases.holder_item_id` (which CASCADEs on work-item delete — the live row has
+-- no reason to survive its holder), this table's `holder_item_id` carries NO foreign key
+-- constraint to `work_items(id)`, and this is intentional, not an oversight:
+--   - The audit trail must remain readable after the holder work item is deleted. A FK with
+--     ON DELETE CASCADE would silently erase exactly the history an operator needs after cleanup;
+--     ON DELETE SET NULL would lose holder attribution, which is the entire point of this table.
+--   - `DirectDatabaseSchemaManagerV16*Test` / the domain model KDoc restate this — keep the Exposed
+--     `ResourceLeaseHistoryTable` object in sync (it must also omit the FK) so the two DDL sources
+--     do not drift.
+--
+-- Time values (acquired_at, expires_at, released_at) are ISO-8601 TEXT, written DB-side via
+-- datetime('now', ...) — never the JVM clock — matching the V15__Resource_Leases.sql convention.
+--
+-- ## Interval lifecycle
+--
+-- One row per hold interval, appended on acquire (fresh or steal-of-expired), updated in place
+-- while open (same-holder TTL refresh extends expires_at on the OPEN row — no new row), and closed
+-- exactly once (released_at + release_reason set) on release / steal / force-release. See
+-- SQLiteResourceLeaseRepository for the write-path details.
+--
+-- Pure CREATE TABLE — no ALTER COLUMN, no table recreation. Follows the V15__Resource_Leases.sql /
+-- V12__Plan_Documents.sql style: BLOB id with a randomblob(16) default.
+--
+-- Data migration: none. This is a brand-new empty table — pre-existing live leases (rows already
+-- in `resource_leases` before this migration ran) simply have no history until their NEXT
+-- lifecycle event (next acquire/refresh/release/force-release); this is documented, accepted
+-- behavior, not a bug — see SQLiteResourceLeaseRepository's write paths, which self-heal by opening
+-- a fresh interval the first time such a lease is touched again.
+
+CREATE TABLE resource_lease_history (
+    id                     BLOB PRIMARY KEY DEFAULT (randomblob(16)),
+    resource_key           TEXT NOT NULL,
+    holder_item_id         BLOB NOT NULL,
+    acquired_by_actor_id   TEXT NULL,
+    acquired_at            TEXT NOT NULL,
+    expires_at             TEXT NOT NULL,
+    released_at            TEXT NULL,
+    release_reason         TEXT NULL,
+    released_by_actor_id   TEXT NULL
+);
+
+-- Supports the at-T lookup (findHoldersAt) and recent-activity listing, both filtered/ordered by key + acquired_at.
+CREATE INDEX idx_resource_lease_history_key_acquired ON resource_lease_history(resource_key, acquired_at);
+
+-- Supports open-interval scans (released_at IS NULL) used by the acquire/release write paths.
+CREATE INDEX idx_resource_lease_history_released_at ON resource_lease_history(released_at);

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceServiceLeaseGateTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceServiceLeaseGateTest.kt
@@ -1,0 +1,683 @@
+package io.github.jpicklyk.mcptask.current.application.service
+
+import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceDefinition
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceMode
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceRequirement
+import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.RoleTransition
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
+import io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseAcquireResult
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseReleaseResult
+import io.github.jpicklyk.mcptask.current.domain.repository.NoteRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.domain.repository.RoleTransitionRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
+import io.mockk.Called
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for step 4.5 of [AdvanceService] — the resource-lease gate — plus every release path
+ * out of [Role.WORK] and the start-cascade suppression behavior.
+ *
+ * Conventions mirror [AdvanceServiceTest]: MockK repositories, `inTransaction` delegating straight
+ * to its block, no real database. The lease repository and the two resource resolvers are injected
+ * per-test so the enforcement matrix can be driven row by row.
+ */
+class AdvanceServiceLeaseGateTest {
+    private lateinit var workItemRepo: WorkItemRepository
+    private lateinit var depRepo: DependencyRepository
+    private lateinit var roleTransitionRepo: RoleTransitionRepository
+    private lateinit var noteRepo: NoteRepository
+    private lateinit var leaseRepo: ResourceLeaseRepository
+
+    @BeforeEach
+    fun setUp() {
+        workItemRepo = mockk()
+        depRepo = mockk()
+        roleTransitionRepo = mockk()
+        noteRepo = mockk()
+        leaseRepo = mockk()
+
+        coEvery { workItemRepo.dbNow() } returns Instant.now()
+        coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+        coEvery { workItemRepo.inTransaction(any()) } coAnswers {
+            firstArg<suspend () -> Unit>().invoke()
+        }
+        coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+        coEvery { noteRepo.findByItemId(any()) } returns Result.Success(emptyList())
+        every { depRepo.findByToItemId(any()) } returns emptyList()
+        every { depRepo.findByFromItemId(any()) } returns emptyList()
+
+        // Default lease behavior: acquires succeed, releases free one row.
+        coEvery { leaseRepo.acquireAll(any(), any(), any()) } returns LeaseAcquireResult.Success(emptyList())
+        coEvery { leaseRepo.releaseAllForItem(any()) } returns LeaseReleaseResult.Success(1)
+    }
+
+    private fun makeItem(
+        id: UUID = UUID.randomUUID(),
+        role: Role = Role.QUEUE,
+        previousRole: Role? = null,
+        title: String = "Item",
+        parentId: UUID? = null
+    ): WorkItem =
+        WorkItem(
+            id = id,
+            title = title,
+            role = role,
+            previousRole = previousRole,
+            parentId = parentId,
+            depth = if (parentId != null) 1 else 0
+        )
+
+    /**
+     * Builds a service wired with the shared mocks plus the resource collaborators under test.
+     * Every resource parameter is defaulted to its dormant value so each test states only the row
+     * of the enforcement matrix it exercises.
+     */
+    private fun serviceWith(
+        requirements: List<ResourceRequirement> = emptyList(),
+        registry: Map<String, ResourceDefinition> = emptyMap(),
+        schema: WorkItemSchema? = null,
+        leaseRepository: ResourceLeaseRepository? = leaseRepo,
+        resourceLeasesEnforced: Boolean = true,
+        requirementsByItem: Map<UUID, List<ResourceRequirement>>? = null
+    ): AdvanceService =
+        AdvanceService(
+            workItemRepository = workItemRepo,
+            roleTransitionRepository = roleTransitionRepo,
+            dependencyRepository = depRepo,
+            noteRepository = noteRepo,
+            statusLabelService = NoOpStatusLabelService,
+            schemaResolver = { schema },
+            resourceLeaseRepository = leaseRepository,
+            resourceRequirementsResolver = { item ->
+                requirementsByItem?.get(item.id) ?: requirements
+            },
+            resourceRegistryResolver = { registry },
+            resourceLeasesEnforced = resourceLeasesEnforced
+        )
+
+    /** Captures the [RoleTransition] audit row written by the primary transition. */
+    private fun captureTransition(): io.mockk.CapturingSlot<RoleTransition> {
+        val slot = slot<RoleTransition>()
+        coEvery { roleTransitionRepo.create(capture(slot)) } returns Result.Success(mockk())
+        return slot
+    }
+
+    private fun exclusive(
+        key: String,
+        ttlSeconds: Int? = null
+    ) = ResourceRequirement(key, ResourceMode.EXCLUSIVE, ttlSeconds)
+
+    private fun advisory(key: String) = ResourceRequirement(key, ResourceMode.ADVISORY, null)
+
+    // ──────────────────────────────────────────────
+    // Short-circuit: the common (non-adopter) path
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `no declared resources means ZERO lease repository interactions on start into work`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.QUEUE)
+
+            val outcome =
+                serviceWith().advance(
+                    item,
+                    "start",
+                    null,
+                    null,
+                    null,
+                    DegradedModePolicy.ACCEPT_CACHED,
+                    enforceOwnership = true
+                )
+
+            assertIs<AdvanceOutcome.Success>(outcome)
+            // The whole point of the short-circuit: an item without resources must never touch the
+            // lease store — not acquireAll, not releaseAllForItem, not a read.
+            verify { leaseRepo wasNot Called }
+        }
+
+    @Test
+    fun `no declared resources leaves caller credentialRefs untouched`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.QUEUE)
+            val transition = captureTransition()
+
+            serviceWith().advance(
+                item,
+                "start",
+                null,
+                null,
+                null,
+                DegradedModePolicy.ACCEPT_CACHED,
+                enforceOwnership = true,
+                credentialRefs = listOf("some-unregistered-label")
+            )
+
+            // Rung-1 behavior preserved: with no declarations and an empty registry there is no
+            // set-membership check, so an arbitrary (well-formatted) label still passes through.
+            assertEquals(listOf("some-unregistered-label"), transition.captured.consumedCredentials)
+        }
+
+    // ──────────────────────────────────────────────
+    // Acquisition
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `exclusive requirement is acquired on start into work`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.QUEUE)
+            val requests = slot<List<Pair<String, Int>>>()
+            coEvery { leaseRepo.acquireAll(item.id, any(), capture(requests)) } returns
+                LeaseAcquireResult.Success(emptyList())
+
+            val outcome =
+                serviceWith(requirements = listOf(exclusive("staging-db", ttlSeconds = 600))).advance(
+                    item,
+                    "start",
+                    null,
+                    null,
+                    null,
+                    DegradedModePolicy.ACCEPT_CACHED,
+                    enforceOwnership = true
+                )
+
+            assertIs<AdvanceOutcome.Success>(outcome)
+            assertEquals(listOf("staging-db" to 600), requests.captured)
+        }
+
+    @Test
+    fun `resume from BLOCKED into work acquires leases`(): Unit =
+        runBlocking {
+            // The note gate keys on trigger == start/complete and so ignores resume; the resource
+            // gate keys on targetRole, which is why resume is covered.
+            val item = makeItem(role = Role.BLOCKED, previousRole = Role.WORK)
+
+            val outcome =
+                serviceWith(requirements = listOf(exclusive("staging-db"))).advance(
+                    item,
+                    "resume",
+                    null,
+                    null,
+                    null,
+                    DegradedModePolicy.ACCEPT_CACHED,
+                    enforceOwnership = true
+                )
+
+            val success = assertIs<AdvanceOutcome.Success>(outcome)
+            assertEquals(Role.WORK, success.result.newRole)
+            coVerify(exactly = 1) { leaseRepo.acquireAll(item.id, any(), any()) }
+        }
+
+    @Test
+    fun `contended acquire is rejected with ALL contended keys and the retry hint`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.QUEUE)
+            coEvery { leaseRepo.acquireAll(any(), any(), any()) } returns
+                LeaseAcquireResult.Contended(listOf("staging-db", "prod-cred"), retryAfterMs = 45_000)
+
+            val outcome =
+                serviceWith(
+                    requirements = listOf(exclusive("staging-db"), exclusive("prod-cred"))
+                ).advance(item, "start", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true)
+
+            val failure = assertIs<AdvanceOutcome.Failure>(outcome)
+            val blocked = assertIs<AdvanceFailure.ResourceLeaseUnavailable>(failure.failure)
+            assertEquals(listOf("staging-db", "prod-cred"), blocked.contendedResources)
+            assertEquals(45_000L, blocked.retryAfterMs)
+            assertEquals(Role.WORK, blocked.targetRole)
+            // Nothing was persisted — the transition never reached applyTransition.
+            coVerify(exactly = 0) { roleTransitionRepo.create(any()) }
+        }
+
+    @Test
+    fun `lease store DBError is surfaced as a transient rejection with the default backoff`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.QUEUE)
+            coEvery { leaseRepo.acquireAll(any(), any(), any()) } returns
+                LeaseAcquireResult.DBError(IllegalStateException("SQLITE_BUSY_SNAPSHOT"))
+
+            val outcome =
+                serviceWith(requirements = listOf(exclusive("staging-db"))).advance(
+                    item,
+                    "start",
+                    null,
+                    null,
+                    null,
+                    DegradedModePolicy.ACCEPT_CACHED,
+                    true
+                )
+
+            val failure = assertIs<AdvanceOutcome.Failure>(outcome)
+            val blocked = assertIs<AdvanceFailure.ResourceLeaseUnavailable>(failure.failure)
+            assertEquals(listOf("staging-db"), blocked.contendedResources)
+            assertEquals(AdvanceService.LEASE_DB_ERROR_RETRY_AFTER_MS, blocked.retryAfterMs)
+            assertTrue(blocked.message.contains("transient"), "message should name the transient cause")
+        }
+
+    @Test
+    fun `advisory requirement is never leased but IS derived into consumedCredentials`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.QUEUE)
+            val transition = captureTransition()
+
+            val outcome =
+                serviceWith(requirements = listOf(advisory("shared-runner"))).advance(
+                    item,
+                    "start",
+                    null,
+                    null,
+                    null,
+                    DegradedModePolicy.ACCEPT_CACHED,
+                    true
+                )
+
+            assertIs<AdvanceOutcome.Success>(outcome)
+            coVerify(exactly = 0) { leaseRepo.acquireAll(any(), any(), any()) }
+            assertEquals(listOf("shared-runner"), transition.captured.consumedCredentials)
+        }
+
+    @Test
+    fun `derived keys precede caller extras and duplicates collapse`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.QUEUE)
+            val transition = captureTransition()
+
+            serviceWith(
+                requirements = listOf(exclusive("staging-db"), advisory("shared-runner")),
+                registry = mapOf("extra-cred" to ResourceDefinition("extra-cred"))
+            ).advance(
+                item,
+                "start",
+                null,
+                null,
+                null,
+                DegradedModePolicy.ACCEPT_CACHED,
+                true,
+                // "staging-db" duplicates a derived key; "extra-cred" is a registry-known extra.
+                credentialRefs = listOf("staging-db", "extra-cred")
+            )
+
+            assertEquals(
+                listOf("staging-db", "shared-runner", "extra-cred"),
+                transition.captured.consumedCredentials
+            )
+        }
+
+    // ──────────────────────────────────────────────
+    // credentialRefs set-membership tightening
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `caller credentialRef outside declared and registry keys is rejected`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.QUEUE)
+
+            val outcome =
+                serviceWith(
+                    requirements = listOf(exclusive("staging-db")),
+                    registry = mapOf("prod-cred" to ResourceDefinition("prod-cred"))
+                ).advance(
+                    item,
+                    "start",
+                    null,
+                    null,
+                    null,
+                    DegradedModePolicy.ACCEPT_CACHED,
+                    true,
+                    credentialRefs = listOf("staging-db", "who-knows")
+                )
+
+            val failure = assertIs<AdvanceOutcome.Failure>(outcome)
+            val validation = assertIs<AdvanceFailure.ValidationFailed>(failure.failure)
+            assertTrue(validation.message.contains("who-knows"), "error must name the unknown ref")
+            coVerify(exactly = 0) { leaseRepo.acquireAll(any(), any(), any()) }
+        }
+
+    @Test
+    fun `caller credentialRef naming a registry-only key is accepted`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.QUEUE)
+
+            val outcome =
+                serviceWith(
+                    requirements = listOf(exclusive("staging-db")),
+                    registry = mapOf("prod-cred" to ResourceDefinition("prod-cred"))
+                ).advance(
+                    item,
+                    "start",
+                    null,
+                    null,
+                    null,
+                    DegradedModePolicy.ACCEPT_CACHED,
+                    true,
+                    credentialRefs = listOf("prod-cred")
+                )
+
+            assertIs<AdvanceOutcome.Success>(outcome)
+        }
+
+    // ──────────────────────────────────────────────
+    // TTL resolution
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `TTL prefers the requirement override then the registry default then 3600`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.QUEUE)
+            val requests = slot<List<Pair<String, Int>>>()
+            coEvery { leaseRepo.acquireAll(any(), any(), capture(requests)) } returns
+                LeaseAcquireResult.Success(emptyList())
+
+            serviceWith(
+                requirements =
+                    listOf(
+                        exclusive("has-override", ttlSeconds = 120),
+                        exclusive("registry-default"),
+                        exclusive("unregistered")
+                    ),
+                registry =
+                    mapOf(
+                        "has-override" to ResourceDefinition("has-override", defaultTtlSeconds = 999),
+                        "registry-default" to ResourceDefinition("registry-default", defaultTtlSeconds = 1800)
+                    )
+            ).advance(item, "start", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true)
+
+            assertEquals(
+                listOf(
+                    "has-override" to 120,
+                    "registry-default" to 1800,
+                    "unregistered" to AdvanceService.DEFAULT_RESOURCE_TTL_SECONDS
+                ),
+                requests.captured
+            )
+        }
+
+    @Test
+    fun `TTL is clamped to the 1 to 86400 second bounds`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.QUEUE)
+            val requests = slot<List<Pair<String, Int>>>()
+            coEvery { leaseRepo.acquireAll(any(), any(), capture(requests)) } returns
+                LeaseAcquireResult.Success(emptyList())
+
+            serviceWith(
+                requirements = listOf(exclusive("too-small", ttlSeconds = 0), exclusive("too-big", ttlSeconds = 999_999))
+            ).advance(item, "start", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true)
+
+            assertEquals(
+                listOf(
+                    "too-small" to AdvanceService.MIN_RESOURCE_TTL_SECONDS,
+                    "too-big" to AdvanceService.MAX_RESOURCE_TTL_SECONDS
+                ),
+                requests.captured
+            )
+        }
+
+    // ──────────────────────────────────────────────
+    // Enforcement matrix: the two off switches
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `enforceResourceLeases false skips acquisition entirely`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.QUEUE)
+
+            val outcome =
+                serviceWith(requirements = listOf(exclusive("staging-db"))).advance(
+                    item,
+                    "start",
+                    null,
+                    null,
+                    null,
+                    DegradedModePolicy.ACCEPT_CACHED,
+                    enforceOwnership = true,
+                    credentialRefs = emptyList(),
+                    enforceResourceLeases = false
+                )
+
+            assertIs<AdvanceOutcome.Success>(outcome)
+            coVerify(exactly = 0) { leaseRepo.acquireAll(any(), any(), any()) }
+        }
+
+    @Test
+    fun `RESOURCE_LEASES_ENFORCED kill switch off skips acquisition even when the caller enforces`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.QUEUE)
+
+            val outcome =
+                serviceWith(
+                    requirements = listOf(exclusive("staging-db")),
+                    resourceLeasesEnforced = false
+                ).advance(
+                    item,
+                    "start",
+                    null,
+                    null,
+                    null,
+                    DegradedModePolicy.ACCEPT_CACHED,
+                    enforceOwnership = true,
+                    credentialRefs = emptyList(),
+                    enforceResourceLeases = true
+                )
+
+            assertIs<AdvanceOutcome.Success>(outcome)
+            coVerify(exactly = 0) { leaseRepo.acquireAll(any(), any(), any()) }
+        }
+
+    @Test
+    fun `kill switch parses only the literal false as disabled`() {
+        assertTrue(AdvanceService.resourceLeasesEnforcedFromEnv { null })
+        assertTrue(AdvanceService.resourceLeasesEnforcedFromEnv { "true" })
+        assertTrue(AdvanceService.resourceLeasesEnforcedFromEnv { "0" })
+        assertTrue(!AdvanceService.resourceLeasesEnforcedFromEnv { "false" })
+        assertTrue(!AdvanceService.resourceLeasesEnforcedFromEnv { "FALSE" })
+    }
+
+    // ──────────────────────────────────────────────
+    // Release paths — every exit from WORK
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `complete out of work releases leases`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.WORK)
+
+            val outcome =
+                serviceWith(requirements = listOf(exclusive("staging-db"))).advance(
+                    item,
+                    "complete",
+                    null,
+                    null,
+                    null,
+                    DegradedModePolicy.ACCEPT_CACHED,
+                    true
+                )
+
+            assertIs<AdvanceOutcome.Success>(outcome)
+            coVerify(exactly = 1) { leaseRepo.releaseAllForItem(item.id) }
+        }
+
+    @Test
+    fun `cancel out of work releases leases`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.WORK)
+
+            serviceWith().advance(item, "cancel", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true)
+
+            coVerify(exactly = 1) { leaseRepo.releaseAllForItem(item.id) }
+        }
+
+    @Test
+    fun `block out of work releases leases`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.WORK)
+
+            serviceWith().advance(item, "block", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true)
+
+            coVerify(exactly = 1) { leaseRepo.releaseAllForItem(item.id) }
+        }
+
+    @Test
+    fun `hold out of work releases leases`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.WORK)
+
+            serviceWith().advance(item, "hold", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true)
+
+            coVerify(exactly = 1) { leaseRepo.releaseAllForItem(item.id) }
+        }
+
+    @Test
+    fun `a transition that does not leave work does not release`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.QUEUE)
+
+            serviceWith().advance(item, "start", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true)
+
+            coVerify(exactly = 0) { leaseRepo.releaseAllForItem(any()) }
+        }
+
+    @Test
+    fun `release runs even when the kill switch is off`(): Unit =
+        runBlocking {
+            // Releasing is always safe: leases taken while enforcement was on must still be freed.
+            val item = makeItem(role = Role.WORK)
+
+            serviceWith(resourceLeasesEnforced = false).advance(
+                item,
+                "complete",
+                null,
+                null,
+                null,
+                DegradedModePolicy.ACCEPT_CACHED,
+                true
+            )
+
+            coVerify(exactly = 1) { leaseRepo.releaseAllForItem(item.id) }
+        }
+
+    @Test
+    fun `a release DBError is logged and does NOT fail the transition`(): Unit =
+        runBlocking {
+            val item = makeItem(role = Role.WORK)
+            coEvery { leaseRepo.releaseAllForItem(any()) } returns
+                LeaseReleaseResult.DBError(IllegalStateException("db down"))
+
+            val outcome =
+                serviceWith().advance(item, "complete", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true)
+
+            // The role change already committed; the TTL is the backstop for the orphaned lease.
+            val success = assertIs<AdvanceOutcome.Success>(outcome)
+            assertEquals(Role.TERMINAL, success.result.newRole)
+        }
+
+    // ──────────────────────────────────────────────
+    // Start-cascade suppression
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `a contended parent start cascade is suppressed while the child advance still succeeds`(): Unit =
+        runBlocking {
+            val parentId = UUID.randomUUID()
+            val parent = makeItem(id = parentId, role = Role.QUEUE, title = "Parent")
+            val child = makeItem(role = Role.QUEUE, title = "Child", parentId = parentId)
+
+            coEvery { workItemRepo.getById(parentId) } returns Result.Success(parent)
+            // The child declares nothing; the parent needs an exclusive resource that is taken.
+            coEvery { leaseRepo.acquireAll(parentId, any(), any()) } returns
+                LeaseAcquireResult.Contended(listOf("staging-db"), retryAfterMs = 5_000)
+
+            val outcome =
+                serviceWith(
+                    requirementsByItem = mapOf(parentId to listOf(exclusive("staging-db")))
+                ).advance(child, "start", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true)
+
+            val success = assertIs<AdvanceOutcome.Success>(outcome)
+            assertEquals(Role.WORK, success.result.newRole, "the child's own advance must still succeed")
+
+            val cascade = success.result.cascadeEvents.single()
+            assertEquals(parentId, cascade.itemId)
+            assertTrue(!cascade.applied, "the parent cascade must NOT be applied")
+            assertTrue(cascade.resourceBlocked, "the cascade must be flagged resourceBlocked")
+            assertEquals(listOf("staging-db"), cascade.contendedResources)
+        }
+
+    @Test
+    fun `an uncontended parent start cascade acquires the parent leases and applies`(): Unit =
+        runBlocking {
+            val parentId = UUID.randomUUID()
+            val parent = makeItem(id = parentId, role = Role.QUEUE, title = "Parent")
+            val child = makeItem(role = Role.QUEUE, title = "Child", parentId = parentId)
+
+            coEvery { workItemRepo.getById(parentId) } returns Result.Success(parent)
+
+            val outcome =
+                serviceWith(
+                    requirementsByItem = mapOf(parentId to listOf(exclusive("staging-db")))
+                ).advance(child, "start", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true)
+
+            val success = assertIs<AdvanceOutcome.Success>(outcome)
+            val cascade = success.result.cascadeEvents.single()
+            assertTrue(cascade.applied)
+            assertTrue(!cascade.resourceBlocked)
+            // Cascades carry no actor, so the lease's audit actor is null.
+            coVerify(exactly = 1) { leaseRepo.acquireAll(parentId, null, listOf("staging-db" to 3600)) }
+        }
+
+    @Test
+    fun `start cascade acquisition is skipped when the kill switch is off`(): Unit =
+        runBlocking {
+            val parentId = UUID.randomUUID()
+            val parent = makeItem(id = parentId, role = Role.QUEUE, title = "Parent")
+            val child = makeItem(role = Role.QUEUE, title = "Child", parentId = parentId)
+
+            coEvery { workItemRepo.getById(parentId) } returns Result.Success(parent)
+
+            val outcome =
+                serviceWith(
+                    requirementsByItem = mapOf(parentId to listOf(exclusive("staging-db"))),
+                    resourceLeasesEnforced = false
+                ).advance(child, "start", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true)
+
+            val success = assertIs<AdvanceOutcome.Success>(outcome)
+            assertTrue(
+                success.result.cascadeEvents
+                    .single()
+                    .applied
+            )
+            coVerify(exactly = 0) { leaseRepo.acquireAll(any(), any(), any()) }
+        }
+
+    @Test
+    fun `a null lease repository does not break an item that declares resources`(): Unit =
+        runBlocking {
+            // Defensive wiring-bug path: the gate logs an error and proceeds rather than wedging.
+            val item = makeItem(role = Role.QUEUE)
+
+            val outcome =
+                serviceWith(
+                    requirements = listOf(exclusive("staging-db")),
+                    leaseRepository = null
+                ).advance(item, "start", null, null, null, DegradedModePolicy.ACCEPT_CACHED, true)
+
+            assertIs<AdvanceOutcome.Success>(outcome)
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/ProjectConfigPushServiceTest.kt
@@ -235,6 +235,9 @@ class ProjectConfigPushServiceTest {
                   mode: reject
                 status_labels:
                   start: "custom-started"
+                resources:
+                  staging-db-credential:
+                    description: "Shared staging DB credential"
                 """.trimIndent()
 
             val result = service.push(rootId, yaml)

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContextResourceMergeTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolExecutionContextResourceMergeTest.kt
@@ -1,0 +1,355 @@
+package io.github.jpicklyk.mcptask.current.application.tools
+
+import io.github.jpicklyk.mcptask.current.application.service.NoteSchemaService
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceDefinition
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceMode
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceRequirement
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItemSchema
+import io.github.jpicklyk.mcptask.current.infrastructure.config.PerRootConfigService
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [ToolExecutionContext.resolveResourceRequirements] and
+ * [ToolExecutionContext.resolveResourceRegistry] — the resource-declaration resolution layer (T4).
+ * No enforcement/leasing is exercised here (that's a follow-on task); these tests only verify the
+ * config-merge algorithm.
+ */
+class ToolExecutionContextResourceMergeTest {
+    private lateinit var noteSchemaService: NoteSchemaService
+    private lateinit var context: ToolExecutionContext
+
+    @BeforeEach
+    fun setUp() {
+        noteSchemaService = mockk()
+        every { noteSchemaService.getSchemaForType(any()) } returns null
+        every { noteSchemaService.getSchemaForTags(any()) } returns null
+        every { noteSchemaService.getTraitResources(any()) } returns emptyList()
+        every { noteSchemaService.getResourceRegistry() } returns emptyMap()
+
+        val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+        context = ToolExecutionContext(repoProvider, noteSchemaService)
+    }
+
+    private fun makeItem(
+        type: String? = null,
+        tags: String? = null,
+        properties: String? = null,
+        rootId: UUID? = null
+    ): WorkItem =
+        WorkItem(
+            id = UUID.randomUUID(),
+            title = "Test Item",
+            type = type,
+            tags = tags,
+            properties = properties,
+            rootId = rootId,
+            depth = 0
+        )
+
+    // ──────────────────────────────────────────────
+    // Union across defaultTraits + item traits, dedup
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `resolveResourceRequirements unions defaultTraits and item traits without duplicating keys`() =
+        runBlocking {
+            val baseSchema =
+                WorkItemSchema(
+                    type = "feature-task",
+                    notes = emptyList(),
+                    defaultTraits = listOf("trait-a")
+                )
+            every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
+            every { noteSchemaService.getTraitResources("trait-a") } returns listOf(ResourceRequirement(key = "resource-a"))
+            every { noteSchemaService.getTraitResources("trait-b") } returns listOf(ResourceRequirement(key = "resource-b"))
+
+            val item =
+                makeItem(
+                    type = "feature-task",
+                    properties = """{"traits": ["trait-a", "trait-b"]}"""
+                )
+
+            val result = context.resolveResourceRequirements(item)
+
+            assertEquals(2, result.size)
+            assertEquals(setOf("resource-a", "resource-b"), result.map { it.key }.toSet())
+        }
+
+    @Test
+    fun `resolveResourceRequirements dedups the same key declared by two traits into one entry`() =
+        runBlocking {
+            val baseSchema =
+                WorkItemSchema(
+                    type = "feature-task",
+                    notes = emptyList(),
+                    defaultTraits = listOf("trait-a", "trait-b")
+                )
+            every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
+            every { noteSchemaService.getTraitResources("trait-a") } returns
+                listOf(ResourceRequirement(key = "shared-resource", mode = ResourceMode.ADVISORY))
+            every { noteSchemaService.getTraitResources("trait-b") } returns
+                listOf(ResourceRequirement(key = "shared-resource", mode = ResourceMode.ADVISORY))
+
+            val item = makeItem(type = "feature-task")
+
+            val result = context.resolveResourceRequirements(item)
+
+            assertEquals(1, result.size)
+            assertEquals("shared-resource", result[0].key)
+        }
+
+    // ──────────────────────────────────────────────
+    // Exclusive-wins mode conflict; first-seen wins ttlSeconds
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `resolveResourceRequirements resolves a mode conflict with exclusive winning regardless of order`() =
+        runBlocking {
+            val baseSchema =
+                WorkItemSchema(
+                    type = "feature-task",
+                    notes = emptyList(),
+                    defaultTraits = listOf("trait-advisory-first", "trait-exclusive-second")
+                )
+            every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
+            every { noteSchemaService.getTraitResources("trait-advisory-first") } returns
+                listOf(ResourceRequirement(key = "shared", mode = ResourceMode.ADVISORY, ttlSeconds = 100))
+            every { noteSchemaService.getTraitResources("trait-exclusive-second") } returns
+                listOf(ResourceRequirement(key = "shared", mode = ResourceMode.EXCLUSIVE, ttlSeconds = 200))
+
+            val item = makeItem(type = "feature-task")
+
+            val result = context.resolveResourceRequirements(item)
+
+            assertEquals(1, result.size)
+            assertEquals(ResourceMode.EXCLUSIVE, result[0].mode)
+            // first-seen wins for ttlSeconds — the advisory trait's 100 is retained, not overwritten by 200.
+            assertEquals(100, result[0].ttlSeconds)
+        }
+
+    @Test
+    fun `resolveResourceRequirements keeps exclusive when the second trait also declares exclusive`() =
+        runBlocking {
+            val baseSchema =
+                WorkItemSchema(
+                    type = "feature-task",
+                    notes = emptyList(),
+                    defaultTraits = listOf("trait-a", "trait-b")
+                )
+            every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
+            every { noteSchemaService.getTraitResources("trait-a") } returns
+                listOf(ResourceRequirement(key = "shared", mode = ResourceMode.EXCLUSIVE))
+            every { noteSchemaService.getTraitResources("trait-b") } returns
+                listOf(ResourceRequirement(key = "shared", mode = ResourceMode.ADVISORY))
+
+            val item = makeItem(type = "feature-task")
+
+            val result = context.resolveResourceRequirements(item)
+
+            assertEquals(1, result.size)
+            assertEquals(ResourceMode.EXCLUSIVE, result[0].mode)
+        }
+
+    // ──────────────────────────────────────────────
+    // Schema-free item still resolves from properties traits
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `resolveResourceRequirements resolves from item properties traits even when no schema resolves`() =
+        runBlocking {
+            // No type, no tags — resolveBaseSchemaWithSource returns null (schema-free item).
+            every { noteSchemaService.getSchemaForTags(emptyList()) } returns null
+            every { noteSchemaService.getTraitResources("needs-staging-db") } returns
+                listOf(ResourceRequirement(key = "staging-db-credential"))
+
+            val item =
+                makeItem(
+                    type = null,
+                    tags = null,
+                    properties = """{"traits": ["needs-staging-db"]}"""
+                )
+
+            val result = context.resolveResourceRequirements(item)
+
+            assertEquals(1, result.size)
+            assertEquals("staging-db-credential", result[0].key)
+        }
+
+    @Test
+    fun `resolveResourceRequirements returns empty list when the item has no traits at all`() =
+        runBlocking {
+            val item = makeItem(type = "feature-task")
+            every { noteSchemaService.getSchemaForType("feature-task") } returns
+                WorkItemSchema(type = "feature-task", notes = emptyList(), defaultTraits = emptyList())
+
+            val result = context.resolveResourceRequirements(item)
+
+            assertTrue(result.isEmpty())
+        }
+
+    // ──────────────────────────────────────────────
+    // Per-root trait layering beats global
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `resolveResourceRequirements per-root trait resources override the global trait definition`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>()
+
+            val baseSchema =
+                WorkItemSchema(
+                    type = "feature-task",
+                    notes = emptyList(),
+                    defaultTraits = listOf("needs-staging-db")
+                )
+            every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
+            every { noteSchemaService.getTraitResources("needs-staging-db") } returns
+                listOf(ResourceRequirement(key = "global-resource"))
+
+            val perRootRequirement = ResourceRequirement(key = "per-root-resource", mode = ResourceMode.ADVISORY)
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = emptyMap(),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = null,
+                    fingerprint = "fp",
+                    traitResources = mapOf("needs-staging-db" to listOf(perRootRequirement)),
+                    resourceRegistry = emptyMap()
+                )
+
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
+
+            val item = makeItem(type = "feature-task", rootId = rootId)
+            val result = ctx.resolveResourceRequirements(item)
+
+            assertEquals(1, result.size)
+            assertEquals("per-root-resource", result[0].key)
+            // The global trait-resource lookup must be short-circuited once the per-root layer provides entries.
+            verify(exactly = 0) { noteSchemaService.getTraitResources("needs-staging-db") }
+        }
+
+    @Test
+    fun `resolveResourceRequirements falls through to global trait resources when per-root has none for that trait`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>()
+
+            val baseSchema =
+                WorkItemSchema(
+                    type = "feature-task",
+                    notes = emptyList(),
+                    defaultTraits = listOf("needs-staging-db")
+                )
+            every { noteSchemaService.getSchemaForType("feature-task") } returns baseSchema
+            every { noteSchemaService.getTraitResources("needs-staging-db") } returns
+                listOf(ResourceRequirement(key = "global-resource"))
+
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = emptyMap(),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = null,
+                    fingerprint = "fp",
+                    traitResources = emptyMap(),
+                    resourceRegistry = emptyMap()
+                )
+
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
+
+            val item = makeItem(type = "feature-task", rootId = rootId)
+            val result = ctx.resolveResourceRequirements(item)
+
+            assertEquals(1, result.size)
+            assertEquals("global-resource", result[0].key)
+        }
+
+    // ──────────────────────────────────────────────
+    // resolveResourceRegistry: global-wins collision (inverted vs trait layering)
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `resolveResourceRegistry merges non-colliding per-root and global entries`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>()
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = emptyMap(),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = null,
+                    fingerprint = "fp",
+                    traitResources = emptyMap(),
+                    resourceRegistry = mapOf("per-root-only" to ResourceDefinition(key = "per-root-only"))
+                )
+            every { noteSchemaService.getResourceRegistry() } returns
+                mapOf("global-only" to ResourceDefinition(key = "global-only"))
+
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
+
+            val result = ctx.resolveResourceRegistry(rootId)
+
+            assertEquals(setOf("per-root-only", "global-only"), result.keys)
+        }
+
+    @Test
+    fun `resolveResourceRegistry lets the global definition win on a colliding key`() =
+        runBlocking {
+            val rootId = UUID.randomUUID()
+            val perRoot = mockk<PerRootConfigService>()
+            val perRootDef = ResourceDefinition(key = "shared-key", description = "per-root version", defaultTtlSeconds = 111)
+            val globalDef = ResourceDefinition(key = "shared-key", description = "global version", defaultTtlSeconds = 222)
+
+            coEvery { perRoot.getSnapshot(rootId) } returns
+                PerRootConfigService.Snapshot(
+                    workItemSchemas = emptyMap(),
+                    traits = emptyMap(),
+                    noteLimitsModeExplicit = null,
+                    statusLabels = null,
+                    fingerprint = "fp",
+                    traitResources = emptyMap(),
+                    resourceRegistry = mapOf("shared-key" to perRootDef)
+                )
+            every { noteSchemaService.getResourceRegistry() } returns mapOf("shared-key" to globalDef)
+
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
+
+            val result = ctx.resolveResourceRegistry(rootId)
+
+            assertEquals(1, result.size)
+            assertEquals(globalDef, result["shared-key"], "Global definition must win over the per-root one on collision")
+        }
+
+    @Test
+    fun `resolveResourceRegistry with null rootId returns the global registry unchanged`() =
+        runBlocking {
+            val perRoot = mockk<PerRootConfigService>()
+            every { noteSchemaService.getResourceRegistry() } returns
+                mapOf("global-only" to ResourceDefinition(key = "global-only"))
+
+            val repoProvider = mockk<RepositoryProvider>(relaxed = true)
+            val ctx = ToolExecutionContext(repoProvider, noteSchemaService, perRootConfigService = perRoot)
+
+            val result = ctx.resolveResourceRegistry(null)
+
+            assertEquals(setOf("global-only"), result.keys)
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
@@ -106,7 +106,7 @@ class ToolTokenBudgetTest {
             "manage_notes" to 2057,
             "complete_tree" to 1760, // was 1712; see note above
             "query_dependencies" to 1708,
-            "advance_item" to 2100, // was 1450; measured 2006 after singular itemId+trigger call-shape sugar (eb4b3fd5)
+            "advance_item" to 2250, // was 2100; measured 2199 after the credentialRefs audit param (resource-leasing T1)
             "get_blocked_items" to 1250, // was 830; T2.3 added the `ancestorId` scope parameter
             "get_next_status" to 470,
             "manage_project_config" to 3150, // measured 2698 after get `fingerprint` param + relation (fast-forward guard, t5)

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
@@ -106,7 +106,7 @@ class ToolTokenBudgetTest {
             "manage_notes" to 2057,
             "complete_tree" to 1760, // was 1712; see note above
             "query_dependencies" to 1708,
-            "advance_item" to 2250, // was 2100; measured 2199 after the credentialRefs audit param (resource-leasing T1)
+            "advance_item" to 2650, // was 2100; credentialRefs param (T1) + resource-lease gate semantics (T5), measured 2602
             "get_blocked_items" to 1250, // was 830; T2.3 added the `ancestorId` scope parameter
             "get_next_status" to 470,
             "manage_project_config" to 3150, // measured 2698 after get `fingerprint` param + relation (fast-forward guard, t5)

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeToolTest.kt
@@ -6,7 +6,9 @@ import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
 import io.github.jpicklyk.mcptask.current.application.tools.ToolValidationException
 import io.github.jpicklyk.mcptask.current.domain.model.*
 import io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseReleaseResult
 import io.github.jpicklyk.mcptask.current.domain.repository.NoteRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
 import io.github.jpicklyk.mcptask.current.domain.repository.RoleTransitionRepository
 import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
@@ -44,6 +46,7 @@ class CompleteTreeToolTest {
         every { repoProvider.dependencyRepository() } returns depRepo
         every { repoProvider.noteRepository() } returns noteRepo
         every { repoProvider.roleTransitionRepository() } returns roleTransitionRepo
+        every { repoProvider.resourceLeaseRepository() } returns mockk(relaxed = true)
         // dbNow() is called for ownership checks; default to JVM time for non-clock-skew tests.
         coEvery { workItemRepo.dbNow() } returns Instant.now()
         // inTransaction delegates to its block directly — no real DB transaction in unit tests
@@ -201,6 +204,7 @@ class CompleteTreeToolTest {
             every { repoProvider.dependencyRepository() } returns depRepo
             every { repoProvider.noteRepository() } returns noteRepo
             every { repoProvider.roleTransitionRepository() } returns roleTransitionRepo
+            every { repoProvider.resourceLeaseRepository() } returns mockk(relaxed = true)
             val gatedContext = ToolExecutionContext(repoProvider, noteSchemaService)
 
             coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
@@ -271,6 +275,7 @@ class CompleteTreeToolTest {
             every { repoProvider.dependencyRepository() } returns depRepo
             every { repoProvider.noteRepository() } returns noteRepo
             every { repoProvider.roleTransitionRepository() } returns roleTransitionRepo
+            every { repoProvider.resourceLeaseRepository() } returns mockk(relaxed = true)
             val gatedContext = ToolExecutionContext(repoProvider, noteSchemaService)
 
             coEvery { workItemRepo.getById(idA) } returns Result.Success(itemA)
@@ -376,6 +381,7 @@ class CompleteTreeToolTest {
         every { gatedRepoProvider.dependencyRepository() } returns depRepo
         every { gatedRepoProvider.noteRepository() } returns noteRepo
         every { gatedRepoProvider.roleTransitionRepository() } returns roleTransitionRepo
+        every { gatedRepoProvider.resourceLeaseRepository() } returns mockk(relaxed = true)
         return ToolExecutionContext(gatedRepoProvider, noteSchemaService)
     }
 
@@ -830,6 +836,7 @@ class CompleteTreeToolTest {
             every { repoProvider.dependencyRepository() } returns depRepo
             every { repoProvider.noteRepository() } returns noteRepo
             every { repoProvider.roleTransitionRepository() } returns roleTransitionRepo
+            every { repoProvider.resourceLeaseRepository() } returns mockk(relaxed = true)
             val gatedContext = ToolExecutionContext(repoProvider, noteSchemaService)
 
             coEvery { workItemRepo.findDescendants(rootId) } returns Result.Success(listOf(child))
@@ -908,6 +915,7 @@ class CompleteTreeToolTest {
             every { repoProvider.dependencyRepository() } returns depRepo
             every { repoProvider.noteRepository() } returns noteRepo
             every { repoProvider.roleTransitionRepository() } returns roleTransitionRepo
+            every { repoProvider.resourceLeaseRepository() } returns mockk(relaxed = true)
             val gatedContext = ToolExecutionContext(repoProvider, noteSchemaService)
 
             // Note exists with non-blank body — gate should pass
@@ -968,6 +976,7 @@ class CompleteTreeToolTest {
             every { repoProvider.dependencyRepository() } returns depRepo
             every { repoProvider.noteRepository() } returns noteRepo
             every { repoProvider.roleTransitionRepository() } returns roleTransitionRepo
+            every { repoProvider.resourceLeaseRepository() } returns mockk(relaxed = true)
             val gatedContext = ToolExecutionContext(repoProvider, noteSchemaService)
 
             // No notes at all — gate would fail for "complete" but should be bypassed by "cancel"
@@ -1025,6 +1034,7 @@ class CompleteTreeToolTest {
             every { repoProvider.dependencyRepository() } returns depRepo
             every { repoProvider.noteRepository() } returns noteRepo
             every { repoProvider.roleTransitionRepository() } returns roleTransitionRepo
+            every { repoProvider.resourceLeaseRepository() } returns mockk(relaxed = true)
             val gatedContext = ToolExecutionContext(repoProvider, noteSchemaService)
 
             coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
@@ -1278,6 +1288,7 @@ class CompleteTreeToolTest {
             every { provider.dependencyRepository() } returns depRepo
             every { provider.noteRepository() } returns noteRepo
             every { provider.roleTransitionRepository() } returns roleTransitionRepo
+            every { provider.resourceLeaseRepository() } returns mockk(relaxed = true)
             return ToolExecutionContext(provider, noteSchemaService)
         }
 
@@ -1439,4 +1450,70 @@ class CompleteTreeToolTest {
                 assertEquals(1, summary["gateFailures"]!!.jsonPrimitive.int)
             }
     }
+
+    // ──────────────────────────────────────────────
+    // Resource-lease release on WORK-exit (complete_tree bypasses AdvanceService, so this tool
+    // must release leases itself — see releaseLeasesOnWorkExit).
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `completing an item in WORK releases its resource leases`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            val item = makeItem(id = itemId, title = "Working Item", role = Role.WORK)
+
+            val leaseRepo = mockk<ResourceLeaseRepository>()
+            coEvery { leaseRepo.releaseAllForItem(itemId) } returns LeaseReleaseResult.Success(1)
+
+            val leaseRepoProvider = mockk<RepositoryProvider>()
+            every { leaseRepoProvider.workItemRepository() } returns workItemRepo
+            every { leaseRepoProvider.dependencyRepository() } returns depRepo
+            every { leaseRepoProvider.noteRepository() } returns noteRepo
+            every { leaseRepoProvider.roleTransitionRepository() } returns roleTransitionRepo
+            every { leaseRepoProvider.resourceLeaseRepository() } returns leaseRepo
+            val leaseContext = ToolExecutionContext(leaseRepoProvider)
+
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+            coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+            coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+            every { depRepo.findByToItemId(itemId) } returns emptyList()
+
+            val params = buildItemIdsParams(listOf(itemId))
+            val result = tool.execute(params, leaseContext)
+
+            val r = extractResults(result)[0].jsonObject
+            assertTrue(r["applied"]!!.jsonPrimitive.boolean, "WORK item should complete")
+
+            coVerify { leaseRepo.releaseAllForItem(itemId) }
+        }
+
+    @Test
+    fun `completing an item from QUEUE never releases resource leases`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            val item = makeItem(id = itemId, title = "Queued Item", role = Role.QUEUE)
+
+            val leaseRepo = mockk<ResourceLeaseRepository>()
+
+            val leaseRepoProvider = mockk<RepositoryProvider>()
+            every { leaseRepoProvider.workItemRepository() } returns workItemRepo
+            every { leaseRepoProvider.dependencyRepository() } returns depRepo
+            every { leaseRepoProvider.noteRepository() } returns noteRepo
+            every { leaseRepoProvider.roleTransitionRepository() } returns roleTransitionRepo
+            every { leaseRepoProvider.resourceLeaseRepository() } returns leaseRepo
+            val leaseContext = ToolExecutionContext(leaseRepoProvider)
+
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+            coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+            coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+            every { depRepo.findByToItemId(itemId) } returns emptyList()
+
+            val params = buildItemIdsParams(listOf(itemId))
+            val result = tool.execute(params, leaseContext)
+
+            val r = extractResults(result)[0].jsonObject
+            assertTrue(r["applied"]!!.jsonPrimitive.boolean, "QUEUE item should complete (jumps straight to TERMINAL)")
+
+            coVerify(exactly = 0) { leaseRepo.releaseAllForItem(any()) }
+        }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolCredentialRefTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolCredentialRefTest.kt
@@ -65,6 +65,10 @@ class AdvanceItemToolCredentialRefTest {
         coEvery { defaultNoteRepo.findByItemId(any(), any()) } returns Result.Success(emptyList())
         every { repoProvider.noteRepository() } returns defaultNoteRepo
         every { repoProvider.roleTransitionRepository() } returns roleTransitionRepo
+        // AdvanceItemTool wires the lease store into AdvanceService on every transition; a strict
+        // mockk provider must answer it even for items that declare no resources (the resource gate
+        // itself short-circuits before touching the repository).
+        every { repoProvider.resourceLeaseRepository() } returns mockk(relaxed = true)
         coEvery { workItemRepo.dbNow() } returns Instant.now()
         coEvery { workItemRepo.inTransaction(any()) } coAnswers {
             firstArg<suspend () -> Unit>().invoke()

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolCredentialRefTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolCredentialRefTest.kt
@@ -1,0 +1,318 @@
+package io.github.jpicklyk.mcptask.current.application.tools.workflow
+
+import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
+import io.github.jpicklyk.mcptask.current.application.tools.ToolValidationException
+import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.RoleTransition
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.NoteRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.domain.repository.RoleTransitionRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the optional `credentialRefs` audit field on `advance_item` transitions (T1).
+ *
+ * Covers: bare-string coercion to a one-element list, array-of-strings acceptance, the >8-entries
+ * rejection, the charset/pattern rejection, and the absent-field no-behavior-change path — plus
+ * verifying the resolved list actually reaches [RoleTransitionRepository.create] via
+ * [RoleTransitionHandler]/[AdvanceService].
+ *
+ * Mirrors the mock setup in [AdvanceItemToolTest].
+ */
+class AdvanceItemToolCredentialRefTest {
+    private lateinit var tool: AdvanceItemTool
+    private lateinit var context: ToolExecutionContext
+    private lateinit var repoProvider: RepositoryProvider
+    private lateinit var workItemRepo: WorkItemRepository
+    private lateinit var depRepo: DependencyRepository
+    private lateinit var roleTransitionRepo: RoleTransitionRepository
+
+    @BeforeEach
+    fun setUp() {
+        tool = AdvanceItemTool()
+        workItemRepo = mockk()
+        depRepo = mockk()
+        roleTransitionRepo = mockk()
+
+        repoProvider = mockk<RepositoryProvider>()
+        every { repoProvider.workItemRepository() } returns workItemRepo
+        every { repoProvider.dependencyRepository() } returns depRepo
+        val defaultNoteRepo = mockk<NoteRepository>()
+        coEvery { defaultNoteRepo.findByItemId(any()) } returns Result.Success(emptyList())
+        coEvery { defaultNoteRepo.findByItemId(any(), any()) } returns Result.Success(emptyList())
+        every { repoProvider.noteRepository() } returns defaultNoteRepo
+        every { repoProvider.roleTransitionRepository() } returns roleTransitionRepo
+        coEvery { workItemRepo.dbNow() } returns Instant.now()
+        coEvery { workItemRepo.inTransaction(any()) } coAnswers {
+            firstArg<suspend () -> Unit>().invoke()
+        }
+
+        context = ToolExecutionContext(repoProvider)
+    }
+
+    private fun makeItem(
+        id: UUID = UUID.randomUUID(),
+        role: Role = Role.QUEUE
+    ): WorkItem = WorkItem(id = id, title = "Test Item", role = role)
+
+    private fun stubHappyPath(itemId: UUID) {
+        val item = makeItem(id = itemId, role = Role.QUEUE)
+        coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+        coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+        every { depRepo.findByToItemId(itemId) } returns emptyList()
+        every { depRepo.findByFromItemId(itemId) } returns emptyList()
+    }
+
+    private fun extractData(result: kotlinx.serialization.json.JsonElement): kotlinx.serialization.json.JsonObject {
+        val obj = result.jsonObject
+        assertTrue(obj["success"]!!.jsonPrimitive.boolean, "Expected success response")
+        return obj["data"]!!.jsonObject
+    }
+
+    // ──────────────────────────────────────────────
+    // Bare-string coercion
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `bare string credentialRefs coerces to a one-element list and reaches the repository`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            stubHappyPath(itemId)
+            val transitionSlot = slot<RoleTransition>()
+            coEvery { roleTransitionRepo.create(capture(transitionSlot)) } answers { Result.Success(firstArg()) }
+
+            val params =
+                buildJsonObject {
+                    put(
+                        "transitions",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("itemId", JsonPrimitive(itemId.toString()))
+                                    put("trigger", JsonPrimitive("start"))
+                                    put("credentialRefs", JsonPrimitive("vault/prod-db-password"))
+                                }
+                            )
+                        }
+                    )
+                }
+
+            val result = tool.execute(params, context)
+            val data = extractData(result)
+            val r = (data["results"] as JsonArray)[0].jsonObject
+            assertTrue(r["applied"]!!.jsonPrimitive.boolean)
+
+            assertEquals(listOf("vault/prod-db-password"), transitionSlot.captured.consumedCredentials)
+        }
+
+    // ──────────────────────────────────────────────
+    // Array of strings accepted
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `array credentialRefs is accepted and reaches the repository in order`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            stubHappyPath(itemId)
+            val transitionSlot = slot<RoleTransition>()
+            coEvery { roleTransitionRepo.create(capture(transitionSlot)) } answers { Result.Success(firstArg()) }
+
+            val params =
+                buildJsonObject {
+                    put(
+                        "transitions",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("itemId", JsonPrimitive(itemId.toString()))
+                                    put("trigger", JsonPrimitive("start"))
+                                    put(
+                                        "credentialRefs",
+                                        buildJsonArray {
+                                            add(JsonPrimitive("vault/prod-db-password"))
+                                            add(JsonPrimitive("github-pat-ci"))
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
+
+            val result = tool.execute(params, context)
+            val data = extractData(result)
+            val r = (data["results"] as JsonArray)[0].jsonObject
+            assertTrue(r["applied"]!!.jsonPrimitive.boolean)
+
+            assertEquals(
+                listOf("vault/prod-db-password", "github-pat-ci"),
+                transitionSlot.captured.consumedCredentials
+            )
+        }
+
+    // ──────────────────────────────────────────────
+    // Absent field -> no behavior change
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `absent credentialRefs results in empty consumedCredentials`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            stubHappyPath(itemId)
+            val transitionSlot = slot<RoleTransition>()
+            coEvery { roleTransitionRepo.create(capture(transitionSlot)) } answers { Result.Success(firstArg()) }
+
+            val params =
+                buildJsonObject {
+                    put(
+                        "transitions",
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("itemId", JsonPrimitive(itemId.toString()))
+                                    put("trigger", JsonPrimitive("start"))
+                                }
+                            )
+                        }
+                    )
+                }
+
+            val result = tool.execute(params, context)
+            val data = extractData(result)
+            val r = (data["results"] as JsonArray)[0].jsonObject
+            assertTrue(r["applied"]!!.jsonPrimitive.boolean)
+
+            assertTrue(transitionSlot.captured.consumedCredentials.isEmpty())
+        }
+
+    // ──────────────────────────────────────────────
+    // Validation failures (validateParams rejects before anything is persisted)
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `more than 8 credentialRefs entries is rejected`() {
+        val itemId = UUID.randomUUID()
+        val params =
+            buildJsonObject {
+                put(
+                    "transitions",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put("itemId", JsonPrimitive(itemId.toString()))
+                                put("trigger", JsonPrimitive("start"))
+                                put(
+                                    "credentialRefs",
+                                    buildJsonArray {
+                                        repeat(9) { i -> add(JsonPrimitive("cred-$i")) }
+                                    }
+                                )
+                            }
+                        )
+                    }
+                )
+            }
+
+        val ex = assertFailsWith<ToolValidationException> { tool.validateParams(params) }
+        assertTrue(ex.message!!.contains("credentialRefs"), "Expected error to mention credentialRefs: ${ex.message}")
+    }
+
+    @Test
+    fun `a credentialRefs entry with an uppercase character is rejected`() {
+        val itemId = UUID.randomUUID()
+        val params =
+            buildJsonObject {
+                put(
+                    "transitions",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put("itemId", JsonPrimitive(itemId.toString()))
+                                put("trigger", JsonPrimitive("start"))
+                                put("credentialRefs", JsonPrimitive("Vault:Prod-DB-Password"))
+                            }
+                        )
+                    }
+                )
+            }
+
+        val ex = assertFailsWith<ToolValidationException> { tool.validateParams(params) }
+        assertTrue(
+            ex.message!!.contains("credentialRefs[0]"),
+            "Expected error to name the offending index: ${ex.message}"
+        )
+    }
+
+    @Test
+    fun `a credentialRefs entry shaped like a raw token is rejected`() {
+        val itemId = UUID.randomUUID()
+        val params =
+            buildJsonObject {
+                put(
+                    "transitions",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put("itemId", JsonPrimitive(itemId.toString()))
+                                put("trigger", JsonPrimitive("start"))
+                                // Raw-looking secret material (uppercase/mixed-case token) must be
+                                // rejected by the pattern — callers must pass an opaque label instead.
+                                put("credentialRefs", JsonPrimitive("ghp_ABCDEF1234567890"))
+                            }
+                        )
+                    }
+                )
+            }
+
+        assertFailsWith<ToolValidationException> { tool.validateParams(params) }
+    }
+
+    @Test
+    fun `a non-string non-array credentialRefs value is rejected`() {
+        val itemId = UUID.randomUUID()
+        val params =
+            buildJsonObject {
+                put(
+                    "transitions",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put("itemId", JsonPrimitive(itemId.toString()))
+                                put("trigger", JsonPrimitive("start"))
+                                put("credentialRefs", JsonPrimitive(42))
+                            }
+                        )
+                    }
+                )
+            }
+
+        val ex = assertFailsWith<ToolValidationException> { tool.validateParams(params) }
+        assertTrue(
+            ex.message!!.contains("string or an array of strings"),
+            "Expected a shape error: ${ex.message}"
+        )
+    }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolLeaseBlockedTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolLeaseBlockedTest.kt
@@ -1,0 +1,240 @@
+package io.github.jpicklyk.mcptask.current.application.tools.workflow
+
+import io.github.jpicklyk.mcptask.current.application.service.WorkItemSchemaService
+import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
+import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceLease
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceMode
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceRequirement
+import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.DependencyRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseAcquireResult
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseReleaseResult
+import io.github.jpicklyk.mcptask.current.domain.repository.NoteRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.domain.repository.RoleTransitionRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end MCP response shape for a resource-lease-blocked `advance_item` call.
+ *
+ * The disclosure assertions here are the point of the file: an agent that can trigger an advance
+ * must be able to learn WHICH resource keys are contended and WHEN to retry, and nothing else. The
+ * holding item's id and the holding actor's id are seeded with distinctive values and asserted
+ * ABSENT from the fully serialized response — enumerating holders is an ADMIN-only capability
+ * exposed through `GET /api/v1/resources/leases`.
+ */
+class AdvanceItemToolLeaseBlockedTest {
+    /** Distinctive seeds so their absence in the serialized response is unambiguous. */
+    private val holderItemId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+    private val holderActorId = "holder-actor-zzz999"
+    private val resourceKey = "staging-db-credential"
+
+    private lateinit var tool: AdvanceItemTool
+    private lateinit var context: ToolExecutionContext
+    private lateinit var repoProvider: RepositoryProvider
+    private lateinit var workItemRepo: WorkItemRepository
+    private lateinit var leaseRepo: ResourceLeaseRepository
+
+    /** Schema service that maps the `needs-staging-db` trait onto one exclusive resource. */
+    private class ResourceTraitSchemaService : WorkItemSchemaService {
+        override fun getSchemaForTags(tags: List<String>): List<NoteSchemaEntry>? = null
+
+        override fun getTraitResources(traitName: String): List<ResourceRequirement> =
+            if (traitName == "needs-staging-db") {
+                listOf(ResourceRequirement("staging-db-credential", ResourceMode.EXCLUSIVE, 600))
+            } else {
+                emptyList()
+            }
+    }
+
+    @BeforeEach
+    fun setUp() {
+        tool = AdvanceItemTool()
+        workItemRepo = mockk()
+        leaseRepo = mockk()
+        val depRepo = mockk<DependencyRepository>()
+        val roleTransitionRepo = mockk<RoleTransitionRepository>()
+        val noteRepo = mockk<NoteRepository>()
+
+        repoProvider = mockk<RepositoryProvider>()
+        every { repoProvider.workItemRepository() } returns workItemRepo
+        every { repoProvider.dependencyRepository() } returns depRepo
+        every { repoProvider.noteRepository() } returns noteRepo
+        every { repoProvider.roleTransitionRepository() } returns roleTransitionRepo
+        every { repoProvider.resourceLeaseRepository() } returns leaseRepo
+
+        coEvery { noteRepo.findByItemId(any()) } returns Result.Success(emptyList())
+        coEvery { noteRepo.findByItemId(any(), any()) } returns Result.Success(emptyList())
+        coEvery { workItemRepo.dbNow() } returns Instant.now()
+        coEvery { workItemRepo.update(any()) } answers { Result.Success(firstArg()) }
+        coEvery { workItemRepo.inTransaction(any()) } coAnswers {
+            firstArg<suspend () -> Unit>().invoke()
+        }
+        coEvery { roleTransitionRepo.create(any()) } returns Result.Success(mockk())
+        coEvery { leaseRepo.releaseAllForItem(any()) } returns LeaseReleaseResult.Success(0)
+        every { depRepo.findByToItemId(any()) } returns emptyList()
+        every { depRepo.findByFromItemId(any()) } returns emptyList()
+
+        context = ToolExecutionContext(repoProvider, ResourceTraitSchemaService())
+    }
+
+    private fun tracedItem(id: UUID): WorkItem =
+        WorkItem(
+            id = id,
+            title = "Needs staging DB",
+            role = Role.QUEUE,
+            depth = 0,
+            properties = """{"traits":["needs-staging-db"]}"""
+        )
+
+    private fun startParams(itemId: UUID): JsonObject =
+        buildJsonObject {
+            put(
+                "transitions",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("itemId", itemId.toString())
+                            put("trigger", "start")
+                        }
+                    )
+                }
+            )
+        }
+
+    @Test
+    fun `a lease-blocked start returns a transient resource_unavailable result with keys and backoff`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(tracedItem(itemId))
+            coEvery { leaseRepo.acquireAll(itemId, any(), any()) } returns
+                LeaseAcquireResult.Contended(listOf(resourceKey), retryAfterMs = 30_000)
+
+            val result = tool.execute(startParams(itemId), context)
+            val transition =
+                (result as JsonObject)["data"]!!
+                    .jsonObject["results"]!!
+                    .jsonArray[0]
+                    .jsonObject
+
+            assertFalse(transition["applied"]!!.jsonPrimitive.content.toBoolean())
+            assertEquals("resource_unavailable", transition["errorCode"]!!.jsonPrimitive.content)
+            assertEquals("transient", transition["errorKind"]!!.jsonPrimitive.content)
+            assertEquals(30_000L, transition["retryAfterMs"]!!.jsonPrimitive.content.toLong())
+            assertEquals(
+                listOf(resourceKey),
+                transition["contendedResources"]!!.jsonArray.map { it.jsonPrimitive.content }
+            )
+            // The advance was rejected before apply — nothing persisted.
+            coVerify(exactly = 0) { workItemRepo.update(any()) }
+        }
+
+    @Test
+    fun `a lease-blocked response discloses NO holder item id and NO actor id`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(tracedItem(itemId))
+            // The seeded holder identity is what a leaky implementation would echo back.
+            coEvery { leaseRepo.acquireAll(itemId, any(), any()) } returns
+                LeaseAcquireResult.Contended(listOf(resourceKey), retryAfterMs = 30_000)
+            // The holder IS discoverable from the lease store — the assertion below is that the
+            // advance response never reaches for it.
+            val now = Instant.now()
+            coEvery { leaseRepo.findActiveByKeys(any()) } returns
+                listOf(
+                    ResourceLease(
+                        resourceKey = resourceKey,
+                        holderItemId = holderItemId,
+                        acquiredByActorId = holderActorId,
+                        acquiredAt = now,
+                        expiresAt = now.plusSeconds(600),
+                        originalAcquiredAt = now
+                    )
+                )
+
+            val result = tool.execute(startParams(itemId), context)
+            val serialized = Json.encodeToString(JsonObject.serializer(), result as JsonObject)
+
+            assertTrue(
+                serialized.contains(resourceKey),
+                "the contended resource KEY must be disclosed so the agent can reason about backoff"
+            )
+            assertFalse(
+                serialized.contains(holderItemId.toString()),
+                "holder item id must never appear in an advance rejection: $serialized"
+            )
+            assertFalse(
+                serialized.contains(holderActorId),
+                "holder actor id must never appear in an advance rejection: $serialized"
+            )
+            assertFalse(
+                serialized.contains("contendedItemId"),
+                "contendedItemId is a claim-race field and must stay absent here: $serialized"
+            )
+        }
+
+    @Test
+    fun `a DB error from the lease store is reported as transient with the default backoff`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(tracedItem(itemId))
+            coEvery { leaseRepo.acquireAll(itemId, any(), any()) } returns
+                LeaseAcquireResult.DBError(IllegalStateException("write conflict"))
+
+            val result = tool.execute(startParams(itemId), context)
+            val transition =
+                (result as JsonObject)["data"]!!
+                    .jsonObject["results"]!!
+                    .jsonArray[0]
+                    .jsonObject
+
+            assertEquals("resource_unavailable", transition["errorCode"]!!.jsonPrimitive.content)
+            assertEquals("transient", transition["errorKind"]!!.jsonPrimitive.content)
+            assertEquals(1000L, transition["retryAfterMs"]!!.jsonPrimitive.content.toLong())
+        }
+
+    @Test
+    fun `an uncontended start acquires the trait-declared lease and succeeds`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(tracedItem(itemId))
+            coEvery { leaseRepo.acquireAll(itemId, any(), any()) } returns
+                LeaseAcquireResult.Success(emptyList())
+
+            val result = tool.execute(startParams(itemId), context)
+            val transition =
+                (result as JsonObject)["data"]!!
+                    .jsonObject["results"]!!
+                    .jsonArray[0]
+                    .jsonObject
+
+            assertTrue(transition["applied"]!!.jsonPrimitive.content.toBoolean())
+            assertEquals("work", transition["newRole"]!!.jsonPrimitive.content)
+            // TTL comes from the trait's own ttlSeconds override (600), not the 3600 default.
+            coVerify(exactly = 1) { leaseRepo.acquireAll(itemId, any(), listOf(resourceKey to 600)) }
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
@@ -51,6 +51,10 @@ class AdvanceItemToolTest {
         coEvery { defaultNoteRepo.findByItemId(any(), any()) } returns Result.Success(emptyList())
         every { repoProvider.noteRepository() } returns defaultNoteRepo
         every { repoProvider.roleTransitionRepository() } returns roleTransitionRepo
+        // AdvanceItemTool wires the lease store into AdvanceService on every transition; a strict
+        // mockk provider must answer it even for items that declare no resources (the resource gate
+        // itself short-circuits before touching the repository).
+        every { repoProvider.resourceLeaseRepository() } returns mockk(relaxed = true)
         // dbNow() is called for ownership checks; default to JVM time for non-clock-skew tests.
         coEvery { workItemRepo.dbNow() } returns Instant.now()
         // inTransaction delegates to its block directly — no real DB transaction in unit tests
@@ -1095,6 +1099,7 @@ class AdvanceItemToolTest {
         every { repoProvider.dependencyRepository() } returns depRepo
         every { repoProvider.noteRepository() } returns noteRepo
         every { repoProvider.roleTransitionRepository() } returns roleTransitionRepo
+        every { repoProvider.resourceLeaseRepository() } returns mockk(relaxed = true)
         return ToolExecutionContext(repoProvider, noteSchemaService)
     }
 
@@ -2099,11 +2104,13 @@ class AdvanceItemToolTest {
             assertTrue(r["applied"]!!.jsonPrimitive.boolean)
             assertEquals("root-started", r["statusLabel"]!!.jsonPrimitive.content)
             // A single advance resolves the per-root layer from exactly two snapshot fetches — one
-            // for schema resolution (AdvanceService's schemaResolver) and one for status-label
-            // resolution (resolveRootAwareStatusLabelService) — NOT one fetch per trigger and NOT
-            // the old 8-wide (every UserTrigger + "cascade") fan-out. The status-label fetch alone
-            // resolves both consulted triggers ("start" + "cascade") from a SINGLE snapshot.
-            coVerify(exactly = 2) { perRoot.getSnapshot(rootId) }
+            // for schema resolution (AdvanceService's schemaResolver), one for status-label
+            // resolution (resolveRootAwareStatusLabelService), and one for resource-requirement
+            // resolution (resolveResourceRequirements' per-root trait lookup on WORK entry) — NOT
+            // one fetch per trigger and NOT the old 8-wide (every UserTrigger + "cascade") fan-out.
+            // The status-label fetch alone resolves both consulted triggers ("start" + "cascade")
+            // from a SINGLE snapshot.
+            coVerify(exactly = 3) { perRoot.getSnapshot(rootId) }
         }
 
     @Test
@@ -3578,6 +3585,7 @@ class AdvanceItemToolTest {
                     every { provider.dependencyRepository() } returns depRepo
                     every { provider.noteRepository() } returns noteRepo
                     every { provider.roleTransitionRepository() } returns roleTransitionRepo
+                    every { provider.resourceLeaseRepository() } returns mockk(relaxed = true)
                     ToolExecutionContext(provider, noteSchemaService)
                 }
 
@@ -3649,6 +3657,7 @@ class AdvanceItemToolTest {
                     every { provider.dependencyRepository() } returns depRepo
                     every { provider.noteRepository() } returns noteRepo
                     every { provider.roleTransitionRepository() } returns roleTransitionRepo
+                    every { provider.resourceLeaseRepository() } returns mockk(relaxed = true)
                     ToolExecutionContext(provider, noteSchemaService)
                 }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolResourceLeaseTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolResourceLeaseTest.kt
@@ -1,0 +1,240 @@
+package io.github.jpicklyk.mcptask.current.application.tools.workflow
+
+import io.github.jpicklyk.mcptask.current.application.service.NoOpNoteSchemaService
+import io.github.jpicklyk.mcptask.current.application.service.WorkItemSchemaService
+import io.github.jpicklyk.mcptask.current.application.tools.ToolExecutionContext
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceLease
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceMode
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceRequirement
+import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.ClaimStatusCounts
+import io.github.jpicklyk.mcptask.current.domain.repository.NoteRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.domain.repository.RoleTransitionRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [GetContextTool] resource-lease disclosure (T3: lease read surfaces).
+ *
+ * Per the disclosure matrix mirrored from claim detail (see [GetContextToolClaimTest]):
+ * - Item mode: full `resourceLeases` array (declared + held resources, holder identity, actor id)
+ *   — diagnostic only, the sanctioned surface for holder identity.
+ * - Health-check / session-resume modes: no resourceLeases, no lease identity anywhere.
+ */
+class GetContextToolResourceLeaseTest {
+    private lateinit var tool: GetContextTool
+    private lateinit var workItemRepo: WorkItemRepository
+    private lateinit var noteRepo: NoteRepository
+    private lateinit var roleTransitionRepo: RoleTransitionRepository
+    private lateinit var leaseRepo: ResourceLeaseRepository
+
+    /** Test-only schema service declaring a single trait's resource requirements. */
+    private class FakeSchemaService(
+        private val traitResources: Map<String, List<ResourceRequirement>>
+    ) : WorkItemSchemaService {
+        override fun getSchemaForTags(tags: List<String>) = null
+
+        override fun getTraitResources(traitName: String): List<ResourceRequirement> = traitResources[traitName] ?: emptyList()
+    }
+
+    private fun contextWith(schemaService: WorkItemSchemaService = NoOpNoteSchemaService): ToolExecutionContext {
+        val repoProvider = mockk<RepositoryProvider>()
+        every { repoProvider.workItemRepository() } returns workItemRepo
+        every { repoProvider.noteRepository() } returns noteRepo
+        every { repoProvider.roleTransitionRepository() } returns roleTransitionRepo
+        every { repoProvider.dependencyRepository() } returns mockk()
+        every { repoProvider.resourceLeaseRepository() } returns leaseRepo
+        return ToolExecutionContext(repoProvider, schemaService)
+    }
+
+    @BeforeEach
+    fun setUp() {
+        tool = GetContextTool()
+        workItemRepo = mockk()
+        noteRepo = mockk()
+        roleTransitionRepo = mockk()
+        leaseRepo = mockk()
+        coEvery { workItemRepo.dbNow() } returns Instant.now()
+    }
+
+    private fun extractData(result: JsonElement): JsonObject {
+        val obj = result as JsonObject
+        assertTrue(obj["success"]!!.jsonPrimitive.boolean, "Expected success=true but got: $obj")
+        return obj["data"] as JsonObject
+    }
+
+    private fun makeLease(
+        resourceKey: String,
+        holderItemId: UUID,
+        actorId: String? = "agent-1",
+        expiresAt: Instant = Instant.now().plusSeconds(300)
+    ) = ResourceLease(
+        resourceKey = resourceKey,
+        holderItemId = holderItemId,
+        acquiredByActorId = actorId,
+        acquiredAt = Instant.now().minusSeconds(60),
+        expiresAt = expiresAt,
+        originalAcquiredAt = Instant.now().minusSeconds(60)
+    )
+
+    // ──────────────────────────────────────────────
+    // Item mode — declared + held resources with holder identity
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `item mode shows declared and held resource with holder identity`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            val item =
+                WorkItem(
+                    id = itemId,
+                    title = "Migration task",
+                    role = Role.WORK,
+                    properties = """{"traits":["needs-lock"]}"""
+                )
+            val schemaService =
+                FakeSchemaService(
+                    mapOf(
+                        "needs-lock" to
+                            listOf(ResourceRequirement(key = "db-migration-lock", mode = ResourceMode.EXCLUSIVE, ttlSeconds = 300))
+                    )
+                )
+            val context = contextWith(schemaService)
+
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+            coEvery { noteRepo.findByItemId(itemId) } returns Result.Success(emptyList())
+            val heldLease = makeLease("db-migration-lock", holderItemId = itemId, actorId = "agent-77")
+            coEvery { leaseRepo.findActiveForItem(itemId) } returns listOf(heldLease)
+            coEvery { leaseRepo.findActiveByKeys(listOf("db-migration-lock")) } returns listOf(heldLease)
+
+            val data = extractData(tool.execute(JsonObject(mapOf("itemId" to JsonPrimitive(itemId.toString()))), context))
+
+            val leases = data["resourceLeases"]?.jsonArray
+            assertNotNull(leases, "resourceLeases must be present for an item that declares a resource")
+            assertEquals(1, leases.size)
+            val entry = leases[0].jsonObject
+            assertEquals("db-migration-lock", entry["key"]?.jsonPrimitive?.content)
+            assertEquals("exclusive", entry["mode"]?.jsonPrimitive?.content)
+            assertTrue(entry["held"]!!.jsonPrimitive.boolean, "held must be true — this item holds the lease")
+            assertEquals(itemId.toString(), entry["holderItemId"]?.jsonPrimitive?.content)
+            assertEquals("agent-77", entry["acquiredByActorId"]?.jsonPrimitive?.content)
+            assertNotNull(entry["expiresAt"], "expiresAt must be present when a lease is active")
+        }
+
+    @Test
+    fun `item mode shows declared resource not currently held with no holder`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            val item =
+                WorkItem(
+                    id = itemId,
+                    title = "Migration task",
+                    role = Role.WORK,
+                    properties = """{"traits":["needs-lock"]}"""
+                )
+            val schemaService =
+                FakeSchemaService(
+                    mapOf(
+                        "needs-lock" to
+                            listOf(ResourceRequirement(key = "db-migration-lock", mode = ResourceMode.ADVISORY, ttlSeconds = 60))
+                    )
+                )
+            val context = contextWith(schemaService)
+
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+            coEvery { noteRepo.findByItemId(itemId) } returns Result.Success(emptyList())
+            coEvery { leaseRepo.findActiveForItem(itemId) } returns emptyList()
+            coEvery { leaseRepo.findActiveByKeys(listOf("db-migration-lock")) } returns emptyList()
+
+            val data = extractData(tool.execute(JsonObject(mapOf("itemId" to JsonPrimitive(itemId.toString()))), context))
+
+            val leases = data["resourceLeases"]?.jsonArray
+            assertNotNull(leases)
+            assertEquals(1, leases.size)
+            val entry = leases[0].jsonObject
+            assertEquals("db-migration-lock", entry["key"]?.jsonPrimitive?.content)
+            assertEquals("advisory", entry["mode"]?.jsonPrimitive?.content)
+            assertFalse(entry["held"]!!.jsonPrimitive.boolean, "held must be false — no active lease exists")
+            assertNull(entry["holderItemId"], "holderItemId must be absent when nobody holds the resource")
+            assertNull(entry["acquiredByActorId"])
+            assertNull(entry["expiresAt"])
+        }
+
+    @Test
+    fun `item mode omits resourceLeases when item declares nothing and holds nothing`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            val item = WorkItem(id = itemId, title = "Plain task", role = Role.WORK)
+            val context = contextWith(NoOpNoteSchemaService)
+
+            coEvery { workItemRepo.getById(itemId) } returns Result.Success(item)
+            coEvery { noteRepo.findByItemId(itemId) } returns Result.Success(emptyList())
+            coEvery { leaseRepo.findActiveForItem(itemId) } returns emptyList()
+
+            val data = extractData(tool.execute(JsonObject(mapOf("itemId" to JsonPrimitive(itemId.toString()))), context))
+
+            assertNull(data["resourceLeases"], "resourceLeases must be absent when the item declares nothing and holds nothing")
+        }
+
+    // ──────────────────────────────────────────────
+    // Health-check / session-resume modes — no lease identity disclosure
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `health-check mode contains no resourceLeases or lease identity`(): Unit =
+        runBlocking {
+            val context = contextWith(NoOpNoteSchemaService)
+            coEvery { workItemRepo.findByRole(Role.WORK, limit = any()) } returns Result.Success(emptyList())
+            coEvery { workItemRepo.findByRole(Role.REVIEW, limit = any()) } returns Result.Success(emptyList())
+            coEvery { workItemRepo.findByRole(Role.BLOCKED, limit = any()) } returns Result.Success(emptyList())
+            coEvery { workItemRepo.countByClaimStatus(null) } returns
+                Result.Success(ClaimStatusCounts(active = 0, expired = 0, unclaimed = 0))
+
+            val result = tool.execute(JsonObject(emptyMap()), context)
+            val serialized = result.toString()
+
+            assertFalse("\"resourceLeases\"" in serialized, "Health-check mode must NEVER expose \"resourceLeases\"")
+            assertFalse("\"acquiredByActorId\"" in serialized, "Health-check mode must NEVER expose \"acquiredByActorId\"")
+            assertFalse("\"holderItemId\"" in serialized, "Health-check mode must NEVER expose \"holderItemId\"")
+        }
+
+    @Test
+    fun `session-resume mode contains no resourceLeases or lease identity`(): Unit =
+        runBlocking {
+            val context = contextWith(NoOpNoteSchemaService)
+            val since = Instant.now().minusSeconds(3600)
+            coEvery { workItemRepo.findByRole(Role.WORK, limit = any()) } returns Result.Success(emptyList())
+            coEvery { workItemRepo.findByRole(Role.REVIEW, limit = any()) } returns Result.Success(emptyList())
+            coEvery { roleTransitionRepo.findSince(any(), limit = any()) } returns Result.Success(emptyList())
+
+            val result = tool.execute(JsonObject(mapOf("since" to JsonPrimitive(since.toString()))), context)
+            val serialized = result.toString()
+
+            assertFalse("\"resourceLeases\"" in serialized, "Session-resume mode must NEVER expose \"resourceLeases\"")
+            assertFalse("\"acquiredByActorId\"" in serialized, "Session-resume mode must NEVER expose \"acquiredByActorId\"")
+            assertFalse("\"holderItemId\"" in serialized, "Session-resume mode must NEVER expose \"holderItemId\"")
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolResourceLeaseTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolResourceLeaseTest.kt
@@ -90,15 +90,20 @@ class GetContextToolResourceLeaseTest {
         resourceKey: String,
         holderItemId: UUID,
         actorId: String? = "agent-1",
-        expiresAt: Instant = Instant.now().plusSeconds(300)
-    ) = ResourceLease(
-        resourceKey = resourceKey,
-        holderItemId = holderItemId,
-        acquiredByActorId = actorId,
-        acquiredAt = Instant.now().minusSeconds(60),
-        expiresAt = expiresAt,
-        originalAcquiredAt = Instant.now().minusSeconds(60)
-    )
+        expiresAt: Instant? = null
+    ): ResourceLease {
+        // Single Instant.now() — two separate calls can differ by microseconds, and
+        // originalAcquiredAt > acquiredAt trips ResourceLease.validate() (seen on CI).
+        val now = Instant.now()
+        return ResourceLease(
+            resourceKey = resourceKey,
+            holderItemId = holderItemId,
+            acquiredByActorId = actorId,
+            acquiredAt = now.minusSeconds(60),
+            expiresAt = expiresAt ?: now.plusSeconds(300),
+            originalAcquiredAt = now.minusSeconds(60)
+        )
+    }
 
     // ──────────────────────────────────────────────
     // Item mode — declared + held resources with holder identity

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextToolTest.kt
@@ -54,6 +54,7 @@ class GetContextToolTest {
         every { noteSchemaService.getSchemaForType(any()) } returns null
         every { noteSchemaService.getDefaultTraits(any()) } returns emptyList()
         every { noteSchemaService.getTraitNotes(any()) } returns null
+        every { noteSchemaService.getTraitResources(any()) } returns emptyList()
 
         val repoProvider = mockk<RepositoryProvider>()
         every { repoProvider.workItemRepository() } returns workItemRepo

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/AppConfigTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/AppConfigTest.kt
@@ -60,7 +60,7 @@ class AppConfigTest {
         assertEquals(emptyList(), c.corsAllowedOrigins)
         assertEquals(listOf("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"), c.corsAllowedMethods)
         assertEquals(listOf("Authorization", "Content-Type", "If-Match"), c.corsAllowedHeaders)
-        assertEquals(listOf("ETag", "Last-Event-ID"), c.corsExposeHeaders)
+        assertEquals(listOf("ETag", "Last-Event-ID", "Retry-After"), c.corsExposeHeaders)
         assertEquals(3600L, c.corsMaxAgeSeconds)
     }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlSchemaParserResourcesTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/config/YamlSchemaParserResourcesTest.kt
@@ -1,0 +1,346 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.config
+
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceMode
+import org.yaml.snakeyaml.LoaderOptions
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [YamlSchemaParser]'s `resources:` parsing — both the per-trait
+ * `traits.<name>.resources:` requirement lists (short/long form) and the top-level `resources:`
+ * registry.
+ *
+ * Parses real YAML text via [SafeConstructor] (mirroring how [YamlWorkItemSchemaService] and
+ * [PerRootConfigService] parse the same document) rather than hand-building `Map<String, Any>`
+ * literals, so these tests exercise the exact same SnakeYAML type coercion production code sees.
+ */
+class YamlSchemaParserResourcesTest {
+    private fun parse(yaml: String): YamlSchemaParser.ParsedConfig {
+        @Suppress("UNCHECKED_CAST")
+        val root = Yaml(SafeConstructor(LoaderOptions())).load<Map<String, Any>>(yaml) ?: emptyMap()
+        return YamlSchemaParser.parseRoot(root, warnOnMissingSchemas = false)
+    }
+
+    // ──────────────────────────────────────────────
+    // Short form: bare key strings
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `short form resources list parses as exclusive mode with null ttl`() {
+        val parsed =
+            parse(
+                """
+                traits:
+                  needs-staging-db:
+                    resources: [staging-db-credential, staging-env]
+                """.trimIndent()
+            )
+
+        val reqs = parsed.traitResources["needs-staging-db"]
+        assertEquals(2, reqs?.size)
+        assertEquals("staging-db-credential", reqs!![0].key)
+        assertEquals(ResourceMode.EXCLUSIVE, reqs[0].mode)
+        assertNull(reqs[0].ttlSeconds)
+        assertEquals("staging-env", reqs[1].key)
+    }
+
+    // ──────────────────────────────────────────────
+    // Long form: maps with key/mode/ttlSeconds
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `long form resources entry parses mode and ttlSeconds`() {
+        val parsed =
+            parse(
+                """
+                traits:
+                  needs-staging-db:
+                    resources:
+                      - key: staging-db-credential
+                        mode: exclusive
+                        ttlSeconds: 900
+                """.trimIndent()
+            )
+
+        val req = parsed.traitResources["needs-staging-db"]!!.single()
+        assertEquals("staging-db-credential", req.key)
+        assertEquals(ResourceMode.EXCLUSIVE, req.mode)
+        assertEquals(900, req.ttlSeconds)
+    }
+
+    @Test
+    fun `long form mode is case-insensitive`() {
+        val parsed =
+            parse(
+                """
+                traits:
+                  needs-audit-log:
+                    resources:
+                      - key: audit-log
+                        mode: Advisory
+                """.trimIndent()
+            )
+
+        val req = parsed.traitResources["needs-audit-log"]!!.single()
+        assertEquals(ResourceMode.ADVISORY, req.mode)
+    }
+
+    @Test
+    fun `unknown mode falls back to exclusive with a warning`() {
+        val parsed =
+            parse(
+                """
+                traits:
+                  needs-x:
+                    resources:
+                      - key: some-resource
+                        mode: bogus-mode
+                """.trimIndent()
+            )
+
+        val req = parsed.traitResources["needs-x"]!!.single()
+        assertEquals(ResourceMode.EXCLUSIVE, req.mode)
+        assertTrue(parsed.warnings.any { it.contains("unknown mode") && it.contains("bogus-mode") })
+    }
+
+    @Test
+    fun `long form entry with no mode defaults to exclusive`() {
+        val parsed =
+            parse(
+                """
+                traits:
+                  needs-x:
+                    resources:
+                      - key: some-resource
+                """.trimIndent()
+            )
+
+        val req = parsed.traitResources["needs-x"]!!.single()
+        assertEquals(ResourceMode.EXCLUSIVE, req.mode)
+        assertNull(req.ttlSeconds)
+    }
+
+    // ──────────────────────────────────────────────
+    // Malformed sections — non-fatal
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `malformed resources section (not a list) is skipped with a warning, load continues`() {
+        val parsed =
+            parse(
+                """
+                work_item_schemas:
+                  feature-task:
+                    notes: []
+                traits:
+                  needs-x:
+                    resources: "not-a-list"
+                """.trimIndent()
+            )
+
+        assertTrue(parsed.traitResources["needs-x"].isNullOrEmpty())
+        assertTrue(parsed.warnings.any { it.contains("malformed 'resources' section") })
+        // The rest of the config still loaded.
+        assertTrue(parsed.workItemSchemas.containsKey("feature-task"))
+    }
+
+    @Test
+    fun `resources list entry missing key is skipped with a warning`() {
+        val parsed =
+            parse(
+                """
+                traits:
+                  needs-x:
+                    resources:
+                      - mode: advisory
+                """.trimIndent()
+            )
+
+        assertTrue(parsed.traitResources["needs-x"].isNullOrEmpty())
+        assertTrue(parsed.warnings.any { it.contains("missing required field 'key'") })
+    }
+
+    @Test
+    fun `invalid resource key is skipped with a warning`() {
+        val parsed =
+            parse(
+                """
+                traits:
+                  needs-x:
+                    resources: ["Invalid Key With Spaces"]
+                """.trimIndent()
+            )
+
+        assertTrue(parsed.traitResources["needs-x"].isNullOrEmpty())
+        assertTrue(parsed.warnings.any { it.contains("invalid key") })
+    }
+
+    // ──────────────────────────────────────────────
+    // Top-level registry
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `registry parses description defaultTtlSeconds and maxHolders`() {
+        val parsed =
+            parse(
+                """
+                resources:
+                  staging-db-credential:
+                    description: "Shared staging DB credential"
+                    defaultTtlSeconds: 1800
+                    maxHolders: 1
+                """.trimIndent()
+            )
+
+        val def = parsed.resourceRegistry["staging-db-credential"]!!
+        assertEquals("Shared staging DB credential", def.description)
+        assertEquals(1800, def.defaultTtlSeconds)
+        assertEquals(1, def.maxHolders)
+    }
+
+    @Test
+    fun `registry entry with maxHolders 1 loads without error`() {
+        val parsed =
+            parse(
+                """
+                resources:
+                  ok-resource:
+                    maxHolders: 1
+                """.trimIndent()
+            )
+
+        assertTrue(parsed.resourceRegistry.containsKey("ok-resource"))
+        assertTrue(parsed.warnings.none { it.contains("ok-resource") })
+    }
+
+    @Test
+    fun `registry entry with maxHolders greater than 1 is rejected as an error`() {
+        val parsed =
+            parse(
+                """
+                resources:
+                  fan-in-resource:
+                    maxHolders: 2
+                """.trimIndent()
+            )
+
+        assertTrue(!parsed.resourceRegistry.containsKey("fan-in-resource"))
+        assertTrue(
+            parsed.warnings.any { it.contains("fan-in-resource") && it.contains("maxHolders > 1 not yet supported") }
+        )
+    }
+
+    @Test
+    fun `registry entry budget keys are parsed and warned but not stored`() {
+        val parsed =
+            parse(
+                """
+                resources:
+                  budget-resource:
+                    budgetLimit: 100
+                    budgetWindowSeconds: 3600
+                """.trimIndent()
+            )
+
+        assertTrue(parsed.resourceRegistry.containsKey("budget-resource"))
+        assertTrue(parsed.warnings.any { it.contains("budgetLimit") && it.contains("reserved for future use") })
+        assertTrue(parsed.warnings.any { it.contains("budgetWindowSeconds") && it.contains("reserved for future use") })
+    }
+
+    // ──────────────────────────────────────────────
+    // Undeclared-key and fan-out warnings
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `trait referencing a key absent from the registry is warned but still honored`() {
+        val parsed =
+            parse(
+                """
+                traits:
+                  needs-x:
+                    resources: [unregistered-key]
+                """.trimIndent()
+            )
+
+        // Warned...
+        assertTrue(
+            parsed.warnings.any {
+                it.contains("undeclared resource") && it.contains("unregistered-key") && it.contains("3600")
+            }
+        )
+        // ...but still present (warn-and-honor, never skipped for being undeclared).
+        assertEquals("unregistered-key", parsed.traitResources["needs-x"]!!.single().key)
+    }
+
+    @Test
+    fun `a resource key declared by 3 or more traits triggers a fan-out warning`() {
+        val parsed =
+            parse(
+                """
+                resources:
+                  shared-key:
+                    description: "shared"
+                traits:
+                  trait-a:
+                    resources: [shared-key]
+                  trait-b:
+                    resources: [shared-key]
+                  trait-c:
+                    resources: [shared-key]
+                """.trimIndent()
+            )
+
+        assertTrue(parsed.warnings.any { it.contains("shared-key") && it.contains("3 traits") })
+    }
+
+    @Test
+    fun `a resource key declared by only 2 traits does not trigger a fan-out warning`() {
+        val parsed =
+            parse(
+                """
+                resources:
+                  shared-key:
+                    description: "shared"
+                traits:
+                  trait-a:
+                    resources: [shared-key]
+                  trait-b:
+                    resources: [shared-key]
+                """.trimIndent()
+            )
+
+        assertTrue(parsed.warnings.none { it.contains("fan-out") })
+    }
+
+    // ──────────────────────────────────────────────
+    // Traits with no resources key are absent, not empty-listed
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `trait with no resources key is absent from traitResources`() {
+        val parsed =
+            parse(
+                """
+                traits:
+                  plain-trait:
+                    notes:
+                      - key: some-note
+                        role: work
+                """.trimIndent()
+            )
+
+        assertTrue(!parsed.traitResources.containsKey("plain-trait"))
+    }
+
+    @Test
+    fun `document with no traits or resources keys parses to empty maps`() {
+        val parsed = parse("work_item_schemas:\n  feature-task:\n    notes: []")
+
+        assertTrue(parsed.traitResources.isEmpty())
+        assertTrue(parsed.resourceRegistry.isEmpty())
+    }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/V14ConsumedCredentialsMigrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/V14ConsumedCredentialsMigrationTest.kt
@@ -1,0 +1,258 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database
+
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration test for the V14 migration (`V14__Add_Consumed_Credentials.sql`) — the additive
+ * `consumed_credentials` TEXT column on `role_transitions` (T1: credentialRefs audit field).
+ *
+ * Follows the [V9RootIdMigrationTest] pattern: hand-build the *pre-migration* `role_transitions`
+ * schema (matching V1__Current_Initial_Schema.sql's original columns, i.e. without the later
+ * actor/verification columns which are irrelevant to this ALTER TABLE ADD COLUMN and without
+ * `consumed_credentials`), seed rows via raw JDBC, apply the real V14 SQL file straight off the
+ * classpath, then assert the column exists, defaults to NULL on both pre-existing and freshly
+ * inserted rows, and round-trips an explicit value.
+ */
+class V14ConsumedCredentialsMigrationTest {
+    private lateinit var database: Database
+    private lateinit var keepAliveConnection: Connection
+
+    @BeforeEach
+    fun setUp() {
+        val dbName = "v14_consumed_credentials_${System.nanoTime()}"
+        val jdbcUrl = "jdbc:sqlite:file:$dbName?mode=memory&cache=shared"
+        keepAliveConnection = DriverManager.getConnection(jdbcUrl)
+        database = Database.connect(url = jdbcUrl, driver = "org.sqlite.JDBC")
+        TransactionManager.manager.defaultIsolationLevel = Connection.TRANSACTION_SERIALIZABLE
+        createPreV14Schema()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        try {
+            TransactionManager.closeAndUnregister(database)
+        } catch (_: Exception) {
+        }
+        try {
+            keepAliveConnection.close()
+        } catch (_: Exception) {
+        }
+    }
+
+    /** Minimal pre-V14 schema: work_items (FK target) + role_transitions without consumed_credentials. */
+    private fun createPreV14Schema() {
+        transaction(db = database) {
+            exec(
+                """
+                CREATE TABLE work_items (
+                    id    BLOB PRIMARY KEY DEFAULT (randomblob(16)),
+                    title TEXT NOT NULL
+                )
+                """.trimIndent()
+            )
+            exec(
+                """
+                CREATE TABLE role_transitions (
+                    id                  BLOB PRIMARY KEY DEFAULT (randomblob(16)),
+                    item_id             BLOB NOT NULL REFERENCES work_items(id) ON DELETE CASCADE,
+                    from_role           VARCHAR(20) NOT NULL,
+                    to_role             VARCHAR(20) NOT NULL,
+                    from_status_label   TEXT,
+                    to_status_label     TEXT,
+                    trigger             VARCHAR(50) NOT NULL,
+                    summary             TEXT,
+                    transitioned_at     TIMESTAMP NOT NULL
+                )
+                """.trimIndent()
+            )
+            exec("CREATE INDEX idx_role_trans_item ON role_transitions(item_id)")
+            exec("CREATE INDEX idx_role_trans_time ON role_transitions(transitioned_at)")
+        }
+    }
+
+    /**
+     * Reads the real `V14__Add_Consumed_Credentials.sql` off the classpath and executes it.
+     * Strips full-line `--` comments, then splits on `;` (mirrors [V9RootIdMigrationTest]) — safe
+     * here since the migration's single ALTER TABLE statement contains no embedded semicolon.
+     */
+    private fun applyV14Migration() {
+        val resourceStream =
+            requireNotNull(
+                Thread.currentThread().contextClassLoader.getResourceAsStream(
+                    "db/migration/V14__Add_Consumed_Credentials.sql"
+                )
+            ) { "V14__Add_Consumed_Credentials.sql not found on the test classpath" }
+        val sqlText = resourceStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+        val withoutComments =
+            sqlText
+                .lineSequence()
+                .filterNot { it.trimStart().startsWith("--") }
+                .joinToString("\n")
+        val statements =
+            withoutComments
+                .split(";")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+
+        transaction(db = database) {
+            statements.forEach { statement -> exec(statement) }
+        }
+    }
+
+    private fun uuidToBytes(id: UUID): ByteArray {
+        val buf = ByteBuffer.allocate(16)
+        buf.putLong(id.mostSignificantBits)
+        buf.putLong(id.leastSignificantBits)
+        return buf.array()
+    }
+
+    private fun insertWorkItem(
+        id: UUID,
+        title: String
+    ) {
+        keepAliveConnection.prepareStatement("INSERT INTO work_items (id, title) VALUES (?, ?)").use { stmt ->
+            stmt.setBytes(1, uuidToBytes(id))
+            stmt.setString(2, title)
+            stmt.executeUpdate()
+        }
+    }
+
+    private fun insertPreV14Transition(
+        id: UUID,
+        itemId: UUID
+    ) {
+        keepAliveConnection
+            .prepareStatement(
+                """
+                INSERT INTO role_transitions (id, item_id, from_role, to_role, trigger, transitioned_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """.trimIndent()
+            ).use { stmt ->
+                stmt.setBytes(1, uuidToBytes(id))
+                stmt.setBytes(2, uuidToBytes(itemId))
+                stmt.setString(3, "queue")
+                stmt.setString(4, "work")
+                stmt.setString(5, "start")
+                stmt.setTimestamp(6, Timestamp.from(Instant.now()))
+                stmt.executeUpdate()
+            }
+    }
+
+    @Test
+    fun `V14 migration adds the consumed_credentials column`(): Unit =
+        runBlocking {
+            applyV14Migration()
+
+            var hasColumn = false
+            transaction(db = database) {
+                exec("PRAGMA table_info(role_transitions)") { rs ->
+                    while (rs.next()) {
+                        if (rs.getString("name") == "consumed_credentials") hasColumn = true
+                    }
+                }
+            }
+            assertTrue(hasColumn, "Expected consumed_credentials column to exist after V14")
+        }
+
+    @Test
+    fun `V14 pre-existing rows default consumed_credentials to NULL`(): Unit =
+        runBlocking {
+            val itemId = UUID.randomUUID()
+            val transitionId = UUID.randomUUID()
+            insertWorkItem(itemId, "Pre-existing item")
+            insertPreV14Transition(transitionId, itemId)
+
+            applyV14Migration()
+
+            var value: String? = "not-read"
+            keepAliveConnection
+                .prepareStatement("SELECT consumed_credentials FROM role_transitions WHERE id = ?")
+                .use { stmt ->
+                    stmt.setBytes(1, uuidToBytes(transitionId))
+                    stmt.executeQuery().use { rs ->
+                        assertTrue(rs.next(), "Expected the pre-existing row to still be present after V14")
+                        value = rs.getString(1)
+                    }
+                }
+            assertNull(value, "Expected consumed_credentials to default to NULL for a pre-existing row")
+        }
+
+    @Test
+    fun `V14 freshly inserted row without consumed_credentials defaults to NULL`(): Unit =
+        runBlocking {
+            applyV14Migration()
+
+            val itemId = UUID.randomUUID()
+            val transitionId = UUID.randomUUID()
+            insertWorkItem(itemId, "Fresh item")
+            insertPreV14Transition(transitionId, itemId)
+
+            var value: String? = "not-read"
+            keepAliveConnection
+                .prepareStatement("SELECT consumed_credentials FROM role_transitions WHERE id = ?")
+                .use { stmt ->
+                    stmt.setBytes(1, uuidToBytes(transitionId))
+                    stmt.executeQuery().use { rs ->
+                        assertTrue(rs.next())
+                        value = rs.getString(1)
+                    }
+                }
+            assertNull(value, "Expected consumed_credentials to default to NULL when omitted on insert")
+        }
+
+    @Test
+    fun `V14 round-trips an explicit JSON array value`(): Unit =
+        runBlocking {
+            applyV14Migration()
+
+            val itemId = UUID.randomUUID()
+            val transitionId = UUID.randomUUID()
+            insertWorkItem(itemId, "Item with credentialRefs")
+            val jsonValue = """["vault:prod-db-password","github-pat-ci"]"""
+
+            keepAliveConnection
+                .prepareStatement(
+                    """
+                    INSERT INTO role_transitions
+                        (id, item_id, from_role, to_role, trigger, transitioned_at, consumed_credentials)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """.trimIndent()
+                ).use { stmt ->
+                    stmt.setBytes(1, uuidToBytes(transitionId))
+                    stmt.setBytes(2, uuidToBytes(itemId))
+                    stmt.setString(3, "queue")
+                    stmt.setString(4, "work")
+                    stmt.setString(5, "start")
+                    stmt.setTimestamp(6, Timestamp.from(Instant.now()))
+                    stmt.setString(7, jsonValue)
+                    stmt.executeUpdate()
+                }
+
+            var value: String? = null
+            keepAliveConnection
+                .prepareStatement("SELECT consumed_credentials FROM role_transitions WHERE id = ?")
+                .use { stmt ->
+                    stmt.setBytes(1, uuidToBytes(transitionId))
+                    stmt.executeQuery().use { rs ->
+                        assertTrue(rs.next())
+                        value = rs.getString(1)
+                    }
+                }
+            assertEquals(jsonValue, value)
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/V15ResourceLeasesMigrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/V15ResourceLeasesMigrationTest.kt
@@ -1,0 +1,254 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database
+
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.SQLException
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration test for the V15 migration (`V15__Resource_Leases.sql`) — the new `resource_leases`
+ * table, its semaphore-ready `(resource_key, holder_item_id)` unique index, and its `holder_item_id`
+ * CASCADE FK to `work_items`.
+ *
+ * Follows the [V12PlanDocumentsMigrationTest] pattern: hand-build a minimal pre-V15 `work_items`
+ * table with raw SQL, apply the real V15 SQL file read straight off the classpath, then assert
+ * table/index existence and FK CASCADE behavior via raw JDBC. `PRAGMA foreign_keys = ON` is set
+ * explicitly since CASCADE behavior is under test.
+ */
+class V15ResourceLeasesMigrationTest {
+    private lateinit var database: Database
+    private lateinit var keepAliveConnection: Connection
+
+    @BeforeEach
+    fun setUp() {
+        val dbName = "v15_resource_leases_${System.nanoTime()}"
+        val jdbcUrl = "jdbc:sqlite:file:$dbName?mode=memory&cache=shared"
+        keepAliveConnection = DriverManager.getConnection(jdbcUrl)
+        keepAliveConnection.createStatement().use { it.execute("PRAGMA foreign_keys = ON") }
+        database = Database.connect(url = jdbcUrl, driver = "org.sqlite.JDBC")
+        TransactionManager.manager.defaultIsolationLevel = Connection.TRANSACTION_SERIALIZABLE
+        createMinimalWorkItemsTable()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        try {
+            TransactionManager.closeAndUnregister(database)
+        } catch (_: Exception) {
+        }
+        try {
+            keepAliveConnection.close()
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun createMinimalWorkItemsTable() {
+        transaction(db = database) {
+            exec(
+                """
+                CREATE TABLE work_items (
+                    id    BLOB PRIMARY KEY DEFAULT (randomblob(16)),
+                    title TEXT NOT NULL
+                )
+                """.trimIndent()
+            )
+        }
+    }
+
+    /**
+     * Reads the real `V15__Resource_Leases.sql` off the classpath and executes each statement.
+     * Strips full-line `--` comments, then splits on `;` — safe here since none of the migration's
+     * statements contain an embedded semicolon (mirrors [V12PlanDocumentsMigrationTest.applyV12Migration]).
+     */
+    private fun applyV15Migration() {
+        val resourceStream =
+            requireNotNull(
+                Thread.currentThread().contextClassLoader.getResourceAsStream("db/migration/V15__Resource_Leases.sql")
+            ) { "V15__Resource_Leases.sql not found on the test classpath" }
+        val sqlText = resourceStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+        val withoutComments =
+            sqlText
+                .lineSequence()
+                .filterNot { it.trimStart().startsWith("--") }
+                .joinToString("\n")
+        val statements =
+            withoutComments
+                .split(";")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+
+        transaction(db = database) {
+            statements.forEach { statement -> exec(statement) }
+        }
+    }
+
+    private fun insertWorkItem(
+        id: UUID,
+        title: String
+    ) {
+        keepAliveConnection.prepareStatement("INSERT INTO work_items (id, title) VALUES (?, ?)").use { stmt ->
+            stmt.setBytes(1, uuidToBytes(id))
+            stmt.setString(2, title)
+            stmt.executeUpdate()
+        }
+    }
+
+    private fun insertResourceLease(
+        resourceKey: String,
+        holderItemId: UUID,
+        acquiredAt: String = "2026-01-01 00:00:00",
+        expiresAt: String = "2026-01-01 01:00:00",
+        originalAcquiredAt: String = "2026-01-01 00:00:00"
+    ) {
+        keepAliveConnection
+            .prepareStatement(
+                """
+                INSERT INTO resource_leases
+                    (resource_key, holder_item_id, acquired_at, expires_at, original_acquired_at)
+                VALUES (?, ?, ?, ?, ?)
+                """.trimIndent()
+            ).use { stmt ->
+                stmt.setString(1, resourceKey)
+                stmt.setBytes(2, uuidToBytes(holderItemId))
+                stmt.setString(3, acquiredAt)
+                stmt.setString(4, expiresAt)
+                stmt.setString(5, originalAcquiredAt)
+                stmt.executeUpdate()
+            }
+    }
+
+    private fun countLeaseRows(holderItemId: UUID): Int {
+        var count = 0
+        keepAliveConnection.prepareStatement("SELECT COUNT(*) FROM resource_leases WHERE holder_item_id = ?").use { stmt ->
+            stmt.setBytes(1, uuidToBytes(holderItemId))
+            stmt.executeQuery().use { rs ->
+                if (rs.next()) count = rs.getInt(1)
+            }
+        }
+        return count
+    }
+
+    private fun uuidToBytes(id: UUID): ByteArray {
+        val buf = ByteBuffer.allocate(16)
+        buf.putLong(id.mostSignificantBits)
+        buf.putLong(id.leastSignificantBits)
+        return buf.array()
+    }
+
+    @Test
+    fun `V15 migration creates the resource_leases table and its indexes`(): Unit =
+        runBlocking {
+            applyV15Migration()
+
+            var hasTable = false
+            transaction(db = database) {
+                exec("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'resource_leases'") { rs ->
+                    hasTable = rs.next()
+                }
+            }
+            assertTrue(hasTable, "Expected resource_leases table to exist after V15")
+
+            val expectedIndexes =
+                listOf(
+                    "idx_resource_leases_key_holder",
+                    "idx_resource_leases_resource_key",
+                    "idx_resource_leases_expires_at",
+                )
+            for (indexName in expectedIndexes) {
+                var hasIndex = false
+                transaction(db = database) {
+                    exec("SELECT name FROM sqlite_master WHERE type = 'index' AND name = '$indexName'") { rs ->
+                        hasIndex = rs.next()
+                    }
+                }
+                assertTrue(hasIndex, "Expected $indexName index to exist after V15")
+            }
+        }
+
+    @Test
+    fun `V15 (resource_key, holder_item_id) is unique — a second insert for the same pair fails`(): Unit =
+        runBlocking {
+            applyV15Migration()
+            val holder = UUID.randomUUID()
+            insertWorkItem(holder, "Holder")
+            insertResourceLease("staging-db-credential", holder)
+
+            var threw = false
+            try {
+                insertResourceLease("staging-db-credential", holder)
+            } catch (e: SQLException) {
+                threw = true
+            }
+            assertTrue(threw, "Expected a UNIQUE constraint violation on a second insert for the same (resource_key, holder_item_id)")
+        }
+
+    @Test
+    fun `V15 the same resource_key is allowed for two different holders (semaphore-ready)`(): Unit =
+        runBlocking {
+            applyV15Migration()
+            val holderA = UUID.randomUUID()
+            val holderB = UUID.randomUUID()
+            insertWorkItem(holderA, "Holder A")
+            insertWorkItem(holderB, "Holder B")
+            insertResourceLease("staging-db-credential", holderA)
+
+            var threw = false
+            try {
+                insertResourceLease("staging-db-credential", holderB)
+            } catch (e: SQLException) {
+                threw = true
+            }
+            assertTrue(!threw, "The same resource_key must be insertable for a different holder_item_id")
+        }
+
+    @Test
+    fun `V15 deleting the holder work item cascades to delete its resource_leases rows`(): Unit =
+        runBlocking {
+            applyV15Migration()
+            val holder = UUID.randomUUID()
+            insertWorkItem(holder, "Holder")
+            insertResourceLease("staging-db-credential", holder)
+
+            assertEquals(1, countLeaseRows(holder), "Sanity check: lease row exists before delete")
+
+            keepAliveConnection.prepareStatement("DELETE FROM work_items WHERE id = ?").use { stmt ->
+                stmt.setBytes(1, uuidToBytes(holder))
+                stmt.executeUpdate()
+            }
+
+            assertEquals(0, countLeaseRows(holder), "Expected ON DELETE CASCADE to remove the resource_leases row")
+        }
+
+    @Test
+    fun `V15 fresh apply and upgrade-path apply both succeed`(): Unit =
+        runBlocking {
+            // "Fresh apply" — a brand-new DB applying only V15 (work_items pre-created above, mirroring
+            // the minimal fixture every migration test in this suite uses).
+            applyV15Migration()
+            var hasTable = false
+            transaction(db = database) {
+                exec("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'resource_leases'") { rs ->
+                    hasTable = rs.next()
+                }
+            }
+            assertTrue(hasTable, "Fresh apply must create resource_leases")
+
+            // "Upgrade path" — inserting a row post-migration behaves as a normal already-migrated
+            // database would (no re-apply of V15 is attempted; Flyway itself guards against re-running
+            // an already-applied version — this asserts the table is usable immediately after apply).
+            val holder = UUID.randomUUID()
+            insertWorkItem(holder, "Holder")
+            insertResourceLease("staging-db-credential", holder)
+            assertEquals(1, countLeaseRows(holder), "Table must be immediately usable after V15 apply")
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/V16ResourceLeaseHistoryMigrationTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/V16ResourceLeaseHistoryMigrationTest.kt
@@ -1,0 +1,237 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database
+
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.sql.Connection
+import java.sql.DriverManager
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration test for the V16 migration (`V16__Resource_Lease_History.sql`) — the new append-only
+ * `resource_lease_history` table.
+ *
+ * Follows the [V15ResourceLeasesMigrationTest] pattern: hand-build a minimal pre-V16 `work_items`
+ * + `resource_leases` schema with raw SQL, apply the real V16 SQL file read straight off the
+ * classpath, then assert table/index existence and — critically — the ABSENCE of any foreign key
+ * on `holder_item_id` (see the migration header for why this is deliberate).
+ */
+class V16ResourceLeaseHistoryMigrationTest {
+    private lateinit var database: Database
+    private lateinit var keepAliveConnection: Connection
+
+    @BeforeEach
+    fun setUp() {
+        val dbName = "v16_resource_lease_history_${System.nanoTime()}"
+        val jdbcUrl = "jdbc:sqlite:file:$dbName?mode=memory&cache=shared"
+        keepAliveConnection = DriverManager.getConnection(jdbcUrl)
+        keepAliveConnection.createStatement().use { it.execute("PRAGMA foreign_keys = ON") }
+        database = Database.connect(url = jdbcUrl, driver = "org.sqlite.JDBC")
+        TransactionManager.manager.defaultIsolationLevel = Connection.TRANSACTION_SERIALIZABLE
+        createMinimalPreV16Schema()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        try {
+            TransactionManager.closeAndUnregister(database)
+        } catch (_: Exception) {
+        }
+        try {
+            keepAliveConnection.close()
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun createMinimalPreV16Schema() {
+        transaction(db = database) {
+            exec(
+                """
+                CREATE TABLE work_items (
+                    id    BLOB PRIMARY KEY DEFAULT (randomblob(16)),
+                    title TEXT NOT NULL
+                )
+                """.trimIndent()
+            )
+            exec(
+                """
+                CREATE TABLE resource_leases (
+                    id                     BLOB PRIMARY KEY DEFAULT (randomblob(16)),
+                    resource_key           TEXT NOT NULL,
+                    holder_item_id         BLOB NOT NULL REFERENCES work_items(id) ON DELETE CASCADE,
+                    acquired_by_actor_id   TEXT NULL,
+                    acquired_at            TEXT NOT NULL,
+                    expires_at             TEXT NOT NULL,
+                    original_acquired_at   TEXT NOT NULL,
+                    version                INTEGER NOT NULL DEFAULT 0
+                )
+                """.trimIndent()
+            )
+        }
+    }
+
+    /**
+     * Reads the real `V16__Resource_Lease_History.sql` off the classpath and executes each
+     * statement. Strips full-line `--` comments, then splits on `;` — safe here since none of the
+     * migration's statements contain an embedded semicolon (mirrors
+     * [V15ResourceLeasesMigrationTest.applyV15Migration]).
+     */
+    private fun applyV16Migration() {
+        val resourceStream =
+            requireNotNull(
+                Thread.currentThread().contextClassLoader.getResourceAsStream("db/migration/V16__Resource_Lease_History.sql")
+            ) { "V16__Resource_Lease_History.sql not found on the test classpath" }
+        val sqlText = resourceStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+        val withoutComments =
+            sqlText
+                .lineSequence()
+                .filterNot { it.trimStart().startsWith("--") }
+                .joinToString("\n")
+        val statements =
+            withoutComments
+                .split(";")
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+
+        transaction(db = database) {
+            statements.forEach { statement -> exec(statement) }
+        }
+    }
+
+    private fun insertWorkItem(
+        id: UUID,
+        title: String
+    ) {
+        keepAliveConnection.prepareStatement("INSERT INTO work_items (id, title) VALUES (?, ?)").use { stmt ->
+            stmt.setBytes(1, uuidToBytes(id))
+            stmt.setString(2, title)
+            stmt.executeUpdate()
+        }
+    }
+
+    private fun insertHistoryRow(
+        resourceKey: String,
+        holderItemId: UUID,
+        acquiredAt: String = "2026-01-01 00:00:00",
+        expiresAt: String = "2026-01-01 01:00:00"
+    ) {
+        keepAliveConnection
+            .prepareStatement(
+                """
+                INSERT INTO resource_lease_history
+                    (resource_key, holder_item_id, acquired_at, expires_at)
+                VALUES (?, ?, ?, ?)
+                """.trimIndent()
+            ).use { stmt ->
+                stmt.setString(1, resourceKey)
+                stmt.setBytes(2, uuidToBytes(holderItemId))
+                stmt.setString(3, acquiredAt)
+                stmt.setString(4, expiresAt)
+                stmt.executeUpdate()
+            }
+    }
+
+    private fun countHistoryRows(holderItemId: UUID): Int {
+        var count = 0
+        keepAliveConnection.prepareStatement("SELECT COUNT(*) FROM resource_lease_history WHERE holder_item_id = ?").use { stmt ->
+            stmt.setBytes(1, uuidToBytes(holderItemId))
+            stmt.executeQuery().use { rs ->
+                if (rs.next()) count = rs.getInt(1)
+            }
+        }
+        return count
+    }
+
+    private fun uuidToBytes(id: UUID): ByteArray {
+        val buf = ByteBuffer.allocate(16)
+        buf.putLong(id.mostSignificantBits)
+        buf.putLong(id.leastSignificantBits)
+        return buf.array()
+    }
+
+    @Test
+    fun `V16 migration creates the resource_lease_history table and its indexes`(): Unit =
+        runBlocking {
+            applyV16Migration()
+
+            var hasTable = false
+            transaction(db = database) {
+                exec("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'resource_lease_history'") { rs ->
+                    hasTable = rs.next()
+                }
+            }
+            assertTrue(hasTable, "Expected resource_lease_history table to exist after V16")
+
+            val expectedIndexes =
+                listOf(
+                    "idx_resource_lease_history_key_acquired",
+                    "idx_resource_lease_history_released_at",
+                )
+            for (indexName in expectedIndexes) {
+                var hasIndex = false
+                transaction(db = database) {
+                    exec("SELECT name FROM sqlite_master WHERE type = 'index' AND name = '$indexName'") { rs ->
+                        hasIndex = rs.next()
+                    }
+                }
+                assertTrue(hasIndex, "Expected $indexName index to exist after V16")
+            }
+        }
+
+    @Test
+    fun `V16 resource_lease_history has NO foreign key on holder_item_id`(): Unit =
+        runBlocking {
+            applyV16Migration()
+
+            var fkCount = 0
+            transaction(db = database) {
+                exec("PRAGMA foreign_key_list(resource_lease_history)") { rs ->
+                    while (rs.next()) fkCount++
+                }
+            }
+            assertEquals(0, fkCount, "resource_lease_history must carry NO foreign keys — the audit trail must survive holder deletion")
+        }
+
+    @Test
+    fun `V16 history rows survive deletion of the holder work item (unlike the CASCADE-linked live row)`(): Unit =
+        runBlocking {
+            applyV16Migration()
+            val holder = UUID.randomUUID()
+            insertWorkItem(holder, "Holder")
+            insertHistoryRow("staging-db-credential", holder)
+
+            assertEquals(1, countHistoryRows(holder), "Sanity check: history row exists before delete")
+
+            keepAliveConnection.prepareStatement("DELETE FROM work_items WHERE id = ?").use { stmt ->
+                stmt.setBytes(1, uuidToBytes(holder))
+                stmt.executeUpdate()
+            }
+
+            assertEquals(1, countHistoryRows(holder), "History row must survive holder deletion — no FK, no CASCADE")
+        }
+
+    @Test
+    fun `V16 fresh apply and upgrade-path apply both succeed`(): Unit =
+        runBlocking {
+            applyV16Migration()
+            var hasTable = false
+            transaction(db = database) {
+                exec("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'resource_lease_history'") { rs ->
+                    hasTable = rs.next()
+                }
+            }
+            assertTrue(hasTable, "Fresh apply must create resource_lease_history")
+
+            val holder = UUID.randomUUID()
+            insertWorkItem(holder, "Holder")
+            insertHistoryRow("staging-db-credential", holder)
+            assertEquals(1, countHistoryRows(holder), "Table must be immediately usable after V16 apply")
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteResourceLeaseRepositoryConcurrencyTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteResourceLeaseRepositoryConcurrencyTest.kt
@@ -1,0 +1,151 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database.repository
+
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.ClaimResult
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseAcquireResult
+import io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.domain.repository.WorkItemRepository
+import io.github.jpicklyk.mcptask.current.test.SQLiteRepositoryTestBase
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Concurrency tests for [ResourceLeaseRepository.acquireAll], mirroring the real-thread race
+ * pattern in [SQLiteWorkItemRepositoryClaimTest] (`concurrent claim race with two real threads`).
+ *
+ * Also covers the gap-#1 regression: a claim ([WorkItemRepository.claim]) and a resource lease
+ * ([ResourceLeaseRepository.acquireAll]) on the SAME item are independent lifecycles — acquiring a
+ * lease must never disturb an existing claim, and refreshing a claim must never disturb existing
+ * leases (see the "Isolation from claims" section of [ResourceLeaseRepository]'s KDoc).
+ */
+class SQLiteResourceLeaseRepositoryConcurrencyTest : SQLiteRepositoryTestBase() {
+    private fun leaseRepository(): ResourceLeaseRepository = repositoryProvider.resourceLeaseRepository()
+
+    private fun workItemRepository(): WorkItemRepository = repositoryProvider.workItemRepository()
+
+    private suspend fun createHolder(title: String = "Holder"): UUID {
+        val result = workItemRepository().create(WorkItem(title = title))
+        assertIs<Result.Success<WorkItem>>(result)
+        return result.data.id
+    }
+
+    @Test
+    fun `N threads race one key — exactly one Success`(): Unit =
+        runBlocking {
+            org.jetbrains.exposed.v1.jdbc.transactions.transaction(db = database) {
+                exec("PRAGMA busy_timeout = 15000")
+            }
+
+            val threadCount = 5
+            val holders = (1..threadCount).map { createHolder("Racer $it") }
+            val executor = Executors.newFixedThreadPool(threadCount)
+            val startGate = CountDownLatch(1)
+            val results = List(threadCount) { AtomicReference<Any?>() }
+
+            val futures =
+                (0 until threadCount).map { i ->
+                    executor.submit {
+                        startGate.await()
+                        try {
+                            results[i].set(
+                                runBlocking {
+                                    leaseRepository().acquireAll(holders[i], "agent-$i", listOf("contended-key" to 900))
+                                }
+                            )
+                        } catch (e: Exception) {
+                            results[i].set(e)
+                        }
+                    }
+                }
+
+            startGate.countDown()
+            futures.forEach { it.get(30, TimeUnit.SECONDS) }
+            executor.shutdown()
+
+            val outcomes = results.map { it.get() }
+            outcomes.forEach { assertNotNull(it, "Every thread must produce an outcome (result or exception)") }
+
+            val successes = outcomes.filterIsInstance<LeaseAcquireResult.Success>()
+            assertEquals(1, successes.size, "Exactly one thread may win the lease race; got outcomes: $outcomes")
+
+            // The final DB row must be atomically consistent — held by exactly the single winner.
+            val active = leaseRepository().findActiveByKeys(listOf("contended-key"))
+            assertEquals(1, active.size)
+            assertEquals(
+                successes
+                    .single()
+                    .leases
+                    .single()
+                    .holderItemId,
+                active.single().holderItemId
+            )
+        }
+
+    // -----------------------------------------------------------------------
+    // Gap-#1 regression: claim and lease acquisition are independent lifecycles
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `acquiring a resource lease does not disturb an existing claim on the same item`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+
+            val claim = workItemRepository().claim(holder, "agent-x", 900)
+            assertIs<ClaimResult.Success>(claim)
+
+            val lease = leaseRepository().acquireAll(holder, "agent-x", listOf("staging-db" to 900))
+            assertIs<LeaseAcquireResult.Success>(lease)
+
+            val afterLease = workItemRepository().getById(holder)
+            assertIs<Result.Success<WorkItem>>(afterLease)
+            assertEquals("agent-x", afterLease.data.claimedBy, "The claim must survive lease acquisition")
+            assertNotNull(afterLease.data.claimedAt)
+            assertNotNull(afterLease.data.claimExpiresAt)
+            assertNotNull(afterLease.data.originalClaimedAt)
+        }
+
+    @Test
+    fun `refreshing a claim does not disturb existing resource leases held by the same item`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+
+            val lease = leaseRepository().acquireAll(holder, "agent-x", listOf("staging-db" to 900))
+            assertIs<LeaseAcquireResult.Success>(lease)
+
+            // Re-claim (refresh TTL) on the same item.
+            val refreshedClaim = workItemRepository().claim(holder, "agent-x", 1800)
+            assertIs<ClaimResult.Success>(refreshedClaim)
+
+            val activeLeases = leaseRepository().findActiveForItem(holder)
+            assertEquals(1, activeLeases.size, "The lease must survive a claim refresh")
+            assertEquals("staging-db", activeLeases.single().resourceKey)
+        }
+
+    @Test
+    fun `releasing an item's claim does not release its resource leases`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+
+            assertIs<ClaimResult.Success>(workItemRepository().claim(holder, "agent-x", 900))
+            assertIs<LeaseAcquireResult.Success>(leaseRepository().acquireAll(holder, "agent-x", listOf("staging-db" to 900)))
+
+            workItemRepository().release(holder, "agent-x")
+
+            val afterRelease = workItemRepository().getById(holder)
+            assertIs<Result.Success<WorkItem>>(afterRelease)
+            assertNull(afterRelease.data.claimedBy, "Claim must be released")
+
+            val activeLeases = leaseRepository().findActiveForItem(holder)
+            assertEquals(1, activeLeases.size, "Releasing the claim must not release the item's resource leases")
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteResourceLeaseRepositoryHistoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteResourceLeaseRepositoryHistoryTest.kt
@@ -1,0 +1,277 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database.repository
+
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseAcquireResult
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseReleaseResult
+import io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.test.SQLiteRepositoryTestBase
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.core.VarCharColumnType
+import org.jetbrains.exposed.v1.core.java.UUIDColumnType
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for the `resource_lease_history` write paths on
+ * [io.github.jpicklyk.mcptask.current.infrastructure.repository.SQLiteResourceLeaseRepository] —
+ * interval-open-on-acquire, refresh-extends-in-place, steal-closes-prior-as-expired,
+ * release/force-release close reasons, at-T boundary semantics, and history's survival of holder
+ * work-item deletion (unlike the CASCADE-linked live `resource_leases` row). Companion to
+ * [SQLiteResourceLeaseRepositoryTest], which covers the live-row behavior this history mirrors.
+ */
+class SQLiteResourceLeaseRepositoryHistoryTest : SQLiteRepositoryTestBase() {
+    private lateinit var repository: ResourceLeaseRepository
+
+    @BeforeEach
+    fun setUp() {
+        repository = repositoryProvider.resourceLeaseRepository()
+    }
+
+    private suspend fun createHolder(title: String = "Holder"): UUID {
+        val result = repositoryProvider.workItemRepository().create(WorkItem(title = title))
+        assertIs<Result.Success<WorkItem>>(result)
+        return result.data.id
+    }
+
+    /** Backdates every LIVE lease row for (resourceKey, holderItemId) to an already-expired expires_at. */
+    private fun expireLease(
+        resourceKey: String,
+        holderItemId: UUID
+    ) {
+        transaction(db = database) {
+            val uuidType = UUIDColumnType()
+            val keyType = VarCharColumnType(255)
+            exec(
+                """
+                UPDATE resource_leases
+                   SET expires_at = datetime('now', '-10 seconds')
+                 WHERE resource_key = ? AND holder_item_id = ?
+                """.trimIndent(),
+                args = listOf(keyType to resourceKey, uuidType to holderItemId)
+            )
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Interval lifecycle: open / refresh / steal
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `a fresh acquire opens exactly one interval`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holder, "agent-a", listOf("staging-db" to 900)))
+
+            val intervals = repository.findRecentIntervals("staging-db", 10)
+            assertEquals(1, intervals.size)
+            val interval = intervals.single()
+            assertEquals(holder, interval.holderItemId)
+            assertEquals("agent-a", interval.acquiredByActorId)
+            assertNull(interval.releasedAt, "a freshly opened interval must have no releasedAt")
+            assertNull(interval.releaseReason)
+        }
+
+    @Test
+    fun `a same-holder refresh extends expiresAt in place without opening a new row`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+            val first = repository.acquireAll(holder, "agent-a", listOf("staging-db" to 900))
+            assertIs<LeaseAcquireResult.Success>(first)
+            val firstExpiry = first.leases.single().expiresAt
+
+            Thread.sleep(1100)
+
+            val second = repository.acquireAll(holder, "agent-a", listOf("staging-db" to 1800))
+            assertIs<LeaseAcquireResult.Success>(second)
+
+            val intervals = repository.findRecentIntervals("staging-db", 10)
+            assertEquals(1, intervals.size, "a same-holder refresh must extend the OPEN interval, not open a second row")
+            val interval = intervals.single()
+            assertNull(interval.releasedAt)
+            assertTrue(interval.expiresAt > firstExpiry, "refresh must extend expiresAt")
+        }
+
+    @Test
+    fun `stealing an expired lease closes the prior holder's interval as expired at its own old expiry`(): Unit =
+        runBlocking {
+            val holderA = createHolder("Holder A")
+            val holderB = createHolder("Holder B")
+
+            val acquiredByA = repository.acquireAll(holderA, "agent-a", listOf("staging-db" to 900))
+            assertIs<LeaseAcquireResult.Success>(acquiredByA)
+            // Backdates the LIVE row's expires_at to ~10s in the past — the steal must close A's
+            // interval at THAT (post-backdate) expiry, which is what the DB factually records as
+            // the moment the lease lapsed.
+            expireLease("staging-db", holderA)
+
+            val stolen = repository.acquireAll(holderB, "agent-b", listOf("staging-db" to 900))
+            assertIs<LeaseAcquireResult.Success>(stolen)
+
+            val intervals = repository.findRecentIntervals("staging-db", 10)
+            assertEquals(2, intervals.size, "expect the closed A interval plus the new open B interval")
+
+            val aInterval = intervals.single { it.holderItemId == holderA }
+            val bInterval = intervals.single { it.holderItemId == holderB }
+            assertEquals("expired", aInterval.releaseReason)
+            val aReleasedAt = requireNotNull(aInterval.releasedAt)
+            assertTrue(
+                aReleasedAt.isBefore(bInterval.acquiredAt.minusSeconds(5)),
+                "A's interval must close at its (backdated) old expiry — clearly before the steal, not 'now'",
+            )
+
+            assertNull(bInterval.releasedAt, "B's new interval must be open")
+        }
+
+    // -----------------------------------------------------------------------
+    // Release / force-release close reasons
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `releaseAllForItem closes the open interval with reason released`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holder, "agent-a", listOf("staging-db" to 900)))
+
+            val released = repository.releaseAllForItem(holder)
+            assertIs<LeaseReleaseResult.Success>(released)
+
+            val interval = repository.findRecentIntervals("staging-db", 10).single()
+            assertEquals("released", interval.releaseReason)
+            assertEquals(null, interval.releasedByActorId, "a normal release has no acting principal")
+            assertTrue(interval.releasedAt != null)
+        }
+
+    @Test
+    fun `forceReleaseByKey closes the open interval with reason force_released and records the actor`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holder, "agent-a", listOf("staging-db" to 900)))
+
+            val released = repository.forceReleaseByKey("staging-db", "admin-token-123")
+            assertIs<LeaseReleaseResult.Success>(released)
+
+            val interval = repository.findRecentIntervals("staging-db", 10).single()
+            assertEquals("force_released", interval.releaseReason)
+            assertEquals("admin-token-123", interval.releasedByActorId)
+        }
+
+    @Test
+    fun `forceReleaseByKey with no actorId records a null released-by`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holder, "agent-a", listOf("staging-db" to 900)))
+
+            assertIs<LeaseReleaseResult.Success>(repository.forceReleaseByKey("staging-db"))
+
+            val interval = repository.findRecentIntervals("staging-db", 10).single()
+            assertEquals("force_released", interval.releaseReason)
+            assertNull(interval.releasedByActorId)
+        }
+
+    // -----------------------------------------------------------------------
+    // findHoldersAt — boundary semantics
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `findHoldersAt treats at equal to acquiredAt as held`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+            val acquired = repository.acquireAll(holder, "agent-a", listOf("staging-db" to 900))
+            assertIs<LeaseAcquireResult.Success>(acquired)
+            val interval = repository.findRecentIntervals("staging-db", 1).single()
+
+            val holders = repository.findHoldersAt("staging-db", interval.acquiredAt)
+            assertEquals(1, holders.size, "at == acquiredAt must be treated as held (inclusive lower bound)")
+            assertEquals(holder, holders.single().holderItemId)
+        }
+
+    @Test
+    fun `findHoldersAt treats at equal to the open interval's expiresAt as NOT held`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holder, "agent-a", listOf("staging-db" to 900)))
+            val interval = repository.findRecentIntervals("staging-db", 1).single()
+
+            val holders = repository.findHoldersAt("staging-db", interval.expiresAt)
+            assertTrue(holders.isEmpty(), "at == expiresAt must be treated as NOT held (exclusive upper bound)")
+        }
+
+    @Test
+    fun `findHoldersAt treats at equal to a closed interval's releasedAt as NOT held`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holder, "agent-a", listOf("staging-db" to 900)))
+            // SQLite timestamps are second-precision: a same-second acquire+release produces an
+            // empty [S, S) interval where nothing is ever "held". Sleep past the second boundary
+            // so acquired_at < released_at and the just-before probe has a real interval to hit.
+            Thread.sleep(1100)
+            assertIs<LeaseReleaseResult.Success>(repository.releaseAllForItem(holder))
+            val interval = repository.findRecentIntervals("staging-db", 1).single()
+            val releasedAt = requireNotNull(interval.releasedAt)
+
+            val heldAtRelease = repository.findHoldersAt("staging-db", releasedAt)
+            assertTrue(heldAtRelease.isEmpty(), "at == releasedAt must be treated as NOT held (exclusive upper bound)")
+
+            val heldJustBefore = repository.findHoldersAt("staging-db", releasedAt.minusMillis(1))
+            assertEquals(1, heldJustBefore.size, "an instant just before releasedAt must still be held")
+        }
+
+    @Test
+    fun `an open interval is bounded by expiresAt for at-T queries even though it never closed`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holder, "agent-a", listOf("staging-db" to 900)))
+            val interval = repository.findRecentIntervals("staging-db", 1).single()
+
+            val farFuture = interval.expiresAt.plusSeconds(3600)
+            val holders = repository.findHoldersAt("staging-db", farFuture)
+            assertTrue(holders.isEmpty(), "an open interval must not be reported held past its own expiresAt")
+        }
+
+    @Test
+    fun `findHoldersAt with a null resourceKey searches across all keys`(): Unit =
+        runBlocking {
+            val holderA = createHolder("Holder A")
+            val holderB = createHolder("Holder B")
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holderA, "agent-a", listOf("key-a" to 900)))
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holderB, "agent-b", listOf("key-b" to 900)))
+
+            val now = Instant.now()
+            val holders = repository.findHoldersAt(null, now)
+            assertEquals(2, holders.size)
+            assertEquals(setOf(holderA, holderB), holders.map { it.holderItemId }.toSet())
+        }
+
+    // -----------------------------------------------------------------------
+    // History survives holder deletion
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `history survives work-item DELETE`(): Unit =
+        runBlocking {
+            // The live-row ON DELETE CASCADE is pinned by V15ResourceLeasesMigrationTest /
+            // V16ResourceLeaseHistoryMigrationTest with PRAGMA foreign_keys=ON (the shared test-base
+            // connection does not enable that pragma, so cascades are not observable here). This
+            // test pins the complementary property: history rows have NO foreign key and outlive
+            // both the lease lifecycle and the holder work item itself.
+            val holder = createHolder()
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holder, "agent-a", listOf("staging-db" to 900)))
+            assertIs<LeaseReleaseResult.Success>(repository.releaseAllForItem(holder))
+
+            val deleteResult = repositoryProvider.workItemRepository().delete(holder)
+            assertIs<Result.Success<Boolean>>(deleteResult)
+
+            val intervals = repository.findRecentIntervals("staging-db", 10)
+            assertEquals(1, intervals.size, "the history row must survive holder deletion — no FK, no CASCADE")
+            assertEquals(holder, intervals.single().holderItemId)
+            assertEquals("released", intervals.single().releaseReason)
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteResourceLeaseRepositoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteResourceLeaseRepositoryTest.kt
@@ -1,0 +1,253 @@
+package io.github.jpicklyk.mcptask.current.infrastructure.database.repository
+
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseAcquireResult
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseReleaseResult
+import io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.test.SQLiteRepositoryTestBase
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for [ResourceLeaseRepository] (SQLite implementation), using a real SQLite
+ * in-memory database (via [SQLiteRepositoryTestBase]) since the acquire path uses SQLite-specific
+ * `datetime('now', '+N seconds')` / `ON CONFLICT ... DO UPDATE` / `julianday()` syntax that H2
+ * does not support.
+ */
+class SQLiteResourceLeaseRepositoryTest : SQLiteRepositoryTestBase() {
+    private lateinit var repository: ResourceLeaseRepository
+
+    @BeforeEach
+    fun setUp() {
+        repository = repositoryProvider.resourceLeaseRepository()
+    }
+
+    private suspend fun createHolder(title: String = "Holder"): UUID {
+        val result = repositoryProvider.workItemRepository().create(WorkItem(title = title))
+        assertIs<Result.Success<WorkItem>>(result)
+        return result.data.id
+    }
+
+    /** Backdates every lease row for (resourceKey, holderItemId) to an already-expired expires_at. */
+    private fun expireLease(
+        resourceKey: String,
+        holderItemId: UUID
+    ) {
+        transaction(db = database) {
+            val uuidType =
+                org.jetbrains.exposed.v1.core.java
+                    .UUIDColumnType()
+            val keyType =
+                org.jetbrains.exposed.v1.core
+                    .VarCharColumnType(255)
+            exec(
+                """
+                UPDATE resource_leases
+                   SET expires_at = datetime('now', '-10 seconds')
+                 WHERE resource_key = ? AND holder_item_id = ?
+                """.trimIndent(),
+                args = listOf(keyType to resourceKey, uuidType to holderItemId)
+            )
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Acquire — success cases
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `fresh acquire on an unheld key succeeds and sets all three timestamps`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+
+            val result = repository.acquireAll(holder, "agent-a", listOf("staging-db" to 900))
+
+            assertIs<LeaseAcquireResult.Success>(result)
+            assertEquals(1, result.leases.size)
+            val lease = result.leases.single()
+            assertEquals("staging-db", lease.resourceKey)
+            assertEquals(holder, lease.holderItemId)
+            assertEquals("agent-a", lease.acquiredByActorId)
+            assertTrue(lease.acquiredAt <= lease.expiresAt)
+            assertEquals(
+                lease.acquiredAt.epochSecond,
+                lease.originalAcquiredAt.epochSecond,
+                "originalAcquiredAt should equal acquiredAt on first acquire"
+            )
+        }
+
+    @Test
+    fun `acquiring multiple distinct keys in one call succeeds for all of them`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+
+            val result = repository.acquireAll(holder, "agent-a", listOf("key-a" to 900, "key-b" to 900, "key-c" to 900))
+
+            assertIs<LeaseAcquireResult.Success>(result)
+            assertEquals(setOf("key-a", "key-b", "key-c"), result.leases.map { it.resourceKey }.toSet())
+        }
+
+    @Test
+    fun `same-item re-acquire refreshes TTL but preserves originalAcquiredAt`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+
+            val first = repository.acquireAll(holder, "agent-a", listOf("staging-db" to 900))
+            assertIs<LeaseAcquireResult.Success>(first)
+            val firstOriginal = first.leases.single().originalAcquiredAt
+
+            Thread.sleep(1100)
+
+            val second = repository.acquireAll(holder, "agent-a", listOf("staging-db" to 1800))
+            assertIs<LeaseAcquireResult.Success>(second)
+            val secondLease = second.leases.single()
+
+            assertEquals(
+                firstOriginal.epochSecond,
+                secondLease.originalAcquiredAt.epochSecond,
+                "originalAcquiredAt must be preserved on re-acquire by the same holder"
+            )
+            assertTrue(
+                secondLease.expiresAt > first.leases.single().expiresAt,
+                "re-acquire should extend expiresAt"
+            )
+        }
+
+    // -----------------------------------------------------------------------
+    // Acquire — contention cases
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `different-item acquire on an actively held key returns Contended with positive retryAfterMs`(): Unit =
+        runBlocking {
+            val holderA = createHolder("Holder A")
+            val holderB = createHolder("Holder B")
+
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holderA, "agent-a", listOf("staging-db" to 900)))
+
+            val result = repository.acquireAll(holderB, "agent-b", listOf("staging-db" to 900))
+
+            assertIs<LeaseAcquireResult.Contended>(result)
+            assertEquals(listOf("staging-db"), result.contendedKeys)
+            assertTrue(result.retryAfterMs > 0, "retryAfterMs should be positive for an actively held lease")
+        }
+
+    @Test
+    fun `an expired lease is stealable by a different item`(): Unit =
+        runBlocking {
+            val holderA = createHolder("Holder A")
+            val holderB = createHolder("Holder B")
+
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holderA, "agent-a", listOf("staging-db" to 900)))
+            expireLease("staging-db", holderA)
+
+            val result = repository.acquireAll(holderB, "agent-b", listOf("staging-db" to 900))
+
+            assertIs<LeaseAcquireResult.Success>(result)
+            assertEquals(holderB, result.leases.single().holderItemId)
+        }
+
+    @Test
+    fun `all-or-nothing - one contended key among several blocks the whole batch and persists nothing`(): Unit =
+        runBlocking {
+            val holderA = createHolder("Holder A")
+            val holderB = createHolder("Holder B")
+
+            // Holder A holds "key-x"; "key-y" is free.
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holderA, "agent-a", listOf("key-x" to 900)))
+
+            val result = repository.acquireAll(holderB, "agent-b", listOf("key-y" to 900, "key-x" to 900))
+
+            assertIs<LeaseAcquireResult.Contended>(result)
+            assertEquals(listOf("key-x"), result.contendedKeys)
+
+            // Nothing must have been written for holder B — not even for the free "key-y".
+            val holderBLeases = repository.findActiveForItem(holderB)
+            assertTrue(holderBLeases.isEmpty(), "No partial rows may persist for holder B after a Contended result")
+
+            val keyYLeases = repository.findActiveByKeys(listOf("key-y"))
+            assertTrue(keyYLeases.isEmpty(), "key-y must remain unacquired after the all-or-nothing rollback")
+        }
+
+    // -----------------------------------------------------------------------
+    // Release
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `releaseAllForItem removes every lease held by that item and no others`(): Unit =
+        runBlocking {
+            val holderA = createHolder("Holder A")
+            val holderB = createHolder("Holder B")
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holderA, "agent-a", listOf("key-a" to 900, "key-b" to 900)))
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holderB, "agent-b", listOf("key-c" to 900)))
+
+            val result = repository.releaseAllForItem(holderA)
+
+            assertIs<LeaseReleaseResult.Success>(result)
+            assertEquals(2, result.releasedCount)
+            assertTrue(repository.findActiveForItem(holderA).isEmpty())
+            assertEquals(1, repository.findActiveForItem(holderB).size, "Holder B's lease must be untouched")
+        }
+
+    @Test
+    fun `forceReleaseByKey frees the key for the next acquire regardless of current holder`(): Unit =
+        runBlocking {
+            val holderA = createHolder("Holder A")
+            val holderB = createHolder("Holder B")
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holderA, "agent-a", listOf("staging-db" to 900)))
+
+            val released = repository.forceReleaseByKey("staging-db")
+            assertIs<LeaseReleaseResult.Success>(released)
+            assertEquals(1, released.releasedCount)
+
+            val result = repository.acquireAll(holderB, "agent-b", listOf("staging-db" to 900))
+            assertIs<LeaseAcquireResult.Success>(result)
+            assertEquals(holderB, result.leases.single().holderItemId)
+        }
+
+    // -----------------------------------------------------------------------
+    // Reads
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `findActiveByKeys excludes expired rows`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holder, "agent-a", listOf("staging-db" to 900)))
+            expireLease("staging-db", holder)
+
+            val active = repository.findActiveByKeys(listOf("staging-db"))
+            assertTrue(active.isEmpty(), "Expired leases must not be reported as active")
+        }
+
+    @Test
+    fun `findActiveForItem excludes expired rows`(): Unit =
+        runBlocking {
+            val holder = createHolder()
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holder, "agent-a", listOf("staging-db" to 900)))
+            expireLease("staging-db", holder)
+
+            assertTrue(repository.findActiveForItem(holder).isEmpty())
+        }
+
+    @Test
+    fun `findAllActive excludes expired rows across all holders`(): Unit =
+        runBlocking {
+            val holderA = createHolder("Holder A")
+            val holderB = createHolder("Holder B")
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holderA, "agent-a", listOf("key-a" to 900)))
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holderB, "agent-b", listOf("key-b" to 900)))
+            expireLease("key-a", holderA)
+
+            val active = repository.findAllActive()
+            assertEquals(1, active.size)
+            assertEquals("key-b", active.single().resourceKey)
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteRoleTransitionRepositoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteRoleTransitionRepositoryTest.kt
@@ -438,4 +438,63 @@ class SQLiteRoleTransitionRepositoryTest {
             assertEquals(VerificationStatus.VERIFIED, actorFound.verification.status)
             assertEquals("test-verifier", actorFound.verification.verifier)
         }
+
+    // --- consumedCredentials (V14) ---
+
+    @Test
+    fun `create transition with empty consumedCredentials round-trips to empty list, not null`() =
+        runBlocking {
+            val transition =
+                RoleTransition(
+                    itemId = testItemId,
+                    fromRole = "queue",
+                    toRole = "work",
+                    trigger = "start"
+                    // consumedCredentials defaults to emptyList()
+                )
+            transitionRepository.create(transition)
+
+            val result = transitionRepository.findByItemId(testItemId)
+            assertIs<Result.Success<List<RoleTransition>>>(result)
+            assertEquals(1, result.data.size)
+            assertTrue(result.data[0].consumedCredentials.isEmpty())
+        }
+
+    @Test
+    fun `create transition with multi-entry consumedCredentials round-trips in order`() =
+        runBlocking {
+            val refs = listOf("vault:prod-db-password", "github-pat-ci", "aws-role/deploy")
+            val transition =
+                RoleTransition(
+                    itemId = testItemId,
+                    fromRole = "work",
+                    toRole = "review",
+                    trigger = "complete",
+                    consumedCredentials = refs
+                )
+            transitionRepository.create(transition)
+
+            val result = transitionRepository.findByItemId(testItemId)
+            assertIs<Result.Success<List<RoleTransition>>>(result)
+            assertEquals(1, result.data.size)
+            assertEquals(refs, result.data[0].consumedCredentials)
+        }
+
+    @Test
+    fun `create transition with single-entry consumedCredentials round-trips`() =
+        runBlocking {
+            val transition =
+                RoleTransition(
+                    itemId = testItemId,
+                    fromRole = "queue",
+                    toRole = "work",
+                    trigger = "start",
+                    consumedCredentials = listOf("vault:prod-db-password")
+                )
+            transitionRepository.create(transition)
+
+            val result = transitionRepository.findByItemId(testItemId)
+            assertIs<Result.Success<List<RoleTransition>>>(result)
+            assertEquals(listOf("vault:prod-db-password"), result.data[0].consumedCredentials)
+        }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/AdvanceRouteResourceLeaseTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/AdvanceRouteResourceLeaseTest.kt
@@ -170,6 +170,20 @@ class AdvanceRouteResourceLeaseTest {
             val fake = LeaseGateFakeRepository()
             val item = h2.createTracedItem("Needs staging DB")
             fake.forceContended = listOf("staging-db-credential")
+            // Distinctive seeds so their absence in the serialized 409 body is unambiguous — mirrors
+            // AdvanceItemToolLeaseBlockedTest's disclosure assertion for the MCP surface.
+            val holderItemId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+            val holderActorId = "holder-actor-zzz999"
+            val now = Instant.now()
+            fake.leases +=
+                ResourceLease(
+                    resourceKey = "staging-db-credential",
+                    holderItemId = holderItemId,
+                    acquiredByActorId = holderActorId,
+                    acquiredAt = now,
+                    expiresAt = now.plusSeconds(600),
+                    originalAcquiredAt = now,
+                )
             application { configureLeaseTestApp(LeaseOverridingProvider(h2, fake)) }
 
             val response =
@@ -185,6 +199,8 @@ class AdvanceRouteResourceLeaseTest {
             val body = response.bodyAsText()
             assertTrue(body.contains("resource_unavailable"), "body: $body")
             assertTrue(body.contains("staging-db-credential"), "body: $body")
+            assertFalse(body.contains(holderItemId.toString()), "holder item id must never appear in a 409 body: $body")
+            assertFalse(body.contains(holderActorId), "holder actor id must never appear in a 409 body: $body")
 
             // Hard negative: the item did NOT advance.
             val persisted = runBlocking { h2.workItemRepository().getById(item.id) }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/AdvanceRouteResourceLeaseTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/AdvanceRouteResourceLeaseTest.kt
@@ -6,6 +6,7 @@ import io.github.jpicklyk.mcptask.current.application.service.WorkItemSchemaServ
 import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
 import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
 import io.github.jpicklyk.mcptask.current.domain.model.ResourceLease
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceLeaseInterval
 import io.github.jpicklyk.mcptask.current.domain.model.ResourceMode
 import io.github.jpicklyk.mcptask.current.domain.model.ResourceRequirement
 import io.github.jpicklyk.mcptask.current.domain.model.Role
@@ -54,6 +55,7 @@ import kotlin.test.assertTrue
  */
 private class LeaseGateFakeRepository : ResourceLeaseRepository {
     val leases = mutableListOf<ResourceLease>()
+    val intervals = mutableListOf<ResourceLeaseInterval>()
 
     /** When non-null, every acquire is forced to report these keys contended. */
     var forceContended: List<String>? = null
@@ -72,12 +74,46 @@ private class LeaseGateFakeRepository : ResourceLeaseRepository {
         val now = Instant.now()
         val acquired =
             requirements.map { (key, ttl) ->
+                val expiresAt = now.plusSeconds(ttl.toLong())
+                val ownRowExisted = leases.any { it.resourceKey == key && it.holderItemId == holderItemId }
+                if (ownRowExisted) {
+                    val openIdx =
+                        intervals.indexOfLast { it.resourceKey == key && it.holderItemId == holderItemId && it.releasedAt == null }
+                    if (openIdx >= 0) {
+                        intervals[openIdx] = intervals[openIdx].copy(expiresAt = expiresAt)
+                    } else {
+                        intervals +=
+                            ResourceLeaseInterval(
+                                resourceKey = key,
+                                holderItemId = holderItemId,
+                                acquiredByActorId = actorId,
+                                acquiredAt = now,
+                                expiresAt = expiresAt,
+                            )
+                    }
+                } else {
+                    intervals.replaceAll { iv ->
+                        if (iv.resourceKey == key && iv.holderItemId != holderItemId && iv.releasedAt == null) {
+                            iv.copy(releasedAt = iv.expiresAt, releaseReason = "expired")
+                        } else {
+                            iv
+                        }
+                    }
+                    intervals +=
+                        ResourceLeaseInterval(
+                            resourceKey = key,
+                            holderItemId = holderItemId,
+                            acquiredByActorId = actorId,
+                            acquiredAt = now,
+                            expiresAt = expiresAt,
+                        )
+                }
                 ResourceLease(
                     resourceKey = key,
                     holderItemId = holderItemId,
                     acquiredByActorId = actorId,
                     acquiredAt = now,
-                    expiresAt = now.plusSeconds(ttl.toLong()),
+                    expiresAt = expiresAt,
                     originalAcquiredAt = now,
                 )
             }
@@ -88,12 +124,31 @@ private class LeaseGateFakeRepository : ResourceLeaseRepository {
     override suspend fun releaseAllForItem(holderItemId: UUID): LeaseReleaseResult {
         val before = leases.size
         leases.removeAll { it.holderItemId == holderItemId }
+        val now = Instant.now()
+        intervals.replaceAll { iv ->
+            if (iv.holderItemId == holderItemId && iv.releasedAt == null) {
+                iv.copy(releasedAt = now, releaseReason = "released")
+            } else {
+                iv
+            }
+        }
         return LeaseReleaseResult.Success(before - leases.size)
     }
 
-    override suspend fun forceReleaseByKey(resourceKey: String): LeaseReleaseResult {
+    override suspend fun forceReleaseByKey(
+        resourceKey: String,
+        actorId: String?,
+    ): LeaseReleaseResult {
         val before = leases.size
         leases.removeAll { it.resourceKey == resourceKey }
+        val now = Instant.now()
+        intervals.replaceAll { iv ->
+            if (iv.resourceKey == resourceKey && iv.releasedAt == null) {
+                iv.copy(releasedAt = now, releaseReason = "force_released", releasedByActorId = actorId)
+            } else {
+                iv
+            }
+        }
         return LeaseReleaseResult.Success(before - leases.size)
     }
 
@@ -102,6 +157,26 @@ private class LeaseGateFakeRepository : ResourceLeaseRepository {
     override suspend fun findActiveForItem(holderItemId: UUID): List<ResourceLease> = leases.filter { it.holderItemId == holderItemId }
 
     override suspend fun findAllActive(): List<ResourceLease> = leases.toList()
+
+    override suspend fun findHoldersAt(
+        resourceKey: String?,
+        at: Instant,
+    ): List<ResourceLeaseInterval> =
+        intervals
+            .filter { iv ->
+                (resourceKey == null || iv.resourceKey == resourceKey) &&
+                    !at.isBefore(iv.acquiredAt) &&
+                    at.isBefore(iv.releasedAt ?: iv.expiresAt)
+            }.sortedByDescending { it.acquiredAt }
+
+    override suspend fun findRecentIntervals(
+        resourceKey: String?,
+        limit: Int,
+    ): List<ResourceLeaseInterval> =
+        intervals
+            .filter { resourceKey == null || it.resourceKey == resourceKey }
+            .sortedByDescending { it.acquiredAt }
+            .take(limit)
 }
 
 /** H2-backed provider with only [resourceLeaseRepository] swapped for the in-memory fake. */

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/AdvanceRouteResourceLeaseTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/AdvanceRouteResourceLeaseTest.kt
@@ -1,0 +1,345 @@
+package io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes
+
+import io.github.jpicklyk.mcptask.current.application.service.IdempotencyCache
+import io.github.jpicklyk.mcptask.current.application.service.NoOpStatusLabelService
+import io.github.jpicklyk.mcptask.current.application.service.WorkItemSchemaService
+import io.github.jpicklyk.mcptask.current.domain.model.DegradedModePolicy
+import io.github.jpicklyk.mcptask.current.domain.model.NoteSchemaEntry
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceLease
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceMode
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceRequirement
+import io.github.jpicklyk.mcptask.current.domain.model.Role
+import io.github.jpicklyk.mcptask.current.domain.model.WorkItem
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseAcquireResult
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseReleaseResult
+import io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository
+import io.github.jpicklyk.mcptask.current.domain.repository.Result
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.ApiBearerAuth
+import io.github.jpicklyk.mcptask.current.interfaces.api.v1.auth.BearerTokenStore
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import io.ktor.server.sse.SSE
+import io.ktor.server.testing.testApplication
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * REST enforcement-matrix tests for the resource-lease gate on `POST /items/{id}/advance`.
+ *
+ * Storage for leases is an in-memory fake, for the same reason [ResourceLeaseRoutesTest] uses one:
+ * the SQLite-dialect repository (`datetime('now')`) does not run on the H2 database these route
+ * tests use, and what is under test here is the route's enforcement/serialization behavior, not
+ * lease storage semantics.
+ */
+private class LeaseGateFakeRepository : ResourceLeaseRepository {
+    val leases = mutableListOf<ResourceLease>()
+
+    /** When non-null, every acquire is forced to report these keys contended. */
+    var forceContended: List<String>? = null
+
+    override suspend fun acquireAll(
+        holderItemId: UUID,
+        actorId: String?,
+        requirements: List<Pair<String, Int>>,
+    ): LeaseAcquireResult {
+        forceContended?.let { return LeaseAcquireResult.Contended(it, retryAfterMs = 30_000) }
+        val contended =
+            requirements
+                .map { it.first }
+                .filter { key -> leases.any { it.resourceKey == key && it.holderItemId != holderItemId } }
+        if (contended.isNotEmpty()) return LeaseAcquireResult.Contended(contended, retryAfterMs = 30_000)
+        val now = Instant.now()
+        val acquired =
+            requirements.map { (key, ttl) ->
+                ResourceLease(
+                    resourceKey = key,
+                    holderItemId = holderItemId,
+                    acquiredByActorId = actorId,
+                    acquiredAt = now,
+                    expiresAt = now.plusSeconds(ttl.toLong()),
+                    originalAcquiredAt = now,
+                )
+            }
+        leases += acquired
+        return LeaseAcquireResult.Success(acquired)
+    }
+
+    override suspend fun releaseAllForItem(holderItemId: UUID): LeaseReleaseResult {
+        val before = leases.size
+        leases.removeAll { it.holderItemId == holderItemId }
+        return LeaseReleaseResult.Success(before - leases.size)
+    }
+
+    override suspend fun forceReleaseByKey(resourceKey: String): LeaseReleaseResult {
+        val before = leases.size
+        leases.removeAll { it.resourceKey == resourceKey }
+        return LeaseReleaseResult.Success(before - leases.size)
+    }
+
+    override suspend fun findActiveByKeys(keys: List<String>): List<ResourceLease> = leases.filter { it.resourceKey in keys }
+
+    override suspend fun findActiveForItem(holderItemId: UUID): List<ResourceLease> = leases.filter { it.holderItemId == holderItemId }
+
+    override suspend fun findAllActive(): List<ResourceLease> = leases.toList()
+}
+
+/** H2-backed provider with only [resourceLeaseRepository] swapped for the in-memory fake. */
+private class LeaseOverridingProvider(
+    private val delegate: RepositoryProvider,
+    private val fake: ResourceLeaseRepository,
+) : RepositoryProvider by delegate {
+    override fun resourceLeaseRepository(): ResourceLeaseRepository = fake
+}
+
+/** Maps the `needs-staging-db` trait onto one exclusive resource with a 600s TTL. */
+private class LeaseTraitSchemaService : WorkItemSchemaService {
+    override fun getSchemaForTags(tags: List<String>): List<NoteSchemaEntry>? = null
+
+    override fun getTraitResources(traitName: String): List<ResourceRequirement> =
+        if (traitName == "needs-staging-db") {
+            listOf(ResourceRequirement("staging-db-credential", ResourceMode.EXCLUSIVE, 600))
+        } else {
+            emptyList()
+        }
+}
+
+private fun Application.configureLeaseTestApp(provider: RepositoryProvider) {
+    install(ContentNegotiation) { json(McpJson) }
+    install(SSE)
+    val authConfig = makeWriteAuthConfig()
+    routing {
+        route("/api/v1") {
+            install(ApiBearerAuth) {
+                this.authConfig = authConfig
+                tokenEntries =
+                    authConfig.tokens.mapValues { (_, p) ->
+                        BearerTokenStore.TokenEntry(p, expiresAt = null)
+                    }
+            }
+            itemWriteRoutes(
+                provider,
+                DegradedModePolicy.ACCEPT_CACHED,
+                IdempotencyCache(),
+                LeaseTraitSchemaService(),
+                statusLabelService = NoOpStatusLabelService,
+            )
+        }
+    }
+}
+
+/** Creates a queued item carrying the resource-declaring trait. */
+private fun DefaultRepositoryProvider.createTracedItem(title: String): WorkItem =
+    runBlocking {
+        workItemRepository()
+            .create(
+                WorkItem(
+                    title = title,
+                    role = Role.QUEUE,
+                    depth = 0,
+                    properties = """{"traits":["needs-staging-db"]}""",
+                ),
+            ).getOrNull()!!
+    }
+
+class AdvanceRouteResourceLeaseTest {
+    @Test
+    fun `contended resource returns 409 with Retry-After and the contended keys`(): Unit =
+        testApplication {
+            val h2 = buildH2RepositoryProvider()
+            val fake = LeaseGateFakeRepository()
+            val item = h2.createTracedItem("Needs staging DB")
+            fake.forceContended = listOf("staging-db-credential")
+            application { configureLeaseTestApp(LeaseOverridingProvider(h2, fake)) }
+
+            val response =
+                client.post("/api/v1/items/${item.id}/advance") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"trigger":"start"}""")
+                }
+
+            assertEquals(HttpStatusCode.Conflict, response.status)
+            // 30_000ms rounds UP to 30s — a client must never retry before the lease can expire.
+            assertEquals("30", response.headers[HttpHeaders.RetryAfter])
+            val body = response.bodyAsText()
+            assertTrue(body.contains("resource_unavailable"), "body: $body")
+            assertTrue(body.contains("staging-db-credential"), "body: $body")
+
+            // Hard negative: the item did NOT advance.
+            val persisted = runBlocking { h2.workItemRepository().getById(item.id) }
+            assertEquals(Role.QUEUE, (persisted as Result.Success).data.role)
+        }
+
+    @Test
+    fun `an uncontended advance acquires the lease and succeeds`(): Unit =
+        testApplication {
+            val h2 = buildH2RepositoryProvider()
+            val fake = LeaseGateFakeRepository()
+            val item = h2.createTracedItem("Needs staging DB")
+            application { configureLeaseTestApp(LeaseOverridingProvider(h2, fake)) }
+
+            val response =
+                client.post("/api/v1/items/${item.id}/advance") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"trigger":"start"}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(1, fake.leases.size)
+            assertEquals("staging-db-credential", fake.leases.single().resourceKey)
+            assertEquals(item.id, fake.leases.single().holderItemId)
+        }
+
+    @Test
+    fun `leaving the work phase releases the lease`(): Unit =
+        testApplication {
+            val h2 = buildH2RepositoryProvider()
+            val fake = LeaseGateFakeRepository()
+            val item = h2.createTracedItem("Needs staging DB")
+            application { configureLeaseTestApp(LeaseOverridingProvider(h2, fake)) }
+
+            val started =
+                client.post("/api/v1/items/${item.id}/advance") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"trigger":"start"}""")
+                }
+            assertEquals(HttpStatusCode.OK, started.status)
+            assertEquals(1, fake.leases.size)
+
+            val completed =
+                client.post("/api/v1/items/${item.id}/advance") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"trigger":"complete"}""")
+                }
+            assertEquals(HttpStatusCode.OK, completed.status)
+            assertTrue(fake.leases.isEmpty(), "leases must be released on exit from the work phase")
+        }
+
+    // ──────────────────────────────────────────────
+    // overrideResourceLeases — the ADMIN-only escape hatch
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `overrideResourceLeases from a non-admin principal is rejected with 403`(): Unit =
+        testApplication {
+            val h2 = buildH2RepositoryProvider()
+            val fake = LeaseGateFakeRepository()
+            val item = h2.createTracedItem("Needs staging DB")
+            fake.forceContended = listOf("staging-db-credential")
+            application { configureLeaseTestApp(LeaseOverridingProvider(h2, fake)) }
+
+            val response =
+                client.post("/api/v1/items/${item.id}/advance") {
+                    // WRITE_TOKEN holds ADVANCE but NOT ADMIN.
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"trigger":"start","overrideResourceLeases":true}""")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+            assertTrue(response.bodyAsText().contains("insufficient_capability"), response.bodyAsText())
+
+            // The flag must never be silently ignored — the item stays put.
+            val persisted = runBlocking { h2.workItemRepository().getById(item.id) }
+            assertEquals(Role.QUEUE, (persisted as Result.Success).data.role)
+        }
+
+    @Test
+    fun `overrideResourceLeases from an ADMIN principal proceeds past contention and is audited`(): Unit =
+        testApplication {
+            val h2 = buildH2RepositoryProvider()
+            val fake = LeaseGateFakeRepository()
+            val item = h2.createTracedItem("Needs staging DB")
+            fake.forceContended = listOf("staging-db-credential")
+            application { configureLeaseTestApp(LeaseOverridingProvider(h2, fake)) }
+
+            val response =
+                client.post("/api/v1/items/${item.id}/advance") {
+                    header("Authorization", "Bearer $ADMIN_TOKEN")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"trigger":"start","overrideResourceLeases":true}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val persisted = runBlocking { h2.workItemRepository().getById(item.id) }
+            assertEquals(Role.WORK, (persisted as Result.Success).data.role)
+            // No lease was taken — the gate was skipped, not satisfied.
+            assertTrue(fake.leases.isEmpty())
+
+            // The durable audit row records the override alongside the WARN log line.
+            val transitions =
+                runBlocking { h2.roleTransitionRepository().findByItemId(item.id) }
+                    .let { (it as Result.Success).data }
+            val summary = transitions.firstNotNullOfOrNull { it.summary }
+            assertNotNull(summary, "the override must be recorded on the transition audit row")
+            assertTrue(summary.contains("resource leases overridden"), "summary was: $summary")
+        }
+
+    @Test
+    fun `omitting overrideResourceLeases keeps the gate enforced for an ADMIN principal`(): Unit =
+        testApplication {
+            val h2 = buildH2RepositoryProvider()
+            val fake = LeaseGateFakeRepository()
+            val item = h2.createTracedItem("Needs staging DB")
+            fake.forceContended = listOf("staging-db-credential")
+            application { configureLeaseTestApp(LeaseOverridingProvider(h2, fake)) }
+
+            val response =
+                client.post("/api/v1/items/${item.id}/advance") {
+                    header("Authorization", "Bearer $ADMIN_TOKEN")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"trigger":"start"}""")
+                }
+
+            // Admin authority alone does NOT waive the resource gate — it takes the explicit flag.
+            assertEquals(HttpStatusCode.Conflict, response.status)
+        }
+
+    @Test
+    fun `an item declaring no resources is unaffected by the gate`(): Unit =
+        testApplication {
+            val h2 = buildH2RepositoryProvider()
+            val fake = LeaseGateFakeRepository()
+            val item =
+                runBlocking {
+                    h2.workItemRepository().create(WorkItem(title = "Plain", depth = 0)).getOrNull()!!
+                }
+            fake.forceContended = listOf("staging-db-credential")
+            application { configureLeaseTestApp(LeaseOverridingProvider(h2, fake)) }
+
+            val response =
+                client.post("/api/v1/items/${item.id}/advance") {
+                    header("Authorization", "Bearer $WRITE_TOKEN")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"trigger":"start"}""")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertFalse(response.bodyAsText().contains("resource_unavailable"))
+            assertTrue(fake.leases.isEmpty())
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ResourceLeaseRoutesTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ResourceLeaseRoutesTest.kt
@@ -1,6 +1,7 @@
 package io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes
 
 import io.github.jpicklyk.mcptask.current.domain.model.ResourceLease
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceLeaseInterval
 import io.github.jpicklyk.mcptask.current.domain.repository.LeaseAcquireResult
 import io.github.jpicklyk.mcptask.current.domain.repository.LeaseReleaseResult
 import io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -32,6 +34,12 @@ import kotlin.test.assertTrue
 private class FakeResourceLeaseRepository : ResourceLeaseRepository {
     val leases = mutableListOf<ResourceLease>()
 
+    /**
+     * Mirrors (a simplified version of) `SQLiteResourceLeaseRepository`'s interval bookkeeping,
+     * for the `/resources/leases/history` route tests.
+     */
+    val intervals = mutableListOf<ResourceLeaseInterval>()
+
     override suspend fun acquireAll(
         holderItemId: UUID,
         actorId: String?,
@@ -45,12 +53,46 @@ private class FakeResourceLeaseRepository : ResourceLeaseRepository {
         val now = Instant.now()
         val acquired =
             requirements.map { (key, ttl) ->
+                val expiresAt = now.plusSeconds(ttl.toLong())
+                val ownRowExisted = leases.any { it.resourceKey == key && it.holderItemId == holderItemId }
+                if (ownRowExisted) {
+                    val openIdx =
+                        intervals.indexOfLast { it.resourceKey == key && it.holderItemId == holderItemId && it.releasedAt == null }
+                    if (openIdx >= 0) {
+                        intervals[openIdx] = intervals[openIdx].copy(expiresAt = expiresAt)
+                    } else {
+                        intervals +=
+                            ResourceLeaseInterval(
+                                resourceKey = key,
+                                holderItemId = holderItemId,
+                                acquiredByActorId = actorId,
+                                acquiredAt = now,
+                                expiresAt = expiresAt,
+                            )
+                    }
+                } else {
+                    intervals.replaceAll { iv ->
+                        if (iv.resourceKey == key && iv.holderItemId != holderItemId && iv.releasedAt == null) {
+                            iv.copy(releasedAt = iv.expiresAt, releaseReason = "expired")
+                        } else {
+                            iv
+                        }
+                    }
+                    intervals +=
+                        ResourceLeaseInterval(
+                            resourceKey = key,
+                            holderItemId = holderItemId,
+                            acquiredByActorId = actorId,
+                            acquiredAt = now,
+                            expiresAt = expiresAt,
+                        )
+                }
                 ResourceLease(
                     resourceKey = key,
                     holderItemId = holderItemId,
                     acquiredByActorId = actorId,
                     acquiredAt = now,
-                    expiresAt = now.plusSeconds(ttl.toLong()),
+                    expiresAt = expiresAt,
                     originalAcquiredAt = now,
                 )
             }
@@ -61,12 +103,31 @@ private class FakeResourceLeaseRepository : ResourceLeaseRepository {
     override suspend fun releaseAllForItem(holderItemId: UUID): LeaseReleaseResult {
         val before = leases.size
         leases.removeAll { it.holderItemId == holderItemId }
+        val now = Instant.now()
+        intervals.replaceAll { iv ->
+            if (iv.holderItemId == holderItemId && iv.releasedAt == null) {
+                iv.copy(releasedAt = now, releaseReason = "released")
+            } else {
+                iv
+            }
+        }
         return LeaseReleaseResult.Success(before - leases.size)
     }
 
-    override suspend fun forceReleaseByKey(resourceKey: String): LeaseReleaseResult {
+    override suspend fun forceReleaseByKey(
+        resourceKey: String,
+        actorId: String?,
+    ): LeaseReleaseResult {
         val before = leases.size
         leases.removeAll { it.resourceKey == resourceKey }
+        val now = Instant.now()
+        intervals.replaceAll { iv ->
+            if (iv.resourceKey == resourceKey && iv.releasedAt == null) {
+                iv.copy(releasedAt = now, releaseReason = "force_released", releasedByActorId = actorId)
+            } else {
+                iv
+            }
+        }
         return LeaseReleaseResult.Success(before - leases.size)
     }
 
@@ -75,6 +136,26 @@ private class FakeResourceLeaseRepository : ResourceLeaseRepository {
     override suspend fun findActiveForItem(holderItemId: UUID): List<ResourceLease> = leases.filter { it.holderItemId == holderItemId }
 
     override suspend fun findAllActive(): List<ResourceLease> = leases.toList()
+
+    override suspend fun findHoldersAt(
+        resourceKey: String?,
+        at: Instant,
+    ): List<ResourceLeaseInterval> =
+        intervals
+            .filter { iv ->
+                (resourceKey == null || iv.resourceKey == resourceKey) &&
+                    !at.isBefore(iv.acquiredAt) &&
+                    at.isBefore(iv.releasedAt ?: iv.expiresAt)
+            }.sortedByDescending { it.acquiredAt }
+
+    override suspend fun findRecentIntervals(
+        resourceKey: String?,
+        limit: Int,
+    ): List<ResourceLeaseInterval> =
+        intervals
+            .filter { resourceKey == null || it.resourceKey == resourceKey }
+            .sortedByDescending { it.acquiredAt }
+            .take(limit)
 }
 
 private fun leaseTestProvider(fake: FakeResourceLeaseRepository): RepositoryProvider {
@@ -231,5 +312,206 @@ class ResourceLeaseDeleteRouteTest {
                 }
 
             assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+}
+
+class ResourceLeaseHistoryRouteTest {
+    @Test
+    fun `GET resources leases history with READ token returns 200 without actor fields`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            fake.seedLease(actorId = "agent-77")
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val response =
+                client.get("/api/v1/resources/leases/history") {
+                    header("Authorization", "Bearer $TEST_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("db-migration-lock"))
+            assertTrue(
+                !body.contains("agent-77") && !body.contains("\"acquiredByActorId\""),
+                "non-admin caller must not see acquiredByActorId, got: $body",
+            )
+        }
+
+    @Test
+    fun `GET resources leases history with ADMIN token returns 200 including actor fields`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            fake.seedLease(actorId = "agent-77")
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val response =
+                client.get("/api/v1/resources/leases/history") {
+                    header("Authorization", "Bearer $ADMIN_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("\"acquiredByActorId\":\"agent-77\""), "admin caller must see acquiredByActorId, got: $body")
+        }
+
+    @Test
+    fun `GET resources leases history without any token returns 401`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val response = client.get("/api/v1/resources/leases/history")
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+    @Test
+    fun `GET resources leases history with an invalid at value returns 400`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val response =
+                client.get("/api/v1/resources/leases/history?at=not-a-timestamp") {
+                    header("Authorization", "Bearer $ADMIN_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Test
+    fun `GET resources leases history with an invalid key returns 400`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val response =
+                client.get("/api/v1/resources/leases/history?key=Invalid_Key!") {
+                    header("Authorization", "Bearer $ADMIN_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Test
+    fun `GET resources leases history with an at filter returns only intervals held at that instant`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            val now = Instant.now()
+            val holderA = UUID.randomUUID()
+            val holderB = UUID.randomUUID()
+            // A: held from now-3600s to now-1800s (closed, released).
+            fake.intervals +=
+                ResourceLeaseInterval(
+                    resourceKey = "staging-db",
+                    holderItemId = holderA,
+                    acquiredAt = now.minusSeconds(3600),
+                    expiresAt = now.minusSeconds(1200),
+                    releasedAt = now.minusSeconds(1800),
+                    releaseReason = "released",
+                )
+            // B: held from now-900s onward, still open.
+            fake.intervals +=
+                ResourceLeaseInterval(
+                    resourceKey = "staging-db",
+                    holderItemId = holderB,
+                    acquiredAt = now.minusSeconds(900),
+                    expiresAt = now.plusSeconds(900),
+                )
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val at = now.minusSeconds(2400) // inside A's held window, before B even acquired
+            val response =
+                client.get("/api/v1/resources/leases/history?at=$at") {
+                    header("Authorization", "Bearer $ADMIN_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains(holderA.toString()), "holder A should be reported held at $at, body: $body")
+            assertFalse(body.contains(holderB.toString()), "holder B must not be reported held at $at, body: $body")
+        }
+
+    @Test
+    fun `GET resources leases history without at returns recent intervals newest-first`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            val now = Instant.now()
+            val older = UUID.randomUUID()
+            val newer = UUID.randomUUID()
+            fake.intervals +=
+                ResourceLeaseInterval(
+                    resourceKey = "staging-db",
+                    holderItemId = older,
+                    acquiredAt = now.minusSeconds(600),
+                    expiresAt = now.plusSeconds(600),
+                )
+            fake.intervals +=
+                ResourceLeaseInterval(
+                    resourceKey = "staging-db",
+                    holderItemId = newer,
+                    acquiredAt = now.minusSeconds(60),
+                    expiresAt = now.plusSeconds(600),
+                )
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val response =
+                client.get("/api/v1/resources/leases/history?limit=1") {
+                    header("Authorization", "Bearer $ADMIN_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains(newer.toString()), "the single most-recent interval must be returned, body: $body")
+            assertFalse(body.contains(older.toString()), "limit=1 must exclude the older interval, body: $body")
+        }
+
+    @Test
+    fun `GET resources leases history clamps limit=0 up to the minimum of 1`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            val now = Instant.now()
+            val older = UUID.randomUUID()
+            val newer = UUID.randomUUID()
+            fake.intervals +=
+                ResourceLeaseInterval(
+                    resourceKey = "staging-db",
+                    holderItemId = older,
+                    acquiredAt = now.minusSeconds(600),
+                    expiresAt = now.plusSeconds(600),
+                )
+            fake.intervals +=
+                ResourceLeaseInterval(
+                    resourceKey = "staging-db",
+                    holderItemId = newer,
+                    acquiredAt = now.minusSeconds(60),
+                    expiresAt = now.plusSeconds(600),
+                )
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val response =
+                client.get("/api/v1/resources/leases/history?limit=0") {
+                    header("Authorization", "Bearer $ADMIN_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains(newer.toString()))
+            assertFalse(body.contains(older.toString()), "limit=0 must clamp to 1, not 0/unlimited, body: $body")
+        }
+
+    @Test
+    fun `GET resources leases history accepts a limit far above the max without erroring`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            fake.seedLease()
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val response =
+                client.get("/api/v1/resources/leases/history?limit=99999") {
+                    header("Authorization", "Bearer $ADMIN_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
         }
 }

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ResourceLeaseRoutesTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/interfaces/api/v1/routes/ResourceLeaseRoutesTest.kt
@@ -1,0 +1,235 @@
+package io.github.jpicklyk.mcptask.current.interfaces.api.v1.routes
+
+import io.github.jpicklyk.mcptask.current.domain.model.ResourceLease
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseAcquireResult
+import io.github.jpicklyk.mcptask.current.domain.repository.LeaseReleaseResult
+import io.github.jpicklyk.mcptask.current.domain.repository.ResourceLeaseRepository
+import io.github.jpicklyk.mcptask.current.infrastructure.repository.RepositoryProvider
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Exercises the REST `GET /api/v1/resources/leases` and `DELETE /api/v1/resources/leases/{key}`
+ * routes registered by [resourceLeaseRoutes]. Reuses [TEST_TOKEN] (read-only) / [ADMIN_TOKEN] from
+ * [ApiTestHelper] — same conventions as [PlanDocumentRoutesTest] / [ProjectConfigRoutesTest].
+ *
+ * Storage is an in-memory [FakeResourceLeaseRepository] rather than the SQLite-backed
+ * implementation: the real repository's raw SQL is SQLite-dialect (`datetime('now')`) and does not
+ * run on the H2 database these route tests use, and route tests assert auth/serialization
+ * behavior, not storage semantics (those are covered by `SQLiteResourceLeaseRepositoryTest`).
+ */
+private class FakeResourceLeaseRepository : ResourceLeaseRepository {
+    val leases = mutableListOf<ResourceLease>()
+
+    override suspend fun acquireAll(
+        holderItemId: UUID,
+        actorId: String?,
+        requirements: List<Pair<String, Int>>,
+    ): LeaseAcquireResult {
+        val contended =
+            requirements
+                .map { it.first }
+                .filter { key -> leases.any { it.resourceKey == key && it.holderItemId != holderItemId } }
+        if (contended.isNotEmpty()) return LeaseAcquireResult.Contended(contended, retryAfterMs = 1000)
+        val now = Instant.now()
+        val acquired =
+            requirements.map { (key, ttl) ->
+                ResourceLease(
+                    resourceKey = key,
+                    holderItemId = holderItemId,
+                    acquiredByActorId = actorId,
+                    acquiredAt = now,
+                    expiresAt = now.plusSeconds(ttl.toLong()),
+                    originalAcquiredAt = now,
+                )
+            }
+        leases += acquired
+        return LeaseAcquireResult.Success(acquired)
+    }
+
+    override suspend fun releaseAllForItem(holderItemId: UUID): LeaseReleaseResult {
+        val before = leases.size
+        leases.removeAll { it.holderItemId == holderItemId }
+        return LeaseReleaseResult.Success(before - leases.size)
+    }
+
+    override suspend fun forceReleaseByKey(resourceKey: String): LeaseReleaseResult {
+        val before = leases.size
+        leases.removeAll { it.resourceKey == resourceKey }
+        return LeaseReleaseResult.Success(before - leases.size)
+    }
+
+    override suspend fun findActiveByKeys(keys: List<String>): List<ResourceLease> = leases.filter { it.resourceKey in keys }
+
+    override suspend fun findActiveForItem(holderItemId: UUID): List<ResourceLease> = leases.filter { it.holderItemId == holderItemId }
+
+    override suspend fun findAllActive(): List<ResourceLease> = leases.toList()
+}
+
+private fun leaseTestProvider(fake: FakeResourceLeaseRepository): RepositoryProvider {
+    val provider = mockk<RepositoryProvider>()
+    every { provider.resourceLeaseRepository() } returns fake
+    return provider
+}
+
+private fun FakeResourceLeaseRepository.seedLease(
+    resourceKey: String = "db-migration-lock",
+    actorId: String? = "agent-99",
+    holderItemId: UUID = UUID.randomUUID(),
+): UUID {
+    val result = runBlocking { acquireAll(holderItemId, actorId, listOf(resourceKey to 300)) }
+    check(result is LeaseAcquireResult.Success) { "Failed to seed lease: $result" }
+    return holderItemId
+}
+
+class ResourceLeaseGetRouteTest {
+    @Test
+    fun `GET resources leases with READ token returns 200 without acquiredByActorId`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            fake.seedLease(actorId = "agent-99")
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val response =
+                client.get("/api/v1/resources/leases") {
+                    header("Authorization", "Bearer $TEST_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("db-migration-lock"))
+            assertTrue(
+                !body.contains("agent-99") && !body.contains("\"acquiredByActorId\""),
+                "non-admin caller must not see acquiredByActorId, got: $body",
+            )
+        }
+
+    @Test
+    fun `GET resources leases with ADMIN token returns 200 including acquiredByActorId`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            fake.seedLease(actorId = "agent-99")
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val response =
+                client.get("/api/v1/resources/leases") {
+                    header("Authorization", "Bearer $ADMIN_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("\"acquiredByActorId\":\"agent-99\""), "admin caller must see acquiredByActorId, got: $body")
+        }
+
+    @Test
+    fun `GET resources leases without any token returns 401`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val response = client.get("/api/v1/resources/leases")
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+}
+
+class ResourceLeaseDeleteRouteTest {
+    @Test
+    fun `DELETE resources leases key with READ-only token returns 403`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            fake.seedLease()
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val response =
+                client.delete("/api/v1/resources/leases/db-migration-lock") {
+                    header("Authorization", "Bearer $TEST_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.Forbidden, response.status)
+            val remaining = runBlocking { fake.findActiveByKeys(listOf("db-migration-lock")) }
+            assertTrue(remaining.isNotEmpty(), "READ-only caller must not be able to force-release a lease")
+        }
+
+    @Test
+    fun `DELETE resources leases key with ADMIN token on an active lease returns 200 and releases it`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            fake.seedLease()
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val response =
+                client.delete("/api/v1/resources/leases/db-migration-lock") {
+                    header("Authorization", "Bearer $ADMIN_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("\"resourceKey\":\"db-migration-lock\""))
+            assertTrue(body.contains("\"releasedCount\":1"))
+
+            val remaining = runBlocking { fake.findActiveByKeys(listOf("db-migration-lock")) }
+            assertTrue(remaining.isEmpty(), "lease must be gone after force-release")
+
+            // Verify re-acquire-ability: the key must now be free for a fresh acquire by a new holder.
+            val reacquired =
+                runBlocking {
+                    fake.acquireAll(UUID.randomUUID(), "agent-2", listOf("db-migration-lock" to 60))
+                }
+            assertTrue(reacquired is LeaseAcquireResult.Success, "key must be immediately re-acquirable after force-release")
+        }
+
+    @Test
+    fun `DELETE resources leases key for an unknown key returns 404`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val response =
+                client.delete("/api/v1/resources/leases/no-such-key") {
+                    header("Authorization", "Bearer $ADMIN_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun `DELETE resources leases key with an invalid key format returns 400`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val response =
+                client.delete("/api/v1/resources/leases/Invalid_Key!") {
+                    header("Authorization", "Bearer $ADMIN_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+    @Test
+    fun `DELETE resources leases key exceeding max length returns 400`(): Unit =
+        io.ktor.server.testing.testApplication {
+            val fake = FakeResourceLeaseRepository()
+            application { configureTestApp(routeBlock = { resourceLeaseRoutes(leaseTestProvider(fake)) }) }
+
+            val tooLong = "a".repeat(129)
+            val response =
+                client.delete("/api/v1/resources/leases/$tooLong") {
+                    header("Authorization", "Bearer $ADMIN_TOKEN")
+                }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+}

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/test/SQLiteRepositoryTestBase.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/test/SQLiteRepositoryTestBase.kt
@@ -3,6 +3,7 @@ package io.github.jpicklyk.mcptask.current.test
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.DependenciesTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.NotesTable
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ResourceLeaseHistoryTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ResourceLeasesTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.RoleTransitionsTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.WorkItemsTable
@@ -60,6 +61,7 @@ abstract class SQLiteRepositoryTestBase {
                 DependenciesTable,
                 RoleTransitionsTable,
                 ResourceLeasesTable,
+                ResourceLeaseHistoryTable,
             )
         }
 

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/test/SQLiteRepositoryTestBase.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/test/SQLiteRepositoryTestBase.kt
@@ -3,6 +3,7 @@ package io.github.jpicklyk.mcptask.current.test
 import io.github.jpicklyk.mcptask.current.infrastructure.database.DatabaseManager
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.DependenciesTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.NotesTable
+import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.ResourceLeasesTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.RoleTransitionsTable
 import io.github.jpicklyk.mcptask.current.infrastructure.database.schema.WorkItemsTable
 import io.github.jpicklyk.mcptask.current.infrastructure.repository.DefaultRepositoryProvider
@@ -58,6 +59,7 @@ abstract class SQLiteRepositoryTestBase {
                 NotesTable,
                 DependenciesTable,
                 RoleTransitionsTable,
+                ResourceLeasesTable,
             )
         }
 


### PR DESCRIPTION
Implements resource/credential leasing (#261): work items can declare shared external resources (credentials, single-occupancy environments, activity mutexes) via a `resources:` dimension on traits, and the server enforces TTL-based leases at the work-phase-entry gate. Closes the "which agent is acting as this principal right now" blind spot raised in discussion #97.

## What's in here (three rungs, independently reviewable commits)

**Rung 1 — consumed-credential audit field**
- `V14`: `role_transitions.consumed_credentials` (JSON array, nullable)
- Optional `credentialRefs` on `advance_item` transitions (MCP + REST), validated (≤8 entries, ≤128 chars, `^[a-z0-9][a-z0-9\-_./]*$` — blocks secret-material paste by construction), surfaced on `RoleTransitionDto`

**Rung 2 — lease namespace**
- `V15`: `resource_leases` — **item-keyed exclusivity** (`holder_item_id` is the subject; actor id is audit metadata only, so the guarantee is independent of identity quality), **semaphore-ready storage** (`UNIQUE(resource_key, holder_item_id)` + count-guard admission; `maxHolders` parsed, `>1` rejected in v1)
- `ResourceLeaseRepository`: all-or-nothing sorted `acquireAll` (deadlock-free by construction), lazy TTL expiry, no cross-row sweep — an agent can hold a work-item claim AND resource leases simultaneously (the gap #261 called out)

**Rung 3 — declaration + gate**
- Trait `resources:` (short/long form; `mode: exclusive | advisory` — advisory is audit-only, no lock), optional top-level `resources:` registry (per-root pushable, global-wins on key collision — the lock namespace is server-wide)
- `AdvanceService` step 4.5: acquiring the gate — transitions entering WORK (start *and* resume) atomically acquire all exclusive resources; contention is **transient-shaped** (`resource_unavailable` + `retryAfterMs` + `contendedResources`, holder never disclosed in contention responses); leases release on every WORK exit including cascades and `complete_tree`
- Enforcement matrix: MCP always; REST enforces by default (independent of the claim-ownership bypass); ADMIN `overrideResourceLeases` escape hatch; `RESOURCE_LEASES_ENFORCED` env kill switch
- Diagnostics: `get_context` item-mode `resourceLeases` block (the sanctioned holder-identity surface), `GET /api/v1/resources/leases`, ADMIN `DELETE /api/v1/resources/leases/{key}` force-release for crash recovery

## Review process

Every task was implemented and independently reviewed by separate agents (api-compatibility ×5, security-assessment ×4, plugin-impact ×2, migration-assessment ×2, performance-baseline). The adversarial review of the gate integration found and fixed a real liveness leak (`complete_tree` orphaning leases until TTL) plus disclosure/doc-accuracy issues. Deferred non-blocking findings are tracked internally (snapshot fan-out optimization, REST cascade-event parity, apply-fail compensating release).

## Guarantees (documented in workflow-guide.md)

At most one work item admitted per resource key at any moment, across agents/projects/surfaces, independent of actor identity. Explicit non-guarantees documented honestly: entry-time precondition (not a continuous invariant), no fairness/queueing, crash recovery = TTL remainder or ADMIN force-release, keys are opaque labels never secret values.

## Testing

~90 new tests: real-thread concurrency races (single winner), claim+lease coexistence regressions, all-or-nothing rollback, disclosure regressions (seeded distinctive identifiers asserted absent from full serialized responses), migration fresh+upgrade paths, Direct/Flyway drift parity, full enforcement-matrix coverage. Full suite green; zero behavior change for deployments without `resources:` config (empty-declaration short-circuit pays zero lease queries).

Refs #261. Design discussion: #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
