### PR TITLE
fix(plugin): skill-enforcement hook — advisory-once semantics, maxLength-aware floor, exact-name skill-pointer docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lapsing inside the current second could compare as unexpired in SQLite's lexicographic TEXT
   comparison — skipping the expiry clamp and recording `released` instead of `expired`. Sub-second
   window, audit view only (beta field report).
+- **Plugin: `skill-enforcement` hook no longer nags in a loop.** The hook's `additionalContext`
+  previously told the model to "abort this call, invoke the skill, then retry" — the model obeyed,
+  retried, and re-triggered the same warning forever, since the hook kept no state and its 200-char
+  substantive floor was unreachable for concise-by-design notes bound to a small `maxLength`.
+  Now: advisory-once semantics (a per-session/item/key marker suppresses a repeat warning for the
+  same note), a `maxLength`-aware substantive floor (scales down when a key's configured
+  `maxLength` is small), and honest wording that no longer claims the call is blocked and adds an
+  "Unknown skill" escape hatch for invalid skill pointers. Also documented the skill-pointer
+  exact-name rule (qualified vs. bare names, built-in name collisions like `review`) in
+  `config-format.md`, and added a `manage-schemas` `validate` check that flags `skill:` values
+  colliding with built-in skill names (`review`, `plan`, `run`, `init`).
 
 ## [3.13.0] - 2026-07-25
 

--- a/claude-plugins/task-orchestrator/hooks/skill-enforcement.mjs
+++ b/claude-plugins/task-orchestrator/hooks/skill-enforcement.mjs
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
-// PreToolUse manage_notes — enforces skill invocation for notes with skill requirements.
+// PreToolUse manage_notes — suggests skill invocation for notes with skill requirements.
 // Reads config.yaml to find which note keys have a `skill` field, then checks if the
 // note body being upserted is substantive enough to reflect skill-framework output.
+//
+// Advisory only: this hook never blocks the call (additionalContext is non-blocking) and
+// never claims to. It warns at most once per (session, itemId, key) — see the marker
+// discipline below — so a concise-by-design note that keeps getting re-upserted does not
+// re-trigger the same suggestion forever.
 
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { resolve, join, dirname } from 'path';
+import os from 'os';
 
 // Read hook input from stdin
 let input = '';
@@ -25,6 +31,41 @@ const toolInput = hookInput.tool_input;
 if (!toolInput || toolInput.operation !== 'upsert' || !Array.isArray(toolInput.notes)) {
   process.exit(0);
 }
+
+// --- Once-per-(session, item, key) marker -----------------------------------------------
+// Fail-open discipline mirrors retro-lib.mjs's readMarker/writeMarker (implemented locally
+// here per scope — this hook does not import retro-lib.mjs). Any I/O error is treated as
+// "no marker" / "write silently dropped"; a marker failure must never crash the hook.
+
+function sanitizeForFilename(value) {
+  return String(value).replace(/[^a-zA-Z0-9-]/g, '_');
+}
+
+function markerPath(sessionId) {
+  const key = sessionId ? sanitizeForFilename(sessionId) : 'unknown';
+  return join(os.tmpdir(), 'task-orchestrator', `skill-enforce-${key}.json`);
+}
+
+function readMarker(path) {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeMarker(path, obj) {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(obj));
+  } catch {
+    // swallow all errors — a marker write must never crash a hook
+  }
+}
+
+const marker = markerPath(hookInput.session_id);
+const warnedPairs = readMarker(marker);
 
 // Locate config.yaml — check AGENT_CONFIG_DIR, then walk up from cwd to find
 // the project root containing .taskorchestrator/. This handles worktrees where
@@ -56,10 +97,12 @@ if (!configContent) {
   process.exit(0);
 }
 
-// Parse skill requirements from config using a line-based state machine.
-// Builds a map: noteKey → skillName for entries that have a `skill:` field.
-// Note: if multiple schemas define the same key with different skills, last wins.
+// Parse skill requirements (and per-key maxLength) from config using a line-based state
+// machine. Builds two maps keyed by note key: skillMap (noteKey → skillName) and
+// maxLengthMap (noteKey → maxLength as configured). Note: if multiple schemas define the
+// same key with different values, last wins.
 const skillMap = new Map();
