### PR TITLE
chore(skills): adopt proposals 002fa6c6/d7662676/4aa8d058

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -49,6 +49,13 @@ For each item, call `get_context(itemId=...)` to understand:
 
 If the item has no schema tag, apply `quick-fix` for Direct tier or leave untagged for Delegated/Parallel (the `default` schema catches these).
 
+**Trait application on classification.** When the tier resolves to Delegated or Parallel and the
+workspace defines a `delegated` trait (it appears in `availableTraits` on create responses), apply
+it before any dispatch — `traits: "delegated"` at item creation, or
+`manage_items(operation="update", items=[{itemId: "<uuid>", traits: "delegated"}])` for an existing
+item. This makes the orchestrator-filled `delegation-metadata` note schema-visible instead of
+convention-only. Direct tier: do not apply it — nothing is delegated.
+
 **Interaction mode** — orthogonal to tier:
 
 | Signal | Mode |
@@ -83,6 +90,18 @@ git checkout -b <branch-name>
 ```
 
 **Delegated tier** (single subagent) — same as Direct: orchestrator creates the branch on the main directory, the subagent works against it. No worktree.
+
+**If the main checkout is unavailable** (another branch checked out, uncommitted changes present)
+**or the orchestrator itself runs from a worktree** — Direct and Delegated tiers both: do not touch
+the occupied checkout. Create a dedicated worktree instead:
+
+```bash
+git worktree add .claude/worktrees/<slug> -b <branch-name> origin/main
+```
+
+Work there using absolute paths and `git -C` (never `cd`); after the PR merges, remove the worktree
+and delete the branch. Sync local `main` via `git fetch origin main:main` while `main` is not
+checked out anywhere, or a normal `git pull` from the main checkout when it is.
 
 **Parallel tier** (parent feature with multiple children) — create a **single feature worktree** that all child agents share:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Adopted three retrospective improvement proposals** (002fa6c6, d7662676, 4aa8d058): `/implement`
+  Step 2 gains the dedicated-worktree fallback for an unavailable/dirty main checkout; CLAUDE.md's
+  plugin-refresh instruction is replaced with the verified version-keyed-cache procedure (purge +
+  lazy extraction + verification); `/implement` Step 1 and the `workflow-orchestrator` output style
+  now apply the `delegated` trait at Delegated/Parallel classification so `delegation-metadata`
+  notes are schema-visible.
+
 ### Added
 
 - **Mid-session config re-sync.** The plugin now pushes a project's `.taskorchestrator/config.yaml`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,7 +275,16 @@ Two skill systems — do not confuse them:
 ```
 - Marketplace name: `task-orchestrator-marketplace` (from `.claude-plugin/marketplace.json` → `name`)
 - If plugin stops loading: `/plugin marketplace add .claude-plugin` then `/plugin enable task-orchestrator@task-orchestrator-marketplace`
-- After editing plugin files: remove and re-add the marketplace (content is cached)
+- After editing plugin files: the plugin cache is **version-keyed** — while the plugin version is
+  unchanged, `claude plugin marketplace update` AND full remove/re-add both silently reuse the stale
+  cached copy at `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`. Force a refresh:
+  `rm -rf ~/.claude/plugins/cache/task-orchestrator-marketplace`, then
+  `claude plugin marketplace update task-orchestrator-marketplace`. Re-extraction is **lazy** (next
+  session start) — an empty cache dir right after the update is normal, not broken. Verify after the
+  next session starts by grepping the cached files for your change. A session that amends plugin
+  content must treat same-session invocations of those skills/hooks as stale (diff loaded content
+  against disk before following it). The marketplace serves the working **tree** — confirm the
+  checkout is on the branch you intend to install before refreshing.
 
 ## Documentation
 

--- a/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
+++ b/claude-plugins/task-orchestrator/output-styles/workflow-orchestrator.md
@@ -84,7 +84,7 @@ Delegation prompts must include entity IDs and full context — subagents start 
 
 **Notes are the report.** Subagents write findings into their work item's notes; their final message back is 1-2 lines (item ID, outcome, note keys filled). Never ask agents to restate note content in replies.
 
-**Delegation metadata (recommended).** If your project defines a `delegated` trait (see your schema config), applying it is recommended for Delegated/Parallel items: after each subagent returns, fill its `delegation-metadata` work note — model · isolation · one-line rationale · one-line outcome. The orchestrator fills this, not the subagent (only the orchestrator knows the dispatch details). It feeds `/session-retrospective`'s delegation-alignment scoring; projects that don't define the trait simply skip it.
+**Delegation metadata (recommended).** If your project defines a `delegated` trait (see your schema config), applying it is recommended for Delegated/Parallel items: apply the trait at item creation (`traits: "delegated"` — it appears in `availableTraits` on create responses) or via `manage_items` update before dispatch, so the note below is schema-visible rather than convention-only. Then, after each subagent returns, fill its `delegation-metadata` work note — model · isolation · one-line rationale · one-line outcome. The orchestrator fills this, not the subagent (only the orchestrator knows the dispatch details). It feeds `/session-retrospective`'s delegation-alignment scoring; projects that don't define the trait simply skip it.
 
 ## Retrospective
 


### PR DESCRIPTION
## Summary
Adopts three project-scoped improvement proposals accepted in today's /review-proposals triage — each graduated from a multi-session retrospective trend.

## Changes
- `.claude/skills/implement/SKILL.md` — Step 2: dedicated-worktree fallback when the main checkout is unavailable/dirty or the orchestrator runs from a worktree (proposal `002fa6c6`, 6 validated applications); Step 1: apply the `delegated` trait at Delegated/Parallel classification so `delegation-metadata` is schema-visible (proposal `4aa8d058`, 3 same-day trait-skip instances).
- `CLAUDE.md` — replaced the insufficient 'remove and re-add the marketplace' line with the verified version-keyed cache-refresh procedure: purge, lazy re-extraction at session start, grep verification, working-tree caveat (proposal `d7662676`, 4 occurrences incl. one post-graduation).
- `workflow-orchestrator.md` — delegation-metadata section teaches the trait-application step (Zone 1; analyst mirror updated at user level, drift-diff clean).
- `CHANGELOG.md` — Unreleased/Changed entry.

## Testing
Content-only; no code surface. Zone 1 drift-diff verified in sync.

## MCP
Proposals: `002fa6c6`, `d7662676`, `4aa8d058` (dispositions recorded after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)