### PR TITLE
docs: state the one-actor-per-item modelling assumption for leases and claims

### DIFF
--- a/current/docs/fleet-deployment.md
+++ b/current/docs/fleet-deployment.md
@@ -551,6 +551,18 @@ docker run --rm -i \
 
 SQLite is a single-writer database backed by a file on a single host. Understanding this constraint is essential for fleet sizing.
 
+### Item Granularity — One Concurrent Actor Per Item
+
+Before sizing the fleet, size the *items*. Both the claim mechanism and resource leasing assume
+**one concurrent actor per work item**: claims bind one actor to an item, and resource leases are
+item-keyed — two sessions working inside the same item share its lease and its claim, and the
+server cannot detect the interference (it arbitrates transitions, not actions). Field pattern to
+avoid: modelling "one conceptual task" as one item while multiple sessions (a watcher and an
+extractor, say) operate inside it — the lease holds, and the sessions still collide on the shared
+browser tab / compose window / rate budget underneath. Cut items at actor granularity: if two
+sessions run concurrently, give each its own item (children of a shared parent work well), let
+each claim its own item, and declare the shared resource on both so the lease serializes them.
+
 ### Write Rate Estimates
 
 | Activity | Write rate estimate |

--- a/current/docs/workflow-guide.md
+++ b/current/docs/workflow-guide.md
@@ -1150,6 +1150,15 @@ invariant, and not fairness. Read this section before relying on it for anything
   lease — there is no per-actor "only the acquiring actor can release" check. This is a deliberate
   simplification, not an oversight: the exclusivity guarantee above is about the item, not about who
   is allowed to touch it.
+- **One item = one concurrent actor is an assumed modelling obligation.** Item-keyed exclusivity
+  arbitrates between *items*, not between actors working inside the same item — two sessions
+  operating under one work item share its lease, and the schema cannot detect that violation (the
+  server sees transitions, not actions). Identity still matters, one level up, in how you cut
+  items: model concurrent actors as separate work items at actor granularity. In fleet
+  deployments, `claim_item` is the opt-in enforcement of exactly this assumption — it binds one
+  verified actor to an item with a TTL, and an agent can hold its item claim and the item's
+  resource leases simultaneously by design. The release-side corollary of the same assumption:
+  any actor's work-exit transition on the shared item releases the lease for all of them.
 - **The kill switch is read per request, not once at startup.** `RESOURCE_LEASES_ENFORCED=false`
   disables acquisition (releases still always run) — and because the pipeline is constructed fresh
   per `advance_item`/`POST .../advance` call, flipping this env var takes effect on the **next


### PR DESCRIPTION
One sentence-level gap surfaced by field feedback on #262: item-keyed exclusivity relocates the guarantee's burden onto item granularity — two actors inside one item share its lease and nothing in the schema can detect it. States the assumption in the workflow-guide guarantees section (next to 'identity governs early release, not exclusion', where the over-reading happens) and adds an item-granularity subsection to fleet capacity planning, with claim_item named as the opt-in enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)