### PR TITLE
fix(skills): prepare-release release-notes extraction silently yielded an empty body

### DIFF
--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -471,14 +471,31 @@ as the release body:
 ```bash
 RELNOTES="$(mktemp)"
 awk -v ver="X.Y.Z" '
-  $0 ~ "^## \\[" ver "\\]" { capture=1; next }   # skip the version header line (redundant with the release title)
-  capture && /^## \[/ { exit }                    # stop at the next version section
+  BEGIN { hdr = "## [" ver "]" }
+  index($0, hdr) == 1 { capture=1; next }          # skip the version header line (redundant with the release title)
+  capture && index($0, "## [") == 1 { exit }       # stop at the next version section
   capture { print }
 ' CHANGELOG.md > "$RELNOTES"
+
+# Never publish an empty body. `gh release edit --notes-file` accepts an empty file without
+# complaint, so a silently-failed extraction replaces the auto-generated notes with NOTHING —
+# strictly worse than leaving them. Fail loudly instead.
+if [ ! -s "$RELNOTES" ]; then
+  echo "ERROR: extracted release notes are empty — check that CHANGELOG.md contains a '## [X.Y.Z]' header" >&2
+  rm -f "$RELNOTES"
+  exit 1
+fi
 
 gh release edit vX.Y.Z --notes-file "$RELNOTES"
 rm -f "$RELNOTES"
 ```
+
+**Match the header literally — do not build a regex from the version string.** `X.Y.Z` contains
+`.` (any-char in a regex) and sits inside `[`…`]`, so the obvious `$0 ~ "^## \\[" ver "\\]"` form
+is fragile: in a *dynamic* (string-built) regex the bracket escaping is interpreted twice, and on
+gawk it degrades to a character class — the match never fires and the extraction silently yields
+zero lines. `index($0, hdr) == 1` compares plain strings, so version dots and brackets carry no
+special meaning. Verified failing on gawk 2026-08-04 during the v3.13.1 release.
 
 Verify the body now leads with the curated notes:
 ```bash


### PR DESCRIPTION
## The bug

Step 11g of `/prepare-release` extracts the current version's `CHANGELOG.md` section and publishes it as the GitHub Release body. It built a **dynamic regex** from the version string:

```awk
$0 ~ "^## \[" ver "\]" { capture=1; next }
```

Bracket escaping is interpreted twice in a string-built regex, and on gawk it degrades to a character class rather than a literal `[`. The header never matches and the extraction yields **zero lines**.

## Why it matters

`gh release edit --notes-file` accepts an empty file without complaint. So the documented command replaces GitHub's auto-generated notes with **nothing** — strictly worse than leaving them, and completely silent. There is no error, no warning, and the release simply ends up with a blank body.

Observed live during the **v3.13.1** release. The curated notes survived only because the extraction was inspected before publishing rather than piped straight through.

## The fix

- Match the header with `index($0, hdr) == 1` — plain string comparison, so version dots and brackets carry no regex meaning.
- Add a non-empty guard that exits 1 with a diagnostic instead of publishing a blank body. This is the more valuable half: it converts a silent failure into a loud one regardless of how the matcher is later edited.
- Add a short note explaining *why* the regex form is fragile, so it doesn't get "simplified" back.

## Verification

Run against the real `CHANGELOG.md`:

- Correct version `3.13.1` → **98 lines**, `traits` behavior-change callout present, no bleed into `[3.13.0]`.
- Bogus version `9.9.9` → empty extraction, **guard fires**, would exit 1 rather than wipe the notes.

Docs-only change to a skill file — no server code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)