### PR TITLE
docs(retro): point the trend file at MCP for proposal state instead of mirroring it

### DIFF
--- a/claude-plugins/task-orchestrator/skills/session-retrospective/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/session-retrospective/SKILL.md
@@ -150,6 +150,8 @@ Identify themes across entries (e.g., "3 friction entries related to gate failur
 
 Read the trend memory file `memory/retrospectives.md` from the auto memory directory (file read, not MCP call). The auto memory path is shown at session start — typically `~/.claude/projects/<project-key>/memory/`.
 
+A sibling `memory/retrospectives-history.md` may exist, holding archived (addressed / obsolete / accepted-environmental) patterns and superseded records. **Do not read it during a normal run** — it is a provenance archive kept out of the working file to bound its size. Read it only when tracing the evidence chain of an entry that cites an archived pattern by name.
+
 **If the file does not exist:** This is the first retrospective. Skip trend comparison — all findings are new baselines.
 
 **If the file exists:** For each dimension finding from step 3:
@@ -246,7 +248,9 @@ Read `memory/retrospectives.md` from the auto memory directory. Update each sect
 - **Schema Effectiveness:** Add or update entries from dimension 3a findings. Format: `- <schema-note-key>: <observation>. Sessions: N. Last seen: YYYY-MM-DD`
 - **Delegation Patterns:** Add or update from dimension 3b. Format: `- <pattern>. Sessions: N. Last seen: YYYY-MM-DD`
 - **Note Quality:** Add or update from dimension 3c. Format: `- <note-key>: <observation>. Sessions: N. Last seen: YYYY-MM-DD`
-- **Improvement Proposals:** Add new proposal references if created in step 7.
+- **Improvement Proposals:** Record the proposal ID *inline on the trend entry that graduated* (`GRADUATED -> proposal <id>`). Do NOT write proposal status, priority, dates, or descriptions into this file — MCP owns those, and a mirrored copy drifts. Resolve current state on demand with `query_items(operation="overview", anchorId="<proposals-container-uuid>", includeChildren=true)`. Per-proposal outcome narrative belongs on the proposal item's own `adoption-decision` / `outcome-verification` notes.
+
+**Retire, don't accumulate.** When a pattern becomes archived (addressed and non-recurring, obsolete, or accepted-environmental), move its entry to `memory/retrospectives-history.md` rather than leaving an `[ARCHIVED]` line in the working file. Likewise, when appending new evidence to a long-running entry, condense the older per-session detail rather than appending indefinitely — the working file is read whole on every run, so unbounded entries are the dominant cost.
 
 Write the updated file.
 
@@ -302,8 +306,14 @@ query_items(operation="search", tags="session-retrospective", limit=20)
 
 **If 3+ retrospectives exist**, evaluate:
 
-1. **Trend durability:** Did previously identified trends get addressed? Check if improvement proposals in terminal state exist for prior trends.
-2. **Proposal staleness:** Any proposals created 3+ retrospectives ago with no movement (still in queue)?
+Proposal state for both checks below comes from MCP, never from the trend file — query the container once and read roles off the result:
+
+```
+query_items(operation="overview", anchorId="<proposals-container-uuid>", includeChildren=true)
+```
+
+1. **Trend durability:** Did previously identified trends get addressed? Check whether the proposal a trend graduated into is terminal.
+2. **Proposal staleness:** Any proposals created 3+ retrospectives ago with no movement (still in queue)? Also flag any stuck in `work` — a proposal sitting in-progress across runs is usually a stalled adoption, not active work.
 3. **Self-quality:** Are retrospective notes converging on useful patterns, or repeating the same observations without resolution? Are notes too verbose (>800 tokens each) or too shallow (<100 tokens)?
 
 If meta-findings warrant it, add a brief note to the current retrospective's `improvement-signals` note via:


### PR DESCRIPTION
## Summary

Implements steps 1 and 2 of the trend-memory cleanup agreed after retrospective `eb6ea54d`. Skill-side only — the corresponding surgery on the local trend file has already been applied.

**Step 1 — stop mirroring proposal state.** The trend memory file kept its own copy of each improvement proposal's status, and it drifted twice:

| Audit | Found |
|---|---|
| 2026-07-13 | `82034e9a`, `43c05c0c` recorded as open; both terminal in MCP |
| 2026-07-27 | `f9b4e55f`, `c88fb0fc` recorded as open; both terminal. List also incomplete — 19 entries in the file against 24 in the container |

Same root cause both times: a fact copied into a second location where the copy drifts from its source. Step 6 now records only the proposal ID, inline on the trend that graduated. Status, priority, dates, and description stay in MCP; per-proposal outcome narrative belongs on the proposal item's own `adoption-decision` / `outcome-verification` notes.

**Step 2 — bound the working file.** Archived patterns now move to a `retrospectives-history.md` sibling instead of lingering as `[ARCHIVED]` lines, and long-running entries get condensed rather than appended to indefinitely. Step 4 tells the skill that history file exists and should *not* be read on a normal run.

Also: Step 8's meta-evaluation now explicitly sources proposal state from a container query rather than the file, and flags proposals stuck in `work` as likely stalled adoptions (one currently is).

## Effect on the local trend file

Already applied via a scripted split, backed up first and verified by entry counts:

- 17 archived trends + the 19-entry proposal mirror moved to `retrospectives-history.md`
- Working file 154,042 → 133,482 bytes (−13%); 116 → 99 trend entries
- Nothing dropped: total bytes across both files went slightly *up*, from the added headers

Honest caveat: the archive prune helped less than hoped. The dominant cost is a handful of very long append-only active entries — `review-pipeline-catches-real-bugs` alone is 5,013 chars — which is why the condense-don't-append rule was added alongside it.

## Test Results

No tests — skill markdown only, no code paths touched. The `.claude/settings.json` key reorder present in the working tree was not authored here and was deliberately left unstaged.

## Deferred

Making trends first-class MCP items with derived occurrence counts (dependency edges from retro → trend, so `Sessions: N` is computed rather than hand-maintained) is tracked separately for future consideration, not done here.

## MCP

Follows retrospective `eb6ea54d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)