### PR TITLE
feat: adopt Claude prompt-engineering guide recommendations across tool descriptions, skills, and plugin prompts

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -434,6 +434,10 @@ Read ALL files from that directory. Do NOT read from the main working directory.
 Tests have already been verified green by the orchestrator after the most recent
 commit batch. Do NOT re-run gradle — focus on plan alignment, test quality, and
 simplification per the review-quality skill.
+
+Report every finding at every severity — do not self-filter to a high-severity-only
+bar. Mark each finding blocking or observation and state your confidence; the
+orchestrator's verdict handling is the downstream filter, not your own judgment.
 ```
 
 **If using Direct or Delegated tier** (single working branch on the main directory),

--- a/.claude/skills/review-quality/SKILL.md
+++ b/.claude/skills/review-quality/SKILL.md
@@ -152,10 +152,17 @@ Every review must end with a clear verdict:
 
 ### Findings Format
 
+Report every finding you observe, at every severity. Do not withhold minor findings
+and do not apply a high-severity-only bar — current models follow severity filters
+literally, which suppresses real findings. Mark each finding blocking or observation
+and state your confidence; the orchestrator's verdict handling (see Verdict, above)
+is the downstream filter, not your own judgment about what is worth mentioning.
+
 For each finding, state:
 - **What was expected** (from the planning note or test strategy)
 - **What was found** (in the code or test output)
 - **Severity** (blocking or observation)
+- **Confidence** (how sure you are this is a real issue, not a false positive)
 
 Be specific. "Tests could be better" is not actionable. "Test `testCreateItem` asserts
 only that the result is not null — it should verify the item's title and status match

--- a/.taskorchestrator/config.yaml
+++ b/.taskorchestrator/config.yaml
@@ -22,7 +22,8 @@ work_item_schemas:
         role: work
         required: true
         description: "Context handoff for downstream agents — deviations, surprises, and decisions that affect dependent work."
-        guidance: "Document decisions made during implementation that weren't in the feature-summary. Focus on what downstream agents need to know: deviations from the plan, API or interface surprises, assumptions that turned out wrong, and any patterns discovered that affect dependent tasks."
+        guidance: "Document decisions made during implementation that weren't in the feature-summary. Focus on what downstream agents need to know: deviations from the plan, API or interface surprises, assumptions that turned out wrong, and any patterns discovered that affect dependent tasks. Cover the substance — do not pad with boilerplate, restated spec content, or redundant summaries."
+        maxLength: 3000
       - key: review-checklist
         role: review
         required: true
@@ -44,7 +45,8 @@ work_item_schemas:
         role: work
         required: true
         description: "Context handoff — deviations, surprises, and decisions that affect dependent work."
-        guidance: "Document decisions made during implementation that weren't in the task scope. Focus on what downstream agents need to know: deviations from the plan, API or interface surprises, assumptions that turned out wrong, and any patterns discovered that affect dependent tasks."
+        guidance: "Document decisions made during implementation that weren't in the task scope. Focus on what downstream agents need to know: deviations from the plan, API or interface surprises, assumptions that turned out wrong, and any patterns discovered that affect dependent tasks. Cover the substance — do not pad with boilerplate, restated spec content, or redundant summaries."
+        maxLength: 3000
 
   bug-fix:
     lifecycle: auto
@@ -60,7 +62,8 @@ work_item_schemas:
         role: work
         required: true
         description: "Context handoff for downstream agents — what changed, deviations from the diagnosis, and patterns to apply elsewhere."
-        guidance: "Document what was changed and why. Focus on what downstream agents need to know: deviations from the planned fix, whether the root cause was different than diagnosed, patterns that should be applied elsewhere (e.g., same bug exists in similar code paths), and any assumptions that turned out wrong."
+        guidance: "Document what was changed and why. Focus on what downstream agents need to know: deviations from the planned fix, whether the root cause was different than diagnosed, patterns that should be applied elsewhere (e.g., same bug exists in similar code paths), and any assumptions that turned out wrong. Cover the substance — do not pad with boilerplate, restated spec content, or redundant summaries."
+        maxLength: 3000
       - key: review-checklist
         role: review
         required: true
@@ -168,7 +171,8 @@ traits:
         role: work
         required: true
         description: "Session context — what was done, how it went, and anything the retrospective should know."
-        guidance: "Record what happened during implementation. Structure: - **Outcome**: success | partial | failure - **Files changed**: list with brief rationale - **Deviations**: anything that differed from the specification or plan - **Friction**: tool errors, roundtrips, workarounds, API confusion (type + description) - **Gate interactions**: note fill attempts, gate failures encountered - **Observations**: anything worth tracking for process improvement - **Test results**: pass/fail counts, new tests added. Keep it factual and concise — this feeds the session retrospective."
+        guidance: "Record what happened during implementation. Structure: - **Outcome**: success | partial | failure - **Files changed**: list with brief rationale - **Deviations**: anything that differed from the specification or plan - **Friction**: tool errors, roundtrips, workarounds, API confusion (type + description) - **Gate interactions**: note fill attempts, gate failures encountered - **Observations**: anything worth tracking for process improvement - **Test results**: pass/fail counts, new tests added. Keep it factual and concise — this feeds the session retrospective. Cover the substance — do not pad with boilerplate, restated spec content, or redundant summaries."
+        maxLength: 2000
 
 # Resource leasing — reference example only, NOT activated on this project's items.
 # Uncomment and adapt to declare a shared-resource registry and reference it from a trait.

--- a/claude-plugins/task-orchestrator/hooks/subagent-start.mjs
+++ b/claude-plugins/task-orchestrator/hooks/subagent-start.mjs
@@ -45,7 +45,7 @@ const output = {
 ## Subagent Discipline
 
 1. **Commit before returning.** Stage and commit all file changes with a descriptive message — the orchestrator squash-merges your branch.
-2. **Stay in scope.** Touch only files for your assigned task. No version bumps, shared config, or CI edits.
+2. **Stay in scope.** Touch only files for your assigned task. No version bumps, shared config, or CI edits. Deliver what the task asked at the scope intended: finish the whole task rather than leaving stubs, and stop short of work clearly beyond it.
 3. **Notes are the report.** Write findings into your item's notes — distill inline; route verbatim artifacts (test output, diffs, logs) via \`bodyFromFile\`. Your final message to the orchestrator is 1-2 lines: item ID, outcome, and which note keys were filled. Do not restate note content.`
   }
 };

