### PR TITLE
feat(plugin): add pattern-driven schema advisor to manage-schemas skill

### DIFF
--- a/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: manage-schemas
-description: "Creates, views, edits, deletes, and validates note schemas for the MCP Task Orchestrator in .taskorchestrator/config.yaml — the templates that define which notes agents must fill at each workflow phase. Also manages the actor_authentication config block: set actor authentication policy, configure degraded mode, show actor_authentication config, set degradedModePolicy to reject, what's the current degraded mode policy. Use when user says: create schema, show schemas, edit schema, delete schema, validate config, what schemas exist, add a note to schema, remove note from schema, or configure gates."
-argument-hint: "[optional: action + schema name or 'actor_authentication', e.g. 'view bug-fix', 'create research-spike', 'validate', 'set degradedModePolicy reject']"
+description: "Creates, views, edits, deletes, and validates note schemas for the MCP Task Orchestrator in .taskorchestrator/config.yaml — the templates that define which notes agents must fill at each workflow phase. Also recommends schema designs from a library of workflow patterns (autonomous coding loops, spec-driven teams, research pipelines, content production, support triage, data pipelines, incident response, document review) — use this skill whenever the user describes a workflow they want tracked or gated, even without the word 'schema': what schema should I use, help me design schemas, recommend gates for X, set up schemas for my team/workflow/pipeline. Also manages the actor_authentication config block: set actor authentication policy, configure degraded mode, show actor_authentication config, set degradedModePolicy to reject, what's the current degraded mode policy. Use when user says: create schema, show schemas, edit schema, delete schema, validate config, what schemas exist, add a note to schema, remove note from schema, or configure gates."
+argument-hint: "[optional: action + schema name, workflow description, or 'actor_authentication', e.g. 'view bug-fix', 'create research-spike', 'recommend schemas for support triage', 'validate', 'set degradedModePolicy reject']"
 ---
 
 # Manage Schemas — Note Schema Lifecycle
@@ -17,6 +17,7 @@ Classify from `$ARGUMENTS` and conversation context before making any tool calls
 | Signal words | Action |
 |---|---|
 | "create", "build", "new", "add schema", "define", "set up" | CREATE |
+| "recommend", "advise", "design", "what schema should I use", "help me choose", a described workflow with no schema name | CREATE (advisor path) |
 | "show", "view", "list", "what schemas", "display" | VIEW |
 | "edit", "modify", "change", "update", "add note to", "remove note from" | EDIT |
 | "delete", "remove schema", "drop" | DELETE |
@@ -49,7 +50,11 @@ Check if `.taskorchestrator/config.yaml` exists by reading it.
 
 ### CREATE — Build a New Schema
 
-Interactive Q&A flow that gathers schema requirements, generates YAML, merges into config, and optionally creates a companion lifecycle skill.
+Three entry paths: a pattern-driven **advisor** (the user describes their workflow; classify it
+against `references/workflow-patterns.md` and recommend a configuration with per-gate
+rationale), starter **templates**, and from-scratch **Q&A**. All three converge on the same
+customize → write → smoke-test machinery. When the user described a workflow rather than naming
+a schema, go straight to the advisor path.
 
 For detailed workflow, see `references/create-workflow.md` in this skill folder.
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/create-workflow.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/create-workflow.md
@@ -1,27 +1,105 @@
 # Create Schema Workflow
 
-Full interactive flow for building a new note schema. Offers starter templates before falling back to from-scratch Q&A.
+Full interactive flow for building a new note schema. Three entry paths: a pattern-driven
+advisor that recommends a configuration from the user's described workflow, starter templates,
+and from-scratch Q&A.
 
 ---
 
 ## Step 1 — Choose Starting Point
 