+const maxLengthMap = new Map();
 let currentKey = null;
 
 for (const line of configContent.split('\n')) {
@@ -79,8 +122,15 @@ for (const line of configContent.split('\n')) {
     continue;
   }
 
-  // Reset on section boundary (any line ending in `:` except `skill:`)
-  if (trimmed.endsWith(':') && !trimmed.startsWith('skill:')) {
+  // Match `maxLength: <n>` within a note entry
+  const maxLengthMatch = trimmed.match(/^maxLength:\s*(\d+)/);
+  if (maxLengthMatch && currentKey) {
+    maxLengthMap.set(currentKey, Number(maxLengthMatch[1]));
+    continue;
+  }
+
+  // Reset on section boundary (any line ending in `:` except `skill:`/`maxLength:`)
+  if (trimmed.endsWith(':') && !trimmed.startsWith('skill:') && !trimmed.startsWith('maxLength:')) {
     currentKey = null;
   }
 }
@@ -102,39 +152,61 @@ const PLACEHOLDER_PATTERNS = [
   /^will\s+fill\s+(later|soon)/i
 ];
 
-// Minimum character count for a note body to be considered substantive.
-// Notes below this threshold trigger the skill-invocation directive.
-const MIN_SUBSTANTIVE_LENGTH = 200;
+// Default minimum character count for a note body to be considered substantive.
+const DEFAULT_SUBSTANTIVE_LENGTH = 200;
+
+// Effective substantive floor for a key: when the key's configured maxLength is small
+// (< 800), a flat 200-char floor would be unreachable for a compliant note, so the floor
+// scales down with maxLength instead. Otherwise the default 200-char floor applies.
+function substantiveFloor(key) {
+  const maxLength = maxLengthMap.get(key);
+  if (maxLength !== undefined && maxLength < 800) {
+    return Math.min(DEFAULT_SUBSTANTIVE_LENGTH, Math.floor(maxLength / 4));
+  }
+  return DEFAULT_SUBSTANTIVE_LENGTH;
+}
 
 // Check each note being upserted against skill requirements
 const warnings = [];
+const newlyWarnedPairs = [];
 
 for (const note of toolInput.notes) {
-  const { key, body } = note;
+  const { key, body, itemId } = note;
   if (!key || !skillMap.has(key)) continue;
+
+  const dedupKey = `${itemId}::${key}`;
+  if (warnedPairs[dedupKey]) continue; // already suggested once this session for this item+key
 
   const skill = skillMap.get(key);
   const trimmedBody = (body || '').trim();
   const bodyLen = trimmedBody.length;
+  const floor = substantiveFloor(key);
 
   // Only check placeholders on short bodies — long notes that happen to start
-  // with "Looks fine..." followed by substantive analysis should not be blocked.
-  const isPlaceholder = bodyLen < MIN_SUBSTANTIVE_LENGTH &&
+  // with "Looks fine..." followed by substantive analysis should not be flagged.
+  const isPlaceholder = bodyLen < floor &&
     PLACEHOLDER_PATTERNS.some(p => p.test(trimmedBody));
 
-  if (!body || bodyLen < MIN_SUBSTANTIVE_LENGTH || isPlaceholder) {
+  if (!body || bodyLen < floor || isPlaceholder) {
     warnings.push(
-      `⊘ SKILL REQUIRED — The note "${key}" requires the /${skill} skill framework.\n` +
-      `Before filling this note, invoke the Skill tool with skill="${skill}" and follow its structured evaluation.\n` +
-      `A note produced without the skill framework will not meet the quality bar.\n` +
-      `Abort this call, invoke the skill, then retry with substantive findings.`
+      `⊘ SKILL SUGGESTED — the note "${key}" is schema-bound to the /${skill} framework. ` +
+      `If you have not already, invoke the Skill tool with skill="${skill}" and incorporate ` +
+      `its structured evaluation before finalizing this note. If the Skill tool reports ` +
+      `'Unknown skill', the schema's skill pointer is invalid — log that as an observation ` +
+      `instead of retrying. (Shown once per item+key per session.)`
     );
+    newlyWarnedPairs.push(dedupKey);
   }
 }
 
 if (warnings.length === 0) {
   process.exit(0);
 }
+
+for (const pair of newlyWarnedPairs) {
+  warnedPairs[pair] = true;
+}
+writeMarker(marker, warnedPairs);
 
 const output = {
   hookSpecificOutput: {

--- a/claude-plugins/task-orchestrator/hooks/tests/skill-enforcement.test.mjs
+++ b/claude-plugins/task-orchestrator/hooks/tests/skill-enforcement.test.mjs
@@ -1,0 +1,290 @@
+// Drives skill-enforcement.mjs as a subprocess with fixture JSON on stdin. Marker isolation:
+// every test uses a fixture (randomly-generated) session_id, so the shared marker file at
+// os.tmpdir()/task-orchestrator/skill-enforce-<session>.json is never the live marker for a
+// real session. Markers are cleaned up in `finally` blocks using a locally-duplicated
+// markerPath (the hook does not export it — it is deliberately self-contained, see scope
+// note in skill-enforcement.mjs).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+const HOOK = fileURLToPath(new URL('../skill-enforcement.mjs', import.meta.url));
+
+const FIXTURE_CONFIG = `
+work_item_schemas:
+  test-schema:
+    notes:
+      - key: security-assessment
+        role: review
+        required: true
+        description: "Security review"
+        skill: "security-review"
+      - key: quick-review
+        role: review
+        required: true
+        description: "Quick review"
+        skill: "review-quality"
+        maxLength: 300
+`;
+
+function writeConfig(dir, content) {
+  const cfgDir = join(dir, '.taskorchestrator');
+  mkdirSync(cfgDir, { recursive: true });
+  writeFileSync(join(cfgDir, 'config.yaml'), content, 'utf-8');
+}
+
+function markerPath(sessionId) {
+  const sanitized = sessionId ? String(sessionId).replace(/[^a-zA-Z0-9-]/g, '_') : 'unknown';
+  return join(tmpdir(), 'task-orchestrator', `skill-enforce-${sanitized}.json`);
+}
+
+function spawnHook(agentConfigDir, payload, extra = {}) {
+  return spawnSync(process.execPath, [HOOK], {
+    input: JSON.stringify(payload),
+    env: { ...process.env, AGENT_CONFIG_DIR: agentConfigDir, ...extra.env },
+    encoding: 'utf-8',
+    cwd: extra.cwd,
+  });
+}
+
+function tmpConfigDir() {
+  return mkdtempSync(join(tmpdir(), 'to-skill-enforcement-'));
+}
+
+function upsertPayload(sessionId, notes) {
+  return {
+    session_id: sessionId,
+    tool_name: 'mcp__mcp-task-orchestrator__manage_notes',
+    tool_input: { operation: 'upsert', notes },
+  };
+}
+
+test('short body on skill-bound key warns with advisory, non-blocking wording', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, FIXTURE_CONFIG);
+  const sessionId = `test-warn-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    const res = spawnHook(dir, upsertPayload(sessionId, [
+      { itemId: 'item-1', key: 'security-assessment', role: 'review', body: 'too short' },
+    ]));
+    assert.equal(res.status, 0);
+    const out = JSON.parse(res.stdout);
+    const text = out.hookSpecificOutput.additionalContext;
+    assert.ok(text.includes('SKILL SUGGESTED'), text);
+    assert.ok(text.includes('Unknown skill'), text);
+    assert.ok(!text.includes('Abort this call'), text);
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('same session_id + itemId + key again is silent (dedup)', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, FIXTURE_CONFIG);
+  const sessionId = `test-dedup-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    const first = spawnHook(dir, upsertPayload(sessionId, [
+      { itemId: 'item-1', key: 'security-assessment', role: 'review', body: 'too short' },
+    ]));
+    assert.equal(first.status, 0);
+    assert.ok(first.stdout.length > 0);
+
+    const second = spawnHook(dir, upsertPayload(sessionId, [
+      { itemId: 'item-1', key: 'security-assessment', role: 'review', body: 'still too short' },
+    ]));
+    assert.equal(second.status, 0);
+    assert.equal(second.stdout.trim(), '');
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('same session_id, different itemId warns again (dedup is per item+key)', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, FIXTURE_CONFIG);
+  const sessionId = `test-diffitem-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    const first = spawnHook(dir, upsertPayload(sessionId, [
+      { itemId: 'item-1', key: 'security-assessment', role: 'review', body: 'too short' },
+    ]));
+    assert.ok(first.stdout.length > 0);
+
+    const second = spawnHook(dir, upsertPayload(sessionId, [
+      { itemId: 'item-2', key: 'security-assessment', role: 'review', body: 'also too short' },
+    ]));
+    assert.equal(second.status, 0);
+    const out = JSON.parse(second.stdout);
+    assert.ok(out.hookSpecificOutput.additionalContext.includes('SKILL SUGGESTED'));
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('different session_id warns again (marker is per session)', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, FIXTURE_CONFIG);
+  const sessionId1 = `test-sess-a-${randomUUID()}`;
+  const sessionId2 = `test-sess-b-${randomUUID()}`;
+  const marker1 = markerPath(sessionId1);
+  const marker2 = markerPath(sessionId2);
+  try {
+    const first = spawnHook(dir, upsertPayload(sessionId1, [
+      { itemId: 'item-1', key: 'security-assessment', role: 'review', body: 'too short' },
+    ]));
+    assert.ok(first.stdout.length > 0);
+
+    const second = spawnHook(dir, upsertPayload(sessionId2, [
+      { itemId: 'item-1', key: 'security-assessment', role: 'review', body: 'too short' },
+    ]));
+    assert.equal(second.status, 0);
+    const out = JSON.parse(second.stdout);
+    assert.ok(out.hookSpecificOutput.additionalContext.includes('SKILL SUGGESTED'));
+  } finally {
+    rmSync(marker1, { force: true });
+    rmSync(marker2, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('body >= 200 chars is silent and records no marker entry (a later short body still warns)', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, FIXTURE_CONFIG);
+  const sessionId = `test-longbody-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    const longBody = 'x'.repeat(200);
+    const first = spawnHook(dir, upsertPayload(sessionId, [
+      { itemId: 'item-1', key: 'security-assessment', role: 'review', body: longBody },
+    ]));
+    assert.equal(first.status, 0);
+    assert.equal(first.stdout.trim(), '');
+
+    // If the long-body call had (incorrectly) recorded a marker entry, this would stay silent.
+    const second = spawnHook(dir, upsertPayload(sessionId, [
+      { itemId: 'item-1', key: 'security-assessment', role: 'review', body: 'too short' },
+    ]));
+    assert.equal(second.status, 0);
+    const out = JSON.parse(second.stdout);
+    assert.ok(out.hookSpecificOutput.additionalContext.includes('SKILL SUGGESTED'));
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('maxLength: 300 key scales the floor to min(200, 75) = 75', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, FIXTURE_CONFIG);
+  const sessionId = `test-maxlen-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    // 100 chars >= floor(75) -> silent, no marker recorded.
+    const first = spawnHook(dir, upsertPayload(sessionId, [
+      { itemId: 'item-1', key: 'quick-review', role: 'review', body: 'x'.repeat(100) },
+    ]));
+    assert.equal(first.status, 0);
+    assert.equal(first.stdout.trim(), '');
+
+    // 50 chars < floor(75) -> warns.
+    const second = spawnHook(dir, upsertPayload(sessionId, [
+      { itemId: 'item-1', key: 'quick-review', role: 'review', body: 'x'.repeat(50) },
+    ]));
+    assert.equal(second.status, 0);
+    const out = JSON.parse(second.stdout);
+    assert.ok(out.hookSpecificOutput.additionalContext.includes('SKILL SUGGESTED'));
+    assert.ok(out.hookSpecificOutput.additionalContext.includes('quick-review'));
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('placeholder body under the floor warns', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, FIXTURE_CONFIG);
+  const sessionId = `test-placeholder-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    const res = spawnHook(dir, upsertPayload(sessionId, [
+      { itemId: 'item-1', key: 'security-assessment', role: 'review', body: 'n/a' },
+    ]));
+    assert.equal(res.status, 0);
+    const out = JSON.parse(res.stdout);
+    assert.ok(out.hookSpecificOutput.additionalContext.includes('SKILL SUGGESTED'));
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('fail-open: operation != upsert is silent', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, FIXTURE_CONFIG);
+  const sessionId = `test-notupsert-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    const res = spawnHook(dir, {
+      session_id: sessionId,
+      tool_name: 'mcp__mcp-task-orchestrator__manage_notes',
+      tool_input: { operation: 'get', notes: [{ itemId: 'item-1', key: 'security-assessment', body: 'n/a' }] },
+    });
+    assert.equal(res.status, 0);
+    assert.equal(res.stdout.trim(), '');
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('fail-open: missing notes array is silent', () => {
+  const dir = tmpConfigDir();
+  writeConfig(dir, FIXTURE_CONFIG);
+  const sessionId = `test-nonotes-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    const res = spawnHook(dir, {
+      session_id: sessionId,
+      tool_name: 'mcp__mcp-task-orchestrator__manage_notes',
+      tool_input: { operation: 'upsert' },
+    });
+    assert.equal(res.status, 0);
+    assert.equal(res.stdout.trim(), '');
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('fail-open: unparseable stdin is silent', () => {
+  const res = spawnSync(process.execPath, [HOOK], { input: '{not valid json', encoding: 'utf-8' });
+  assert.equal(res.status, 0);
+  assert.equal(res.stdout.trim(), '');
+});
+
+test('fail-open: no discoverable config is silent', () => {
+  const emptyDir = tmpConfigDir();
+  const sessionId = `test-noconfig-${randomUUID()}`;
+  const marker = markerPath(sessionId);
+  try {
+    const res = spawnHook(emptyDir, upsertPayload(sessionId, [
+      { itemId: 'item-1', key: 'security-assessment', role: 'review', body: 'n/a' },
+    ]), { cwd: tmpdir() }); // cwd override: don't let the cwd-walk fallback find this repo's real config.yaml
+    assert.equal(res.status, 0);
+    assert.equal(res.stdout.trim(), '');
+  } finally {
+    rmSync(marker, { force: true });
+    rmSync(emptyDir, { recursive: true, force: true });
+  }
+});

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/SKILL.md
@@ -125,6 +125,12 @@ For detailed workflow, see `references/delete-workflow.md` in this skill folder.
 ### VALIDATE — Check Config Integrity
 
 Run structural and semantic checks on the config file and report issues with fix suggestions.
+In addition to the checks in `references/validate-workflow.md`, flag any `skill:` value that is
+exactly one of `review`, `plan`, `run`, or `init` as a probable built-in-skill collision (warning,
+not an error) — these bare names resolve to a Claude Code built-in (e.g. `review` is the
+GitHub-PR review skill) rather than a project's intended framework skill. Suggest the likely
+intended framework skill name (e.g. `review-quality` instead of `review`) and cite the exact-name
+rule in `references/config-format.md` → "`skill` — exact-name rule".
 
 For detailed workflow, see `references/validate-workflow.md` in this skill folder.
 

--- a/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
+++ b/claude-plugins/task-orchestrator/skills/manage-schemas/references/config-format.md
@@ -111,6 +111,24 @@ These fields serve different purposes and work together:
 | Both | The skill provides the structured process; guidance adds project-specific requirements the skill doesn't cover. The agent invokes the skill first, then uses guidance to fill in domain-specific details. |
 | Neither | The note key and description are self-explanatory — no additional direction needed. |
 
+### `skill` — exact-name rule
+
+A `skill:` value must be the **exact name** the Skill tool accepts in the workspace where the
+note gets filled — the Skill tool resolves strictly (no fuzzy matching, unlike a user typing a
+slash command):
+
+- **Plugin-shipped skills** (this plugin's `claude-plugins/task-orchestrator/skills/`) are
+  **qualified**: `task-orchestrator:session-retrospective`, `task-orchestrator:review-quality`, etc.
+- **Project-level skills** (`.claude/skills/`) and **Claude Code built-in skills** are **bare**:
+  `review-quality`, `security-review`, `plan`, `review`, etc.
+
+**Watch for built-in name collisions.** A short, generic `skill:` value can silently resolve to
+the wrong built-in instead of your intended framework skill — especially `review` (Claude Code's
+GitHub-PR review skill, not a note-quality framework), and also `plan`, `run`, `init`. If you want
+a review-quality framework, point at the actual framework skill name (e.g. `review-quality`), not
+the collision-prone generic word. `manage-schemas`'s `validate` operation flags known collisions
+in this set — see `SKILL.md` → VALIDATE.
+
 ---
 
 ## Lifecycle Modes


### PR DESCRIPTION
## Summary

Fixes a user-reported nag loop: the `skill-enforcement.mjs` PreToolUse hook repeatedly urged running a skill (with "Abort this call … retry" wording) before every upsert of a concise, skill-bound note. Three compounding causes: the directive commanded an abort it never enforced (additionalContext is non-blocking), the hardcoded 200-char "substantive" floor was unreachable for concise-by-design notes, and the hook kept no state — so a compliant agent looped forever. A fourth hazard: the hook relays configured skill names verbatim, and short generics like `review` silently resolve to Claude Code's built-in GitHub-PR review skill (observed live: a config's `skill: "review"` pointer on a note whose guidance meant a review *framework*).

## Changes

- `hooks/skill-enforcement.mjs` — advisory-once semantics: warns at most once per (session, itemId, key) via a fail-open marker file (`tmpdir/task-orchestrator/skill-enforce-<session>.json`, retro-lib discipline implemented locally); `maxLength`-aware substantive floor (`maxLength < 800` scales the floor to `min(200, maxLength/4)` so compliant concise notes can pass); honest advisory wording — "SKILL SUGGESTED", no abort claim, plus an Unknown-skill escape hatch ("log it as an observation instead of retrying"). All existing fail-open paths preserved.
- `hooks/tests/skill-enforcement.test.mjs` — NEW, 11 tests: warn/dedup matrix (same pair silent, different item warns, different session warns), floor behavior incl. maxLength scaling, placeholder detection, wording assertions (contains Unknown-skill guidance, never "Abort this call"), and all silent-exit paths.
- `skills/manage-schemas/references/config-format.md` — the skill-pointer **exact-name rule**: plugin-shipped skills are qualified (`task-orchestrator:x`), project-level/built-in skills are bare; the Skill tool resolves strictly; short generics shadowing built-ins (`review`, `plan`, `run`, `init`) silently resolve to the wrong skill.
- `skills/manage-schemas/SKILL.md` — validate operation flags `skill:` values in the built-in-collision set with a suggested correction.
- `CHANGELOG.md` — Unreleased/Fixed entry.

## Testing

- [x] Hook suite `node --test`: **95/95 pass** (84 baseline + 11 new), verified independently by the orchestrator after the implementation agent's run
- [ ] `./gradlew test` — N/A (no Kotlin surface)
- [x] Manual verification — diff review of marker discipline, parser extension, and wording

## Checklist

- [x] Follows [contribution guidelines](../CONTRIBUTING.md)
- [x] Commit messages follow conventional commit format
- [ ] Database migrations — N/A
- [ ] API reference — N/A
- [x] CHANGELOG.md updated

## MCP

Item: `41a8dcaf-55f5-494e-a7bc-90544b9aca8b` (observation → fix)
Companion config-side fix applied directly: the triggering workspace's two `skill: "review"` pointers removed (guidance already self-contained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
