### PR TITLE
fix(advance-item): name previousRole/targetRole on gate-blocked results

### DIFF
--- a/current/docs/api-reference.md
+++ b/current/docs/api-reference.md
@@ -1184,7 +1184,7 @@ All cascade types are recorded in `cascadeEvents`.
 
 `blockers` is only present when the transition failed due to dependency constraints. `error` contains a human-readable description of why the transition was rejected. Note that (unlike success results) `trigger` **is** present on failed results, while `previousRole`, `newRole`, and `expectedNotes` are absent.
 
-**Gate-blocked failure.** When the gate itself rejects the transition (missing required notes), the result includes a `missingNotes` array instead of `blockers`. Each entry carries the **full** guidance text — this and `manage_notes(upsert)`'s `itemContext.guidancePointer` are the only two places full guidance text is returned directly (everywhere else you get a `guidanceKey`/`skillPointer` reference and resolve via `query_items(operation="schema")`):
+**Gate-blocked failure.** When the gate itself rejects the transition (missing required notes), the result includes a `missingNotes` array instead of `blockers`, plus `previousRole` and `targetRole` naming the blocked transition (the phase the item was in when the gate fired, and the phase it would have moved to). Each `missingNotes` entry carries the **full** guidance text — this and `manage_notes(upsert)`'s `itemContext.guidancePointer` are the only two places full guidance text is returned directly (everywhere else you get a `guidanceKey`/`skillPointer` reference and resolve via `query_items(operation="schema")`):
 
 ```json
 {
@@ -1196,14 +1196,16 @@ All cascade types are recorded in `cascadeEvents`.
       "error": "Gate check failed: required notes not filled for queue phase: feature-summary",
       "missingNotes": [
         { "key": "feature-summary", "description": "...", "guidance": "...", "skill": "spec-quality" }
-      ]
+      ],
+      "previousRole": "queue",
+      "targetRole": "work"
     }
   ],
   "summary": { "total": 1, "succeeded": 0, "failed": 1 }
 }
 ```
 
-`guidance` and `skill` are omitted per-entry when unset.
+`guidance` and `skill` are omitted per-entry when unset. `previousRole`/`targetRole` are present only on gate-blocked failures — other failure shapes (dependency `blockers`, ownership/policy rejection, resource-lease contention) do not carry them.
 
 **Ownership / policy rejection.** When a transition is rejected because another agent holds a live claim, or by `degradedModePolicy=reject`, the failed result carries structured fields alongside `error`: `errorKind`, `errorCode` (`not_claim_holder` or `rejected_by_policy`), and — for ownership rejections — `contendedItemId`.
 

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceService.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceService.kt
@@ -52,11 +52,14 @@ sealed class AdvanceFailure {
      * A required-note gate blocked the transition (start or complete).
      *
      * @property message human-readable summary including the missing keys
+     * @property previousRole the item's role at the time the transition was attempted (the phase
+     *   whose gate rejected it)
      * @property targetRole the role the transition would have moved to (for context)
      * @property missingNotes the structured required notes that are still unfilled
      */
     data class GateBlocked(
         val message: String,
+        val previousRole: Role,
         val targetRole: Role,
         val missingNotes: List<NoteSchemaEntry>
     ) : AdvanceFailure()
@@ -481,7 +484,7 @@ class AdvanceService(
             } else {
                 "Gate check failed: required notes not filled: $missingKeys"
             }
-        return AdvanceFailure.GateBlocked(message, targetRole, missingEntries)
+        return AdvanceFailure.GateBlocked(message, item.role, targetRole, missingEntries)
     }
 
     /** Result of the step-4.5 resource gate: proceed (with derived refs) or reject the advance. */

--- a/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
+++ b/current/src/main/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemTool.kt
@@ -8,6 +8,7 @@ import io.github.jpicklyk.mcptask.current.application.service.buildExpectedNotes
 import io.github.jpicklyk.mcptask.current.application.service.computePhaseNoteContext
 import io.github.jpicklyk.mcptask.current.application.tools.*
 import io.github.jpicklyk.mcptask.current.domain.model.ErrorKind
+import io.github.jpicklyk.mcptask.current.domain.model.Role
 import io.github.jpicklyk.mcptask.current.domain.model.ToolError
 import io.github.jpicklyk.mcptask.current.domain.model.UserTrigger
 import io.github.jpicklyk.mcptask.current.domain.repository.Result
@@ -57,6 +58,11 @@ into a one-element array. If `transitions` is present the singular fields are ig
 **Gate enforcement (when tags match a note schema):**
 - start: required notes for the current phase must be filled before advancing
 - complete: all required notes across all phases must be filled
+- `start`'s gate is scoped to the item's CURRENT phase, so successive `start` calls gate different
+  note sets as the role advances (QUEUE notes, then WORK notes, then REVIEW notes) — this is
+  deterministic per-phase behavior, not a timing-dependent artifact. A transition can also cascade
+  a parent straight to TERMINAL when the parent's downstream gates are already satisfied by
+  previously prefilled notes.
 
 **Resource-lease gate:** transitions entering the work phase acquire an exclusive lease per resource
 declared by the item's traits; contention rejects with transient `resource_unavailable` +
@@ -698,7 +704,9 @@ Call to move an item between phases once its work is done — never edit status 
                     itemId,
                     trigger,
                     failure.message,
-                    missingNotes = NoteSchemaJsonHelpers.buildMissingNotesArray(failure.missingNotes)
+                    missingNotes = NoteSchemaJsonHelpers.buildMissingNotesArray(failure.missingNotes),
+                    previousRole = failure.previousRole,
+                    targetRole = failure.targetRole
                 )
         }
 
