### PR TITLE
fix+docs: lease-history double-holder on re-take; one-actor-per-item assumption

### DIFF
--- a/current/docs/fleet-deployment.md
+++ b/current/docs/fleet-deployment.md
@@ -551,6 +551,18 @@ docker run --rm -i \
 
 SQLite is a single-writer database backed by a file on a single host. Understanding this constraint is essential for fleet sizing.
 
+### Item Granularity — One Concurrent Actor Per Item
+
+Before sizing the fleet, size the *items*. Both the claim mechanism and resource leasing assume
+**one concurrent actor per work item**: claims bind one actor to an item, and resource leases are
+item-keyed — two sessions working inside the same item share its lease and its claim, and the
+server cannot detect the interference (it arbitrates transitions, not actions). Field pattern to
+avoid: modelling "one conceptual task" as one item while multiple sessions (a watcher and an
+extractor, say) operate inside it — the lease holds, and the sessions still collide on the shared
+browser tab / compose window / rate budget underneath. Cut items at actor granularity: if two
+sessions run concurrently, give each its own item (children of a shared parent work well), let
+each claim its own item, and declare the shared resource on both so the lease serializes them.
+
 ### Write Rate Estimates
 
 | Activity | Write rate estimate |

--- a/current/docs/workflow-guide.md
+++ b/current/docs/workflow-guide.md
@@ -1150,6 +1150,15 @@ invariant, and not fairness. Read this section before relying on it for anything
   lease — there is no per-actor "only the acquiring actor can release" check. This is a deliberate
   simplification, not an oversight: the exclusivity guarantee above is about the item, not about who
   is allowed to touch it.