--- a/claude-plugins/task-orchestrator/output-styles/ralph-iteration.md
+++ b/claude-plugins/task-orchestrator/output-styles/ralph-iteration.md
@@ -56,3 +56,4 @@ These are explicit overrides — even if other parts of your context (memory, pr
 - **Respect the budget cap.** If you find yourself making 30-40+ tool calls without making progress, emit `error` rather than burning through `--max-budget-usd`.
 - **Use `/schema-workflow` for note-driven advancement.** It reads each note's `guidance` field and applies it consistently. Don't reimplement that logic in your own loop.
 - **Commit, don't push, unless the schema says otherwise.** The schema's terminal phase may declare push or PR steps; if it does, follow them. Otherwise, leaving the worktree with a commit is sufficient — the operator decides what to do with it.
+- **Persist as you go.** Fill notes incrementally as each piece of work completes rather than batching them at the end — if the iteration dies mid-run (budget cap, crash), written notes are the only recovery state. Do not wrap up early because context feels long; the harness compacts automatically.

--- a/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
+++ b/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
@@ -80,6 +80,8 @@ When session context carries a project rootId (injected by the SessionStart hook
 
 Delegation prompts must include entity IDs and full context — subagents start fresh.
 
+**Do not delegate verification.** Do not dispatch subagents to verify or double-check your own work. Verification belongs to the schema's review phase (a separate reviewer) or to inline review on Direct tier. Current models self-verify well, so a redundant verification agent adds cost without catching more.
+
 **Notes are the report.** Subagents write findings into their work item's notes; their final message back is 1-2 lines (item ID, outcome, note keys filled). Never ask agents to restate note content in replies.
 
 **Delegation metadata (recommended).** If your project defines a `delegated` trait (see your schema config), applying it is recommended for Delegated/Parallel items: after each subagent returns, fill its `delegation-metadata` work note — model · isolation · one-line rationale · one-line outcome. The orchestrator fills this, not the subagent (only the orchestrator knows the dispatch details). It feeds `/session-retrospective`'s delegation-alignment scoring; projects that don't define the trait simply skip it.

--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -443,6 +443,8 @@ attach children, deps, and notes directly to an existing item. When `root.id` is
 is optional (ignored if both are given). The existing item is NOT re-inserted; children are created
 under it at `existing.depth + 1`. Providing both `root.id` and `parentId` is rejected with `VALIDATION_ERROR`.
 
+**When to call.** Call when materializing a planned hierarchy — one atomic call instead of per-item create sequences.
+
 **Operations.** Single operation (no `operation` parameter).
 
 #### Key Parameters
@@ -565,6 +567,8 @@ When both `notes` and `createNotes: true` are provided, explicit `notes` entries
 **Purpose.** Batch-complete (or cancel) all descendants of a root item, or an explicit list of
 items, in topological dependency order. Gate enforcement applies per item: if required notes are
 missing, that item fails and its downstream dependents within the set are skipped.
+
+**When to call.** Call when closing out a finished hierarchy — one atomic call instead of per-item advance sequences.
 
 **Operations.** Single operation (no `operation` parameter).
 
@@ -1037,6 +1041,8 @@ REST path bypasses it (see `api-rest.md`). Both enforce the same note gates and 
 resource-lease gate (REST accepts an ADMIN-only override for the lease gate; MCP does not), and
 report the same cascade/unblock results.
 
+**When to call.** Call to move an item between phases once its work is done — never edit status via `manage_items`.
+
 #### Key Parameters
 
 | Parameter | Type | Required | Description |
@@ -1264,6 +1270,8 @@ force-release, item-keyed exclusivity, single-DB arbiter, opaque-labels-never-se
 **Purpose.** Read-only status progression recommendation for a single WorkItem. Returns whether
 the item is Ready to advance, Blocked, or Terminal, without making any changes.
 
+**When to call.** Call to check one item's advance-readiness when a full context snapshot is not needed.
+
 #### Key Parameters
 
 | Parameter | Type | Required | Description |
@@ -1325,6 +1333,8 @@ supplied. Use for session startup, work-summary dashboards, and pre-advance gate
 - **Health check** — pass `mode: "health-check"` (or omit all mode-selecting params): all active items (work/review), blocked items, and stalled items.
 
 When `mode` is omitted, the mode is inferred from which parameters are present (`itemId` → item, `since` → session-resume, neither → health-check).
+
+**When to call.** Call with no arguments to resume a session; call with `itemId` before any advance or dispatch decision.
 
 #### Key Parameters
 
@@ -1476,6 +1486,8 @@ be competing with the feature's orchestrator. Root items (no parent) are unaffec
 `includeClaimed=true`, ancestor-claim filtering is NOT applied — that path uses `findForNextItem`
 and is intentionally inclusive.
 
+**When to call.** Call when choosing what to work on next — at session start or after finishing an item.
+
 #### Key Parameters
 
 | Parameter | Type | Required | Description |
@@ -1609,6 +1621,8 @@ FIFO queue drain — oldest unclaimed item first:
 claiming a new item auto-releases any prior claim held by the same agent. Claims are
 time-bounded (TTL, default 900s). Re-claiming an already-held item refreshes the TTL without
 changing the claim holder.
+
+**When to call.** Call only in claim-mode deployments, to take ownership before working an item.
 
 > **See also:** [Workflow Guide §10 — Claim Mechanism](./workflow-guide.md#10-claim-mechanism-for-multi-agent-fleets) for the agent-side lifecycle, heartbeat pattern, and discovery patterns. [Fleet Deployment Guide](./fleet-deployment.md) for `degradedModePolicy`, capacity planning, tiered disclosure, and Claims Troubleshooting.
 
@@ -1806,6 +1820,8 @@ On `already_claimed`, `retryAfterMs` approximates the remaining TTL of the exist
 **Purpose.** Identifies all WorkItems that are blocked, either explicitly (role=blocked via a
 block/hold trigger) or implicitly (items in queue/work/review with unsatisfied blocking
 dependency edges). Terminal items are never included.
+
+**When to call.** Call when work appears stalled or someone asks why an item cannot start.
 
 #### Key Parameters
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CompleteTreeTool.kt
@@ -46,6 +46,8 @@ Complete or cancel all descendants of a root item (or an explicit list of items)
   to be skipped.
 - Items already in TERMINAL role are recorded as skipped.
 - When rootId is used with includeRoot=true (the default), the root item is processed last, after all its descendants.
+
+Call when closing out a finished hierarchy — one atomic call instead of per-item advance sequences.
         """.trimIndent()
 
     override val category = ToolCategory.WORKFLOW

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/compound/CreateWorkTreeTool.kt
@@ -55,6 +55,8 @@ document is marked adopted by the created/attached root. Precedence on `(itemRef
 explicit `notes` win over `noteAnchors`; `noteAnchors` win over `createNotes=true` blanks. Any anchor
 miss, an unresolved document, a `docRef.rootId` mismatch, or an already-adopted document fails the
 WHOLE call atomically — no items are created. Without `docRef`, behavior is unchanged.
+
+Call when materializing a planned hierarchy — one atomic call instead of per-item create sequences.
         """.trimIndent()
 
     override val category = ToolCategory.ITEM_MANAGEMENT

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -64,6 +64,8 @@ declared by the item's traits; contention rejects with transient `resource_unava
 
 **Batch actor constraint:** all transitions in a call must either all omit `actor` or all use the same
 `actor.id`; cascade-triggered transitions always have a null actor.
+
+Call to move an item between phases once its work is done — never edit status via manage_items.
         """.trimIndent()
 
     override val category = ToolCategory.WORKFLOW

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/ClaimItemTool.kt
@@ -86,6 +86,8 @@ Each `claims` entry uses exactly one of `itemId` (ID mode) or `selector` (find-a
 `rejected_by_policy`.
 
 **Release outcomes:** `success`, `not_claimed_by_you`, `not_found`.
+
+Call only in claim-mode deployments, to take ownership before working an item.
         """.trimIndent()
 
     override val category = ToolCategory.WORKFLOW

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetBlockedItemsTool.kt
@@ -35,6 +35,8 @@ Identifies WorkItems blocked by dependencies or explicitly in BLOCKED role.
 2. Items in QUEUE/WORK/REVIEW with unsatisfied blocking dependencies (blockType = "dependency")
 
 Items in TERMINAL role are never included.
+
+Call when work appears stalled or someone asks why an item cannot start.
         """.trimIndent()
 
     override val category = ToolCategory.WORKFLOW

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetContextTool.kt
@@ -49,6 +49,8 @@ blocked items, stalled items, and a claim-count summary (no identity).
 
 When `mode` is omitted, it is inferred from which parameters are provided (`itemId` → item, `since` →
 session-resume, neither → health-check); explicit `mode` takes precedence.
+
+Call with no arguments to resume a session; call with `itemId` before any advance or dispatch decision.
         """.trimIndent()
 
     override val category = ToolCategory.WORKFLOW

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextItemTool.kt
@@ -35,6 +35,8 @@ Recommends next work item(s) based on role, dependencies, priority, and complexi
 Selection pipeline: finds items in the requested role, filters out dependency-blocked items and
 (by default) actively-claimed items, then ranks by `orderBy` and returns the top `limit`. See each
 parameter's schema description for field-level semantics.
+
+Call when choosing what to work on next — at session start or after finishing an item.
         """.trimIndent()
 
     override val category = ToolCategory.WORKFLOW

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextStatusTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/GetNextStatusTool.kt
@@ -25,6 +25,8 @@ class GetNextStatusTool : BaseToolDefinition() {
 Read-only status progression recommendation for a WorkItem: "Ready" (can advance via the "start"
 trigger), "Blocked" (unsatisfied dependencies, or explicit BLOCKED role — use "resume" to return to
 its previous role), or "Terminal" (workflow already complete).
+
+Call to check one item's advance-readiness when a full context snapshot is not needed.
         """.trimIndent()
 
     override val category = ToolCategory.WORKFLOW

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
@@ -102,22 +102,25 @@ class ToolTokenBudgetTest {
             "manage_items" to 2950, // was 2520; measured 2526 after items[].id -> itemId / ids -> itemIds (de711807)
             "query_notes" to 2386,
             "get_context" to 2650, // was 1909; T2.3 added the `ancestorId` scope parameter
-            "claim_item" to 2200, // was 2100; +when-to-call trigger sentence, measured 2181
+            "claim_item" to 2550, // was 2100; +when-to-call trigger sentence, measured 2181
             "manage_notes" to 2057,
-            "complete_tree" to 1850, // was 1760; +when-to-call trigger sentence, measured 1819
+            "complete_tree" to 2100, // was 1760; +when-to-call trigger sentence, measured 1819
             "query_dependencies" to 1708,
-            "advance_item" to 2750, // was 2650; +when-to-call trigger sentence, measured 2701
+            "advance_item" to 3150, // was 2650; +when-to-call trigger sentence, measured 2701
             "get_blocked_items" to 1250, // was 830; T2.3 added the `ancestorId` scope parameter
-            "get_next_status" to 600, // was 470; +when-to-call trigger sentence, measured 559
+            "get_next_status" to 650, // was 470; +when-to-call trigger sentence, measured 559
             "manage_project_config" to 3150, // measured 2698 after get `fingerprint` param + relation (fast-forward guard, t5)
             "manage_plan_documents" to 2150, // measured 1834; new tool: stash/get/list per-root plan documents (dual REST+MCP ingestion)
         )
 
     /**
      * Sum of the (unrounded) measured-per-tool-values * 1.15; see BUDGET PHILOSOPHY point 2.
-     * Was 43_350; measured total 39_004 after create_work_tree's docRef/noteAnchors addition.
+     * Was 44_900 (from measured total 39_004); measured total 41_102 after the when-to-call
+     * trigger sentences were added to the 8 workflow/lifecycle tool descriptions. The other 8
+     * tools (the CRUD/query surface) were deliberately left untouched — they trigger on obvious
+     * need, and over-prompting tools that already trigger correctly causes overtriggering.
      */
-    private val totalCeiling = 44_900
+    private val totalCeiling = 47_300
 
     // explicitNulls = false mirrors the compact-wire-shape convention already used elsewhere
     // in this codebase (see EventRoutes.kt / ItemWriteRoutes.kt / NoteWriteRoutes.kt) — a

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/ToolTokenBudgetTest.kt
@@ -102,13 +102,13 @@ class ToolTokenBudgetTest {
             "manage_items" to 2950, // was 2520; measured 2526 after items[].id -> itemId / ids -> itemIds (de711807)
             "query_notes" to 2386,
             "get_context" to 2650, // was 1909; T2.3 added the `ancestorId` scope parameter
-            "claim_item" to 2100,
+            "claim_item" to 2200, // was 2100; +when-to-call trigger sentence, measured 2181
             "manage_notes" to 2057,
-            "complete_tree" to 1760, // was 1712; see note above
+            "complete_tree" to 1850, // was 1760; +when-to-call trigger sentence, measured 1819
             "query_dependencies" to 1708,
-            "advance_item" to 2650, // was 2100; credentialRefs param (T1) + resource-lease gate semantics (T5), measured 2602
+            "advance_item" to 2750, // was 2650; +when-to-call trigger sentence, measured 2701
             "get_blocked_items" to 1250, // was 830; T2.3 added the `ancestorId` scope parameter
-            "get_next_status" to 470,
+            "get_next_status" to 600, // was 470; +when-to-call trigger sentence, measured 559
             "manage_project_config" to 3150, // measured 2698 after get `fingerprint` param + relation (fast-forward guard, t5)
             "manage_plan_documents" to 2150, // measured 1834; new tool: stash/get/list per-root plan documents (dual REST+MCP ingestion)
         )


### PR DESCRIPTION
## Summary

Adopts the applicable recommendations from Anthropic's [Opus 5 prompting guide](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5) and [general prompting best practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices). Prompt and description surfaces only — no behavioral code changes.

- **When-to-call trigger conditions** on the 8 workflow/lifecycle tool descriptions. Current models reach for tools conservatively, and trigger conditions in the description measurably lift should-call rate. This is the only change that reaches MCP consumers *without* the plugin's skills steering them (claim-mode/fleet agents, third-party clients).
- **Coverage-first review reporting** in `review-quality` and `implement`. Severity filters are now followed literally — told "only report high-severity issues", the model finds real bugs and then withholds the ones below the bar. Reviewers now report everything with severity + confidence; the existing Pass / Pass-with-observations / Fail verdict handling is the downstream filter, and is unchanged.
- **Three plugin prompt edits**: scope discipline in the subagent-start hook, a no-verification-delegation clause in the orchestrator output style, and persist-as-you-go in the ralph iteration style.
- **Note-length calibration**: `maxLength` on `session-tracking` (2000) and every `implementation-notes` declaration (3000), plus anti-padding guidance. `note_limits.mode` stays at its default `warn`, so over-length notes are flagged rather than rejected — a soft calibration, not a new hard gate.

## Scope decision: 8 tools, not 16

The original plan called for trigger sentences on every tool. Measuring `ToolTokenBudgetTest` first showed headroom of 8 chars (`query_notes`), 1 char (`claim_item`), and 1 char (`get_next_status`) — the full sweep would have broken nine per-tool ceilings.

Narrowed to the workflow/lifecycle tools where under-triggering is a genuine risk. The CRUD/query surface is reached for by obvious need, and the guidance explicitly warns that prompting tools which already trigger correctly causes *over*triggering.

**Token cost: `tools/list` grows 40,352 → 41,102 chars** (+1.9%), paid once per client session.

## Test Results

`:current:test` + `:current:ktlintCheck` green from the feature worktree (BUILD SUCCESSFUL, exit 0). `git status` clean after `ktlintFormat` — no formatting fix-ups needed. `config.yaml` independently validated with PyYAML; `node --check` passes on the modified hook.

No new tests. The change is prose/config only and is guarded by the existing `ToolTokenBudgetTest` and `ToolDocumentationConsistencyTest` — the budget test did its job, forcing the token cost to be made explicit rather than absorbed silently.

## Review

**Pass with observations.** Two judgment calls worth a second opinion before merge:

1. **`totalCeiling` raised 44,900 → 47,300.** BUDGET PHILOSOPHY points 2 and 3 require the aggregate to move in lockstep with the per-tool table, but 44,900 still passed at 41,102 measured — keeping the tighter bound was defensible. Chose contract-consistency; happy to revert to 44,900 if you prefer the tighter guard.
2. **`maxLength` values are judgment calls, not measured.** No sampling of real note-length distribution was done. Mode is `warn`, so the failure mode is warning noise, not blocked gates.

Also fixed during review (`a61b39f`): the four raised ceilings were initially set to measured-rounded-up-to-50, leaving 1–2% headroom (`claim_item` had 19 chars) instead of the documented 15%.

## Post-merge adoption steps

Neither is automatic — until both happen, the merged changes are inert:
- **Plugin cache**: remove and re-add the marketplace to pick up the `subagent-start.mjs` change.
- **Config**: `config.yaml` reaches the server when `config-sync` next pushes it per-root.

## MCP

Parent: `c0037cc1-6a6b-4787-9884-15452f33e7ec`
Children: `34e9e924` (tool descriptions) · `c51a88b0` (review reporting) · `d9fd5dfe` (plugin prompts) · `f07dea25` (note calibration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)