@@ -707,7 +715,9 @@ Call to move an item between phases once its work is done — never edit status 
         trigger: String,
         error: String,
         blockers: JsonArray? = null,
-        missingNotes: JsonArray? = null
+        missingNotes: JsonArray? = null,
+        previousRole: Role? = null,
+        targetRole: Role? = null
     ): JsonObject =
         buildJsonObject {
             put("itemId", JsonPrimitive(itemId.toString()))
@@ -720,6 +730,8 @@ Call to move an item between phases once its work is done — never edit status 
             if (missingNotes != null) {
                 put("missingNotes", missingNotes)
             }
+            previousRole?.let { put("previousRole", JsonPrimitive(it.toJsonString())) }
+            targetRole?.let { put("targetRole", JsonPrimitive(it.toJsonString())) }
         }
 
     /**

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceServiceTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/service/AdvanceServiceTest.kt
@@ -157,6 +157,7 @@ class AdvanceServiceTest {
             val failure = assertIs<AdvanceOutcome.Failure>(outcome)
             val gate = assertIs<AdvanceFailure.GateBlocked>(failure.failure)
             assertEquals(listOf("spec"), gate.missingNotes.map { it.key })
+            assertEquals(Role.QUEUE, gate.previousRole)
             assertEquals(Role.WORK, gate.targetRole)
             assertTrue(gate.message.contains("queue"))
         }
@@ -202,6 +203,7 @@ class AdvanceServiceTest {
             val failure = assertIs<AdvanceOutcome.Failure>(outcome)
             val gate = assertIs<AdvanceFailure.GateBlocked>(failure.failure)
             assertEquals(listOf("impl"), gate.missingNotes.map { it.key })
+            assertEquals(Role.WORK, gate.previousRole)
         }
 
     @Test

--- a/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
+++ b/current/src/test/kotlin/io/github/jpicklyk/mcptask/current/application/tools/workflow/AdvanceItemToolTest.kt
@@ -1370,6 +1370,9 @@ class AdvanceItemToolTest {
             assertEquals("scope-definition", second["key"]!!.jsonPrimitive.content)
             assertEquals("Scope definition", second["description"]!!.jsonPrimitive.content)
             assertEquals("Describe what is in and out of scope", second["guidance"]!!.jsonPrimitive.content)
+
+            assertEquals("queue", r["previousRole"]!!.jsonPrimitive.content)
+            assertEquals("work", r["targetRole"]!!.jsonPrimitive.content)
         }
 
     @Test
@@ -1475,6 +1478,9 @@ class AdvanceItemToolTest {
             assertEquals("implementation-notes", entry["key"]!!.jsonPrimitive.content)
             assertEquals("Implementation notes", entry["description"]!!.jsonPrimitive.content)
             assertNull(entry["guidance"], "guidance key should not be present when guidance is null")
+
+            assertEquals("work", r["previousRole"]!!.jsonPrimitive.content)
+            assertEquals("terminal", r["targetRole"]!!.jsonPrimitive.content)
         }
 
     // ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `AdvanceFailure.GateBlocked` now carries `previousRole` alongside `targetRole`, and `AdvanceItemTool` emits both in the gate-block error JSON — a gate block now names the transition it blocked instead of only listing missing notes.
- Added ~2 sentences to the `advance_item` tool description: `start`'s gate is scoped to the item's **current** phase (successive `start` calls gate different note sets as the role advances — deterministic, not timing-dependent), and cascade-on-prefilled can terminal-ize a parent whose downstream gates are already satisfied.
- `api-reference.md` documents the new fields and both call shapes (batch `transitions[]` and the singular `itemId`+`trigger` sugar).
- Other `AdvanceFailure` arms' JSON is unchanged byte-for-byte (new fields emitted only via `?.let`).

## Scope deviation from the tracked proposal

Issue #275 listed 5 asks. Three were dropped after verifying against current source, not skipped:

- **Singular-form validation hint — obsolete.** `validateParams` calls `normalizeParams` first, which wraps top-level `itemId`+`trigger` into `transitions`. The singular form is already valid, so the proposed "name the batch shape" error would reject a working call.
- **Mechanical singular→batch doc sweep — withdrawn.** Its entire rationale was that the singular form errors. It does not. Replaced with the change that is actually correct: ensure `api-reference.md` documents both shapes.
- **Amend observation `f26cf316` — already done.** That item already carries the retraction.

## Test Results

`:current:test` — 2883 tests, 0 failures, 0 errors, 2 skipped (EXIT=0).
`:current:ktlintCheck` — EXIT=0. Both forced with `--rerun-tasks` after gradle reported a false UP-TO-DATE.
New assertions cover `previousRole`/`targetRole` on gate-blocked results in `AdvanceServiceTest` and `AdvanceItemToolTest`.

## Review

Independent reviewer (did not write the code): **pass-with-observations** — 0 blocking, 6 observations. Confirmed `previousRole` captures the pre-transition role, the other failure arms' JSON is byte-identical, and all three dropped asks are justified against source. Observations filed as follow-up items, notably: the REST `ItemWriteRoutes` 422 payload still omits `previousRole` (MCP/REST asymmetry), and `advance_item`'s description now sits at 3119/3150 chars — ~1% budget headroom.

## MCP

Item: `80947b32-8c66-4272-af9a-7a768d214efb`
Proposal: `6dd88f70` (issue #275)

🤖 Generated with [Claude Code](https://claude.com/claude-code)