### PR TITLE
fix: normalize timestamp shapes in lease-history clamp comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Lease-interval history close comparisons now normalize timestamp shapes with `datetime()`: Exposed
+  timestamp columns store fractional seconds while `datetime('now')` is second-precision, so a hold
+  lapsing inside the current second could compare as unexpired in SQLite's lexicographic TEXT
+  comparison — skipping the expiry clamp and recording `released` instead of `expired`. Sub-second
+  window, audit view only (beta field report).
+
 ## [3.13.0] - 2026-07-25
 
 > **Resource/credential leasing ships in this release as a beta feature.** The interfaces below are

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteResourceLeaseRepository.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/repository/SQLiteResourceLeaseRepository.kt
@@ -388,11 +388,18 @@ class SQLiteResourceLeaseRepository(
                 // Close every OPEN interval this holder has, across all its keys. releasedAt is
                 // stamped DB-side (datetime('now')) — never the JVM clock, matching every other
                 // write in this class.
+                //
+                // datetime(expires_at) wrapping is load-bearing, here and in forceReleaseByKey:
+                // Exposed timestamp columns store fractional seconds ('...:49.937') while
+                // datetime('now') is second-precision ('...:49'), and SQLite compares TEXT
+                // lexicographically — so within a shared second the fractional value sorts LATER
+                // and a just-lapsed hold would compare as unexpired (no clamp, reason 'released').
+                // datetime() canonicalizes both sides to second precision.
                 exec(
                     """
                     UPDATE resource_lease_history
-                       SET released_at = min(datetime('now'), expires_at),
-                           release_reason = CASE WHEN expires_at < datetime('now') THEN 'expired' ELSE 'released' END
+                       SET released_at = min(datetime('now'), datetime(expires_at)),
+                           release_reason = CASE WHEN datetime(expires_at) < datetime('now') THEN 'expired' ELSE 'released' END
                      WHERE holder_item_id = ? AND released_at IS NULL
                     """.trimIndent(),
                     args = listOf(uuidType to holderItemId)
@@ -418,8 +425,8 @@ class SQLiteResourceLeaseRepository(
                 exec(
                     """
                     UPDATE resource_lease_history
-                       SET released_at = min(datetime('now'), expires_at),
-                           release_reason = CASE WHEN expires_at < datetime('now') THEN 'expired' ELSE 'force_released' END,
+                       SET released_at = min(datetime('now'), datetime(expires_at)),
+                           release_reason = CASE WHEN datetime(expires_at) < datetime('now') THEN 'expired' ELSE 'force_released' END,
                            released_by_actor_id = ?
                      WHERE resource_key = ? AND released_at IS NULL
                     """.trimIndent(),

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteResourceLeaseRepositoryHistoryTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/infrastructure/database/repository/SQLiteResourceLeaseRepositoryHistoryTest.kt
@@ -200,6 +200,35 @@ class SQLiteResourceLeaseRepositoryHistoryTest : SQLiteRepositoryTestBase() {
             )
         }
 
+    @Test
+    fun `history close comparisons normalize mixed timestamp shapes via datetime()`(): Unit =
+        runBlocking {
+            // Constants-only pin of the sub-second cross-shape bug (beta field report, PR #262):
+            // Exposed timestamp columns store fractional seconds; datetime('now') is
+            // second-precision; raw TEXT comparison misorders them within a shared second. The
+            // clamp SQL must therefore normalize both sides with datetime(). No wall clock here —
+            // the boundary cannot be exercised deterministically with real time.
+            transaction(db = database) {
+                var sameSecondRaw = ""
+                var normLt = ""
+                var normMin = ""
+                exec(
+                    "SELECT '2026-01-01 00:00:00.937' < '2026-01-01 00:00:00', " +
+                        "datetime('2026-01-01 00:00:00.937') < '2026-01-01 00:00:01', " +
+                        "min('2026-01-01 00:00:01', datetime('2026-01-01 00:00:00.937'))"
+                ) { rs ->
+                    if (rs.next()) {
+                        sameSecondRaw = rs.getString(1)
+                        normLt = rs.getString(2)
+                        normMin = rs.getString(3)
+                    }
+                }
+                assertEquals("0", sameSecondRaw, "raw cross-shape compare within a shared second misorders (the bug shape)")
+                assertEquals("1", normLt, "datetime() normalization restores chronological ordering")
+                assertEquals("2026-01-01 00:00:00", normMin, "the clamp picks the normalized expiry, not 'now'")
+            }
+        }
+
     // -----------------------------------------------------------------------
     // Release / force-release close reasons
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Third field-review finding on #262, verified empirically before fixing: Exposed-written timestamps carry fractional seconds (`2026-07-25 20:08:49.937`) while `datetime('now')` is second-precision (`2026-07-25 21:25:33`) — SQLite TEXT comparison misorders them within a shared second, so a hold lapsing inside the current second skipped the expiry clamp (released_at = now, reason 'released'). Both history close paths now normalize with `datetime(expires_at)`. Constants-based test pins the two shapes and the corrected comparison. Sub-second window, audit view only; live-lease exclusivity unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)