-If `$ARGUMENTS` already contains a schema name that matches a starter template (e.g., "create feature-implementation"), skip to Step 2 with that template pre-selected.
+Fast paths from `$ARGUMENTS` and conversation context — check these before asking anything:
+
+- **Schema name matching a starter template** (e.g., "create feature-implementation") → skip to
+  Step 2 with that template pre-selected.
+- **A workflow description rather than a schema name** (e.g., "create schemas for our support
+  triage", "set up gates for my content pipeline", "what schema should I use for X") → skip to
+  Step 2A (advisor) with the description as seed context.
 
 Otherwise, ask via `AskUserQuestion`:
 
 ```
 ◆ How would you like to create the schema?
-  1. Feature implementation — lean feature-summary gate (queue), implementation evidence
-     + session tracking (work), review checklist (review) — 4 notes
-  2. Bug fix — diagnosis gate (queue), implementation evidence + session tracking (work),
-     review checklist (review) — 4 notes
-  3. Start from scratch — answer questions to build a custom schema
+  1. Recommend from my workflow — describe the work you manage; get a recommended
+     configuration from a library of workflow patterns
+  2. Feature implementation template — lean feature-summary gate (queue), implementation
+     evidence + session tracking (work), review checklist (review) — 4 notes
+  3. Bug fix template — diagnosis gate (queue), implementation evidence + session tracking
+     (work), review checklist (review) — 4 notes
+  4. Start from scratch — answer questions to build a custom schema
 ```
 
 ---
 
-## Step 2 — Template Path (options 1 or 2)
+## Step 2A — Advisor Path (option 1)
+
+Recommend a configuration by classifying the user's workflow against the pattern library.
+Read `references/workflow-patterns.md` (in this skill folder) before proceeding — it carries
+the classification dimensions, a capsule index of all ten profiles, selection tables, the
+cross-domain trait library, and the anti-pattern warnings. The full profiles (YAML + rationale)
+live one-per-file in `references/profiles/` — do NOT read them at this stage; you will read
+only the matched one(s) in 2A.2.
+
+### 2A.1 — Gather workflow facts
+
+Extract answers from what the user has already said first — the conversation usually contains
+most of them. Then ask ONLY for genuine gaps, batched into a single `AskUserQuestion` round
+(max 4 questions), covering the four classification dimensions from `workflow-patterns.md` §1:
+
+1. **Work shape** — what kind of work flows through (features, loop tasks, research, content,
+   tickets, pipeline runs, incidents, documents, generic tasks)
+2. **Sign-off** — does anything need human or second-agent approval before closing, and what
+   evidence does the approver need?
+3. **Executors** — one orchestrated agent, or multiple workers pulling from a shared pool?
+4. **Contention & recurrence** — shared resources that tolerate one user at a time? standing
+   queues? work that reopens later?
+
+Do not run a second interview round unless an answer is genuinely uninterpretable.
+
+### 2A.2 — Classify and recommend
+
+Classify against the profile index in `workflow-patterns.md` §1 — the capsules carry enough
+signal to compare all ten candidates without opening files. Then read ONLY the matched profile
+file from `references/profiles/` (a second file when the classification is ambiguous or the
+workflow is a hybrid; never the whole directory — the two-stage read exists to keep unmatched
+profiles out of context). Then present:
+
+1. **The recommendation** — primary profile, plus any traits pulled from §4 or a second
+   profile. Name the pattern in plain language ("this is a claim-mode triage shape").
+2. **The YAML** — the profile's schema adapted to the user's terms (rename types/keys to the
+   user's vocabulary; keep the structure). Kebab-case keys, explicit `required` on every note,
+   explicit `lifecycle`.
+3. **The rationale, per gate** — one line each on why the gate exists and what failure it
+   prevents, drawn from the profile's "rationale to present". A gate whose purpose the user
+   can't restate will be worked around, not filled.
+4. **Conventions that aren't config** — if the recommendation involves claim mode, actor
+   authentication, or dispatch discipline (e.g., review notes filled by a different agent),
+   say explicitly that these are usage conventions the config cannot enforce.
+
+Where the user's workflow steers toward an anti-pattern (§5 — over-gating, exclusive resources
+on containers, self-review, generic resource keys), raise the warning with its reason as part
+of the recommendation, not after writing.
+
+### 2A.3 — Confirm and hand off
+
+Ask via `AskUserQuestion`:
+
+```
+◆ This is the recommended configuration. What would you like to do?
+  1. Use as-is — write it to config
+  2. Customize first — add, remove, or modify notes before writing
+  3. Cancel — go back
+```
+
+- **Use as-is / Customize:** continue exactly as the template path does (Step 2's "After
+  showing the template" — customize loop, then Write Config, companion skill, smoke test).
+  A companion lifecycle skill (Step 5) is worth offering for any recommendation with 3+ notes
+  or claim-mode conventions.
+- **Cancel:** return to Step 1.
+
+---
+
+## Step 2 — Template Path (options 2 or 3)
 
 ### Feature Implementation Template
 
@@ -106,7 +184,7 @@ Ask via `AskUserQuestion`:
 
 ---
 
-## Step 3 — From-Scratch Path (option 3)
+## Step 3 — From-Scratch Path (option 4)
 
 Ask the user the following questions (use `AskUserQuestion` for structured input):
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/autonomous-loop.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/autonomous-loop.md
@@ -1,0 +1,33 @@
+# Profile — Autonomous Queue-Drain Loop
+
+**Recommend when:** solo dev running bounded agent loops (overnight runs, queue drains); the work
+is coding tasks executed without supervision; review happens at the PR, outside the tracker.
+
+```yaml
+work_item_schemas:
+  loop-task:
+    lifecycle: auto
+    notes:
+      - key: completion-oracle
+        role: queue
+        required: true
+        description: "Machine-checkable done signal — exact command and expected outcome."
+        guidance: "State the exact command that proves completion (test suite, build, lint) and
+          its expected result, plus the bound: max iterations or wall-clock budget before the
+          item escalates to a human. The loop agent may not redefine this mid-run. A vague
+          oracle ('improve the code') makes the loop non-convergent — reject it."
+      - key: iteration-evidence
+        role: work
+        required: true
+        description: "Final evidence — iterations used vs bound, test results, files touched."
+        maxLength: 1500
+  default:
+    lifecycle: auto
+    notes: []
+```
+
+**Rationale to present:** the top documented failure of autonomous loops is the agent
+self-declaring done. Writing the done-signal into a queue gate *before* work starts puts it
+where the loop can't rewrite it. No review phase — the human merge gate lives in the PR. If
+multiple loops can run concurrently, recommend claim mode so a crashed run's lease expires
+instead of stranding the item.

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/content-production.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/content-production.md
@@ -1,0 +1,49 @@
+# Profile — Content Production Pipeline
+
+**Recommend when:** editorial workflows — research/brief → draft → fact-check → approve →
+publish; evergreen pieces get refreshed later; unsupported claims reaching publication is the
+concern.
+
+```yaml
+work_item_schemas:
+  content-piece:
+    lifecycle: auto-reopen      # a refresh child created later reopens the published piece
+    notes:
+      - key: content-brief
+        role: queue
+        required: true
+        description: "Approved brief — audience, angle, keywords, claims that need support."
+        guidance: "A human approves the brief BEFORE drafting starts. Rejecting a bad brief
+          costs minutes; rejecting a bad draft costs the whole draft."
+      - key: fact-check
+        role: work
+        required: true
+        description: "Claims-supported audit — every factual claim sourced, softened, or cut."
+      - key: editorial-signoff
+        role: review
+        required: true
+        description: "Editor's publish decision — voice, structure, accuracy verified."
+  revision-task:
+    lifecycle: auto
+    notes:
+      - key: refresh-scope
+        role: queue
+        required: true
+        description: "What decayed — rankings, stale facts, broken links — and what to update."
+      - key: refresh-evidence
+        role: work
+        required: true
+        description: "What was updated and re-verified."
+
+traits:
+  needs-legal-review:           # apply per-item at briefing time for regulated/YMYL claims
+    notes:
+      - key: legal-review
+        role: review
+        required: true
+        description: "Legal/compliance sign-off for regulated claims."
+```
+
+**Rationale to present:** `auto-reopen` keeps an evergreen piece's history in one item across
+refresh cycles instead of fragmenting it. The per-item `needs-legal-review` trait shows dynamic
+routing: the briefing agent applies it only to pieces that make regulated claims.

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/data-pipeline-ops.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/data-pipeline-ops.md
@@ -1,0 +1,51 @@
+# Profile — Data Pipeline Ops (Resource Leases + Recurring Runs)
+
+**Recommend when:** recurring pipeline/ETL runs; a shared resource (warehouse, cluster, staging
+slot) tolerates only one heavy job at a time; bad data propagating silently is the concern.
+
+```yaml
+resources:
+  analytics-warehouse:
+    description: "Shared warehouse — one heavy transform/backfill at a time"
+    defaultTtlSeconds: 7200
+    maxHolders: 1
+
+work_item_schemas:
+  pipeline-run:
+    lifecycle: auto
+    default_traits: [needs-warehouse-slot]
+    notes:
+      - key: run-scope
+        role: queue
+        required: false
+        description: "What this run covers — date range, tables, backfill vs incremental."
+      - key: quality-scorecard
+        role: work
+        required: true
+        description: "Row counts, anomaly score, schema-drift check results."
+        guidance: "On a threshold breach: apply the needs-anomaly-review trait so a data
+          engineer disposition gate is added before the run closes."
+  data-product:                 # container per recurring pipeline; new runs reopen it
+    lifecycle: auto-reopen
+    notes: []
+
+traits:
+  needs-warehouse-slot:
+    resources:
+      - key: analytics-warehouse
+        mode: exclusive         # WORK entry takes the lease; contention = transient rejection
+      - key: prod-read-credential
+        mode: advisory          # recorded in consumedCredentials, never locks
+  needs-anomaly-review:
+    notes:
+      - key: anomaly-review
+        role: review
+        required: true
+        description: "Data engineer's disposition of the flagged anomaly."
+```
+
+**Rationale to present:** the exclusive lease lives on the **leaf** run type — never the
+container (anti-pattern 2 in `workflow-patterns.md` §4). A second run entering WORK while the
+warehouse is held gets a transient `resource_unavailable` with retry semantics, not a gate
+error. Scope resource keys per team (`analytics/warehouse`, not `db`) — generic keys falsely
+serialize unrelated projects on a shared server.

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/document-review.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/document-review.md
@@ -1,0 +1,31 @@
+# Profile — Document/Contract Review
+
+**Recommend when:** intake → analysis → human sign-off pipelines over documents (contracts,
+compliance, claims); an attributable approval record is the concern.
+
+```yaml
+work_item_schemas:
+  contract-review:
+    lifecycle: auto
+    notes:
+      - key: intake
+        role: queue
+        required: true
+        description: "Counterparty, document type, deadline, playbook version to review against."
+      - key: deviation-analysis
+        role: work
+        required: true
+        description: "Clause table + deviations from playbook with risk flags."
+        guidance: "The reviewer sees flags, not raw text — routine terms consuming expert time
+          is the cost this pipeline removes."
+      - key: reviewer-signoff
+        role: review
+        required: true
+        description: "Human approval to release — attributable, verified if actor auth is on."
+        guidance: "Filled only by the human reviewer, never by the analysis agent."
+```
+
+**Rationale to present:** pair with `actor_authentication` (global config; JWKS verifier) when
+sign-off authorship must be verifiable, not just recorded. Be candid about the boundary: the
+server verifies *who wrote* the note; requiring that a *specific actor class* fills a specific
+note key is convention, not schema-enforced.

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/incident-response.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/incident-response.md
@@ -1,0 +1,45 @@
+# Profile — Incident Response
+
+**Recommend when:** on-call/runbook workflows; severity tiers; the postmortem discipline is
+what the user wants enforced.
+
+```yaml
+work_item_schemas:
+  incident:
+    lifecycle: auto
+    notes:
+      - key: severity-triage
+        role: queue
+        required: true
+        description: "Severity tier, blast radius, on-call paged yes/no."
+        guidance: "Critical severity always pages — agents do not resolve critical incidents
+          autonomously."
+      - key: containment-log
+        role: work
+        required: true
+        description: "Actions taken with timestamps; who approved production access."
+      - key: postmortem
+        role: review
+        required: true
+        description: "Root cause, timeline, action items — the incident can't close without it."
+        guidance: "Blameless. Create a follow-up item per action item and link it as a
+          dependency — unfollowed action items are how the same incident repeats."
+  incidents:                    # standing intake container
+    lifecycle: permanent
+    notes: []
+
+traits:
+  needs-prod-access:
+    notes:
+      - key: access-justification
+        role: work
+        required: true
+        description: "Why production access was needed and who approved it."
+    resources:
+      - key: prod-change-credential
+        mode: advisory          # audit trail without serializing incident work
+```
+
+**Rationale to present:** the review phase here is not code review — it's "the incident is not
+closed until the postmortem exists." Advisory resources give the credential audit trail without
+locking. Map priority to severity so `get_next_item` surfaces the hottest incident.

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/multi-project.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/multi-project.md
@@ -1,0 +1,17 @@
+# Profile — Multi-Project Platform Layering
+
+**Recommend when:** one server, several repos/teams with different workflows. This is a
+layering strategy, not one YAML:
+
+- **Global floor** (`AGENT_CONFIG_DIR` config): only process schemas every project should share
+  (observations, retrospectives, generic containers) plus the `resources:` registry for
+  genuinely server-wide keys (the registry is global-wins by design — a resource key is a
+  server-wide lock namespace).
+- **Per-root** (config-sync / `manage_project_config` push): each team's own types and traits —
+  hot-reloads without restart, wins over the global floor for that root.
+- **Per-team dispatch**: claim-mode fleets and orchestrated projects coexist on one server.
+
+**Rationale to present:** walk the user toward per-root configs per team and a deliberately
+minimal global floor. A gate-free team fences itself off with the empty `default` schema (see
+`schema-free.md`). Resource keys should be project-scoped (`team-a/staging-db`) to avoid false
+serialization across teams.

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/research-pipeline.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/research-pipeline.md
@@ -1,0 +1,45 @@
+# Profile — Deep-Research Pipeline
+
+**Recommend when:** parallel research threads under a lead/orchestrator; a synthesized report
+with sources is the deliverable; hallucinated or uncited claims are the concern.
+
+```yaml
+work_item_schemas:
+  research-mission:
+    lifecycle: manual           # the lead closes the mission after the citation gate
+    notes:
+      - key: research-plan
+        role: queue
+        required: true
+        description: "Decomposition — subquestions, source strategy, output format, stop rule."
+        guidance: "Each planned thread must map to a research-thread child with its own brief.
+          State the stop rule: what makes coverage sufficient."
+      - key: synthesis
+        role: work
+        required: true
+        description: "The synthesized report draft, built from thread findings notes."
+      - key: citation-audit
+        role: review
+        required: true
+        description: "Claim→source mapping — every substantive claim traced or flagged."
+        guidance: "Run as a separate agent from the synthesizer — self-citation is the failure
+          mode. Attach a source pointer per claim, or flag the claim for removal."
+  research-thread:
+    lifecycle: auto
+    notes:
+      - key: thread-brief
+        role: queue
+        required: true
+        description: "Objective, output format, tool guidance, boundaries."
+        guidance: "Filled by the lead before dispatch. State what this thread owns and what it
+          must NOT wander into — vague briefs cause duplicated and gapped coverage."
+      - key: findings
+        role: work
+        required: true
+        description: "Distilled findings with source pointers — this note IS the report."
+        maxLength: 4000
+```
+
+**Rationale to present:** notes are the handoff medium — subagents write findings once, the
+lead reads notes instead of replaying transcripts (the "game of telephone" cost in multi-agent
+systems). The citation audit is a separate reviewer by design.

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/schema-free.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/schema-free.md
@@ -1,0 +1,16 @@
+# Profile — Schema-Free Tracking
+
+**Recommend when:** the user wants plain status/dependency tracking — kanban semantics, no
+gates. Also the per-root fence for a gate-free project on a shared server.
+
+```yaml
+work_item_schemas:
+  default:
+    lifecycle: auto             # or manual/permanent for standing-workflow boards
+    notes: []
+```
+
+**Rationale to present:** every item advances freely; the value is ordering (`get_next_item`),
+dependency blocking (`get_blocked_items`), and hierarchy. On a shared server, pushing this
+per-root fences off the global config entirely (per-root resolution is whole-algorithm-first —
+this root's `default` beats even a global exact-type match).

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/spec-driven-team.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/spec-driven-team.md
@@ -1,0 +1,48 @@
+# Profile — Spec-Driven Development Team
+
+**Recommend when:** a team works plan-first (spec → plan → tasks → implement); epics decompose
+into child tasks; drift between spec and code is the concern.
+
+```yaml
+work_item_schemas:
+  sdd-epic:
+    lifecycle: manual          # a human closes the epic after merge — no auto-cascade
+    notes:
+      - key: specification
+        role: queue
+        required: true
+        description: "The WHAT — user stories, acceptance criteria, non-goals."
+      - key: implementation-plan
+        role: queue
+        required: true
+        description: "The HOW — architecture, task decomposition, dependency edges."
+        guidance: "Derived from the approved specification. Map each spec item to a child
+          sdd-task; record dependency edges; flag risky areas needing review traits."
+      - key: integration-notes
+        role: work
+        required: true
+        description: "Cross-task deviations and decisions discovered during implementation."
+      - key: spec-alignment
+        role: review
+        required: true
+        description: "Diff-vs-spec audit before the epic closes."
+        guidance: "Walk the final result against the specification: flag spec items not built,
+          and built things not in the spec. Catching drift is this note's entire job."
+  sdd-task:
+    lifecycle: auto
+    notes:
+      - key: task-definition
+        role: queue
+        required: true
+        description: "Scope slice from the plan — files, acceptance criteria, constraints."
+      - key: implementation-evidence
+        role: work
+        required: true
+        description: "What was built, test results, deviations from the task definition."
+```
+
+**Rationale to present:** each stage transition is a re-readable document instead of chat
+history — the mechanism practitioners credit for large rework reductions. `manual` lifecycle
+keeps the epic open after children finish so the alignment review and the human close decision
+still happen. Both queue notes gate the same transition; spec-before-plan ordering is guidance,
+not server-enforced — the gate guarantees neither is skipped.

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/support-triage.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/profiles/support-triage.md
@@ -1,0 +1,40 @@
+# Profile — Support/Ticket Triage (Claim-Mode Worker Fleet)
+
+**Recommend when:** multiple worker agents pull from a shared queue; auto-resolve vs escalate
+routing; context loss at human handoff is the concern.
+
+```yaml
+work_item_schemas:
+  support-ticket:
+    lifecycle: auto
+    notes:
+      - key: triage
+        role: queue
+        required: true
+        description: "Intent, urgency, confidence score, routing decision."
+        guidance: "Filled by the triage agent. Below the auto-resolve confidence threshold, or
+          on legal/frustration signals: apply the needs-escalation trait to this item and raise
+          its priority — that adds the escalation gate to THIS ticket only."
+      - key: resolution
+        role: work
+        required: true
+        description: "What was done — resolution summary and customer-visible outcome."
+  intake:                       # standing queue container
+    lifecycle: permanent
+    notes: []
+
+traits:
+  needs-escalation:
+    notes:
+      - key: escalation-packet
+        role: review
+        required: true
+        description: "Full-context handoff bundle for the human agent."
+        guidance: "Everything the human needs without re-reading the thread: the issue, what
+          was tried, customer sentiment, recommended action."
+```
+
+**Rationale to present:** claim mode is the dispatch model — workers `claim_item` with a TTL,
+so a crashed worker's lease expires and the ticket returns to the pool. Priority carries
+urgency into `get_next_item` ordering. An unescalated ticket flows queue→work→terminal; an
+escalated one grows a review phase — same schema, two shapes, via one per-item trait.

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/workflow-patterns.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/workflow-patterns.md
@@ -1,0 +1,160 @@
+# Workflow Pattern Library — Schema Advisor Reference
+
+Pattern library backing the CREATE workflow's advisor path (`create-workflow.md` Step 2A).
+
+**Two-stage read — this matters for context cost.** This file carries everything needed to
+*classify* a workflow: the interview dimensions, a capsule index of all ten profiles, selection
+tables, the trait library, and anti-pattern warnings. The full profiles (YAML + rationale to
+present) live one-per-file in `references/profiles/`. Classify against the capsule index first,
+then read ONLY the matched profile file — two when the classification is ambiguous or the
+workflow is a hybrid. Never read the whole profiles directory: the capsule index exists
+precisely so candidates can be compared without opening files.
+
+**Contents:**
+1. [Classification — dimensions and profile index](#1-classification)
+2. [Selection tables](#2-selection-tables)
+3. [Cross-domain trait library](#3-cross-domain-trait-library)
+4. [Anti-pattern warnings](#4-anti-pattern-warnings)
+
+---
+
+## 1. Classification
+
+Classify from what the user has already said before asking anything — most conversations contain
+the answers. Ask only for genuine gaps, batched into one `AskUserQuestion` round (the four
+dimensions below fit its 4-question limit). Do not interrogate dimension by dimension.
+
+| Dimension | What to determine | Why it matters |
+|---|---|---|
+| **Work shape** | What flows through: features/bugs, loop tasks, research questions, content pieces, tickets, pipeline runs, incidents, documents, generic tasks | Picks the primary profile |
+| **Sign-off** | Does anything require human or second-agent approval before an item closes? Who reviews, and what evidence do they need? | Decides whether a `review` phase exists and what its gate note carries |
+| **Executors** | One orchestrated agent, or multiple independent workers pulling from a pool? Crash-recovery needed? | Pull-based fleet → claim-mode conventions (TTL leases); single driver → orchestration mode |
+| **Contention & recurrence** | Shared resources only one worker may touch at a time? Standing queues? Work that reopens? | Resource traits (`exclusive`/`advisory`); lifecycle (`permanent`, `auto-reopen`) |
+
+### Profile index
+
+| Profile file (`profiles/`) | Recommend when the user says things like | Config shape (capsule) |
+|---|---|---|
+| `autonomous-loop.md` | "overnight runs", "agent loop", "queue drain", "autonomous coding", "Ralph" | Leaf `loop-task`: queue completion-oracle gate (machine-checkable done signal + iteration bound), work iteration-evidence; NO review phase (PR is the human gate); claim mode if loops run concurrently |
+| `spec-driven-team.md` | "spec first", "PRD", "plan before code", "team of devs + agents", "epics" | `sdd-epic` (manual lifecycle, dual queue gates spec+plan, work integration-notes, review spec-alignment audit) + `sdd-task` children (task-definition, implementation-evidence) |
+| `research-pipeline.md` | "research", "deep dive", "report with sources", "parallel investigation" | `research-mission` (manual; plan gate, synthesis, review citation-audit by a separate agent) + `research-thread` children (brief gates dispatch; findings note IS the report, maxLength-bounded) |
+| `content-production.md` | "blog", "articles", "editorial", "publish", "SEO", "content calendar" | `content-piece` (auto-reopen for refresh cycles; brief approval gate → work fact-check → review editorial-signoff) + `revision-task` children; per-item `needs-legal-review` trait for regulated claims |
+| `support-triage.md` | "tickets", "triage", "worker pool", "escalate to a human", "support" | `support-ticket` (triage queue gate w/ confidence routing, work resolution) + permanent `intake` container; per-item `needs-escalation` trait adds review escalation-packet; claim-mode dispatch convention |
+| `data-pipeline-ops.md` | "ETL", "data pipeline", "warehouse", "one run at a time", "data quality" | `pipeline-run` leaf with exclusive resource lease trait (+ advisory credential), work quality-scorecard; `data-product` auto-reopen container; `needs-anomaly-review` trait on threshold breach |
+| `incident-response.md` | "incidents", "on-call", "runbook", "postmortem", "SRE" | `incident` (severity-triage gate, containment-log, review postmortem — can't close without it) + permanent `incidents` container; `needs-prod-access` trait with advisory credential audit |
+| `document-review.md` | "contracts", "documents to review", "redline", "sign-off", "compliance", "audit trail" | `contract-review`: intake gate → work deviation-analysis (flags, not raw text) → review human sign-off; pair with global `actor_authentication` for verified authorship |
+| `schema-free.md` | "just track tasks", "kanban", "no gates", "simple statuses" | Empty `default` schema — status/dependency/hierarchy tracking only; doubles as the per-root fence on a shared server |
+| `multi-project.md` | "multiple projects", "shared server", "different teams, one database" | Layering strategy, not one YAML: minimal global floor (process schemas + resource registry) + per-root config per team; mixed dispatch models coexist |
+
+Hybrids are normal: pick the closest primary profile, read its file, and pull traits from §3 or
+a second profile's file to cover the rest. Say which parts came from where — the user should
+understand the recommendation well enough to maintain it.
+
+---
+
+## 2. Selection Tables
+
+Use these when explaining a recommendation or resolving a customization question.
+
+**Lifecycle mode** (per schema type):
+
+| The user wants | `lifecycle` |
+|---|---|
+| Tree closes itself when children finish | `auto` (default) |
+| A human/lead decides when it closes | `manual` |
+| Standing container that never closes (intake queues, category containers) | `permanent` |
+| Closed parent reopens when new child work arrives (refresh cycles, recurring runs) | `auto-reopen` |
+
+**Dispatch model** (usage convention — not a config key; mention it in the recommendation):
+
+| Situation | Model |
+|---|---|
+| One orchestrator drives items through phases | Orchestration (`advance_item`) |
+| Independent workers pull from a shared pool; crash-safety needed | Claim (`claim_item` + TTL lease) |
+| Worker fleet needing verified identity on writes | Either + `actor_authentication` (global config only) |
+
+**Gate strength** (per note):
+
+| Intent | Mechanism |
+|---|---|
+| Must exist before the phase transition | `required: true` |
+| Useful reminder, never blocks | `required: false` |
+| Must follow a reusable methodology | `required: true` + `skill` |
+| Must cover project specifics | `required: true` + `guidance` |
+| Body must stay distilled | `maxLength` (+ top-level `note_limits.mode: reject` to enforce hard) |
+
+---
+
+## 3. Cross-Domain Trait Library
+
+Offer these during customization when a need surfaces that the chosen profile doesn't cover.
+Merge rules: base-schema note keys beat trait notes; resources union across traits with
+`exclusive` winning mode conflicts.
+
+```yaml
+traits:
+  human-approval:               # generic maker-checker gate
+    notes:
+      - key: approval-decision
+        role: review
+        required: true
+        description: "Human approver's decision with rationale — approve / reject / conditions."
+  needs-fact-check:
+    notes:
+      - key: fact-check
+        role: work
+        required: true
+        description: "Every factual claim sourced, softened, or cut."
+  needs-security-review:
+    notes:
+      - key: security-assessment
+        role: review
+        required: true
+        description: "Input validation, injection risk, access control, data handling."
+  needs-rollback-plan:
+    notes:
+      - key: rollback-plan
+        role: queue
+        required: true
+        description: "How to undo this change if it fails after release."
+  session-tracked:              # feeds /session-retrospective; recommend for agent-run projects
+    notes:
+      - key: session-tracking
+        role: work
+        required: true
+        description: "What happened — outcome, deviations, friction; feeds retrospectives."
+        maxLength: 2000
+  needs-staging-slot:           # exclusive lease — leaf task types only
+    resources:
+      - key: staging-env
+        mode: exclusive
+  records-deploy-credential:    # audit-only credential trail
+    resources:
+      - key: deploy-credential
+        mode: advisory
+```
+
+---
+
+## 4. Anti-Pattern Warnings
+
+Raise these during customization when the user steers toward one — with the reason, not just
+the rule:
+
+1. **Over-gating.** More than 2-3 required notes per phase produces approval fatigue and
+   workarounds; reviewers drown and agents pad. Prefer `required: false` reminders; add the
+   review phase only for genuine sign-off.
+2. **Exclusive resources on containers.** A container sits in WORK for its children's whole
+   duration — it would hold the lease the entire time, starving every leaf that actually needs
+   it. Exclusive resources go on leaf task types only.
+3. **Letting the worker define "done."** Completion criteria belong in a queue note written
+   before work starts — agents quietly redefining done is a top documented failure of
+   autonomous execution.
+4. **Self-review.** The same agent filling work evidence and review disposition defeats the
+   gate. The server enforces note existence, not authorship — keep the separation in dispatch
+   discipline, and say so honestly when recommending review gates.
+5. **Notes as dumping grounds.** Distilled prose in bodies; verbatim artifacts (logs, diffs)
+   via `bodyFromFile`; `maxLength` as the backstop.
+6. **Generic resource keys.** `db` on a shared server falsely serializes unrelated projects —
+   scope keys (`team-a/staging-db`).
+7. **Renaming note keys after use.** Orphans existing notes; keys are stable identifiers.


### PR DESCRIPTION
## Summary

Extends the `manage-schemas` skill with a **pattern-driven schema advisor**: instead of requiring users to already know what gates they need, the CREATE workflow now offers "describe your workflow" as its first path — the skill classifies the description against a ten-profile pattern library and recommends a configuration (schema + traits + lifecycle + dispatch conventions) with per-gate rationale, then hands off to the existing customize → write → smoke-test machinery unchanged.

## What changed

| File | Change |
|---|---|
| `references/workflow-patterns.md` (new) | Classification layer: interview dimensions, capsule index of all 10 profiles, selection tables (lifecycle / dispatch / gate strength), cross-domain trait library, anti-pattern warnings |
| `references/profiles/*.md` (new, 10 files) | Full profiles (YAML + rationale): autonomous loop, spec-driven team, research pipeline, content production, support triage, data pipeline ops, incident response, document review, schema-free, multi-project layering |
| `references/create-workflow.md` | New Step 2A advisor path; menu reordered (advisor first); fast-path routes workflow descriptions straight to it |
| `SKILL.md` | Description advertises advisor triggers; intent table routes recommend/design/choose signals to the advisor |

**Context discipline:** two-stage read — the advisor loads only the ~190-line classification file up front and then exactly the matched profile file (two for hybrids). The capsule index keeps all ten candidates comparable at classification time, so lazy loading costs no recommendation accuracy. Non-advisor operations (VIEW/EDIT/DELETE/VALIDATE, template and from-scratch CREATE) never load the library.

## Evaluation

Skill-creator methodology: 3 scenarios × (new skill vs pre-change snapshot), sandboxed, graded on 20 objective assertions.

- **New skill 20/20 · old skill 19/20** (missed the permanent intake container on the support-fleet scenario)
- Qualitative deltas favor the advisor: dedicated `staging-deploy` leaf type carrying the exclusive lease (baseline leased staging on *every* task type, serializing all implementation work); claim-mode dispatch surfaced explicitly; profile types renamed to the user's vocabulary
- Cost: ~+8% tokens / +12% time on average vs baseline, concentrated in the resource-contention scenario; two simpler scenarios were faster than baseline

## Notes

- Markdown-only plugin change — no server source, hooks, or tests affected; no version bump (`/prepare-release` owns those)
- Local pickup requires marketplace remove/re-add (plugin content is cached)
- Pattern library distilled from the schema use-case research of 2026-07-30 (workflow patterns mapped from agentic-coding, multi-agent orchestration, and knowledge-work pipeline research)
- Work item: `49e39090`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