+- **One item = one concurrent actor is an assumed modelling obligation.** Item-keyed exclusivity
+  arbitrates between *items*, not between actors working inside the same item — two sessions
+  operating under one work item share its lease, and the schema cannot detect that violation (the
+  server sees transitions, not actions). Identity still matters, one level up, in how you cut
+  items: model concurrent actors as separate work items at actor granularity. In fleet
+  deployments, `claim_item` is the opt-in enforcement of exactly this assumption — it binds one
+  verified actor to an item with a TTL, and an agent can hold its item claim and the item's
+  resource leases simultaneously by design. The release-side corollary of the same assumption:
+  any actor's work-exit transition on the shared item releases the lease for all of them.
 - **The kill switch is read per request, not once at startup.** `RESOURCE_LEASES_ENFORCED=false`
   disables acquisition (releases still always run) — and because the pipeline is constructed fresh
   per `advance_item`/`POST .../advance` call, flipping this env var takes effect on the **next

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteResourceLeaseRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteResourceLeaseRepository.kt
@@ -240,16 +240,19 @@ class SQLiteResourceLeaseRepository(
                         // now-stale row — a key can accumulate more than one expired other-holder row
                         // across repeated steals. All of them are guaranteed expired here (the
                         // contention pre-pass above already rejected any ACTIVE other holder).
+                        // Computed UNCONDITIONALLY — including on the own-row refresh/re-take path.
+                        // A re-take of a key this item held before (own expired row still present)
+                        // can follow an intervening holder whose expired row also lingers; guarding
+                        // this on `ownRow == null` left that holder's history interval open, and a
+                        // later releaseAllForItem would then close it at 'now' — making an at-T
+                        // query report two simultaneous holders (found in post-merge field review
+                        // of PR #262).
                         val staleOtherRows =
-                            if (ownRow == null) {
-                                ResourceLeasesTable
-                                    .selectAll()
-                                    .where {
-                                        (ResourceLeasesTable.resourceKey eq key) and (ResourceLeasesTable.holderItemId neq holderItemId)
-                                    }.toList()
-                            } else {
-                                emptyList()
-                            }
+                            ResourceLeasesTable
+                                .selectAll()
+                                .where {
+                                    (ResourceLeasesTable.resourceKey eq key) and (ResourceLeasesTable.holderItemId neq holderItemId)
+                                }.toList()
 
                         exec(
                             """
@@ -307,18 +310,18 @@ class SQLiteResourceLeaseRepository(
      * the live-row upsert `acquireAll` just performed for [key]. Three cases, distinguished by the
      * pre-write state captured before the live upsert ran:
      *
+     * On EVERY branch, stale OTHER-holder rows still on the key (necessarily expired — the
+     * contention pre-pass rejected any active other holder; there can be more than one, since a
+     * steal never deletes the row it supersedes) first have their OPEN history intervals closed
+     * with `releaseReason = "expired"` at each row's own last-known `expiresAt`. This runs on
+     * refresh/re-take too, not only on steals — a re-take of a previously-held key can follow an
+     * intervening expired holder whose interval must not stay open (post-merge fix, PR #262
+     * field review). Then, for the acquiring holder:
+     *
      * 1. **Refresh** ([ownRowExisted] true) — the OPEN history interval for `(key, holderItemId)`
      *    has its `expiresAt` extended in place. If none is open (the bootstrap gap for a lease that
      *    predates V16 — see the migration header), a new interval opens instead.
-     * 2. **Steal** ([ownRowExisted] false, [staleOtherRows] non-empty) — every OTHER holder row
-     *    still on this key (necessarily expired, or `acquireAll`'s contention pre-pass would have
-     *    rejected this call — there can be more than one, since a steal never deletes the row it
-     *    supersedes) has its OPEN history interval closed with `releaseReason = "expired"` at its
-     *    own last-known `expiresAt` (read from the live row BEFORE it was overwritten —
-     *    authoritative regardless of whether history was already in sync; a no-op for any stale row
-     *    with no open interval to close). A new interval then opens for the new holder.
-     * 3. **Fresh** ([ownRowExisted] false, [staleOtherRows] empty) — a never-before-seen (or
-     *    previously fully released) key: a new interval simply opens.
+     * 2. **Fresh/steal** ([ownRowExisted] false) — a new interval opens.
      *
      * [liveRow] is the freshly-upserted `resource_leases` row, read back after the write — its
      * `acquiredAt` / `expiresAt` (both DB-computed) are reused verbatim for the history row so the
@@ -346,6 +349,23 @@ class SQLiteResourceLeaseRepository(
             }
         }
 
+        // Close stale OTHER holders' open intervals FIRST, on every branch — not only on steals.
+        // The refresh/re-take branch can also follow an intervening expired holder (see the
+        // staleOtherRows comment at the call site); each closes at its own last-known live-row
+        // expiry, which is when its hold factually ended.
+        staleOtherRows.forEach { stale ->
+            val staleHolderId = stale[ResourceLeasesTable.holderItemId]
+            val staleExpiresAt = stale[ResourceLeasesTable.expiresAt]
+            ResourceLeaseHistoryTable.update({
+                (ResourceLeaseHistoryTable.resourceKey eq key) and
+                    (ResourceLeaseHistoryTable.holderItemId eq staleHolderId) and
+                    ResourceLeaseHistoryTable.releasedAt.isNull()
+            }) {
+                it[releasedAt] = staleExpiresAt
+                it[releaseReason] = "expired"
+            }
+        }
+
         if (ownRowExisted) {
             val updated =
                 ResourceLeaseHistoryTable.update({
@@ -357,18 +377,6 @@ class SQLiteResourceLeaseRepository(
                 }
             if (updated == 0) openNewInterval()
         } else {
-            staleOtherRows.forEach { stale ->
-                val staleHolderId = stale[ResourceLeasesTable.holderItemId]
-                val staleExpiresAt = stale[ResourceLeasesTable.expiresAt]
-                ResourceLeaseHistoryTable.update({
-                    (ResourceLeaseHistoryTable.resourceKey eq key) and
-                        (ResourceLeaseHistoryTable.holderItemId eq staleHolderId) and
-                        ResourceLeaseHistoryTable.releasedAt.isNull()
-                }) {
-                    it[releasedAt] = staleExpiresAt
-                    it[releaseReason] = "expired"
-                }
-            }
             openNewInterval()
         }
     }
@@ -383,7 +391,8 @@ class SQLiteResourceLeaseRepository(
                 exec(
                     """
                     UPDATE resource_lease_history
-                       SET released_at = datetime('now'), release_reason = 'released'
+                       SET released_at = min(datetime('now'), expires_at),
+                           release_reason = CASE WHEN expires_at < datetime('now') THEN 'expired' ELSE 'released' END
                      WHERE holder_item_id = ? AND released_at IS NULL
                     """.trimIndent(),
                     args = listOf(uuidType to holderItemId)
@@ -409,7 +418,9 @@ class SQLiteResourceLeaseRepository(
                 exec(
                     """
                     UPDATE resource_lease_history
-                       SET released_at = datetime('now'), release_reason = 'force_released', released_by_actor_id = ?
+                       SET released_at = min(datetime('now'), expires_at),
+                           release_reason = CASE WHEN expires_at < datetime('now') THEN 'expired' ELSE 'force_released' END,
+                           released_by_actor_id = ?
                      WHERE resource_key = ? AND released_at IS NULL
                     """.trimIndent(),
                     args = listOf(actorType to actorId, keyType to resourceKey)

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteResourceLeaseRepositoryHistoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteResourceLeaseRepositoryHistoryTest.kt
@@ -16,6 +16,7 @@ import java.time.Instant
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -41,7 +42,13 @@ class SQLiteResourceLeaseRepositoryHistoryTest : SQLiteRepositoryTestBase() {
         return result.data.id
     }
 
-    /** Backdates every LIVE lease row for (resourceKey, holderItemId) to an already-expired expires_at. */
+    /**
+     * Backdates the lease for (resourceKey, holderItemId) to an already-expired expires_at — in
+     * BOTH the live table and the open history interval. Production writes keep the two tables'
+     * expiry in agreement (history is written from the live row's values in the same transaction),
+     * so simulating time-passage must age them together; diverging them would exercise a state the
+     * repository never produces.
+     */
     private fun expireLease(
         resourceKey: String,
         holderItemId: UUID
@@ -54,6 +61,14 @@ class SQLiteResourceLeaseRepositoryHistoryTest : SQLiteRepositoryTestBase() {
                 UPDATE resource_leases
                    SET expires_at = datetime('now', '-10 seconds')
                  WHERE resource_key = ? AND holder_item_id = ?
+                """.trimIndent(),
+                args = listOf(keyType to resourceKey, uuidType to holderItemId)
+            )
+            exec(
+                """
+                UPDATE resource_lease_history
+                   SET expires_at = datetime('now', '-10 seconds')
+                 WHERE resource_key = ? AND holder_item_id = ? AND released_at IS NULL
                 """.trimIndent(),
                 args = listOf(keyType to resourceKey, uuidType to holderItemId)
             )
@@ -128,6 +143,61 @@ class SQLiteResourceLeaseRepositoryHistoryTest : SQLiteRepositoryTestBase() {
             )
 
             assertNull(bInterval.releasedAt, "B's new interval must be open")
+        }
+
+    @Test
+    fun `re-take after an intervening expired holder closes that holder's interval — no double-holder at-T`(): Unit =
+        runBlocking {
+            // Regression for the post-merge field report on PR #262: A holds K, expires; B steals,
+            // expires; A RE-TAKES (own expired row still present -> refresh branch). Before the fix,
+            // staleOtherRows was only computed when A had no prior row, so B's interval stayed open —
+            // and a later releaseAllForItem(B) closed it at 'now', making an at-T query report both
+            // A and B as simultaneous holders.
+            val holderA = createHolder("Holder A")
+            val holderB = createHolder("Holder B")
+
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holderA, "agent-a", listOf("staging-db" to 900)))
+            expireLease("staging-db", holderA)
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holderB, "agent-b", listOf("staging-db" to 900)))
+            expireLease("staging-db", holderB)
+
+            // A re-takes: own stale row exists (refresh path) AND B's stale row exists.
+            val retaken = repository.acquireAll(holderA, "agent-a", listOf("staging-db" to 900))
+            assertIs<LeaseAcquireResult.Success>(retaken)
+
+            val bInterval =
+                repository
+                    .findRecentIntervals("staging-db", 10)
+                    .single { it.holderItemId == holderB }
+            assertEquals("expired", bInterval.releaseReason, "B's interval must be closed as expired by A's re-take")
+            assertNotNull(bInterval.releasedAt)
+
+            // Even if B's item releases later, the audit must never show two holders at once:
+            assertIs<LeaseReleaseResult.Success>(repository.releaseAllForItem(holderB))
+            val now = Instant.now()
+            val holdersNow = repository.findHoldersAt("staging-db", now)
+            assertEquals(1, holdersNow.size, "exactly one holder at T — got: ${holdersNow.map { it.holderItemId }}")
+            assertEquals(holderA, holdersNow.single().holderItemId)
+        }
+
+    @Test
+    fun `releasing an already-expired lease clamps releasedAt to expiresAt with reason expired`(): Unit =
+        runBlocking {
+            // The close timestamp must never extend an interval past its own expiry — otherwise a
+            // late releaseAllForItem inflates the apparent hold window for at-T queries.
+            val holder = createHolder()
+            assertIs<LeaseAcquireResult.Success>(repository.acquireAll(holder, "agent-a", listOf("staging-db" to 900)))
+            expireLease("staging-db", holder)
+
+            assertIs<LeaseReleaseResult.Success>(repository.releaseAllForItem(holder))
+
+            val interval = repository.findRecentIntervals("staging-db", 10).single()
+            assertEquals("expired", interval.releaseReason, "an already-lapsed hold closes as expired, not released")
+            val releasedAt = requireNotNull(interval.releasedAt)
+            assertTrue(
+                !releasedAt.isAfter(Instant.now().minusSeconds(5)),
+                "releasedAt must be clamped to the (backdated) expiry, not stamped 'now': $releasedAt",
+            )
         }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Follow-ups from post-merge field review of #262 (both reported by the same reviewer):

**Fix — history double-holder on re-take.** A re-take of a previously-held key (own expired row present → refresh branch) after an intervening expired holder left that holder's interval open; a later `releaseAllForItem` then closed it at *now*, so `GET /resources/leases/history?at=` could report two simultaneous holders. Stale other-holder intervals now close on every acquire branch, and both release paths clamp `released_at` to `min(now, expires_at)` with a truthful `expired` reason. Regression tests cover the exact reported scenario and the clamp. Live-lease exclusivity was never affected — this is audit-view accuracy.

**Docs — the one-actor-per-item modelling assumption.** Item-keyed exclusivity arbitrates between items, not between actors inside one item; stated explicitly in the guarantees section (next to 'identity governs early release, not exclusion') and as an item-granularity subsection in fleet capacity planning, with `claim_item` named as the opt-in enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)