### PR TITLE
docs(changelog): record #288 and #289 under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exact-name rule (qualified vs. bare names, built-in name collisions like `review`) in
   `config-format.md`, and added a `manage-schemas` `validate` check that flags `skill:` values
   colliding with built-in skill names (`review`, `plan`, `run`, `init`).
+- **`advance_item` gate-blocked results now name the blocked transition.** The gate-block error JSON
+  gains structured `previousRole`/`targetRole` fields alongside `missingNotes`, so a rejected
+  transition identifies which phase's note set it failed instead of leaving the caller to infer it
+  from the trigger. The tool description now also states that `start`'s gate is scoped to the item's
+  CURRENT phase — successive `start` calls gate different note sets as the role advances, which is
+  deterministic and not timing-dependent — and that a transition can cascade a parent to terminal
+  when the parent's downstream gates are already satisfied by prefilled notes. MCP surface only: the
+  REST `422 gate_blocked` payload already carried `targetRole` and does not yet carry `previousRole`.
+- **`manage_items(update)` now honors the top-level `traits` parameter.** It was previously accepted
+  and silently ignored — the call returned `{updated:1, failed:0}` having merged nothing, with no
+  error — because the update branch never read the parameter, while `create` always had. Precedence
+  now matches `create`: a per-item `traits` field overrides the shared top-level default, and traits
+  absent at both levels leave the item's existing traits untouched. Merge semantics are replace, not
+  union. The per-item form (`items: [{itemId, traits: "..."}]`) was never affected and needs no
+  migration.
+  **Behavior change:** `traits: ""` on update now **clears** an item's traits, where it was
+  previously a silent no-op. Because trait-derived note requirements merge into an item's resolved
+  schema, clearing traits also drops their gates — a caller that passes an empty `traits` string on
+  update (e.g. a template that always sets the field) will now strip both. Omit the field entirely
+  to leave traits unchanged.
 
 ## [3.13.0] - 2026-07-25
 


### PR DESCRIPTION
## Summary

Adds the two entries missing from `[Unreleased]` → `Fixed` after today's merges, so `/prepare-release` drafts from a complete section instead of re-deriving them from the commit log.

Docs only — no code, no tests affected.

## Why now

Release finalization is in progress. `/prepare-release` Step 4 re-drafts the changelog from `git log v3.13.0..HEAD`, which recovers the broad strokes but reliably flattens nuance. The specific detail at risk is the behavior change below.

## The entry that matters

`traits: ""` on update now **clears** an item's traits, where it was previously a silent no-op. Because trait-derived note requirements merge into an item's resolved schema, clearing traits also drops their gates — so a caller passing an empty `traits` string from a template would strip both, silently. That is the one non-additive edge in #289 and it belongs in the release notes.

## Scoping note

The #288 entry is deliberately scoped to the MCP surface. The REST `422 gate_blocked` payload already carried `targetRole` and does not yet carry `previousRole` — tracked separately as MCP item `476d3e75`, and additive to fix later.

## MCP

Proposal: `6dd88f70` (closed effective)
Items: `80947b32`, `ac75eed1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)