### PR TITLE
feat(plugin): review-proposals dispositions write back to source trend items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Plugin: `/review-proposals` dispositions now write back to the source trend item.** Rejecting a
+  proposal appends a do-not-re-graduate line to the trend that graduated it; accepting one whose
+  change is applied/landed retires the trend (gate-free `cancel`); the maintainer tracked-only path
+  leaves the trend active until a later retrospective verifies the change. Closes the loop the
+  trend-memory MCP migration made possible — previously the skill could not touch file-based trends.
 - **Plugin: retrospective trend memory moved from a per-project memory file into MCP work items.**
   `/session-retrospective` previously read and rewrote a whole-file `memory/retrospectives.md`
   (~55k tokens at steady state, exceeding the 25k read cap on a single call) on every run; trend

--- a/claude-plugins/task-orchestrator/skills/review-proposals/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/review-proposals/SKILL.md
@@ -198,6 +198,8 @@ If the user picks Reject or Defer, either take a one-line reason from their foll
    dwells in `review` with `outcome-verification` intentionally unfilled — a future
    `/session-retrospective` run verifies whether the applied change actually helped, and fills that
    note then. This is by design, not an oversight.
+9. Apply the **Source-trend write-back** below — the config change is applied, so the source trend
+   retires now.
 
 ### Accept — global
 
@@ -240,6 +242,9 @@ If the user picks Reject or Defer, either take a one-line reason from their foll
      `start` enters work; `complete` then goes straight to terminal — its all-phases note gate
      passes because `proposal`, `adoption-decision`, AND `outcome-verification` are all filled.
      The item is now fully terminal — the GitHub issue is the living tracker, not this workspace.
+   Either way, finish with the **Source-trend write-back** below: community handoff (terminal)
+   retires the source trend now; the maintainer path leaves it active until a later retrospective
+   verifies the landed change.
 
 ### Reject
 
@@ -255,7 +260,7 @@ advance_item(transitions=[{itemId: "<uuid>", trigger: "cancel"}])
 
 `cancel` is a single gate-free call — it goes straight to terminal from any non-terminal role, no
 note gate involved. Do **not** fill `outcome-verification` for a rejection; there is no change to
-verify.
+verify. Then apply the **Source-trend write-back** below.
 
 ### Defer
 
@@ -271,6 +276,33 @@ manage_notes(operation="upsert", notes=[{
 No `advance_item` call — the item stays in `queue`. A later Accept decision overwrites this same
 note via upsert (last-writer-wins), so re-running this skill and accepting a previously-deferred
 proposal works without any special-casing.
+
+### Source-trend write-back
+
+Most proposals graduated from a trend item (tags `retrospective-trend`, one item per cross-session
+pattern) whose summary carries `GRADUATED -> proposal <short-id>`. After carrying out a disposition,
+close the loop at the source. Everything here uses only gate-free operations (`manage_items` update,
+`advance_item` with `cancel`) — never `start` or `complete` on a trend item — so it is safe under
+any schema config. Locate the source trend:
+
+```
+query_items(operation="search", query="<proposal-short-id>", scope={tags: ["retrospective-trend"]})
+```
+
+Skip this write-back silently when no trend matches — proposals can also be created ad hoc without
+a graduating trend.
+
+- **After Reject:** append one line to the trend item's summary via `manage_items(operation="update")`:
+  `proposal <short-id> rejected <YYYY-MM-DD> — do not re-graduate; see its adoption-decision note.`
+  The trend stays active and keeps accumulating evidence, but every future retrospective now sees
+  the rejection inline in the Step 4.2 listing instead of having to discover the cancelled proposal.
+- **After Accept, once the change is actually applied or landed** (project-scoped config pushed, or
+  a community-handoff issue filed and the item taken terminal): retire the trend —
+  `advance_item(itemId="<trend-uuid>", trigger="cancel", summary="archived: addressed via proposal <short-id>")`.
+  When adoption is only *tracked* so far (maintainer path dwelling in `review` awaiting
+  implementation), leave the trend active — the later retrospective that fills
+  `outcome-verification` retires it once the change demonstrably held.
+- **After Defer:** no trend write-back.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the loop the trend-memory MCP migration (#283) made possible: `/review-proposals` dispositions now write back to the source trend item that graduated the proposal. Previously the skill could not touch file-based trends (a user-local memory file); now that trends are MCP items, the write-back is two gate-free operations.

## Changes

- `skills/review-proposals/SKILL.md` — new **Source-trend write-back** subsection after the dispositions (locate the trend via scoped FTS on the proposal short-id; skip silently for ad-hoc proposals), plus execution pointers in each path: **Reject** → append a dated do-not-re-graduate line to the trend summary; **Accept with the change applied/landed** (project config pushed, or community handoff terminal) → retire the trend via `advance_item(cancel)`; **maintainer tracked-only path** → leave the trend active until a later retrospective fills `outcome-verification`. Uses only gate-free operations (`update`/`cancel`) per the #283 lifecycle contract — never `start`/`complete` on trend items.
- `CHANGELOG.md` — Unreleased/Changed entry.

## Testing

- [ ] All existing tests pass (`./gradlew test`) — N/A: content-only skill change, no code surface
- [x] Manual verification completed — call-shape audit against tool schemas; consistency review against the #283 trend lifecycle rules

## Checklist

- [x] Follows [contribution guidelines](../CONTRIBUTING.md)
- [x] Commit messages follow conventional commit format
- [ ] Database migrations — N/A
- [ ] API reference — N/A
- [x] CHANGELOG.md updated

## MCP

Item: `775bbec4-8545-4b36-a745-6188b43d5d6a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
